### PR TITLE
Fix: Correct route in employer edit page

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Employer;
 use App\Models\Employee;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
 
@@ -12,10 +13,23 @@ class EmployerController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-        $employers = Employer::all();
-        return view('employers.index', compact('employers'));
+        $query = Employer::query();
+
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('employerNameTh', 'like', "%{$search}%")
+                  ->orWhere('employerNameEn', 'like', "%{$search}%")
+                  ->orWhere('employerId', 'like', "%{$search}%");
+            });
+        }
+
+        $employers = $query->get();
+        $jobOwners = User::pluck('name', 'id');
+
+        return view('employers.index', compact('employers', 'jobOwners'));
     }
 
     /**

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -227,7 +227,7 @@ $nationalityFlags = [
                 </div>
             </div>
             <div class="btn-group btn-group-sm">
-                <a href="{{ route('employees.edit', $employee->id) }}" class="btn btn-outline-primary" title="แก้ไข"><i class="bi bi-pencil-fill"></i></a>
+                <a href="{{ route('employers.employees.edit', ['employer' => $employer, 'employee' => $employee]) }}" class="btn btn-outline-primary" title="แก้ไข"><i class="bi bi-pencil-fill"></i></a>
                 <button type="button" class="btn btn-outline-warning terminate-employee-btn" data-id="{{ $employee->id }}" title="แจ้งออก/เลิกจ้าง"><i class="bi bi-person-dash-fill"></i></button>
                 <button type="button" class="btn btn-outline-danger delete-employee-btn" data-id="{{ $employee->id }}" title="ลบ"><i class="bi bi-trash-fill"></i></button>
             </div>

--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -10,10 +10,15 @@
         </div>
     @endif
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
-         <h2 class="mb-3 mb-md-0">รายการข้อมูลนายจ้าง</h2>
-         <div class="d-flex gap-2">
+        <h2 class="mb-3 mb-md-0">รายการข้อมูลนายจ้าง</h2>
+        <div class="d-flex gap-2">
+            <form action="{{ route('employers.index') }}" method="GET" class="d-flex gap-2">
+                <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหา..." value="{{ request('search') }}">
+                <button type="submit" class="btn btn-sm btn-primary">ค้นหา</button>
+            </form>
+            <a href="#" class="btn btn-sm btn-outline-success"><i class="bi bi-download"></i> Export</a>
             <a href="{{ route('employers.create') }}" class="btn btn-primary btn-sm"><i class="bi bi-plus-circle me-1"></i> เพิ่มข้อมูลใหม่</a>
-         </div>
+        </div>
     </div>
     <div class="table-responsive">
         <table class="table table-hover align-middle">
@@ -23,6 +28,7 @@
                     <th>ชื่อนายจ้าง (ไทย)</th>
                     <th>รหัสนายจ้าง</th>
                     <th>ประเภทกิจการ</th>
+                    <th>เจ้าของงาน</th>
                     <th class="text-center">จัดการ</th>
                 </tr>
             </thead>
@@ -33,6 +39,7 @@
                         <td>{{ $employer->employerNameTh }}</td>
                         <td>{{ $employer->employerId }}</td>
                         <td>{{ $employer->businessType }}</td>
+                        <td>{{ $jobOwners[$employer->jobOwnerId] ?? 'N/A' }}</td>
                         <td class="text-center">
                             <a href="{{ route('employers.edit', $employer) }}" class="btn btn-sm btn-outline-primary">แก้ไข</a>
                             <form action="{{ route('employers.destroy', $employer) }}" method="POST" class="d-inline">
@@ -44,7 +51,7 @@
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="5" class="text-center text-muted">ไม่พบข้อมูลนายจ้าง</td>
+                        <td colspan="6" class="text-center text-muted">ไม่พบข้อมูลนายจ้าง</td>
                     </tr>
                 @endforelse
             </tbody>


### PR DESCRIPTION
The "Edit" button for an employee on the employer's edit page was pointing to an incorrect route (`employees.edit`), causing a `RouteNotFoundException`.

This commit fixes the issue by updating the `href` to use the correct nested resource route `employers.employees.edit`, passing both the employer and employee IDs as required.

Feat: Enhance employer list page UI

This commit improves the employer list page (`employers.index`) by:
- Adding a search bar to filter employers by name or ID.
- Adding a placeholder "Export" button.
- Adding a "Job Owner" column to the table.
- The `EmployerController@index` method has been updated to support the search functionality and to fetch and pass the list of job owners (users) to the view.