### PR TITLE
Fix incomplete auth.php route file

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,13 +1,13 @@
 <?php
-
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Auth\RegisteredUserController;
 use Illuminate\Support\Facades\Route;
-
+Route::get('register', [RegisteredUserController::class, 'create'])
+            ->name('register');
+Route::post('register', [RegisteredUserController::class, 'store']);
 Route::get('login', [AuthenticatedSessionController::class, 'create'])
-                ->name('login');
-
+            ->name('login');
 Route::post('login', [AuthenticatedSessionController::class, 'store']);
-
 Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->middleware('auth')
-                ->name('logout');
+            ->middleware('auth')
+            ->name('logout');


### PR DESCRIPTION
The `routes/auth.php` file was missing the routes for user registration, causing 404 errors on the `/register` page. This commit adds the necessary `GET` and `POST` routes for `/register` to handle user registration.