### PR TITLE
feat: Create Employee Management UI within Employer Page

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Employee;
+use App\Models\Employer;
 use Illuminate\Http\Request;
 
 class EmployeeController extends Controller
@@ -11,54 +13,77 @@ class EmployeeController extends Controller
      */
     public function index()
     {
-        //
+        // Not used for now
     }
 
     /**
      * Show the form for creating a new resource.
      */
-    public function create()
+    public function create(Employer $employer)
     {
-        //
+        return view('employees.create', compact('employer'));
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(Request $request, Employer $employer)
     {
-        //
+        $request->validate([
+            'employeeNameTh' => 'required',
+            'employeePassport' => 'required|unique:employees',
+        ]);
+
+        $data = $request->all();
+        $data['employer_id'] = $employer->id;
+
+        Employee::create($data);
+
+        return redirect()->route('employers.edit', $employer)
+            ->with('success', 'เพิ่มข้อมูลพนักงานเรียบร้อยแล้ว');
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(Employee $employee)
     {
-        //
+        // Not used for now
     }
 
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(string $id)
+    public function edit(Employee $employee)
     {
-        //
+        return view('employees.edit', compact('employee'));
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(Request $request, Employee $employee)
     {
-        //
+        $request->validate([
+            'employeeNameTh' => 'required',
+            'employeePassport' => 'required|unique:employees,employeePassport,' . $employee->id,
+        ]);
+
+        $employee->update($request->all());
+
+        return redirect()->route('employers.edit', $employee->employer_id)
+            ->with('success', 'อัปเดตข้อมูลพนักงานเรียบร้อยแล้ว');
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(Employee $employee)
     {
-        //
+        $employer_id = $employee->employer_id;
+        $employee->delete();
+
+        return redirect()->route('employers.edit', $employer_id)
+            ->with('success', 'ลบข้อมูลพนักงานเรียบร้อยแล้ว');
     }
 }

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -53,7 +53,8 @@ class EmployerController extends Controller
      */
     public function edit(Employer $employer)
     {
-        return view('employers.edit', compact('employer'));
+        $employees = $employer->employees;
+        return view('employers.edit', compact('employer', 'employees'));
     }
 
     /**

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -9,6 +9,19 @@ class Employee extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'employer_id',
+        'employeeNameTh',
+        'employeeNameEn',
+        'employeeNationality',
+        'employeePassport',
+        'passportExpiryDate',
+        'employeeWorkPermit',
+        'workPermitExpiryDate',
+        'visaExpiryDate',
+        'ninetyDayReportDate',
+    ];
+
     public function employer()
     {
         return $this->belongsTo(Employer::class);

--- a/resources/views/employees/create.blade.php
+++ b/resources/views/employees/create.blade.php
@@ -1,0 +1,60 @@
+@extends('layouts.app')
+
+@section('title', 'เพิ่มพนักงาน')
+
+@section('content')
+<div class="content-section">
+    <h2 class="mb-4">เพิ่มพนักงานสำหรับ {{ $employer->employerNameTh }}</h2>
+    <form action="{{ route('employers.employees.store', $employer) }}" method="POST">
+        @csrf
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="employeeNameTh" class="form-label">ชื่อพนักงาน (ไทย)</label>
+                <input type="text" class="form-control" id="employeeNameTh" name="employeeNameTh" required>
+            </div>
+            <div class="col-md-6">
+                <label for="employeeNameEn" class="form-label">ชื่อพนักงาน (อังกฤษ)</label>
+                <input type="text" class="form-control" id="employeeNameEn" name="employeeNameEn">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="employeeNationality" class="form-label">สัญชาติ</label>
+                <input type="text" class="form-control" id="employeeNationality" name="employeeNationality">
+            </div>
+            <div class="col-md-6">
+                <label for="employeePassport" class="form-label">เลขพาสปอร์ต</label>
+                <input type="text" class="form-control" id="employeePassport" name="employeePassport" required>
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="passportExpiryDate" class="form-label">วันหมดอายุพาสปอร์ต</label>
+                <input type="date" class="form-control" id="passportExpiryDate" name="passportExpiryDate">
+            </div>
+            <div class="col-md-6">
+                <label for="employeeWorkPermit" class="form-label">ใบอนุญาตทำงาน</label>
+                <input type="text" class="form-control" id="employeeWorkPermit" name="employeeWorkPermit">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="workPermitExpiryDate" class="form-label">วันหมดอายุใบอนุญาตทำงาน</label>
+                <input type="date" class="form-control" id="workPermitExpiryDate" name="workPermitExpiryDate">
+            </div>
+            <div class="col-md-6">
+                <label for="visaExpiryDate" class="form-label">วันหมดอายุวีซ่า</label>
+                <input type="date" class="form-control" id="visaExpiryDate" name="visaExpiryDate">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="ninetyDayReportDate" class="form-label">วันที่ต้องรายงาน 90 วัน</label>
+                <input type="date" class="form-control" id="ninetyDayReportDate" name="ninetyDayReportDate">
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary">บันทึก</button>
+        <a href="{{ route('employers.edit', $employer) }}" class="btn btn-secondary">ยกเลิก</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -32,4 +32,41 @@
         <a href="{{ route('employers.index') }}" class="btn btn-secondary">ยกเลิก</a>
     </form>
 </div>
+
+<div class="content-section mt-5">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2>ข้อมูลพนักงาน</h2>
+        <a href="{{ route('employers.employees.create', ['employer' => $employer->id]) }}" class="btn btn-primary">เพิ่มพนักงาน</a>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead class="table-light">
+                <tr>
+                    <th>รูปภาพ</th>
+                    <th>ชื่อ (ไทย)</th>
+                    <th>เลขพาสปอร์ต</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse ($employees as $employee)
+                <tr>
+                    <td>
+                        @if ($employee->employeePhoto)
+                            <img src="{{ asset('storage/' . $employee->employeePhoto) }}" alt="Employee Photo" width="50">
+                        @else
+                            N/A
+                        @endif
+                    </td>
+                    <td>{{ $employee->employeeNameTh }}</td>
+                    <td>{{ $employee->employeePassport }}</td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="3" class="text-center">ไม่พบข้อมูลพนักงาน</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
 @endsection


### PR DESCRIPTION
This commit introduces the employee management UI directly within the employer's edit page.

- Modified `EmployerController` to pass the employer's employees to the edit view.
- Updated `employers/edit.blade.php` to display a list of employees and an "Add Employee" button.
- Created `employees/create.blade.php` with a form to add a new employee.
- Implemented the `EmployeeController` with `create` and `store` actions to handle the creation of new employees. The `store` action uses route-model binding for better security.
- Added `fillable` properties to the `Employee` model to allow mass assignment.