### PR TITLE
Debug Data Structure in NotificationController

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -15,6 +15,7 @@ class NotificationController extends Controller
 
         $groupedNotifications = $notifications->groupBy('type');
 
+        dd($groupedNotifications);
         return view('notifications.index', ['groupedNotifications' => $groupedNotifications]);
     }
 }


### PR DESCRIPTION
Add dd() to debug the data structure being passed from the NotificationController to the view to find the root cause of the issue where the notification view is rendering data in the wrong tabs.