### PR TITLE
Fix and enhance Employer module

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -82,6 +82,27 @@ class EmployerController extends Controller
         }
         $employer->save();
 
+        // Handle Addresses from JSON
+        if ($request->filled('registered_addresses')) {
+            $addresses = json_decode($request->registered_addresses, true);
+            if (is_array($addresses)) {
+                foreach ($addresses as $addressData) {
+                    // The 'type' is already in the JSON data from the form
+                    $employer->addresses()->create($addressData);
+                }
+            }
+        }
+
+        if ($request->filled('workplace_addresses')) {
+            $addresses = json_decode($request->workplace_addresses, true);
+            if (is_array($addresses)) {
+                foreach ($addresses as $addressData) {
+                    // The 'type' is already in the JSON data from the form
+                    $employer->addresses()->create($addressData);
+                }
+            }
+        }
+
         return redirect()->route('employers.index')
             ->with('success', 'เพิ่มข้อมูลนายจ้างเรียบร้อยแล้ว');
     }

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -133,34 +133,34 @@
             </div>
         </div>
         <hr>
-        <p class="text-muted">* ส่วนนี้จะใช้งานได้หลังจากบันทึกข้อมูลนายจ้างแล้ว</p>
-        <fieldset disabled>
-            {{-- Registered Address Section --}}
-            <div class="content-section mt-4">
-                <div class="d-flex justify-content-between align-items-center mb-3">
-                    <h5 class="mb-0">ที่อยู่ตามทะเบียน</h5>
-                    <button type="button" class="btn btn-sm btn-outline-success">
-                        <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
-                    </button>
-                </div>
-                <div class="vstack gap-3">
-                    <p class="text-muted">ยังไม่มีที่อยู่</p>
-                </div>
+        {{-- Registered Address Section --}}
+        <div class="content-section mt-4">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="mb-0">ที่อยู่ตามทะเบียน</h5>
+                <button type="button" class="btn btn-sm btn-outline-success add-address-btn" data-bs-toggle="modal" data-bs-target="#addressModal" data-address-type="registered">
+                    <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
+                </button>
             </div>
+            <div id="registeredAddressList" class="vstack gap-3">
+                <p class="text-muted">ยังไม่มีที่อยู่</p>
+            </div>
+        </div>
 
-            {{-- Workplace Address Section --}}
-            <div class="content-section mt-4">
-                <div class="d-flex justify-content-between align-items-center mb-3">
-                    <h5 class="mb-0">ที่อยู่สถานที่ทำงาน</h5>
-                    <button type="button" class="btn btn-sm btn-outline-success">
-                        <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
-                    </button>
-                </div>
-                <div class="vstack gap-3">
-                    <p class="text-muted">ยังไม่มีที่อยู่</p>
-                </div>
+        {{-- Workplace Address Section --}}
+        <div class="content-section mt-4">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="mb-0">ที่อยู่สถานที่ทำงาน</h5>
+                <button type="button" class="btn btn-sm btn-outline-success add-address-btn" data-bs-toggle="modal" data-bs-target="#addressModal" data-address-type="workplace">
+                    <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
+                </button>
             </div>
-        </fieldset>
+            <div id="workplaceAddressList" class="vstack gap-3">
+                <p class="text-muted">ยังไม่มีที่อยู่</p>
+            </div>
+        </div>
+
+        <input type="hidden" name="registered_addresses" id="registered_addresses_json">
+        <input type="hidden" name="workplace_addresses" id="workplace_addresses_json">
 
         <div class="mt-4">
             <button type="submit" class="btn btn-primary">บันทึก</button>
@@ -169,3 +169,324 @@
     </form>
 </div>
 @endsection
+
+{{-- Add/Edit Address Modal --}}
+<div class="modal fade" id="addressModal" tabindex="-1" aria-labelledby="addressModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addressModalLabel">เพิ่มที่อยู่</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addressForm">
+                    @csrf
+                    <input type="hidden" id="addressId" name="id">
+                    <input type="hidden" id="addressType" name="type">
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrNo" class="form-label">บ้านเลขที่ (ไทย)</label>
+                            <input type="text" class="form-control" id="addrNo" name="addrNo">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="addrNoEn" class="form-label">Address No. (EN)</label>
+                            <input type="text" class="form-control" id="addrNoEn" name="addrNoEn">
+                        </div>
+                    </div>
+                     <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrMoo" class="form-label">หมู่ (ไทย)</label>
+                            <input type="text" class="form-control" id="addrMoo" name="addrMoo">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="addrMooEn" class="form-label">Moo (EN)</label>
+                            <input type="text" class="form-control" id="addrMooEn" name="addrMooEn">
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrSoi" class="form-label">ซอย (ไทย)</label>
+                            <input type="text" class="form-control" id="addrSoi" name="addrSoi">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="addrSoiEn" class="form-label">Soi (EN)</label>
+                            <input type="text" class="form-control" id="addrSoiEn" name="addrSoiEn">
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrRoad" class="form-label">ถนน (ไทย)</label>
+                            <input type="text" class="form-control" id="addrRoad" name="addrRoad">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="addrRoadEn" class="form-label">Road (EN)</label>
+                            <input type="text" class="form-control" id="addrRoadEn" name="addrRoadEn">
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrProvince" class="form-label">จังหวัด (Thai)</label>
+                            <select class="form-select" id="addrProvince" name="addrProvince">
+                                <option selected disabled>--- เลือกจังหวัด ---</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="addrProvinceEn" class="form-label">Province (EN)</label>
+                            <select class="form-select" id="addrProvinceEn" name="addrProvinceEn" disabled>
+                                <option selected disabled>--- Province ---</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrDistrict" class="form-label">อำเภอ/เขต (Thai)</label>
+                            <select class="form-select" id="addrDistrict" name="addrDistrict" disabled>
+                                <option selected disabled>--- เลือกอำเภอ/เขต ---</option>
+                            </select>
+                        </div>
+                         <div class="col-md-6">
+                            <label for="addrDistrictEn" class="form-label">District (EN)</label>
+                            <select class="form-select" id="addrDistrictEn" name="addrDistrictEn" disabled>
+                                <option selected disabled>--- District ---</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrSubDistrict" class="form-label">ตำบล/แขวง (Thai)</label>
+                            <select class="form-select" id="addrSubDistrict" name="addrSubDistrict" disabled>
+                                <option selected disabled>--- เลือกตำบล/แขวง ---</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="addrSubDistrictEn" class="form-label">Sub-district (EN)</label>
+                            <select class="form-select" id="addrSubDistrictEn" name="addrSubDistrictEn" disabled>
+                                <option selected disabled>--- Sub-district ---</option>
+                            </select>
+                        </div>
+                    </div>
+                     <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="addrZipCode" class="form-label">รหัสไปรษณีย์</label>
+                            <input type="text" class="form-control" id="addrZipCode" name="addrZipCode" readonly>
+                            <input type="hidden" id="addrZipCodeEn" name="addrZipCodeEn">
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
+                <button type="button" class="btn btn-primary" id="saveAddress">บันทึก</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    // --- Address Management on Create Page---
+    const addressModalEl = document.getElementById('addressModal');
+    const addressModal = new bootstrap.Modal(addressModalEl);
+    const addressForm = document.getElementById('addressForm');
+    const addressModalLabel = document.getElementById('addressModalLabel');
+
+    const registeredAddressesInput = document.getElementById('registered_addresses_json');
+    const workplaceAddressesInput = document.getElementById('workplace_addresses_json');
+
+    let registeredAddresses = [];
+    let workplaceAddresses = [];
+
+    // Open modal logic
+    document.querySelectorAll('.add-address-btn').forEach(button => {
+        button.addEventListener('click', function () {
+            resetAddressForm();
+            const addressType = this.dataset.addressType;
+            addressForm.querySelector('#addressType').value = addressType;
+            addressModalLabel.textContent = 'เพิ่มที่อยู่';
+        });
+    });
+
+    // Save Address (Client-side)
+    document.getElementById('saveAddress').addEventListener('click', function() {
+        const addressType = addressForm.querySelector('#addressType').value;
+
+        // Temporarily enable selects to include them in FormData
+        const selects = addressForm.querySelectorAll('select:disabled');
+        selects.forEach(s => s.disabled = false);
+
+        const formData = new FormData(addressForm);
+        const address = Object.fromEntries(formData.entries());
+
+        // Re-disable them
+        selects.forEach(s => s.disabled = true);
+
+        // Store address
+        if (addressType === 'registered') {
+            registeredAddresses.push(address);
+            registeredAddressesInput.value = JSON.stringify(registeredAddresses);
+        } else {
+            workplaceAddresses.push(address);
+            workplaceAddressesInput.value = JSON.stringify(workplaceAddresses);
+        }
+
+        renderAddressLists();
+        addressModal.hide();
+    });
+
+    function renderAddressLists() {
+        renderAddressList(registeredAddresses, 'registeredAddressList', 'registered');
+        renderAddressList(workplaceAddresses, 'workplaceAddressList', 'workplace');
+    }
+
+    function renderAddressList(addresses, listId, type) {
+        const listElement = document.getElementById(listId);
+        listElement.innerHTML = ''; // Clear current list
+
+        if (addresses.length === 0) {
+            listElement.innerHTML = '<p class="text-muted">ยังไม่มีที่อยู่</p>';
+            return;
+        }
+
+        addresses.forEach((address, index) => {
+            const addressCardHtml = `
+                <div class="address-card d-flex justify-content-between align-items-start">
+                    <div>
+                        <p class="mb-0">
+                            เลขที่ ${address.addrNo || ''} หมู่ ${address.addrMoo || ''} ซอย${address.addrSoi || ''} ถนน${address.addrRoad || ''}
+                            แขวง/ตำบล ${address.addrSubDistrict || ''} เขต/อำเภอ ${address.addrDistrict || ''}
+                            ${address.addrProvince || ''} ${address.addrZipCode || ''}
+                        </p>
+                    </div>
+                    <div class="btn-group btn-group-sm">
+                        <button type="button" class="btn btn-outline-danger remove-address-btn" data-index="${index}" data-type="${type}"><i class="bi bi-trash"></i></button>
+                    </div>
+                </div>`;
+            listElement.insertAdjacentHTML('beforeend', addressCardHtml);
+        });
+    }
+
+    // Remove address from temporary list
+    document.addEventListener('click', function (e) {
+        if (e.target.closest('.remove-address-btn')) {
+            const button = e.target.closest('.remove-address-btn');
+            const index = parseInt(button.dataset.index, 10);
+            const type = button.dataset.type;
+
+            if (type === 'registered') {
+                registeredAddresses.splice(index, 1);
+                registeredAddressesInput.value = JSON.stringify(registeredAddresses);
+            } else {
+                workplaceAddresses.splice(index, 1);
+                workplaceAddressesInput.value = JSON.stringify(workplaceAddresses);
+            }
+            renderAddressLists();
+        }
+    });
+
+    function resetAddressForm() {
+        addressForm.reset();
+        // Reset dropdowns to their initial disabled state
+        document.getElementById('addrDistrict').disabled = true;
+        document.getElementById('addrSubDistrict').disabled = true;
+        document.getElementById('addrProvinceEn').disabled = true;
+        document.getElementById('addrDistrictEn').disabled = true;
+        document.getElementById('addrSubDistrictEn').disabled = true;
+    }
+
+    // --- Thai Address Dropdown Logic (Copied from edit.blade.php) ---
+    const provinceSelect = document.getElementById('addrProvince');
+    const districtSelect = document.getElementById('addrDistrict');
+    const subDistrictSelect = document.getElementById('addrSubDistrict');
+    const zipCodeInput = document.getElementById('addrZipCode');
+    const provinceEnSelect = document.getElementById('addrProvinceEn');
+    const districtEnSelect = document.getElementById('addrDistrictEn');
+    const subDistrictEnSelect = document.getElementById('addrSubDistrictEn');
+    const zipCodeEnInput = document.getElementById('addrZipCodeEn');
+
+    let addressData = [];
+    fetch('https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_province_with_amphure_tambon.json')
+        .then(response => response.json())
+        .then(data => {
+            addressData = data;
+            populateProvinces();
+        });
+
+    function populateProvinces() {
+        provinceSelect.innerHTML = '<option selected disabled>--- เลือกจังหวัด ---</option>';
+        addressData.forEach(province => {
+            const option = new Option(province.name_th, province.name_th);
+            option.dataset.name_en = province.name_en;
+            provinceSelect.add(option);
+        });
+    }
+
+    function populateEnglishSelect(selectElement, enName, placeholder) {
+        selectElement.innerHTML = '';
+        if (enName) {
+            const enOption = new Option(enName, enName);
+            selectElement.add(enOption);
+            selectElement.value = enName;
+        } else {
+            selectElement.innerHTML = `<option selected disabled>--- ${placeholder} ---</option>`;
+        }
+    }
+
+    provinceSelect.addEventListener('change', function () {
+        districtSelect.innerHTML = '<option selected disabled>--- เลือกอำเภอ/เขต ---</option>';
+        subDistrictSelect.innerHTML = '<option selected disabled>--- เลือกตำบล/แขวง ---</option>';
+        zipCodeInput.value = '';
+        districtSelect.disabled = true;
+        subDistrictSelect.disabled = true;
+
+        const selectedOption = this.options[this.selectedIndex];
+        const provinceEnName = selectedOption.dataset.name_en || '';
+        populateEnglishSelect(provinceEnSelect, provinceEnName, 'Province');
+
+        const selectedProvince = addressData.find(p => p.name_th === this.value);
+        if (selectedProvince) {
+            selectedProvince.amphure.forEach(district => {
+                 const option = new Option(district.name_th, district.name_th);
+                 option.dataset.name_en = district.name_en;
+                 districtSelect.add(option);
+            });
+            districtSelect.disabled = false;
+        }
+    });
+
+    districtSelect.addEventListener('change', function () {
+        subDistrictSelect.innerHTML = '<option selected disabled>--- เลือกตำบล/แขวง ---</option>';
+        zipCodeInput.value = '';
+        subDistrictSelect.disabled = true;
+
+        const selectedOption = this.options[this.selectedIndex];
+        const districtEnName = selectedOption.dataset.name_en || '';
+        populateEnglishSelect(districtEnSelect, districtEnName, 'District');
+
+        const selectedProvince = addressData.find(p => p.name_th === provinceSelect.value);
+        if (selectedProvince) {
+            const selectedDistrict = selectedProvince.amphure.find(d => d.name_th === this.value);
+            if (selectedDistrict) {
+                selectedDistrict.tambon.forEach(subDistrict => {
+                    const option = new Option(subDistrict.name_th, subDistrict.name_th);
+                    option.dataset.name_en = subDistrict.name_en;
+                    option.dataset.zip_code = subDistrict.zip_code;
+                    subDistrictSelect.add(option);
+                });
+                subDistrictSelect.disabled = false;
+            }
+        }
+    });
+
+    subDistrictSelect.addEventListener('change', function () {
+        const selectedOption = this.options[this.selectedIndex];
+        const zipCode = selectedOption.dataset.zip_code || '';
+        zipCodeInput.value = zipCode;
+        if(zipCodeEnInput) zipCodeEnInput.value = zipCode;
+
+        const subDistrictEnName = selectedOption.dataset.name_en || '';
+        populateEnglishSelect(subDistrictEnSelect, subDistrictEnName, 'Sub-district');
+    });
+});
+</script>
+@endpush

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -270,6 +270,7 @@ $nationalityFlags = [
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
+                <div id="address-errors" class="alert alert-danger" style="display: none;"></div>
                 <form id="addressForm">
                     @csrf
                     <input type="hidden" id="addressId" name="id">
@@ -548,6 +549,7 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     function resetAddressForm() {
+        document.getElementById('address-errors').style.display = 'none';
         addressForm.reset();
         addressForm.querySelector('#addressId').value = '';
         provinceSelect.selectedIndex = 0;
@@ -679,7 +681,7 @@ document.addEventListener('DOMContentLoaded', function () {
             formData.append('_method', 'PUT');
         }
         formData.append('addressable_id', employerId);
-        formData.append('addressable_type', 'App\\Models\\Employer');
+        formData.append('addressable_type', 'Employer');
 
         fetch(url, {
             method: 'POST', // Always POST, with _method for spoofing
@@ -739,12 +741,22 @@ document.addEventListener('DOMContentLoaded', function () {
         })
         .catch(error => {
             console.error('Save Address Error:', error);
-            // You can display errors to the user here, e.g., in the modal
-            let errorMsg = 'เกิดข้อผิดพลาดในการบันทึก';
+            const errorDiv = document.getElementById('address-errors');
+            errorDiv.innerHTML = '';
+            errorDiv.style.display = 'none';
+
             if (error.errors) {
-                 errorMsg += ':\n' + Object.values(error.errors).join('\n');
+                let errorList = '<ul>';
+                for (const key in error.errors) {
+                    errorList += `<li>${error.errors[key][0]}</li>`;
+                }
+                errorList += '</ul>';
+                errorDiv.innerHTML = errorList;
+                errorDiv.style.display = 'block';
+            } else {
+                errorDiv.innerHTML = '<ul><li>เกิดข้อผิดพลาดในการบันทึกที่ไม่ทราบสาเหตุ</li></ul>';
+                errorDiv.style.display = 'block';
             }
-            alert(errorMsg);
         });
     });
 


### PR DESCRIPTION
This commit addresses three key issues in the Employer module:

1.  **Fix Address Saving:** The JavaScript on the employer edit page was sending the fully qualified class name for `addressable_type`. This has been corrected to send the short model name ('Employer'), resolving the bug that prevented addresses from being saved. Validation error handling has also been improved to display detailed messages within the modal instead of a generic alert.

2.  **Fix Employee Restore:** The employee restore functionality in the history modal now correctly reloads the page upon successful restoration, ensuring the UI reflects the change immediately.

3.  **Feature: Add Address on Create:** The employer creation form has been enhanced to allow adding registered and workplace addresses before the employer is saved. This is achieved by:
    - Enabling the address input sections on the create page.
    - Using JavaScript to capture address form data, store it as a JSON array in hidden input fields, and provide a temporary client-side view of the added addresses.
    - Updating the `EmployerController@store` method to decode this JSON data and create the corresponding address records when the new employer is created.