### PR TITLE
Fix: Correct employer list view and add success message

### DIFF
--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -4,6 +4,11 @@
 
 @section('content')
 <div class="content-section">
+    @if ($message = Session::get('success'))
+        <div class="alert alert-success mb-4" role="alert">
+            {{ $message }}
+        </div>
+    @endif
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
          <h2 class="mb-3 mb-md-0">รายการข้อมูลนายจ้าง</h2>
          <div class="d-flex gap-2">
@@ -27,7 +32,7 @@
                         <td>{{ $loop->iteration }}</td>
                         <td>{{ $employer->employerNameTh }}</td>
                         <td>{{ $employer->employerId }}</td>
-                        <td>{{ $employer.businessType }}</td>
+                        <td>{{ $employer->businessType }}</td>
                         <td class="text-center">
                             <a href="{{ route('employers.edit', $employer) }}" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil-square"></i></a>
                             <form action="{{ route('employers.destroy', $employer) }}" method="POST" class="d-inline">


### PR DESCRIPTION
This commit addresses two issues in the employer list view (`resources/views/employers/index.blade.php`):

1.  Corrected a typo in the Blade template that prevented the `businessType` from being displayed. The access was changed from `$employer.businessType` to the correct object notation `$employer->businessType`.
2.  Added a section to display a success message from the session. This provides user feedback after successfully creating a new employer, as requested.

The initial task description mentioned a need to add the `$fillable` property to the `Employer` model and implement the `store` method in the `EmployerController`. However, upon inspection, both of these were already correctly implemented. The actual issues preventing the feature from working as expected were in the view file.