### PR TITLE
feat: Implement tabbed view for notifications

### DIFF
--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -3,11 +3,37 @@
 @section('title', 'รายการแจ้งเตือน')
 
 @php
-$notificationTypes = [
-    '90-day-report' => ['name' => 'รายงานตัว 90 วัน', 'color' => 'danger'],
-    'passport-expiry' => ['name' => 'Passport', 'color' => 'warning'],
-    'visa-expiry' => ['name' => 'วีซ่า', 'color' => 'info'],
+// 1. Define the tabs based on the design reference
+$tabs = [
+    '90day' => ['name' => 'รายงานตัว 90 วัน', 'color' => 'danger'],
+    'passport' => ['name' => 'Passport', 'color' => 'danger'],
+    'permits' => ['name' => 'ใบอนุญาต/วีซ่า', 'color' => 'danger'],
+    'ci-renew' => ['name' => 'ต่ออายุ CI', 'color' => 'danger'],
+    'resolution-renew' => ['name' => 'ต่ออายุมติ', 'color' => 'danger'],
+    'cancelled-renew' => ['name' => 'รายการที่ยกเลิก', 'color' => 'secondary'],
 ];
+
+// 2. Map the database notification types to the tab they belong to
+$typeToTabMapping = [
+    'ninety_day_report' => '90day',
+    'passport_expiry' => 'passport',
+    'visa_expiry' => 'permits',
+    'work_permit_expiry' => 'permits',
+    'ci_renewal' => 'ci-renew',
+    'resolution_renewal' => 'resolution-renew',
+    'cancelled_renewal' => 'cancelled-renew',
+];
+
+// 3. Helper to get all notifications for a given tab ID
+function getNotificationsForTab($tabId, $groupedNotifications, $typeToTabMapping) {
+    $notificationsForTab = collect();
+    foreach ($typeToTabMapping as $type => $id) {
+        if ($id === $tabId && $groupedNotifications->has($type)) {
+            $notificationsForTab = $notificationsForTab->merge($groupedNotifications->get($type));
+        }
+    }
+    return $notificationsForTab;
+}
 @endphp
 
 @section('content')
@@ -20,12 +46,15 @@ $notificationTypes = [
         </div>
     @else
         <ul class="nav nav-tabs" id="notificationTab" role="tablist">
-            @foreach($groupedNotifications as $type => $notifications)
-                @if(isset($notificationTypes[$type]))
+            @foreach($tabs as $tabId => $tabDetails)
+                @php
+                    $notificationsForTab = getNotificationsForTab($tabId, $groupedNotifications, $typeToTabMapping);
+                @endphp
+                @if($notificationsForTab->isNotEmpty())
                     <li class="nav-item" role="presentation">
-                        <button class="nav-link {{ $loop->first ? 'active' : '' }}" id="{{ $type }}-tab" data-bs-toggle="tab" data-bs-target="#{{ $type }}-pane" type="button" role="tab" aria-controls="{{ $type }}-pane" aria-selected="{{ $loop->first ? 'true' : 'false' }}">
-                            {{ $notificationTypes[$type]['name'] }}
-                            <span class="badge bg-{{ $notificationTypes[$type]['color'] }} rounded-pill ms-1">{{ $notifications->count() }}</span>
+                        <button class="nav-link {{ $loop->first ? 'active' : '' }}" id="{{ $tabId }}-tab" data-bs-toggle="tab" data-bs-target="#{{ $tabId }}-pane" type="button" role="tab" aria-controls="{{ $tabId }}-pane" aria-selected="{{ $loop->first ? 'true' : 'false' }}">
+                            {{ $tabDetails['name'] }}
+                            <span class="badge bg-{{ $tabDetails['color'] }} rounded-pill ms-1">{{ $notificationsForTab->count() }}</span>
                         </button>
                     </li>
                 @endif
@@ -33,24 +62,29 @@ $notificationTypes = [
         </ul>
 
         <div class="tab-content pt-4" id="notificationTabContent">
-            @foreach($groupedNotifications as $type => $notifications)
-                @if(isset($notificationTypes[$type]))
-                    <div class="tab-pane fade {{ $loop->first ? 'show active' : '' }}" id="{{ $type }}-pane" role="tabpanel" aria-labelledby="{{ $type }}-tab">
+            @foreach($tabs as $tabId => $tabDetails)
+                 @php
+                    $notificationsForTab = getNotificationsForTab($tabId, $groupedNotifications, $typeToTabMapping)->sortBy('due_date');
+                @endphp
+                @if($notificationsForTab->isNotEmpty())
+                    <div class="tab-pane fade {{ $loop->first ? 'show active' : '' }}" id="{{ $tabId }}-pane" role="tabpanel" aria-labelledby="{{ $tabId }}-tab">
                         <div class="vstack gap-3">
-                            @forelse($notifications as $notification)
-                                <div class="alert alert-{{ $notificationTypes[$type]['color'] }} notification-item" role="alert">
+                            @foreach($notificationsForTab as $notification)
+                                <div class="alert alert-warning notification-item" role="alert">
                                     <div class="d-flex w-100 justify-content-between">
-                                        <h5 class="alert-heading">{{ $notification->employee->employeeNameTh ?? 'N/A' }}</h5>
+                                        <h5 class="alert-heading mb-1">{{ $notification->employee->employeeNameTh ?? 'N/A' }}</h5>
+                                        @if($notification->due_date)
                                         <small class="text-muted">ครบกำหนด: {{ \Carbon\Carbon::parse($notification->due_date)->thaidate('j M Y') }}</small>
+                                        @endif
                                     </div>
+                                    @if(isset($notification->employee->employer))
                                     <p class="mb-1">
                                         <strong>นายจ้าง:</strong> {{ $notification->employee->employer->employerNameTh ?? 'N/A' }}
                                     </p>
+                                    @endif
                                     <p class="mb-0">{{ $notification->message }}</p>
                                 </div>
-                            @empty
-                                <p>ไม่มีการแจ้งเตือนสำหรับประเภทนี้</p>
-                            @endforelse
+                            @endforeach
                         </div>
                     </div>
                 @endif


### PR DESCRIPTION
This commit implements the Blade view logic for the notifications page at /notifications.

It introduces a tabbed interface based on the design reference, allowing users to view notifications grouped by type.

Key changes:
- Replaced the placeholder/incorrect logic in `resources/views/notifications/index.blade.php`.
- Created a mapping from database notification types (e.g., 'passport_expiry', 'visa_expiry') to display tabs.
- Implemented logic to correctly group multiple notification types under a single tab (e.g., "ใบอนุญาต/วีซ่า").
- Styled the notification items to show employee and employer details as required.