### PR TITLE
The CheckExpiries command is not removing old notifications, causing …

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -28,8 +28,8 @@ class CheckExpiries extends Command
      */
     public function handle()
     {
-        \App\Models\Notification::truncate();
         $this->info('Checking for expiring documents...');
+        Notification::truncate();
 
         $thresholdDate = Carbon::now()->addDays(45);
         $today = Carbon::now();


### PR DESCRIPTION
…outdated data to persist. This change adds the logic to clear the notifications table before generating new ones by moving the truncate call to the correct position.