### PR TITLE
Fix: Correct notification types in NotificationController

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -15,15 +15,21 @@ class NotificationController extends Controller
     public function index(Request $request)
     {
         $notificationTypes = [
-            '90day', 'passport', 'work_permit', 'work_permit_expired', 'visa',
-            'ci_renew', 'resolution_renew', 'cancelled'
+            'ninety_day_report',
+            'passport_expiry',
+            'work_permit_expiry',
+            'work_permit_expired',
+            'visa_expiry',
+            'ci_renewal',
+            'resolution_renewal',
+            'cancelled'
         ];
 
         $groupedNotifications = collect();
 
         foreach ($notificationTypes as $type) {
             $formPrefix = $type;
-            if (in_array($type, ['work_permit', 'work_permit_expired', 'visa'])) {
+            if (in_array($type, ['work_permit_expiry', 'work_permit_expired', 'visa_expiry'])) {
                 $formPrefix = 'permits';
             }
 
@@ -136,11 +142,6 @@ class NotificationController extends Controller
                      $query->where('type', $type);
                 }
         }
-
-        if (in_array($type, ['work_permit', 'visa'])) {
-            $query->where('type', $type . '_expiry');
-        }
-
 
         // Apply filters
         if ($request->filled("search_{$prefix}")) {


### PR DESCRIPTION
The notification page was not displaying notifications because the controller was using short names for notification types (e.g., 'passport') which did not match the full names being saved in the database (e.g., 'passport_expiry').

This commit corrects the array of notification types in the `index()` method of the `NotificationController` to use the full, correct names.

Additionally, related logic for setting UI prefixes and building the database query has been updated to work with the corrected type names, and a redundant conditional has been removed.