### PR TITLE
This commit introduces a new UI for displaying notifications.

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Notification;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function index()
+    {
+        $notifications = Notification::with('employee.employer')
+            ->where('status', 'unread')
+            ->get();
+
+        $groupedNotifications = $notifications->groupBy('type');
+
+        return view('notifications.index', ['groupedNotifications' => $groupedNotifications]);
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -111,7 +111,7 @@
             <a class="navbar-brand fs-4" href="#"><i class="bi bi-building-fill-gear"></i> Company Records</a>
             <div class="list-group" id="main-nav">
                 <a href="#" class="list-group-item list-group-item-action"><i class="bi bi-pie-chart-fill me-2"></i>ภาพรวม</a>
-                <a href="#" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                <a href="{{ route('notifications.index') }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center {{ request()->routeIs('notifications.*') ? 'active' : '' }}">
                     <span><i class="bi bi-bell-fill me-2"></i>แจ้งเตือน</span>
                 </a>
                 <hr>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.app')
+
+@section('title', 'รายการแจ้งเตือน')
+
+@php
+$notificationTypes = [
+    '90-day-report' => ['name' => 'รายงานตัว 90 วัน', 'color' => 'danger'],
+    'passport-expiry' => ['name' => 'Passport', 'color' => 'warning'],
+    'visa-expiry' => ['name' => 'วีซ่า', 'color' => 'info'],
+];
+@endphp
+
+@section('content')
+<div class="content-section">
+    <h2 class="mb-4">รายการแจ้งเตือน</h2>
+
+    @if($groupedNotifications->isEmpty())
+        <div class="alert alert-success text-center">
+            <i class="bi bi-check-circle-fill me-2"></i> ไม่มีรายการแจ้งเตือนค้าง
+        </div>
+    @else
+        <ul class="nav nav-tabs" id="notificationTab" role="tablist">
+            @foreach($groupedNotifications as $type => $notifications)
+                @if(isset($notificationTypes[$type]))
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link {{ $loop->first ? 'active' : '' }}" id="{{ $type }}-tab" data-bs-toggle="tab" data-bs-target="#{{ $type }}-pane" type="button" role="tab" aria-controls="{{ $type }}-pane" aria-selected="{{ $loop->first ? 'true' : 'false' }}">
+                            {{ $notificationTypes[$type]['name'] }}
+                            <span class="badge bg-{{ $notificationTypes[$type]['color'] }} rounded-pill ms-1">{{ $notifications->count() }}</span>
+                        </button>
+                    </li>
+                @endif
+            @endforeach
+        </ul>
+
+        <div class="tab-content pt-4" id="notificationTabContent">
+            @foreach($groupedNotifications as $type => $notifications)
+                @if(isset($notificationTypes[$type]))
+                    <div class="tab-pane fade {{ $loop->first ? 'show active' : '' }}" id="{{ $type }}-pane" role="tabpanel" aria-labelledby="{{ $type }}-tab">
+                        <div class="vstack gap-3">
+                            @forelse($notifications as $notification)
+                                <div class="alert alert-{{ $notificationTypes[$type]['color'] }} notification-item" role="alert">
+                                    <div class="d-flex w-100 justify-content-between">
+                                        <h5 class="alert-heading">{{ $notification->employee->employeeNameTh ?? 'N/A' }}</h5>
+                                        <small class="text-muted">ครบกำหนด: {{ \Carbon\Carbon::parse($notification->due_date)->thaidate('j M Y') }}</small>
+                                    </div>
+                                    <p class="mb-1">
+                                        <strong>นายจ้าง:</strong> {{ $notification->employee->employer->employerNameTh ?? 'N/A' }}
+                                    </p>
+                                    <p class="mb-0">{{ $notification->message }}</p>
+                                </div>
+                            @empty
+                                <p>ไม่มีการแจ้งเตือนสำหรับประเภทนี้</p>
+                            @endforelse
+                        </div>
+                    </div>
+                @endif
+            @endforeach
+        </div>
+    @endif
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\EmployerController;
 use App\Http\Controllers\ImporterController;
 use App\Http\Controllers\EmployeeController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\NotificationController;
 Route::get('/', function () {
     return view('welcome');
 });
@@ -23,5 +24,7 @@ Route::middleware('auth')->group(function () {
     Route::resource('importers', ImporterController::class);
     Route::resource('agents', AgentController::class);
     Route::resource('delegates', DelegateController::class);
+
+    Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
 });
 require __DIR__.'/auth.php';


### PR DESCRIPTION
A new page has been created at `/notifications` to show all unread notifications from the database. The page is accessible via a "แจ้งเตือน" link in the sidebar.

Key changes include:
- A `NotificationController` to handle fetching and grouping notifications by type.
- A new route in `web.php` for the notifications page, protected by auth middleware.
- An updated sidebar in the main application layout.
- A new view (`notifications/index.blade.php`) that uses a tabbed interface to display notifications, showing employee and employer details for each.