### PR TITLE
Fix: Correct route for adding an employee from employer edit page

### DIFF
--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -197,7 +197,7 @@
                 <option value="no_card">ไม่มีบัตรชมพู</option>
             </select>
             <button type="button" class="btn btn-sm btn-outline-success export-btn" data-export-type="employees"><i class="bi bi-download"></i> ส่งออก</button>
-            <a href="{{ route('employees.create', ['employer_id' => $employer->id]) }}" class="btn btn-sm btn-primary"><i class="bi bi-person-plus"></i> เพิ่มพนักงาน</a>
+            <a href="{{ route('employers.employees.create', $employer) }}" class="btn btn-sm btn-primary"><i class="bi bi-person-plus"></i> เพิ่มพนักงาน</a>
         </div>
     </div>
     <div id="employeeList" class="vstack gap-3">


### PR DESCRIPTION
The "Add Employee" button on the employer edit page was generating a `RouteNotFoundException` because it was using the `employees.create` route without the required `employer` parameter.

This commit corrects the `route()` helper call to use the nested resource route `employers.employees.create` and passes the `$employer` object, resolving the exception.