### PR TITLE
feat: Implement full employer data form

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -32,6 +32,11 @@ class EmployerController extends Controller
         $request->validate([
             'employerNameTh' => 'required',
             'employerId' => 'required|unique:employers',
+            'signerNameTh' => 'nullable',
+            'signerNameEn' => 'nullable',
+            'businessTypeEn' => 'nullable',
+            'regCapital' => 'nullable',
+            'regDate' => 'nullable|date',
         ]);
 
         Employer::create($request->all());
@@ -65,6 +70,11 @@ class EmployerController extends Controller
         $request->validate([
             'employerNameTh' => 'required',
             'employerId' => 'required|unique:employers,employerId,' . $employer->id,
+            'signerNameTh' => 'nullable',
+            'signerNameEn' => 'nullable',
+            'businessTypeEn' => 'nullable',
+            'regCapital' => 'nullable',
+            'regDate' => 'nullable|date',
         ]);
 
         $employer->update($request->all());

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -14,6 +14,11 @@ class Employer extends Model
         'employerId',
         'employerTaxId',
         'businessType',
+        'signerNameTh',
+        'signerNameEn',
+        'businessTypeEn',
+        'regCapital',
+        'regDate',
     ];
 
     public function employees()

--- a/database/migrations/2025_08_30_112500_add_full_fields_to_employers_table.php
+++ b/database/migrations/2025_08_30_112500_add_full_fields_to_employers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->string('signerNameTh')->nullable()->after('businessType');
+            $table->string('signerNameEn')->nullable()->after('signerNameTh');
+            $table->string('businessTypeEn')->nullable()->after('signerNameEn');
+            $table->string('regCapital')->nullable()->after('businessTypeEn');
+            $table->date('regDate')->nullable()->after('regCapital');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->dropColumn([
+                'signerNameTh',
+                'signerNameEn',
+                'businessTypeEn',
+                'regCapital',
+                'regDate',
+            ]);
+        });
+    }
+};

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -27,6 +27,32 @@
                 <input type="text" class="form-control" id="businessType" name="businessType">
             </div>
         </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="signerNameTh" class="form-label">ผู้มีอำนาจลงนาม (ไทย)</label>
+                <input type="text" class="form-control" id="signerNameTh" name="signerNameTh">
+            </div>
+            <div class="col-md-6">
+                <label for="signerNameEn" class="form-label">ผู้มีอำนาจลงนาม (อังกฤษ)</label>
+                <input type="text" class="form-control" id="signerNameEn" name="signerNameEn">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="businessTypeEn" class="form-label">Type of Business</label>
+                <input type="text" class="form-control" id="businessTypeEn" name="businessTypeEn">
+            </div>
+            <div class="col-md-6">
+                <label for="regCapital" class="form-label">ทุนจดทะเบียน</label>
+                <input type="text" class="form-control" id="regCapital" name="regCapital">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="regDate" class="form-label">จดทะเบียนวันที่</label>
+                <input type="date" class="form-control" id="regDate" name="regDate">
+            </div>
+        </div>
         <button type="submit" class="btn btn-primary">บันทึก</button>
         <a href="{{ route('employers.index') }}" class="btn btn-secondary">ยกเลิก</a>
     </form>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -28,6 +28,32 @@
                 <input type="text" class="form-control" id="businessType" name="businessType" value="{{ $employer->businessType }}">
             </div>
         </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="signerNameTh" class="form-label">ผู้มีอำนาจลงนาม (ไทย)</label>
+                <input type="text" class="form-control" id="signerNameTh" name="signerNameTh" value="{{ $employer->signerNameTh }}">
+            </div>
+            <div class="col-md-6">
+                <label for="signerNameEn" class="form-label">ผู้มีอำนาจลงนาม (อังกฤษ)</label>
+                <input type="text" class="form-control" id="signerNameEn" name="signerNameEn" value="{{ $employer->signerNameEn }}">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="businessTypeEn" class="form-label">Type of Business</label>
+                <input type="text" class="form-control" id="businessTypeEn" name="businessTypeEn" value="{{ $employer->businessTypeEn }}">
+            </div>
+            <div class="col-md-6">
+                <label for="regCapital" class="form-label">ทุนจดทะเบียน</label>
+                <input type="text" class="form-control" id="regCapital" name="regCapital" value="{{ $employer->regCapital }}">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="regDate" class="form-label">จดทะเบียนวันที่</label>
+                <input type="date" class="form-control" id="regDate" name="regDate" value="{{ $employer->regDate }}">
+            </div>
+        </div>
         <button type="submit" class="btn btn-primary">อัปเดต</button>
         <a href="{{ route('employers.index') }}" class="btn btn-secondary">ยกเลิก</a>
     </form>


### PR DESCRIPTION
Adds new fields to the employer form as per the design reference.

- Creates a new migration to add `signerNameTh`, `signerNameEn`, `businessTypeEn`, `regCapital`, and `regDate` to the `employers` table.
- Updates the `Employer` model to include the new fields in the `$fillable` array.
- Updates the `EmployerController` to add validation for the new fields in the `store` and `update` methods.
- Updates the `create.blade.php` and `edit.blade.php` views to include the new input fields in the employer form.