### PR TITLE
feat: Create Command to Check for Expiring Documents

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Employee;
+use App\Models\Notification;
+use Carbon\Carbon;
+
+class CheckExpiries extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:check-expiries';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check for expiring employee documents and create notifications.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Checking for expiring documents...');
+
+        $thresholdDate = Carbon::now()->addDays(45);
+        $today = Carbon::now();
+
+        $employees = Employee::all();
+
+        foreach ($employees as $employee) {
+            $documentTypes = [
+                'passport_expiry' => $employee->passportExpiryDate,
+                'visa_expiry' => $employee->visaExpiryDate,
+                'work_permit_expiry' => $employee->workPermitExpiryDate,
+                'ninety_day_report' => $employee->ninetyDayReportDate,
+            ];
+
+            foreach ($documentTypes as $type => $expiryDate) {
+                if ($expiryDate) {
+                    $expiryDate = Carbon::parse($expiryDate);
+
+                    if ($expiryDate->between($today, $thresholdDate)) {
+                        $existingNotification = Notification::where('employee_id', $employee->id)
+                            ->where('type', $type)
+                            ->first();
+
+                        if (!$existingNotification) {
+                            Notification::create([
+                                'employee_id' => $employee->id,
+                                'type' => $type,
+                                'message' => "The employee's " . str_replace('_', ' ', $type) . " is expiring on " . $expiryDate->format('Y-m-d') . ".",
+                                'due_date' => $expiryDate,
+                            ]);
+                        }
+                    }
+                }
+            }
+        }
+
+        $this->info('Done.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    /**
+     * The Artisan commands provided by your application.
+     *
+     * @var array
+     */
+    protected $commands = [
+        \App\Console\Commands\CheckExpiries::class,
+    ];
+
+    /**
+     * Define the application's command schedule.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    protected function schedule(Schedule $schedule)
+    {
+        $schedule->command('app:check-expiries')->daily();
+    }
+
+    /**
+     * Register the commands for the application.
+     *
+     * @return void
+     */
+    protected function commands()
+    {
+        $this->load(__DIR__.'/Commands');
+
+        require base_path('routes/console.php');
+    }
+}


### PR DESCRIPTION
This commit introduces a new Artisan command `app:check-expiries` that scans all employees for documents expiring within the next 45 days.

The command performs the following actions:
- Fetches all employees from the database.
- Checks `passportExpiryDate`, `visaExpiryDate`, `workPermitExpiryDate`, and `ninetyDayReportDate`.
- If a document is expiring within 45 days, it creates a notification in the `notifications` table.
- Includes logic to prevent the creation of duplicate notifications for the same employee and document type.

The command is registered and scheduled to run daily in the `app/Console/Kernel.php` file.