### PR TITLE
feat: Complete all employer page functions

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -7,6 +7,7 @@ use App\Models\Employee;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class EmployerController extends Controller
@@ -171,6 +172,28 @@ class EmployerController extends Controller
         return response()->json(['success' => true, 'message' => 'Employee terminated successfully.']);
     }
 
+    public function restoreEmployee(Employee $employee)
+    {
+        $employee->update([
+            'terminated_at' => null,
+            'termination_reason' => null,
+        ]);
+
+        return response()->json(['success' => true, 'message' => 'Employee restored successfully.']);
+    }
+
+    public function forceDeleteEmployee(Employee $employee)
+    {
+        // Delete photo from storage if it exists
+        if ($employee->employeePhoto && Storage::disk('public')->exists($employee->employeePhoto)) {
+            Storage::disk('public')->delete($employee->employeePhoto);
+        }
+
+        $employee->forceDelete();
+
+        return response()->json(['success' => true, 'message' => 'Employee permanently deleted.']);
+    }
+
     public function filterEmployees(Request $request, Employer $employer)
     {
         $query = $employer->employees()->whereNull('terminated_at');
@@ -252,6 +275,82 @@ class EmployerController extends Controller
         }, 200, [
             'Content-Type' => 'text/csv',
             'Content-Disposition' => 'attachment; filename="employers.csv"',
+        ]);
+
+        return $response;
+    }
+
+    public function exportEmployees(Employer $employer)
+    {
+        $employees = $employer->employees()->whereNull('terminated_at')->get();
+        $csvHeader = [
+            'ID', 'English Name', 'Thai Name', 'Position', 'Nationality', 'Passport No', 'Passport Expiry',
+            'Work Permit No', 'Work Permit Expiry', 'MOU Group', 'Visa Expiry', '90-Day Report'
+        ];
+        $fileName = "{$employer->employerId}_employees.csv";
+
+        $response = new StreamedResponse(function() use ($employees, $csvHeader) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, $csvHeader);
+
+            foreach ($employees as $employee) {
+                $data = [
+                    $employee->id,
+                    $employee->employeeNameEn,
+                    $employee->employeeNameTh,
+                    $employee->employeePosition,
+                    $employee->employeeNationality,
+                    $employee->employeePassport,
+                    $employee->passportExpiryDate,
+                    $employee->employeeWorkPermit,
+                    $employee->workPermitExpiryDate,
+                    $employee->workPermitMOUGroup,
+                    $employee->visaExpiryDate,
+                    $employee->ninetyDayReportDate,
+                ];
+                fputcsv($handle, $data);
+            }
+
+            fclose($handle);
+        }, 200, [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => "attachment; filename=\"{$fileName}\"",
+        ]);
+
+        return $response;
+    }
+
+    public function exportHistory(Employer $employer)
+    {
+        $employees = $employer->employees()->whereNotNull('terminated_at')->get();
+        $csvHeader = [
+            'ID', 'English Name', 'Thai Name', 'Position', 'Nationality', 'Passport No',
+            'Terminated Date', 'Termination Reason'
+        ];
+        $fileName = "{$employer->employerId}_history.csv";
+
+        $response = new StreamedResponse(function() use ($employees, $csvHeader) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, $csvHeader);
+
+            foreach ($employees as $employee) {
+                $data = [
+                    $employee->id,
+                    $employee->employeeNameEn,
+                    $employee->employeeNameTh,
+                    $employee->employeePosition,
+                    $employee->employeeNationality,
+                    $employee->employeePassport,
+                    $employee->terminated_at,
+                    $employee->termination_reason,
+                ];
+                fputcsv($handle, $data);
+            }
+
+            fclose($handle);
+        }, 200, [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => "attachment; filename=\"{$fileName}\"",
         ]);
 
         return $response;

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -132,8 +132,40 @@
                 @enderror
             </div>
         </div>
-        <button type="submit" class="btn btn-primary">บันทึก</button>
-        <a href="{{ route('employers.index') }}" class="btn btn-secondary">ยกเลิก</a>
+        <hr>
+        <p class="text-muted">* ส่วนนี้จะใช้งานได้หลังจากบันทึกข้อมูลนายจ้างแล้ว</p>
+        <fieldset disabled>
+            {{-- Registered Address Section --}}
+            <div class="content-section mt-4">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="mb-0">ที่อยู่ตามทะเบียน</h5>
+                    <button type="button" class="btn btn-sm btn-outline-success">
+                        <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
+                    </button>
+                </div>
+                <div class="vstack gap-3">
+                    <p class="text-muted">ยังไม่มีที่อยู่</p>
+                </div>
+            </div>
+
+            {{-- Workplace Address Section --}}
+            <div class="content-section mt-4">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="mb-0">ที่อยู่สถานที่ทำงาน</h5>
+                    <button type="button" class="btn btn-sm btn-outline-success">
+                        <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
+                    </button>
+                </div>
+                <div class="vstack gap-3">
+                    <p class="text-muted">ยังไม่มีที่อยู่</p>
+                </div>
+            </div>
+        </fieldset>
+
+        <div class="mt-4">
+            <button type="submit" class="btn btn-primary">บันทึก</button>
+            <a href="{{ route('employers.index') }}" class="btn btn-secondary">ยกเลิก</a>
+        </div>
     </form>
 </div>
 @endsection

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -214,7 +214,7 @@ $nationalityFlags = [
                 <option value="has_card">มีบัตรชมพู</option>
                 <option value="no_card">ไม่มีบัตรชมพู</option>
             </select>
-            <button type="button" class="btn btn-sm btn-outline-success export-btn" data-export-type="employees"><i class="bi bi-download"></i> ส่งออก</button>
+            <a href="{{ route('employers.exportEmployees', $employer) }}" class="btn btn-sm btn-outline-success"><i class="bi bi-download"></i> ส่งออก</a>
             <a href="{{ route('employers.employees.create', $employer) }}" class="btn btn-sm btn-primary"><i class="bi bi-person-plus"></i> เพิ่มพนักงาน</a>
         </div>
     </div>
@@ -316,28 +316,47 @@ $nationalityFlags = [
                     </div>
                     <div class="row mb-3">
                         <div class="col-md-6">
-                            <label for="addrProvince" class="form-label">จังหวัด</label>
+                            <label for="addrProvince" class="form-label">จังหวัด (Thai)</label>
                             <select class="form-select" id="addrProvince" name="addrProvince">
                                 <option selected disabled>--- เลือกจังหวัด ---</option>
                             </select>
-                            <input type="hidden" id="addrProvinceEn" name="addrProvinceEn">
                         </div>
                         <div class="col-md-6">
-                            <label for="addrDistrict" class="form-label">อำเภอ/เขต</label>
-                            <select class="form-select" id="addrDistrict" name="addrDistrict" disabled>
-                                <option selected disabled>--- เลือกอำเภอ/เขต ---</option>
+                            <label for="addrProvinceEn" class="form-label">Province (EN)</label>
+                            <select class="form-select" id="addrProvinceEn" name="addrProvinceEn" disabled>
+                                <option selected disabled>--- Province ---</option>
                             </select>
-                            <input type="hidden" id="addrDistrictEn" name="addrDistrictEn">
                         </div>
                     </div>
                     <div class="row mb-3">
                         <div class="col-md-6">
-                            <label for="addrSubDistrict" class="form-label">ตำบล/แขวง</label>
+                            <label for="addrDistrict" class="form-label">อำเภอ/เขต (Thai)</label>
+                            <select class="form-select" id="addrDistrict" name="addrDistrict" disabled>
+                                <option selected disabled>--- เลือกอำเภอ/เขต ---</option>
+                            </select>
+                        </div>
+                         <div class="col-md-6">
+                            <label for="addrDistrictEn" class="form-label">District (EN)</label>
+                            <select class="form-select" id="addrDistrictEn" name="addrDistrictEn" disabled>
+                                <option selected disabled>--- District ---</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrSubDistrict" class="form-label">ตำบล/แขวง (Thai)</label>
                             <select class="form-select" id="addrSubDistrict" name="addrSubDistrict" disabled>
                                 <option selected disabled>--- เลือกตำบล/แขวง ---</option>
                             </select>
-                            <input type="hidden" id="addrSubDistrictEn" name="addrSubDistrictEn">
                         </div>
+                        <div class="col-md-6">
+                            <label for="addrSubDistrictEn" class="form-label">Sub-district (EN)</label>
+                            <select class="form-select" id="addrSubDistrictEn" name="addrSubDistrictEn" disabled>
+                                <option selected disabled>--- Sub-district ---</option>
+                            </select>
+                        </div>
+                    </div>
+                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrZipCode" class="form-label">รหัสไปรษณีย์</label>
                             <input type="text" class="form-control" id="addrZipCode" name="addrZipCode" readonly>
@@ -367,7 +386,7 @@ $nationalityFlags = [
                     <div class="d-flex gap-2">
                         <input type="text" class="form-control form-control-sm" id="searchHistoryInput" placeholder="ค้นหาในประวัติ..." style="width: 200px;">
                     </div>
-                    <button type="button" class="btn btn-sm btn-outline-success export-btn" data-export-type="employmentHistory"><i class="bi bi-download"></i> ส่งออก</button>
+                    <a href="{{ route('employers.exportHistory', $employer) }}" class="btn btn-sm btn-outline-success"><i class="bi bi-download"></i> ส่งออก</a>
                 </div>
                 <div id="employmentHistoryList" class="vstack gap-3">
                     {{-- Terminated employees will be loaded here via JavaScript --}}
@@ -415,19 +434,23 @@ $nationalityFlags = [
 document.addEventListener('DOMContentLoaded', function () {
     const employerId = '{{ $employer->id }}';
 
-    // Thai Address & Address Management (AJAX version)
+    // --- Address Management ---
     const addressModalEl = document.getElementById('addressModal');
     const addressModal = new bootstrap.Modal(addressModalEl);
     const addressForm = document.getElementById('addressForm');
     const addressModalLabel = document.getElementById('addressModalLabel');
+
+    // Thai dropdowns
     const provinceSelect = document.getElementById('addrProvince');
     const districtSelect = document.getElementById('addrDistrict');
     const subDistrictSelect = document.getElementById('addrSubDistrict');
     const zipCodeInput = document.getElementById('addrZipCode');
-    const provinceEnInput = document.getElementById('addrProvinceEn');
-    const districtEnInput = document.getElementById('addrDistrictEn');
-    const subDistrictEnInput = document.getElementById('addrSubDistrictEn');
-    const zipCodeEnInput = document.getElementById('addrZipCodeEn'); // Assuming this exists for consistency
+
+    // English dropdowns
+    const provinceEnSelect = document.getElementById('addrProvinceEn');
+    const districtEnSelect = document.getElementById('addrDistrictEn');
+    const subDistrictEnSelect = document.getElementById('addrSubDistrictEn');
+    const zipCodeEnInput = document.getElementById('addrZipCodeEn');
 
     let addressData = [];
     let isAddressDataLoaded = false;
@@ -450,6 +473,18 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    // Function to populate an English select
+    function populateEnglishSelect(selectElement, enName, placeholder) {
+        selectElement.innerHTML = ''; // Clear options
+        if (enName) {
+            const enOption = new Option(enName, enName);
+            selectElement.add(enOption);
+            selectElement.value = enName;
+        } else {
+            selectElement.innerHTML = `<option selected disabled>--- ${placeholder} ---</option>`;
+        }
+    }
+
     // Event listeners for dropdowns to cascade
     provinceSelect.addEventListener('change', function () {
         districtSelect.innerHTML = '<option selected disabled>--- เลือกอำเภอ/เขต ---</option>';
@@ -457,9 +492,14 @@ document.addEventListener('DOMContentLoaded', function () {
         zipCodeInput.value = '';
         districtSelect.disabled = true;
         subDistrictSelect.disabled = true;
+        populateEnglishSelect(districtEnSelect, '', 'District');
+        populateEnglishSelect(subDistrictEnSelect, '', 'Sub-district');
+
 
         const selectedOption = this.options[this.selectedIndex];
-        provinceEnInput.value = selectedOption.dataset.name_en || '';
+        const provinceEnName = selectedOption.dataset.name_en || '';
+        populateEnglishSelect(provinceEnSelect, provinceEnName, 'Province');
+
 
         const selectedProvince = addressData.find(p => p.name_th === this.value);
         if (selectedProvince) {
@@ -476,9 +516,11 @@ document.addEventListener('DOMContentLoaded', function () {
         subDistrictSelect.innerHTML = '<option selected disabled>--- เลือกตำบล/แขวง ---</option>';
         zipCodeInput.value = '';
         subDistrictSelect.disabled = true;
+        populateEnglishSelect(subDistrictEnSelect, '', 'Sub-district');
 
         const selectedOption = this.options[this.selectedIndex];
-        districtEnInput.value = selectedOption.dataset.name_en || '';
+        const districtEnName = selectedOption.dataset.name_en || '';
+        populateEnglishSelect(districtEnSelect, districtEnName, 'District');
 
         const selectedProvince = addressData.find(p => p.name_th === provinceSelect.value);
         if (selectedProvince) {
@@ -499,8 +541,10 @@ document.addEventListener('DOMContentLoaded', function () {
         const selectedOption = this.options[this.selectedIndex];
         const zipCode = selectedOption.dataset.zip_code || '';
         zipCodeInput.value = zipCode;
-        zipCodeEnInput.value = zipCode; // Assuming we store zip in EN field too
-        subDistrictEnInput.value = selectedOption.dataset.name_en || '';
+        if(zipCodeEnInput) zipCodeEnInput.value = zipCode; // Assuming we store zip in EN field too
+
+        const subDistrictEnName = selectedOption.dataset.name_en || '';
+        populateEnglishSelect(subDistrictEnSelect, subDistrictEnName, 'Sub-district');
     });
 
     function resetAddressForm() {
@@ -511,6 +555,9 @@ document.addEventListener('DOMContentLoaded', function () {
         districtSelect.disabled = true;
         subDistrictSelect.innerHTML = '<option selected disabled>--- เลือกตำบล/แขวง ---</option>';
         subDistrictSelect.disabled = true;
+        populateEnglishSelect(provinceEnSelect, '', 'Province');
+        populateEnglishSelect(districtEnSelect, '', 'District');
+        populateEnglishSelect(subDistrictEnSelect, '', 'Sub-district');
     }
 
     // Use event delegation for address buttons
@@ -530,15 +577,24 @@ document.addEventListener('DOMContentLoaded', function () {
                 // Populate regular inputs
                 Object.keys(data).forEach(key => {
                     const field = addressForm.querySelector(`#${key}`);
-                    if (field && field.tagName !== 'SELECT') field.value = data[key];
+                    if (field && field.tagName !== 'SELECT') {
+                        // Check if the field is not one of the English dropdowns
+                        if (!['addrProvinceEn', 'addrDistrictEn', 'addrSubDistrictEn'].includes(field.id)) {
+                            field.value = data[key];
+                        }
+                    }
                 });
 
                 // Function to handle dropdown population once data is ready
                 const populateDropdowns = () => {
+                    // Thai Province
                     provinceSelect.value = data.addrProvince;
                     const selectedProvince = addressData.find(p => p.name_th === data.addrProvince);
                     if (selectedProvince) {
-                        provinceEnInput.value = selectedProvince.name_en;
+                        // English Province
+                        populateEnglishSelect(provinceEnSelect, data.addrProvinceEn, 'Province');
+
+                        // Thai District
                         districtSelect.innerHTML = ''; // Clear previous options
                         selectedProvince.amphure.forEach(d => {
                             const option = new Option(d.name_th, d.name_th);
@@ -547,11 +603,13 @@ document.addEventListener('DOMContentLoaded', function () {
                         });
                         districtSelect.disabled = false;
                         districtSelect.value = data.addrDistrict;
-                        districtEnInput.value = selectedProvince.amphure.find(d => d.name_th === data.addrDistrict)?.name_en || '';
-
-
                         const selectedDistrict = selectedProvince.amphure.find(d => d.name_th === data.addrDistrict);
+
                         if (selectedDistrict) {
+                            // English District
+                            populateEnglishSelect(districtEnSelect, data.addrDistrictEn, 'District');
+
+                            // Thai Sub-district
                             subDistrictSelect.innerHTML = ''; // Clear previous options
                             selectedDistrict.tambon.forEach(sd => {
                                 const option = new Option(sd.name_th, sd.name_th);
@@ -561,9 +619,15 @@ document.addEventListener('DOMContentLoaded', function () {
                             });
                             subDistrictSelect.disabled = false;
                             subDistrictSelect.value = data.addrSubDistrict;
-                            subDistrictEnInput.value = selectedDistrict.tambon.find(sd => sd.name_th === data.addrSubDistrict)?.name_en || '';
+                            const selectedSubDistrict = selectedDistrict.tambon.find(sd => sd.name_th === data.addrSubDistrict);
 
-                            zipCodeInput.value = selectedDistrict.tambon.find(sd => sd.name_th === data.addrSubDistrict)?.zip_code || '';
+                            if (selectedSubDistrict) {
+                                // English Sub-district
+                                populateEnglishSelect(subDistrictEnSelect, data.addrSubDistrictEn, 'Sub-district');
+                                // Zipcode
+                                zipCodeInput.value = selectedSubDistrict.zip_code || '';
+                                if(zipCodeEnInput) zipCodeEnInput.value = selectedSubDistrict.zip_code || '';
+                            }
                         }
                     }
                 };
@@ -596,7 +660,19 @@ document.addEventListener('DOMContentLoaded', function () {
         const addressId = addressForm.querySelector('#addressId').value;
         const url = addressId ? `/addresses/${addressId}` : '/addresses';
         const method = addressId ? 'PUT' : 'POST';
+
+        // Temporarily enable selects to include them in FormData
+        provinceEnSelect.disabled = false;
+        districtEnSelect.disabled = false;
+        subDistrictEnSelect.disabled = false;
+
         const formData = new FormData(addressForm);
+
+        // Re-disable them
+        provinceEnSelect.disabled = true;
+        districtEnSelect.disabled = true;
+        subDistrictEnSelect.disabled = true;
+
 
         // Laravel needs _method field for PUT/PATCH requests sent via POST
         if (method === 'PUT') {
@@ -852,6 +928,62 @@ document.addEventListener('DOMContentLoaded', function () {
     searchHistoryInput.addEventListener('input', filterHistory);
     // Initial load of history
     filterHistory();
+
+    // --- History Action Buttons ---
+    const historyList = document.getElementById('employmentHistoryList');
+
+    historyList.addEventListener('click', function(e) {
+        const restoreBtn = e.target.closest('.restore-employee-btn');
+        const deleteBtn = e.target.closest('.permanent-delete-btn');
+
+        if (restoreBtn) {
+            const employeeId = restoreBtn.dataset.id;
+            const employeeCard = restoreBtn.closest('.employee-card');
+            if (confirm('Are you sure you want to restore this employee?')) {
+                fetch(`/employees/${employeeId}/restore`, {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                        'Accept': 'application/json'
+                    }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        employeeCard.remove();
+                        // For simplicity, reload the page to update both lists
+                        location.reload();
+                    } else {
+                        alert(data.message || 'Failed to restore employee.');
+                    }
+                })
+                .catch(error => console.error('Restore Error:', error));
+            }
+        }
+
+        if (deleteBtn) {
+            const employeeId = deleteBtn.dataset.id;
+            const employeeCard = deleteBtn.closest('.employee-card');
+            if (confirm('This action is irreversible. Are you sure you want to permanently delete this employee?')) {
+                fetch(`/employees/${employeeId}/force-delete`, {
+                    method: 'DELETE',
+                    headers: {
+                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                        'Accept': 'application/json'
+                    }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        employeeCard.remove();
+                    } else {
+                        alert(data.message || 'Failed to delete employee.');
+                    }
+                })
+                .catch(error => console.error('Delete Error:', error));
+            }
+        }
+    });
 });
 </script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,10 +20,14 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
     // Application routes that require login
     Route::get('/employers/export', [EmployerController::class, 'export'])->name('employers.export');
+    Route::get('/employers/{employer}/export-employees', [EmployerController::class, 'exportEmployees'])->name('employers.exportEmployees');
+    Route::get('/employers/{employer}/export-history', [EmployerController::class, 'exportHistory'])->name('employers.exportHistory');
     Route::resource('employers', EmployerController::class);
     Route::get('/employers/{employer}/employees/filter', [EmployerController::class, 'filterEmployees'])->name('employers.employees.filter');
     Route::get('employers/{employer}/filter-history', [EmployerController::class, 'filterHistory'])->name('employers.history.filter');
     Route::post('employees/{employee}/terminate', [EmployerController::class, 'terminate'])->name('employees.terminate');
+    Route::post('/employees/{employee}/restore', [EmployerController::class, 'restoreEmployee'])->name('employees.restore');
+    Route::delete('/employees/{employee}/force-delete', [EmployerController::class, 'forceDeleteEmployee'])->name('employees.forceDelete');
     Route::resource('employers.employees', EmployeeController::class);
     Route::resource('importers', ImporterController::class);
     Route::resource('agents', AgentController::class);


### PR DESCRIPTION
This commit finalizes the employer module by implementing several key features and improvements across the employer edit and create pages.

Part 1: Finalize the Address Modal
- Added English select dropdowns for Province, District, and Sub-district to the address modal UI in `edit.blade.php`.
- Updated JavaScript to automatically populate the English dropdowns when a Thai location is selected.
- Modified the save address AJAX function to include the new English location data in the form submission.

Part 2: Implement History Action Buttons
- Created `restoreEmployee` and `forceDeleteEmployee` methods in `EmployerController.php`.
- The `restoreEmployee` method clears the termination details for an employee.
- The `forceDeleteEmployee` method permanently deletes an employee record and their associated photo from storage.
- Added new POST and DELETE routes in `web.php` for these actions.
- Implemented JavaScript in the history modal to handle restore and permanent delete actions via AJAX calls.

Part 3: Implement In-Page Export Buttons
- Added `exportEmployees` and `exportHistory` methods to `EmployerController.php` to generate CSV exports scoped to a specific employer.
- Added new GET routes to `web.php` for these employer-specific exports.
- Changed the export buttons in `edit.blade.php` from `<button>` to `<a>` tags pointing to the new export routes.

Part 4: Improve the "Create Employer" Page
- Copied the address sections from `edit.blade.php` to `create.blade.php`.
- Wrapped the new sections in a disabled `<fieldset>` to prevent interaction before the employer is created.
- Added a message to inform the user that the address section will be available after saving the employer.