### PR TITLE
feat: Finalize Notification Page UI & Functionality

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -75,6 +75,50 @@ class NotificationController extends Controller
     }
 
     /**
+     * Renew a notification's due date.
+     */
+    public function renew(Request $request, Notification $notification)
+    {
+        $request->validate([
+            'new_due_date' => 'required|date',
+        ]);
+
+        $newDueDate = $request->input('new_due_date');
+
+        // Update the notification
+        $notification->update([
+            'due_date' => $newDueDate,
+            'status' => 'unread', // Reset status in case it was acted upon
+        ]);
+
+        // Update the corresponding employee field
+        $employee = $notification->employee;
+        switch ($notification->type) {
+            case 'passport_expiry':
+                $employee->passportExpiryDate = $newDueDate;
+                break;
+            case 'ninety_day_report':
+                $employee->ninetyDaysReportDate = $newDueDate;
+                break;
+            case 'visa_expiry':
+                $employee->visaExpiryDate = $newDueDate;
+                break;
+             case 'work_permit_expiry':
+                // This might need more specific logic if work_permit_expiry is a generic type
+                // For now, assuming it updates a general work permit date.
+                // Adjust field name if necessary, e.g., 'workPermitExpiryDate'
+                 if (isset($employee->workPermitExpiryDate)) {
+                    $employee->workPermitExpiryDate = $newDueDate;
+                 }
+                break;
+            // Add other cases as needed for ci_renewal, etc.
+        }
+        $employee->save();
+
+        return back()->with('success', 'การแจ้งเตือนได้รับการต่ออายุเรียบร้อยแล้ว');
+    }
+
+    /**
      * Handle the export of notifications to CSV.
      */
     public function export(Request $request)
@@ -134,12 +178,19 @@ class NotificationController extends Controller
                 $query->where('status', 'cancelled');
                 break;
             case 'work_permit_expired':
-                $query->where('type', 'work_permit_expiry')->whereDate('due_date', '<', now());
+                $query->where('type', 'work_permit_expiry')
+                      ->whereDate('due_date', '<', now())
+                      ->where('status', 'unread');
+                break;
+            case 'work_permit_expiry':
+                $query->where('type', 'work_permit_expiry')
+                      ->whereDate('due_date', '>=', now())
+                      ->where('status', 'unread');
                 break;
             default:
                 $query->where('status', 'unread');
-                if ($type !== 'permits') {
-                     $query->where('type', $type);
+                if ($type !== 'permits') { // 'permits' is a tab group, not a notification type
+                    $query->where('type', $type);
                 }
         }
 

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -19,11 +19,9 @@
 
 <div class="alert {{ $alertClass }} notification-item">
     <div class="d-flex align-items-center gap-3">
-        {{-- Employee Photo Placeholder --}}
+        {{-- Employee Photo --}}
         <div class="flex-shrink-0">
-             <div class="d-flex align-items-center justify-content-center" style="width: 48px; height: 48px; background-color: #e9ecef; border-radius: 50%;">
-                <i class="bi bi-person fs-4 text-muted"></i>
-            </div>
+            <img src="{{ $notification->employee->employeePhoto ? asset('storage/' . $notification->employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}" class="employee-photo-thumb" alt="Photo" style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover;">
         </div>
         <div class="d-flex justify-content-between align-items-start w-100">
             <div class="flex-grow-1">
@@ -59,24 +57,27 @@
                  <p class="mb-0 small"><strong>วันหมดอายุ:</strong> {{ $dueDate->format('d/m/Y') }}</p>
             </div>
             <div class="text-end flex-shrink-0 ms-2">
-                @if($daysRemaining !== null)
-                <span class="badge bg-dark mb-2 d-block text-nowrap">
+                {{-- Days Remaining Badge --}}
+                @php
+                    $dueDate = \Carbon\Carbon::parse($notification->due_date);
+                    $now = \Carbon\Carbon::today(); // Use today() to ignore time part
+                    $daysRemaining = $now->diffInDays($dueDate, false);
+                @endphp
+
+                <span class="badge {{ $daysRemaining < 0 ? 'bg-dark' : ($daysRemaining <= 15 ? 'bg-danger' : 'bg-warning') }} mb-2 d-block text-nowrap">
                     @if ($daysRemaining >= 0)
                         เหลือ {{ $daysRemaining }} วัน
                     @else
                         เลยกำหนด {{ abs($daysRemaining) }} วัน
                     @endif
                 </span>
-                @endif
 
                 <div class="btn-group btn-group-sm">
-                    <a href="#" class="btn btn-info" title="ดูข้อมูล"><i class="bi bi-search"></i></a>
-                    @if($activeTab === 'resolution_renew')
-                        <button type="button" class="btn btn-primary" title="ติดตามงาน"><i class="bi bi-clipboard-check"></i></button>
-                    @else
-                        <button type="button" class="btn btn-success" title="ต่ออายุ"><i class="bi bi-calendar-check"></i></button>
+                    <a href="{{ route('employers.edit', $notification->employee->employer_id) }}" class="btn btn-info" title="ดูข้อมูล"><i class="bi bi-search"></i></a>
+                    @if($activeTab !== 'resolution_renew')
+                        <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
                     @endif
-                    <button type="button" class="btn btn-warning" title="ยกเลิกการต่ออายุ"><i class="bi bi-x-circle"></i></button>
+                    <a href="#" class="btn btn-warning" title="ยกเลิกการต่ออายุ" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
                 </div>
             </div>
         </div>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -332,4 +332,82 @@ $activeTab = request()->input('tab', 'ninety_day_report');
         </div>
     </div>
 </div>
+
+<!-- Cancel Notification Modal -->
+<div class="modal fade" id="cancelNotificationModal" tabindex="-1" aria-labelledby="cancelNotificationModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="cancelNotificationModalLabel">ยืนยันการยกเลิกการต่ออายุ</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form id="cancelNotificationForm" method="POST">
+                @csrf
+                <div class="modal-body">
+                    <input type="hidden" name="notification_id" id="cancelNotificationId">
+                    <div class="mb-3">
+                        <label for="cancellation_reason" class="form-label">กรุณาระบุเหตุผลที่ยกเลิก:</label>
+                        <textarea class="form-control" id="cancellation_reason" name="cancellation_reason" rows="3" required></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
+                    <button type="submit" class="btn btn-danger">ยืนยันการยกเลิก</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Renew Notification Modal -->
+<div class="modal fade" id="renewNotificationModal" tabindex="-1" aria-labelledby="renewNotificationModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="renewNotificationModalLabel">ต่ออายุการแจ้งเตือน</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form id="renewNotificationForm" method="POST">
+                @csrf
+                <div class="modal-body">
+                    <input type="hidden" name="notification_id" id="renewNotificationId">
+                    <div class="mb-3">
+                        <label for="new_due_date" class="form-label">เลือกวันหมดอายุใหม่:</label>
+                        <input type="date" class="form-control" id="new_due_date" name="new_due_date" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
+                    <button type="submit" class="btn btn-primary">บันทึก</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 @endsection
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var cancelModal = document.getElementById('cancelNotificationModal');
+    cancelModal.addEventListener('show.bs.modal', function (event) {
+        var button = event.relatedTarget;
+        var notificationId = button.getAttribute('data-notification-id');
+        var form = document.getElementById('cancelNotificationForm');
+        form.action = '/notifications/' + notificationId + '/cancel';
+        var modalNotificationIdInput = cancelModal.querySelector('#cancelNotificationId');
+        modalNotificationIdInput.value = notificationId;
+    });
+
+    var renewModal = document.getElementById('renewNotificationModal');
+    renewModal.addEventListener('show.bs.modal', function (event) {
+        var button = event.relatedTarget;
+        var notificationId = button.getAttribute('data-notification-id');
+        var form = document.getElementById('renewNotificationForm');
+        form.action = '/notifications/' + notificationId + '/renew';
+        var modalNotificationIdInput = renewModal.querySelector('#renewNotificationId');
+        modalNotificationIdInput.value = notificationId;
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,6 +43,7 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
     Route::post('/notifications/{notification}/cancel', [NotificationController::class, 'cancel'])->name('notifications.cancel');
+    Route::post('/notifications/{notification}/renew', [NotificationController::class, 'renew'])->name('notifications.renew');
     Route::post('/notifications/{notification}/restore', [NotificationController::class, 'restore'])->name('notifications.restore');
     Route::get('/notifications/export', [NotificationController::class, 'export'])->name('notifications.export');
 });


### PR DESCRIPTION
This commit addresses the finalization of the notification page.

- **UI Fixes:**
  - Displays the employee's photo in the notification card, with a placeholder fallback.
  - Implements the correct and accurate calculation for "Days Remaining" using Carbon::today().

- **Action Button Functionality:**
  - The "View" button now correctly links to the employer's edit page.
  - The "Cancel" button now triggers a modal to confirm cancellation with a reason.
  - The "Renew" button now triggers a modal to set a new due date.

- **New Features:**
  - Implemented the backend logic for the "Renew" functionality. A new `renew()` method in `NotificationController` handles updating the due date on both the notification and the related employee record.
  - Added a new POST route for the renew action.

- **Filter Logic:**
  - Refined the `getFilteredNotificationsQuery` method to correctly distinguish between upcoming and expired work permit notifications, ensuring the tabs display the correct data.