### PR TITLE
feat: Implement Auto ID and Job Owner Foundation

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -5,10 +5,12 @@ namespace App\Http\Controllers;
 use App\Models\Employer;
 use App\Models\Employee;
 use App\Models\User;
+use App\Models\Counter;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Illuminate\Support\Facades\DB;
 
 class EmployerController extends Controller
 {
@@ -39,7 +41,11 @@ class EmployerController extends Controller
      */
     public function create()
     {
-        return view('employers.create');
+        $counter = Counter::firstOrCreate(['name' => 'employer'], ['value' => 0]);
+        $nextId = $counter->value + 1;
+        $newEmployerId = 'MC-' . str_pad($nextId, 4, '0', STR_PAD_LEFT);
+
+        return view('employers.create', compact('newEmployerId'));
     }
 
     /**
@@ -64,44 +70,46 @@ class EmployerController extends Controller
             'document_map' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:2048',
         ]);
 
-        $data = $request->except(['document_company_registration', 'document_vat_registration', 'document_map']);
+        DB::transaction(function () use ($request) {
+            $data = $request->except(['document_company_registration', 'document_vat_registration', 'document_map', 'registered_addresses', 'workplace_addresses']);
 
-        $employer = Employer::create($data);
+            $employer = Employer::create($data);
 
-        if ($request->hasFile('document_company_registration')) {
-            $path = $request->file('document_company_registration')->store("employer_documents/{$employer->id}", 'public');
-            $employer->document_company_registration = $path;
-        }
-        if ($request->hasFile('document_vat_registration')) {
-            $path = $request->file('document_vat_registration')->store("employer_documents/{$employer->id}", 'public');
-            $employer->document_vat_registration = $path;
-        }
-        if ($request->hasFile('document_map')) {
-            $path = $request->file('document_map')->store("employer_documents/{$employer->id}", 'public');
-            $employer->document_map = $path;
-        }
-        $employer->save();
+            if ($request->hasFile('document_company_registration')) {
+                $path = $request->file('document_company_registration')->store("employer_documents/{$employer->id}", 'public');
+                $employer->document_company_registration = $path;
+            }
+            if ($request->hasFile('document_vat_registration')) {
+                $path = $request->file('document_vat_registration')->store("employer_documents/{$employer->id}", 'public');
+                $employer->document_vat_registration = $path;
+            }
+            if ($request->hasFile('document_map')) {
+                $path = $request->file('document_map')->store("employer_documents/{$employer->id}", 'public');
+                $employer->document_map = $path;
+            }
+            $employer->save();
 
-        // Handle Addresses from JSON
-        if ($request->filled('registered_addresses')) {
-            $addresses = json_decode($request->registered_addresses, true);
-            if (is_array($addresses)) {
-                foreach ($addresses as $addressData) {
-                    // The 'type' is already in the JSON data from the form
-                    $employer->addresses()->create($addressData);
+            // Handle Addresses from JSON
+            if ($request->filled('registered_addresses')) {
+                $addresses = json_decode($request->registered_addresses, true);
+                if (is_array($addresses)) {
+                    foreach ($addresses as $addressData) {
+                        $employer->addresses()->create($addressData);
+                    }
                 }
             }
-        }
 
-        if ($request->filled('workplace_addresses')) {
-            $addresses = json_decode($request->workplace_addresses, true);
-            if (is_array($addresses)) {
-                foreach ($addresses as $addressData) {
-                    // The 'type' is already in the JSON data from the form
-                    $employer->addresses()->create($addressData);
+            if ($request->filled('workplace_addresses')) {
+                $addresses = json_decode($request->workplace_addresses, true);
+                if (is_array($addresses)) {
+                    foreach ($addresses as $addressData) {
+                        $employer->addresses()->create($addressData);
+                    }
                 }
             }
-        }
+
+            Counter::where('name', 'employer')->increment('value');
+        });
 
         return redirect()->route('employers.index')
             ->with('success', 'เพิ่มข้อมูลนายจ้างเรียบร้อยแล้ว');

--- a/app/Http/Controllers/JobOwnerController.php
+++ b/app/Http/Controllers/JobOwnerController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\JobOwner;
+use Illuminate\Http\Request;
+
+class JobOwnerController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $jobOwners = JobOwner::all();
+        return response()->json($jobOwners);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:job_owners',
+        ]);
+
+        $jobOwner = JobOwner::create($request->all());
+
+        return response()->json($jobOwner, 201);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(JobOwner $jobOwner)
+    {
+        $jobOwner->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/Counter.php
+++ b/app/Models/Counter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Counter extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'value',
+    ];
+}

--- a/app/Models/JobOwner.php
+++ b/app/Models/JobOwner.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JobOwner extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/database/migrations/2025_09_06_083400_create_job_owners_table.php
+++ b/database/migrations/2025_09_06_083400_create_job_owners_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('job_owners', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('job_owners');
+    }
+};

--- a/database/migrations/2025_09_06_083500_add_job_owner_id_to_employers_table.php
+++ b/database/migrations/2025_09_06_083500_add_job_owner_id_to_employers_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->foreignId('job_owner_id')->nullable()->constrained('job_owners')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->dropForeign(['job_owner_id']);
+            $table->dropColumn('job_owner_id');
+        });
+    }
+};

--- a/database/migrations/2025_09_06_083700_create_counters_table.php
+++ b/database/migrations/2025_09_06_083700_create_counters_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('counters', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->unsignedInteger('value');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('counters');
+    }
+};

--- a/database/seeders/CounterSeeder.php
+++ b/database/seeders/CounterSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Counter;
+
+class CounterSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Counter::create([
+            'name' => 'employer',
+            'value' => 0,
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call(CounterSeeder::class);
     }
 }

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -37,7 +37,7 @@
         <div class="row mb-3">
             <div class="col-md-6">
                 <label for="employerId" class="form-label">รหัสนายจ้าง</label>
-                <input type="text" class="form-control @error('employerId') is-invalid @enderror" id="employerId" name="employerId" value="{{ old('employerId') }}" required>
+                <input type="text" class="form-control @error('employerId') is-invalid @enderror" id="employerId" name="employerId" value="{{ $newEmployerId }}" readonly required>
                 @error('employerId')
                     <div class="invalid-feedback">{{ $message }}</div>
                 @enderror

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ImporterController;
 use App\Http\Controllers\EmployeeController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\JobOwnerController;
 Route::get('/', function () {
     return view('welcome');
 });
@@ -32,6 +33,8 @@ Route::middleware('auth')->group(function () {
     Route::resource('importers', ImporterController::class);
     Route::resource('agents', AgentController::class);
     Route::resource('delegates', DelegateController::class);
+
+    Route::resource('job-owners', JobOwnerController::class)->only(['index', 'store', 'destroy']);
 
     Route::post('/addresses', [App\Http\Controllers\AddressController::class, 'store'])->name('addresses.store');
     Route::get('/addresses/{address}/edit', [App\Http\Controllers\AddressController::class, 'edit'])->name('addresses.edit');


### PR DESCRIPTION
This commit introduces the backend foundation for two new features: automatic Employer ID generation and Job Owner management.

Part 1: Job Owner Functionality
- Adds a `job_owners` table with a corresponding `JobOwner` model.
- Adds a nullable `job_owner_id` foreign key to the `employers` table.
- Creates a `JobOwnerController` with `index`, `store`, and `destroy` methods to handle AJAX requests.
- Defines the necessary resource route for `job-owners`.

Part 2: Automatic Employer ID
- Adds a `counters` table with a `Counter` model to manage counters.
- Creates a seeder to initialize the 'employer' counter.
- Modifies `EmployerController@create` to generate the next employer ID (e.g., 'MC-0001') and pass it to the view.
- Updates `EmployerController@store` to use a database transaction, ensuring the employer is created and the counter is incremented atomically.
- Updates the employer creation view to display the new, readonly employer ID.