### PR TITLE
feat: Implement Employee Edit, Update, and Delete UI

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Employee;
 use App\Models\Employer;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class EmployeeController extends Controller
 {
@@ -54,36 +55,53 @@ class EmployeeController extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(Employee $employee)
+    public function edit(Employer $employer, Employee $employee)
     {
-        return view('employees.edit', compact('employee'));
+        return view('employees.edit', compact('employer', 'employee'));
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Employee $employee)
+    public function update(Request $request, Employer $employer, Employee $employee)
     {
         $request->validate([
             'employeeNameTh' => 'required',
             'employeePassport' => 'required|unique:employees,employeePassport,' . $employee->id,
+            'employeePhoto' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ]);
 
-        $employee->update($request->all());
+        $data = $request->all();
 
-        return redirect()->route('employers.edit', $employee->employer_id)
+        if ($request->hasFile('employeePhoto')) {
+            // Delete old photo if it exists
+            if ($employee->employeePhoto) {
+                Storage::disk('public')->delete($employee->employeePhoto);
+            }
+            // Store new photo
+            $path = $request->file('employeePhoto')->store('employee_photos', 'public');
+            $data['employeePhoto'] = $path;
+        }
+
+        $employee->update($data);
+
+        return redirect()->route('employers.edit', $employer)
             ->with('success', 'อัปเดตข้อมูลพนักงานเรียบร้อยแล้ว');
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Employee $employee)
+    public function destroy(Employer $employer, Employee $employee)
     {
-        $employer_id = $employee->employer_id;
+        // Delete photo from storage if it exists
+        if ($employee->employeePhoto) {
+            Storage::disk('public')->delete($employee->employeePhoto);
+        }
+
         $employee->delete();
 
-        return redirect()->route('employers.edit', $employer_id)
+        return redirect()->route('employers.edit', $employer)
             ->with('success', 'ลบข้อมูลพนักงานเรียบร้อยแล้ว');
     }
 }

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -1,0 +1,84 @@
+@extends('layouts.app')
+
+@section('title', 'แก้ไขข้อมูลพนักงาน')
+
+@section('content')
+<div class="content-section">
+    <h2 class="mb-4">แก้ไขข้อมูลพนักงานสำหรับ {{ $employer->employerNameTh }}</h2>
+
+    @if ($errors->any())
+        <div class="alert alert-danger">
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form action="{{ route('employers.employees.update', [$employer, $employee]) }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        @method('PUT')
+
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="employeeNameTh" class="form-label">ชื่อพนักงาน (ไทย)</label>
+                <input type="text" class="form-control" id="employeeNameTh" name="employeeNameTh" value="{{ old('employeeNameTh', $employee->employeeNameTh) }}" required>
+            </div>
+            <div class="col-md-6">
+                <label for="employeeNameEn" class="form-label">ชื่อพนักงาน (อังกฤษ)</label>
+                <input type="text" class="form-control" id="employeeNameEn" name="employeeNameEn" value="{{ old('employeeNameEn', $employee->employeeNameEn) }}">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="employeeNationality" class="form-label">สัญชาติ</label>
+                <input type="text" class="form-control" id="employeeNationality" name="employeeNationality" value="{{ old('employeeNationality', $employee->employeeNationality) }}">
+            </div>
+            <div class="col-md-6">
+                <label for="employeePassport" class="form-label">เลขพาสปอร์ต</label>
+                <input type="text" class="form-control" id="employeePassport" name="employeePassport" value="{{ old('employeePassport', $employee->employeePassport) }}" required>
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="passportExpiryDate" class="form-label">วันหมดอายุพาสปอร์ต</label>
+                <input type="date" class="form-control" id="passportExpiryDate" name="passportExpiryDate" value="{{ old('passportExpiryDate', $employee->passportExpiryDate) }}">
+            </div>
+            <div class="col-md-6">
+                <label for="employeeWorkPermit" class="form-label">ใบอนุญาตทำงาน</label>
+                <input type="text" class="form-control" id="employeeWorkPermit" name="employeeWorkPermit" value="{{ old('employeeWorkPermit', $employee->employeeWorkPermit) }}">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="workPermitExpiryDate" class="form-label">วันหมดอายุใบอนุญาตทำงาน</label>
+                <input type="date" class="form-control" id="workPermitExpiryDate" name="workPermitExpiryDate" value="{{ old('workPermitExpiryDate', $employee->workPermitExpiryDate) }}">
+            </div>
+            <div class="col-md-6">
+                <label for="visaExpiryDate" class="form-label">วันหมดอายุวีซ่า</label>
+                <input type="date" class="form-control" id="visaExpiryDate" name="visaExpiryDate" value="{{ old('visaExpiryDate', $employee->visaExpiryDate) }}">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="ninetyDayReportDate" class="form-label">วันที่ต้องรายงาน 90 วัน</label>
+                <input type="date" class="form-control" id="ninetyDayReportDate" name="ninetyDayReportDate" value="{{ old('ninetyDayReportDate', $employee->ninetyDayReportDate) }}">
+            </div>
+            <div class="col-md-6">
+                <label for="employeePhoto" class="form-label">รูปภาพพนักงาน</label>
+                <input type="file" class="form-control" id="employeePhoto" name="employeePhoto">
+                @if ($employee->employeePhoto)
+                    <div class="mt-2">
+                        <img src="{{ asset('storage/' . $employee->employeePhoto) }}" alt="Employee Photo" width="100">
+                        <p class="form-text">รูปภาพปัจจุบัน</p>
+                    </div>
+                @endif
+            </div>
+        </div>
+
+        <button type="submit" class="btn btn-primary">อัปเดต</button>
+        <a href="{{ route('employers.edit', $employer) }}" class="btn btn-secondary">ยกเลิก</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -45,6 +45,7 @@
                     <th>รูปภาพ</th>
                     <th>ชื่อ (ไทย)</th>
                     <th>เลขพาสปอร์ต</th>
+                    <th class="text-center">จัดการ</th>
                 </tr>
             </thead>
             <tbody>
@@ -59,10 +60,18 @@
                     </td>
                     <td>{{ $employee->employeeNameTh }}</td>
                     <td>{{ $employee->employeePassport }}</td>
+                    <td class="text-center">
+                        <a href="{{ route('employers.employees.edit', [$employer, $employee]) }}" class="btn btn-warning btn-sm">แก้ไข</a>
+                        <form action="{{ route('employers.employees.destroy', [$employer, $employee]) }}" method="POST" style="display:inline-block;">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลพนักงานคนนี้?')">ลบ</button>
+                        </form>
+                    </td>
                 </tr>
                 @empty
                 <tr>
-                    <td colspan="3" class="text-center">ไม่พบข้อมูลพนักงาน</td>
+                    <td colspan="4" class="text-center">ไม่พบข้อมูลพนักงาน</td>
                 </tr>
                 @endforelse
             </tbody>


### PR DESCRIPTION
This commit introduces the full CRUD functionality for employees on the employer's detail page.

- Updates `employers/edit.blade.php` to include 'Edit' and 'Delete' buttons in the employee list, linking to the appropriate routes.
- Implements the `edit`, `update`, and `destroy` methods in `EmployeeController`. The `update` method now handles photo uploads, and the `destroy` method removes the associated photo from storage.
- Creates the `employees/edit.blade.php` view with a form pre-filled with existing data to allow for editing employee details.