### PR TITLE
Fix: Name the login route to fix redirection

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Providers\RouteServiceProvider;
+
+class AuthenticatedSessionController extends Controller
+{
+    /**
+     * Display the login view.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function create()
+    {
+        return view('auth.login');
+    }
+
+    /**
+     * Handle an incoming authentication request.
+     *
+     * @param  \App\Http\Requests\Auth\LoginRequest  $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function store(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+
+            return redirect()->intended(RouteServiceProvider::HOME);
+        }
+
+        return back()->withErrors([
+            'email' => 'The provided credentials do not match our records.',
+        ]);
+    }
+
+    /**
+     * Destroy an authenticated session.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(Request $request)
+    {
+        Auth::guard('web')->logout();
+
+        $request->session()->invalidate();
+
+        $request->session()->regenerateToken();
+
+        return redirect('/');
+    }
+}

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('login', [AuthenticatedSessionController::class, 'create'])
+                ->name('login');
+
+Route::post('login', [AuthenticatedSessionController::class, 'store']);
+
+Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
+                ->middleware('auth')
+                ->name('logout');

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,3 +10,5 @@ Route::get('/', function () {
 
 Route::resource('employers', EmployerController::class);
 Route::resource('importers', ImporterController::class)->middleware('auth');
+
+require __DIR__.'/auth.php';


### PR DESCRIPTION
The application was throwing a "Route [login] not defined" error for unauthenticated users trying to access protected routes. This was because the authentication routes were not defined.

This commit adds the authentication routes in a new `routes/auth.php` file, including a named 'login' route. It also adds a basic `AuthenticatedSessionController` to handle login, logout, and displaying the login form. The new auth routes are included in the main `routes/web.php` file.