### PR TITLE
Fix and Enhance Notification Page

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -35,7 +35,7 @@ class NotificationController extends Controller
 
             $query = $this->getFilteredNotificationsQuery($request, $type, $formPrefix);
             $pageName = str_replace('_', '', $type) . '_page';
-            $notifications = $query->paginate(10, ['*'], $pageName)->withQueryString();
+            $notifications = $query->with('employee.employer')->paginate(10, ['*'], $pageName)->withQueryString();
             $groupedNotifications->put($type, $notifications);
         }
 
@@ -106,7 +106,7 @@ class NotificationController extends Controller
                     $notification->id,
                     $notification->employee->companyWorkerId ?? 'N/A',
                     ($notification->employee->employeeNameTh ?? 'N/A') . ' / ' . ($notification->employee->employeeNameEn ?? 'N/A'),
-                    $notification->employee->employer->name ?? 'N/A',
+                    $notification->employee->employer->employerNameTh ?? 'N/A',
                     $notification->type,
                     $notification->due_date,
                     $notification->status,

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -1,18 +1,17 @@
 @props(['notification'])
 
 @php
-    $daysRemaining = $notification->due_date ? \Carbon\Carbon::parse($notification->due_date)->diffInDays(now(), false) : null;
-    $daysRemaining = $daysRemaining !== null ? $daysRemaining * -1 : null;
+    $dueDate = \Carbon\Carbon::parse($notification->due_date);
+    $now = \Carbon\Carbon::now();
+    $daysRemaining = $now->diffInDays($dueDate, false); // `false` allows negative numbers
 
     $alertClass = 'alert-secondary';
-    if ($daysRemaining !== null) {
-        if ($daysRemaining < 0) {
-            $alertClass = 'alert-dark'; // Expired
-        } elseif ($daysRemaining <= 30) {
-            $alertClass = 'alert-danger'; // Danger zone
-        } elseif ($daysRemaining <= 60) {
-            $alertClass = 'alert-warning'; // Warning zone
-        }
+    if ($daysRemaining < 0) {
+        $alertClass = 'alert-dark'; // Expired
+    } elseif ($daysRemaining <= 30) {
+        $alertClass = 'alert-danger'; // Danger zone
+    } elseif ($daysRemaining <= 60) {
+        $alertClass = 'alert-warning'; // Warning zone
     }
 
     $activeTab = request()->input('tab', '90day');
@@ -28,17 +27,44 @@
         </div>
         <div class="d-flex justify-content-between align-items-start w-100">
             <div class="flex-grow-1">
-                <h5 class="alert-heading mb-1">{{ $notification->employee->name_en ?? 'N/A' }}</h5>
-                <p class="mb-1"><strong>นายจ้าง:</strong> {{ $notification->employee->employer->name ?? 'N/A' }}</p>
-                <p class="mb-0 small"><strong>วันหมดอายุ {{ $notification->type }}:</strong> {{ \Carbon\Carbon::parse($notification->due_date)->format('d/m/Y') }}</p>
+                <p class="mb-1"><strong>ลูกจ้าง:</strong> {{ $notification->employee->employeeNameTh ?? 'N/A' }}</p>
+                <p class="mb-1"><strong>นายจ้าง:</strong> {{ $notification->employee->employer->employerNameTh ?? 'N/A' }}</p>
+                <div class="mb-0 small">
+                    @switch($notification->type)
+                        @case('ninety_day_report')
+                            <p><strong>แจ้งเตือน:</strong> ครบกำหนดรายงานตัว 90 วัน</p>
+                            @break
+                        @case('passport_expiry')
+                            <p><strong>แจ้งเตือน:</strong> Passport ใกล้หมดอายุ</p>
+                            @break
+                        @case('work_permit_expiry')
+                            <p><strong>แจ้งเตือน:</strong> ใบอนุญาตทำงานใกล้หมดอายุ</p>
+                            @break
+                        @case('work_permit_expired')
+                             <p><strong>แจ้งเตือน:</strong> ขาดต่อใบอนุญาตทำงาน</p>
+                            @break
+                        @case('visa_expiry')
+                            <p><strong>แจ้งเตือน:</strong> วีซ่าใกล้หมดอายุ</p>
+                            @break
+                         @case('ci_renewal')
+                            <p><strong>แจ้งเตือน:</strong> ต่ออายุ CI</p>
+                            @break
+                        @case('resolution_renewal')
+                            <p><strong>แจ้งเตือน:</strong> ต่ออายุมติ</p>
+                            @break
+                        @default
+                            <p><strong>แจ้งเตือน:</strong> {{ $notification->type }}</p>
+                    @endswitch
+                </div>
+                 <p class="mb-0 small"><strong>วันหมดอายุ:</strong> {{ $dueDate->format('d/m/Y') }}</p>
             </div>
             <div class="text-end flex-shrink-0 ms-2">
                 @if($daysRemaining !== null)
                 <span class="badge bg-dark mb-2 d-block text-nowrap">
-                    @if($daysRemaining >= 0)
+                    @if ($daysRemaining >= 0)
                         เหลือ {{ $daysRemaining }} วัน
                     @else
-                        หมดอายุแล้ว {{ abs($daysRemaining) }} วัน
+                        เลยกำหนด {{ abs($daysRemaining) }} วัน
                     @endif
                 </span>
                 @endif


### PR DESCRIPTION
This commit addresses several issues on the notification page to improve its functionality and user experience.

- Fixes the data loading by ensuring `employee` and `employer` relationships are eager-loaded for all notification queries. This resolves the 'N/A' values for employer and employee names.
- Updates the notification view to display the correct Thai names for the employer and employee.
- Implements a user-friendly display for notification types using a `@switch` statement to show clear, localized messages.
- Corrects the calculation and display for the 'days remaining' badge, accurately reflecting both upcoming and overdue notifications.
- Fixes a bug in the CSV export where an incorrect property was used for the employer's name.