### PR TITLE
feat: Add passportType and workPermitMOUGroup to employees table

### DIFF
--- a/database/migrations/2025_08_31_073900_add_new_fields_to_employees_table.php
+++ b/database/migrations/2025_08_31_073900_add_new_fields_to_employees_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->string('passportType')->nullable();
+            $table->string('workPermitMOUGroup')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('passportType');
+            $table->dropColumn('workPermitMOUGroup');
+        });
+    }
+};


### PR DESCRIPTION
This commit introduces a new migration to add the `passportType` and `workPermitMOUGroup` columns to the `employees` table. It also updates the `Employee` model to include these new fields in the `$fillable` array.

This is the first part of the implementation for the new CI and Resolution Renewal notifications.