### PR TITLE
Fix Mass Assignment Exception on Notification Model

### DIFF
--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -9,6 +9,8 @@ class Notification extends Model
 {
     use HasFactory;
 
+    protected $fillable = ['employee_id', 'type', 'message', 'due_date', 'status'];
+
     public function employee()
     {
         return $this->belongsTo(Employee::class);


### PR DESCRIPTION
Add the fillable property to the Notification model to allow mass assignment of the following fields: employee_id, type, message, due_date, status.