### PR TITLE
feat: Finalize employer pages

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -7,6 +7,7 @@ use App\Models\Employee;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class EmployerController extends Controller
 {
@@ -220,5 +221,39 @@ class EmployerController extends Controller
         $employees = $query->get();
 
         return response()->json($employees);
+    }
+
+    public function export()
+    {
+        $employers = Employer::all();
+        $csvHeader = ['ID', 'Employer ID', 'Thai Name', 'English Name', 'Business Type', 'Signer Name TH', 'Signer Name EN', 'Tax ID', 'Reg Capital', 'Reg Date'];
+
+        $response = new StreamedResponse(function() use ($employers, $csvHeader) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, $csvHeader);
+
+            foreach ($employers as $employer) {
+                $data = [
+                    $employer->id,
+                    $employer->employerId,
+                    $employer->employerNameTh,
+                    $employer->employerNameEn,
+                    $employer->businessType,
+                    $employer->signerNameTh,
+                    $employer->signerNameEn,
+                    $employer->employerTaxId,
+                    $employer->regCapital,
+                    $employer->regDate,
+                ];
+                fputcsv($handle, $data);
+            }
+
+            fclose($handle);
+        }, 200, [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="employers.csv"',
+        ]);
+
+        return $response;
     }
 }

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -836,6 +836,10 @@ document.addEventListener('DOMContentLoaded', function () {
                                     <p class="mb-0 text-danger small"><strong>เลิกจ้างวันที่:</strong> ${new Date(employee.terminated_at).toLocaleDateString('en-GB')} - ${employee.termination_reason || 'N/A'}</p>
                                 </div>
                             </div>
+                            <div class="btn-group btn-group-sm">
+                                <button type="button" class="btn btn-outline-success restore-employee-btn" data-id="${employee.id}" title="นำกลับ"><i class="bi bi-arrow-counterclockwise"></i></button>
+                                <button type="button" class="btn btn-outline-danger permanent-delete-btn" data-id="${employee.id}" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
+                            </div>
                         </div>`;
                         historyList.innerHTML += card;
                     });

--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -16,7 +16,7 @@
                 <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหา..." value="{{ request('search') }}">
                 <button type="submit" class="btn btn-sm btn-primary">ค้นหา</button>
             </form>
-            <a href="#" class="btn btn-sm btn-outline-success"><i class="bi bi-download"></i> Export</a>
+            <a href="{{ route('employers.export') }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i> Export</a>
             <a href="{{ route('employers.create') }}" class="btn btn-primary btn-sm"><i class="bi bi-plus-circle me-1"></i> เพิ่มข้อมูลใหม่</a>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
     // Application routes that require login
+    Route::get('/employers/export', [EmployerController::class, 'export'])->name('employers.export');
     Route::resource('employers', EmployerController::class);
     Route::get('/employers/{employer}/employees/filter', [EmployerController::class, 'filterEmployees'])->name('employers.employees.filter');
     Route::get('employers/{employer}/filter-history', [EmployerController::class, 'filterHistory'])->name('employers.history.filter');


### PR DESCRIPTION
Implements the export functionality and adds action buttons to the history modal.

- Adds an export() method to EmployerController to generate a CSV of employers.
- Adds a new route for /employers/export.
- Updates the Export button on the index page to link to the new route.
- Adds Restore and Delete buttons to the employment history modal's items.