### PR TITLE
feat: Implement Job Owner management UI

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Employer;
 use App\Models\Employee;
 use App\Models\User;
+use App\Models\JobOwner;
 use App\Models\Counter;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
@@ -44,8 +45,9 @@ class EmployerController extends Controller
         $counter = Counter::firstOrCreate(['name' => 'employer'], ['value' => 0]);
         $nextId = $counter->value + 1;
         $newEmployerId = 'MC-' . str_pad($nextId, 4, '0', STR_PAD_LEFT);
+        $jobOwners = JobOwner::all();
 
-        return view('employers.create', compact('newEmployerId'));
+        return view('employers.create', compact('newEmployerId', 'jobOwners'));
     }
 
     /**
@@ -130,7 +132,8 @@ class EmployerController extends Controller
     {
         $employees = $employer->employees()->whereNull('terminated_at')->get();
         $terminated_employees = $employer->employees()->whereNotNull('terminated_at')->get();
-        return view('employers.edit', compact('employer', 'employees', 'terminated_employees'));
+        $jobOwners = JobOwner::all();
+        return view('employers.edit', compact('employer', 'employees', 'terminated_employees', 'jobOwners'));
     }
 
     /**

--- a/app/Http/Controllers/JobOwnerController.php
+++ b/app/Http/Controllers/JobOwnerController.php
@@ -27,7 +27,7 @@ class JobOwnerController extends Controller
 
         $jobOwner = JobOwner::create($request->all());
 
-        return response()->json($jobOwner, 201);
+        return response()->json(['success' => true, 'jobOwner' => $jobOwner], 201);
     }
 
     /**
@@ -37,6 +37,6 @@ class JobOwnerController extends Controller
     {
         $jobOwner->delete();
 
-        return response()->json(null, 204);
+        return response()->json(['success' => true, 'message' => 'Job owner deleted successfully.']);
     }
 }

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -33,6 +33,19 @@
                     <div class="invalid-feedback">{{ $message }}</div>
                 @enderror
             </div>
+            <div class="col-md-6">
+                <label for="job_owner_id" class="form-label">เจ้าของงาน</label>
+                <div class="input-group">
+                    <select class="form-select" id="job_owner_id" name="job_owner_id">
+                        <option selected disabled>--- เลือกเจ้าของงาน ---</option>
+                        @foreach($jobOwners as $owner)
+                            <option value="{{ $owner->id }}">{{ $owner->name }}</option>
+                        @endforeach
+                    </select>
+                    <button class="btn btn-outline-success" type="button" data-bs-toggle="modal" data-bs-target="#jobOwnerModal">+</button>
+                    <button class="btn btn-outline-danger" type="button" id="deleteJobOwnerBtn">-</button>
+                </div>
+            </div>
         </div>
         <div class="row mb-3">
             <div class="col-md-6">

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -39,6 +39,21 @@
                 <input type="text" class="form-control" id="employerId" name="employerId" value="{{ old('employerId', $employer->employerId) }}" readonly required>
             </div>
             <div class="col-md-6">
+                <label for="job_owner_id" class="form-label">เจ้าของงาน</label>
+                <div class="input-group">
+                    <select class="form-select" id="job_owner_id" name="job_owner_id">
+                        <option selected disabled>--- เลือกเจ้าของงาน ---</option>
+                        @foreach($jobOwners as $owner)
+                            <option value="{{ $owner->id }}" {{ $employer->job_owner_id == $owner->id ? 'selected' : '' }}>{{ $owner->name }}</option>
+                        @endforeach
+                    </select>
+                    <button class="btn btn-outline-success" type="button" data-bs-toggle="modal" data-bs-target="#jobOwnerModal">+</button>
+                    <button class="btn btn-outline-danger" type="button" id="deleteJobOwnerBtn">-</button>
+                </div>
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
                 <label for="employerTaxId" class="form-label">เลขประจำตัวนายจ้าง</label>
                 <input type="text" class="form-control" id="employerTaxId" name="employerTaxId" value="{{ old('employerTaxId', $employer->employerTaxId) }}">
             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -146,6 +146,201 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+
+    {{-- Job Owner Management Modal --}}
+    <div class="modal fade" id="jobOwnerModal" tabindex="-1" aria-labelledby="jobOwnerModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="jobOwnerModalLabel">จัดการข้อมูลเจ้าของงาน</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    {{-- List of current owners --}}
+                    <h5>เจ้าของงานทั้งหมด</h5>
+                    <ul class="list-group mb-3" id="jobOwnerList">
+                        {{-- Owners will be loaded here via JS --}}
+                        <li class="list-group-item text-muted">กำลังโหลด...</li>
+                    </ul>
+
+                    <hr>
+
+                    {{-- Add new owner form --}}
+                    <h6>เพิ่มเจ้าของงานใหม่</h6>
+                    <div class="input-group">
+                        <input type="text" id="newJobOwnerName" class="form-control" placeholder="ชื่อเจ้าของงาน">
+                        <button class="btn btn-primary" type="button" id="saveNewJobOwnerBtn">บันทึก</button>
+                    </div>
+                    <div id="jobOwnerError" class="text-danger small mt-1" style="display: none;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     @stack('scripts')
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const jobOwnerModalEl = document.getElementById('jobOwnerModal');
+        if (!jobOwnerModalEl) return;
+
+        const jobOwnerModal = new bootstrap.Modal(jobOwnerModalEl);
+        const jobOwnerList = document.getElementById('jobOwnerList');
+        const newJobOwnerNameInput = document.getElementById('newJobOwnerName');
+        const saveNewJobOwnerBtn = document.getElementById('saveNewJobOwnerBtn');
+        const jobOwnerError = document.getElementById('jobOwnerError');
+        const mainJobOwnerSelect = document.getElementById('job_owner_id');
+        const deleteJobOwnerBtn = document.getElementById('deleteJobOwnerBtn');
+
+        // --- Main Logic ---
+
+        // 1. Open Modal: Fetch and display all current job owners
+        jobOwnerModalEl.addEventListener('show.bs.modal', function () {
+            fetchJobOwners();
+        });
+
+        // 2. Add Owner: Handle click on "Save New Owner" button
+        saveNewJobOwnerBtn.addEventListener('click', function () {
+            const name = newJobOwnerNameInput.value.trim();
+            if (!name) {
+                showError('กรุณาใส่ชื่อเจ้าของงาน');
+                return;
+            }
+
+            fetch('{{ route('job-owners.store') }}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                    'Accept': 'application/json'
+                },
+                body: JSON.stringify({ name: name })
+            })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(err => { throw err; });
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (data.success) {
+                    // Add to modal list
+                    appendOwnerToList(data.jobOwner);
+                    // Add to main dropdown and select it
+                    if (mainJobOwnerSelect) {
+                        const newOption = new Option(data.jobOwner.name, data.jobOwner.id, true, true);
+                        mainJobOwnerSelect.add(newOption, null);
+                    }
+                    newJobOwnerNameInput.value = '';
+                    hideError();
+                }
+            })
+            .catch(error => {
+                if (error.errors && error.errors.name) {
+                    showError(error.errors.name[0]);
+                } else {
+                    showError('เกิดข้อผิดพลาดในการบันทึก');
+                }
+            });
+        });
+
+        // 3. Delete Owner: Handle clicks on delete icons in the modal
+        jobOwnerList.addEventListener('click', function(e) {
+            if (e.target.classList.contains('delete-job-owner-icon')) {
+                const ownerId = e.target.dataset.id;
+                if (confirm('คุณแน่ใจหรือไม่ว่าต้องการลบเจ้าของงานนี้?')) {
+                    deleteOwner(ownerId);
+                }
+            }
+        });
+
+        // 4. Delete selected owner from the main form
+        if (deleteJobOwnerBtn && mainJobOwnerSelect) {
+            deleteJobOwnerBtn.addEventListener('click', function() {
+                const selectedOwnerId = mainJobOwnerSelect.value;
+                if (selectedOwnerId && selectedOwnerId !== '--- เลือกเจ้าของงาน ---') {
+                     if (confirm('คุณแน่ใจหรือไม่ว่าต้องการลบเจ้าของงานที่เลือก?')) {
+                        deleteOwner(selectedOwnerId);
+                    }
+                } else {
+                    alert('กรุณาเลือกเจ้าของงานที่ต้องการลบ');
+                }
+            });
+        }
+
+
+        // --- Helper Functions ---
+
+        function fetchJobOwners() {
+            jobOwnerList.innerHTML = '<li class="list-group-item text-muted">กำลังโหลด...</li>';
+            fetch('{{ route('job-owners.index') }}')
+                .then(response => response.json())
+                .then(data => {
+                    jobOwnerList.innerHTML = '';
+                    if (data.length === 0) {
+                        jobOwnerList.innerHTML = '<li class="list-group-item text-muted">ไม่มีข้อมูลเจ้าของงาน</li>';
+                    } else {
+                        data.forEach(owner => appendOwnerToList(owner));
+                    }
+                });
+        }
+
+        function appendOwnerToList(owner) {
+             // Check if "no data" placeholder exists and remove it
+            const placeholder = jobOwnerList.querySelector('.text-muted');
+            if (placeholder) {
+                placeholder.parentElement.innerHTML = '';
+            }
+            const li = document.createElement('li');
+            li.className = 'list-group-item d-flex justify-content-between align-items-center';
+            li.id = `job-owner-${owner.id}`;
+            li.textContent = owner.name;
+            const deleteIcon = document.createElement('i');
+            deleteIcon.className = 'bi bi-trash-fill text-danger delete-job-owner-icon';
+            deleteIcon.style.cursor = 'pointer';
+            deleteIcon.dataset.id = owner.id;
+            li.appendChild(deleteIcon);
+            jobOwnerList.appendChild(li);
+        }
+
+        function deleteOwner(ownerId) {
+            fetch(`/job-owners/${ownerId}`, {
+                method: 'DELETE',
+                headers: {
+                    'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                    'Accept': 'application/json'
+                }
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    // Remove from modal list
+                    const listItem = document.getElementById(`job-owner-${ownerId}`);
+                    if (listItem) listItem.remove();
+
+                    // Remove from main dropdown
+                    if (mainJobOwnerSelect) {
+                        const optionToRemove = mainJobOwnerSelect.querySelector(`option[value='${ownerId}']`);
+                        if (optionToRemove) optionToRemove.remove();
+                    }
+                } else {
+                    alert(data.message || 'ไม่สามารถลบข้อมูลได้');
+                }
+            });
+        }
+
+        function showError(message) {
+            jobOwnerError.textContent = message;
+            jobOwnerError.style.display = 'block';
+            newJobOwnerNameInput.classList.add('is-invalid');
+        }
+
+        function hideError() {
+            jobOwnerError.textContent = '';
+            jobOwnerError.style.display = 'none';
+            newJobOwnerNameInput.classList.remove('is-invalid');
+        }
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a complete user interface for managing "Job Owners".

- Updates `EmployerController` to provide `JobOwner` data to the create and edit views.
- Adds a "Job Owner" dropdown with management buttons to the employer forms.
- Creates a Bootstrap modal in the main layout for adding and deleting job owners.
- Implements AJAX logic to handle creating and deleting job owners without page reloads, dynamically updating the UI.