### PR TITLE
Implement employer address management

### DIFF
--- a/app/Http/Controllers/AddressController.php
+++ b/app/Http/Controllers/AddressController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Address;
+use App\Models\Employer;
+use Illuminate\Http\Request;
+
+class AddressController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'addressable_id' => 'required',
+            'addressable_type' => 'required',
+            'type' => 'required|string|in:registered,workplace',
+            'addrNo' => 'nullable|string|max:255',
+            'addrMoo' => 'nullable|string|max:255',
+            'addrSoi' => 'nullable|string|max:255',
+            'addrRoad' => 'nullable|string|max:255',
+            'addrProvince' => 'nullable|string|max:255',
+            'addrDistrict' => 'nullable|string|max:255',
+            'addrSubDistrict' => 'nullable|string|max:255',
+            'addrZipCode' => 'nullable|string|max:255',
+        ]);
+
+        $modelClass = 'App\\Models\\' . ucfirst($request->addressable_type);
+        $parent = $modelClass::findOrFail($request->addressable_id);
+
+        $address = $parent->addresses()->create($request->except(['addressable_id', 'addressable_type']));
+
+        return response()->json($address);
+    }
+
+    public function edit(Address $address)
+    {
+        return response()->json($address);
+    }
+
+    public function update(Request $request, Address $address)
+    {
+        $request->validate([
+            'type' => 'required|string|in:registered,workplace',
+            'addrNo' => 'nullable|string|max:255',
+            'addrMoo' => 'nullable|string|max:255',
+            'addrSoi' => 'nullable|string|max:255',
+            'addrRoad' => 'nullable|string|max:255',
+            'addrProvince' => 'nullable|string|max:255',
+            'addrDistrict' => 'nullable|string|max:255',
+            'addrSubDistrict' => 'nullable|string|max:255',
+            'addrZipCode' => 'nullable|string|max:255',
+        ]);
+
+        $address->update($request->all());
+
+        return response()->json($address);
+    }
+
+    public function destroy(Address $address)
+    {
+        $address->delete();
+
+        return response()->json(['success' => 'Address deleted successfully.']);
+    }
+}

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Address extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'type',
+        'addrNo',
+        'addrMoo',
+        'addrSoi',
+        'addrRoad',
+        'addrProvince',
+        'addrDistrict',
+        'addrSubDistrict',
+        'addrZipCode',
+        'addressable_id',
+        'addressable_type',
+    ];
+
+    public function addressable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -30,4 +30,9 @@ class Employer extends Model
     {
         return $this->hasMany(Employee::class);
     }
+
+    public function addresses()
+    {
+        return $this->morphMany(Address::class, 'addressable');
+    }
 }

--- a/database/migrations/2025_09_02_084400_create_addresses_table.php
+++ b/database/migrations/2025_09_02_084400_create_addresses_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('addresses', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('addressable_id');
+            $table->string('addressable_type');
+            $table->string('type'); // 'registered' or 'workplace'
+            $table->string('addrNo')->nullable();
+            $table->string('addrMoo')->nullable();
+            $table->string('addrSoi')->nullable();
+            $table->string('addrRoad')->nullable();
+            $table->string('addrProvince')->nullable();
+            $table->string('addrDistrict')->nullable();
+            $table->string('addrSubDistrict')->nullable();
+            $table->string('addrZipCode')->nullable();
+            $table->timestamps();
+
+            $table->index(['addressable_id', 'addressable_type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('addresses');
+    }
+};

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -149,6 +149,94 @@
 
 <div class="content-section mt-5">
     <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2>ที่อยู่ตามทะเบียน</h2>
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addressModal" data-address-type="registered">
+            เพิ่มที่อยู่
+        </button>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead class="table-light">
+                <tr>
+                    <th>บ้านเลขที่</th>
+                    <th>หมู่</th>
+                    <th>ซอย</th>
+                    <th>ถนน</th>
+                    <th>จังหวัด</th>
+                    <th>อำเภอ/เขต</th>
+                    <th>ตำบล/แขวง</th>
+                    <th>รหัสไปรษณีย์</th>
+                    <th class="text-center">จัดการ</th>
+                </tr>
+            </thead>
+            <tbody id="registered-addresses-list">
+                @foreach ($employer->addresses->where('type', 'registered') as $address)
+                <tr id="address-{{ $address->id }}">
+                    <td>{{ $address->addrNo }}</td>
+                    <td>{{ $address->addrMoo }}</td>
+                    <td>{{ $address->addrSoi }}</td>
+                    <td>{{ $address->addrRoad }}</td>
+                    <td>{{ $address->addrProvince }}</td>
+                    <td>{{ $address->addrDistrict }}</td>
+                    <td>{{ $address->addrSubDistrict }}</td>
+                    <td>{{ $address->addrZipCode }}</td>
+                    <td class="text-center">
+                        <button type="button" class="btn btn-warning btn-sm edit-address" data-id="{{ $address->id }}" data-bs-toggle="modal" data-bs-target="#addressModal">แก้ไข</button>
+                        <button type="button" class="btn btn-danger btn-sm delete-address" data-id="{{ $address->id }}">ลบ</button>
+                    </td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="content-section mt-5">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2>ที่อยู่สถานที่ทำงาน</h2>
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addressModal" data-address-type="workplace">
+            เพิ่มที่อยู่
+        </button>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead class="table-light">
+                <tr>
+                    <th>บ้านเลขที่</th>
+                    <th>หมู่</th>
+                    <th>ซอย</th>
+                    <th>ถนน</th>
+                    <th>จังหวัด</th>
+                    <th>อำเภอ/เขต</th>
+                    <th>ตำบล/แขวง</th>
+                    <th>รหัสไปรษณีย์</th>
+                    <th class="text-center">จัดการ</th>
+                </tr>
+            </thead>
+            <tbody id="workplace-addresses-list">
+                @foreach ($employer->addresses->where('type', 'workplace') as $address)
+                <tr id="address-{{ $address->id }}">
+                    <td>{{ $address->addrNo }}</td>
+                    <td>{{ $address->addrMoo }}</td>
+                    <td>{{ $address->addrSoi }}</td>
+                    <td>{{ $address->addrRoad }}</td>
+                    <td>{{ $address->addrProvince }}</td>
+                    <td>{{ $address->addrDistrict }}</td>
+                    <td>{{ $address->addrSubDistrict }}</td>
+                    <td>{{ $address->addrZipCode }}</td>
+                    <td class="text-center">
+                        <button type="button" class="btn btn-warning btn-sm edit-address" data-id="{{ $address->id }}" data-bs-toggle="modal" data-bs-target="#addressModal">แก้ไข</button>
+                        <button type="button" class="btn btn-danger btn-sm delete-address" data-id="{{ $address->id }}">ลบ</button>
+                    </td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="content-section mt-5">
+    <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>ข้อมูลพนักงาน</h2>
         <a href="{{ route('employers.employees.create', ['employer' => $employer->id]) }}" class="btn btn-primary">เพิ่มพนักงาน</a>
     </div>
@@ -192,4 +280,207 @@
         </table>
     </div>
 </div>
+@endsection
+
+@push('scripts')
+<!-- Address Modal -->
+<div class="modal fade" id="addressModal" tabindex="-1" aria-labelledby="addressModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addressModalLabel">เพิ่ม/แก้ไขที่อยู่</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addressForm">
+                    @csrf
+                    <input type="hidden" id="addressId" name="id">
+                    <input type="hidden" id="addressType" name="type">
+                    <input type="hidden" name="addressable_id" value="{{ $employer->id }}">
+                    <input type="hidden" name="addressable_type" value="employer">
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="addrNo" class="form-label">บ้านเลขที่</label>
+                            <input type="text" class="form-control" id="addrNo" name="addrNo">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="addrMoo" class="form-label">หมู่</label>
+                            <input type="text" class="form-control" id="addrMoo" name="addrMoo">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="addrSoi" class="form-label">ซอย</label>
+                            <input type="text" class="form-control" id="addrSoi" name="addrSoi">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="addrRoad" class="form-label">ถนน</label>
+                            <input type="text" class="form-control" id="addrRoad" name="addrRoad">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="addrProvince" class="form-label">จังหวัด</label>
+                            <input type="text" class="form-control" id="addrProvince" name="addrProvince">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="addrDistrict" class="form-label">อำเภอ/เขต</label>
+                            <input type="text" class="form-control" id="addrDistrict" name="addrDistrict">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="addrSubDistrict" class="form-label">ตำบล/แขวง</label>
+                            <input type="text" class="form-control" id="addrSubDistrict" name="addrSubDistrict">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="addrZipCode" class="form-label">รหัสไปรษณีย์</label>
+                            <input type="text" class="form-control" id="addrZipCode" name="addrZipCode">
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
+                <button type="button" class="btn btn-primary" id="saveAddress">บันทึก</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const addressModal = document.getElementById('addressModal');
+    const addressForm = document.getElementById('addressForm');
+    const saveAddressBtn = document.getElementById('saveAddress');
+    const addressModalLabel = document.getElementById('addressModalLabel');
+
+    // Handle modal opening for both add and edit
+    addressModal.addEventListener('show.bs.modal', function (event) {
+        const button = event.relatedTarget;
+        const addressId = button.getAttribute('data-id'); // null for new
+        const addressType = button.getAttribute('data-address-type');
+
+        addressForm.reset();
+        document.getElementById('addressId').value = '';
+        if (addressType) {
+            document.getElementById('addressType').value = addressType;
+        }
+
+        if (addressId) { // Editing
+            addressModalLabel.textContent = 'แก้ไขที่อยู่';
+            fetch(`/addresses/${addressId}/edit`)
+                .then(response => response.json())
+                .then(data => {
+                    document.getElementById('addressId').value = data.id;
+                    document.getElementById('addressType').value = data.type;
+                    document.getElementById('addrNo').value = data.addrNo || '';
+                    document.getElementById('addrMoo').value = data.addrMoo || '';
+                    document.getElementById('addrSoi').value = data.addrSoi || '';
+                    document.getElementById('addrRoad').value = data.addrRoad || '';
+                    document.getElementById('addrProvince').value = data.addrProvince || '';
+                    document.getElementById('addrDistrict').value = data.addrDistrict || '';
+                    document.getElementById('addrSubDistrict').value = data.addrSubDistrict || '';
+                    document.getElementById('addrZipCode').value = data.addrZipCode || '';
+                });
+        } else { // Adding
+            addressModalLabel.textContent = 'เพิ่มที่อยู่';
+        }
+    });
+
+    // Handle form submission (save)
+    saveAddressBtn.addEventListener('click', function () {
+        const addressId = document.getElementById('addressId').value;
+        const url = addressId ? `/addresses/${addressId}` : '/addresses';
+        const method = addressId ? 'PUT' : 'POST';
+
+        const formData = new FormData(addressForm);
+        if (method === 'PUT') {
+            formData.append('_method', 'PUT');
+        }
+
+        fetch(url, {
+            method: 'POST', // HTML forms only support GET/POST. Laravel uses a hidden _method field for PUT/PATCH/DELETE.
+            body: formData,
+            headers: {
+                'X-CSRF-TOKEN': document.querySelector('input[name="_token"]').value,
+                'Accept': 'application/json',
+            }
+        })
+        .then(response => {
+            if (!response.ok) {
+                return response.json().then(err => { throw err; });
+            }
+            return response.json();
+        })
+        .then(data => {
+            const address = data;
+            const addressListId = address.type + '-addresses-list';
+            const addressList = document.getElementById(addressListId);
+            let row = document.getElementById('address-' + address.id);
+
+            const rowContent = `
+                <td>${address.addrNo || ''}</td>
+                <td>${address.addrMoo || ''}</td>
+                <td>${address.addrSoi || ''}</td>
+                <td>${address.addrRoad || ''}</td>
+                <td>${address.addrProvince || ''}</td>
+                <td>${address.addrDistrict || ''}</td>
+                <td>${address.addrSubDistrict || ''}</td>
+                <td>${address.addrZipCode || ''}</td>
+                <td class="text-center">
+                    <button type="button" class="btn btn-warning btn-sm edit-address" data-id="${address.id}" data-bs-toggle="modal" data-bs-target="#addressModal">แก้ไข</button>
+                    <button type="button" class="btn btn-danger btn-sm delete-address" data-id="${address.id}">ลบ</button>
+                </td>
+            `;
+
+            if (row) { // Update existing row
+                row.innerHTML = rowContent;
+            } else { // Create new row
+                row = document.createElement('tr');
+                row.id = 'address-' + address.id;
+                row.innerHTML = rowContent;
+                addressList.appendChild(row);
+            }
+
+            var modal = bootstrap.Modal.getInstance(addressModal);
+            modal.hide();
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            // You could display errors to the user here
+            let errorMsg = 'An error occurred.';
+            if (error.errors) {
+                errorMsg = Object.values(error.errors).map(e => e.join(' ')).join('\n');
+            }
+            alert(errorMsg);
+        });
+    });
+
+    // Handle delete
+    document.body.addEventListener('click', function(event) {
+        if (event.target.classList.contains('delete-address')) {
+            if (confirm('คุณแน่ใจหรือไม่ว่าต้องการลบที่อยู่นี้?')) {
+                const addressId = event.target.getAttribute('data-id');
+                fetch(`/addresses/${addressId}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'X-CSRF-TOKEN': document.querySelector('input[name="_token"]').value,
+                        'Accept': 'application/json',
+                    }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        document.getElementById('address-' + addressId).remove();
+                    } else {
+                        alert('Failed to delete address.');
+                    }
+                })
+                .catch(error => console.error('Error:', error));
+            }
+        }
+    });
+});
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,11 @@ Route::middleware('auth')->group(function () {
     Route::resource('agents', AgentController::class);
     Route::resource('delegates', DelegateController::class);
 
+    Route::post('/addresses', [App\Http\Controllers\AddressController::class, 'store'])->name('addresses.store');
+    Route::get('/addresses/{address}/edit', [App\Http\Controllers\AddressController::class, 'edit'])->name('addresses.edit');
+    Route::put('/addresses/{address}', [App\Http\Controllers\AddressController::class, 'update'])->name('addresses.update');
+    Route::delete('/addresses/{address}', [App\Http\Controllers\AddressController::class, 'destroy'])->name('addresses.destroy');
+
     Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
     Route::post('/notifications/{notification}/cancel', [NotificationController::class, 'cancel'])->name('notifications.cancel');
     Route::post('/notifications/{notification}/restore', [NotificationController::class, 'restore'])->name('notifications.restore');


### PR DESCRIPTION
Adds the ability for users to add, edit, and delete multiple addresses (Registered and Workplace) for each employer.

- Creates a new polymorphic Address model and migration.
- Defines the relationships between the Employer and Address models.
- Updates the employer edit view to include sections for both address types.
- Adds a modal for adding/editing addresses with AJAX/Fetch functionality.
- Creates an AddressController to handle the CRUD operations.