### PR TITLE
This commit finalizes the Employer module with two key fixes.

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -49,6 +49,8 @@ class Employee extends Model
         'document_6',
         'document_description_6',
         'nature_of_work',
+        'terminated_at',
+        'termination_reason',
     ];
 
     public function employer()

--- a/database/migrations/2025_09_05_094922_add_english_fields_to_addresses_table.php
+++ b/database/migrations/2025_09_05_094922_add_english_fields_to_addresses_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('addresses', function (Blueprint $table) {
+            $table->string('addrNoEn')->nullable()->after('addrZipCode');
+            $table->string('addrMooEn')->nullable()->after('addrNoEn');
+            $table->string('addrSoiEn')->nullable()->after('addrMooEn');
+            $table->string('addrRoadEn')->nullable()->after('addrSoiEn');
+            $table->string('addrSubDistrictEn')->nullable()->after('addrRoadEn');
+            $table->string('addrDistrictEn')->nullable()->after('addrSubDistrictEn');
+            $table->string('addrProvinceEn')->nullable()->after('addrDistrictEn');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('addresses', function (Blueprint $table) {
+            $table->dropColumn([
+                'addrNoEn',
+                'addrMooEn',
+                'addrSoiEn',
+                'addrRoadEn',
+                'addrSubDistrictEn',
+                'addrDistrictEn',
+                'addrProvinceEn',
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
1.  A new database migration is added to include English address fields (`addrNoEn`, `addrMooEn`, etc.) in the `addresses` table. These fields are all nullable strings.
2.  The `Employee` model's `$fillable` property is updated to include `terminated_at` and `termination_reason`, enabling mass assignment for these fields.

These changes address the remaining issues in the module.