### PR TITLE
Fix: Correct notification page bugs and improve UI

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -95,20 +95,20 @@ class NotificationController extends Controller
         $employee = $notification->employee;
         switch ($notification->type) {
             case 'passport_expiry':
-                $employee->passportExpiryDate = $newDueDate;
+                $employee->passport_expiry_date = $newDueDate;
                 break;
             case 'ninety_day_report':
-                $employee->ninetyDaysReportDate = $newDueDate;
+                $employee->ninety_day_report_date = $newDueDate;
                 break;
             case 'visa_expiry':
-                $employee->visaExpiryDate = $newDueDate;
+                $employee->visa_expiry_date = $newDueDate;
                 break;
              case 'work_permit_expiry':
                 // This might need more specific logic if work_permit_expiry is a generic type
                 // For now, assuming it updates a general work permit date.
-                // Adjust field name if necessary, e.g., 'workPermitExpiryDate'
-                 if (isset($employee->workPermitExpiryDate)) {
-                    $employee->workPermitExpiryDate = $newDueDate;
+                // Adjust field name if necessary, e.g., 'work_permit_expiry_date'
+                 if (isset($employee->work_permit_expiry_date)) {
+                    $employee->work_permit_expiry_date = $newDueDate;
                  }
                 break;
             // Add other cases as needed for ci_renewal, etc.
@@ -164,6 +164,16 @@ class NotificationController extends Controller
     }
 
     /**
+     * Permanently delete a notification.
+     */
+    public function forceDelete(Notification $notification)
+    {
+        $notification->delete();
+
+        return back()->with('success', 'รายการถูกลบอย่างถาวร');
+    }
+
+    /**
      * Reusable private method to get filtered notification queries.
      */
     private function getFilteredNotificationsQuery(Request $request, string $type, ?string $formPrefix = null): Builder
@@ -195,38 +205,36 @@ class NotificationController extends Controller
         }
 
         // Apply filters
-        if ($request->filled("search_{$prefix}")) {
-            $searchTerm = $request->input("search_{$prefix}");
+        if ($searchTerm = $request->input("search_{$prefix}")) {
             $query->whereHas('employee', function ($q) use ($searchTerm) {
-                $q->where('employeeNameTh', 'like', "%{$searchTerm}%")
-                  ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
-                  ->orWhere('companyWorkerId', 'like', "%{$searchTerm}%");
+                $q->where(function ($q) use ($searchTerm) {
+                    $q->where('employeeNameTh', 'like', "%{$searchTerm}%")
+                      ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
+                      ->orWhere('companyWorkerId', 'like', "%{$searchTerm}%");
+                });
             });
         }
 
-        if ($request->filled("nationality_{$prefix}")) {
-            $query->whereHas('employee', function ($q) use ($request, $prefix) {
-                $q->where('employeeNationality', $request->input("nationality_{$prefix}"));
+        if ($nationality = $request->input("nationality_{$prefix}")) {
+            $query->whereHas('employee', function ($q) use ($nationality) {
+                $q->where('employeeNationality', $nationality);
             });
         }
 
-        if ($request->filled("mou_{$prefix}")) {
-            $query->whereHas('employee', function ($q) use ($request, $prefix) {
-                $q->where('workPermitMOUGroup', $request->input("mou_{$prefix}"));
+        if ($mouGroup = $request->input("mou_{$prefix}")) {
+            $query->whereHas('employee', function ($q) use ($mouGroup) {
+                $q->where('workPermitMOUGroup', $mouGroup);
             });
         }
 
-        if ($request->filled("month_{$prefix}")) {
-            $month = $request->input("month_{$prefix}");
-            $query->whereMonth('due_date', '=', (int)$month + 1);
+        if ($month = $request->input("month_{$prefix}")) {
+            if (is_numeric($month)) {
+                $query->whereMonth('due_date', '=', (int)$month + 1);
+            }
         }
 
-        if ($type === 'resolution_renew' && $request->filled("step_{$prefix}")) {
-            // This requires a more complex condition based on employee's JSON data
-            // Assuming 'task_tracking_data' is a JSON field on the employee model
-            $step = $request->input("step_{$prefix}");
+        if ($type === 'resolution_renew' && ($step = $request->input("step_{$prefix}"))) {
             $query->whereHas('employee', function($q) use ($step) {
-                // Example logic, may need adjustment based on actual JSON structure
                 switch($step) {
                     case 'not_started':
                         $q->whereJsonContains('task_tracking_data->step1_checked', false);

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -235,7 +235,7 @@ $nationalityFlags = [
     </div>
     <div id="employeeList" class="vstack gap-3">
         @forelse ($employees as $employee)
-        <div class="employee-card d-flex justify-content-between align-items-start gap-3">
+        <div class="employee-card d-flex justify-content-between align-items-start gap-3" id="employee-card-{{ $employee->id }}">
             <div class="d-flex align-items-center flex-grow-1">
                 <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}" class="employee-photo-thumb" alt="Employee Photo" style="width: 48px; height: 48px; object-fit: cover;">
                 <div class="flex-grow-1">

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -309,17 +309,22 @@ $activeTab = request()->input('tab', 'ninety_day_report');
                         <div class="d-flex align-items-center gap-3">
                             <div class="d-flex justify-content-between align-items-start w-100">
                                 <div class="flex-grow-1">
-                                    <h5 class="alert-heading mb-1">{{ $notification->employee->name_en ?? 'N/A' }}</h5>
-                                    <p class="mb-1"><strong>นายจ้าง:</strong> {{ $notification->employee->employer->name ?? 'N/A' }}</p>
+                                    <h5 class="alert-heading mb-1">{{ $notification->employee->employeeNameEn ?? 'N/A' }}</h5>
+                                    <p class="mb-1"><strong>นายจ้าง:</strong> {{ $notification->employee->employer->employerNameTh ?? 'N/A' }}</p>
                                     <p class="mb-0 small"><strong>ประเภทที่ยกเลิก:</strong> {{ $notification->type }}</p>
                                     <p class="mb-0 small text-danger"><strong>เหตุผล:</strong> {{ $notification->cancellation_reason }}</p>
                                 </div>
                                 <div class="text-end flex-shrink-0 ms-2">
+                                    <a href="{{ route('employers.edit', $notification->employee->employer_id) }}#employee-card-{{ $notification->employee_id }}" class="btn btn-info btn-sm"><i class="bi bi-search"></i> View Info</a>
                                     <form action="{{ route('notifications.restore', $notification) }}" method="POST" class="d-inline">
                                         @csrf
-                                        <button type="submit" class="btn btn-success btn-sm"><i class="bi bi-arrow-counterclockwise"></i> นำกลับ</button>
+                                        <button type="submit" class="btn btn-success btn-sm"><i class="bi bi-arrow-counterclockwise"></i> Restore</button>
                                     </form>
-                                    <a href="#" class="btn btn-info btn-sm"><i class="bi bi-search"></i> ดูข้อมูล</a>
+                                    <form action="{{ route('notifications.forceDelete', $notification) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to permanently delete this notification?');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-danger btn-sm"><i class="bi bi-trash"></i> Permanent Delete</button>
+                                    </form>
                                 </div>
                             </div>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/notifications/{notification}/cancel', [NotificationController::class, 'cancel'])->name('notifications.cancel');
     Route::post('/notifications/{notification}/renew', [NotificationController::class, 'renew'])->name('notifications.renew');
     Route::post('/notifications/{notification}/restore', [NotificationController::class, 'restore'])->name('notifications.restore');
+    Route::delete('/notifications/{notification}/force-delete', [NotificationController::class, 'forceDelete'])->name('notifications.forceDelete');
     Route::get('/notifications/export', [NotificationController::class, 'export'])->name('notifications.export');
 });
 require __DIR__.'/auth.php';


### PR DESCRIPTION
This commit addresses several issues on the notification page:

1.  **Fix Renew Error:** Corrected camelCase column names to snake_case in `NotificationController::renew()` to match the database schema, resolving errors when renewing notifications.

2.  **Fix Cancelled Tab UI:**
    - Corrected the employee and employer name properties in `notifications/index.blade.php` to display data correctly.
    - Added a "Permanent Delete" button to the cancelled tab, including the necessary route and `forceDelete` method in the controller.

3.  **Implement Anchor Link:**
    - Added a unique ID to each employee card on the employer edit page.
    - Updated the "View Info" button on the notification page to link directly to the corresponding employee card using an anchor hash.

4.  **Fix Search & Filter Logic:**
    - Refactored the `getFilteredNotificationsQuery()` method in `NotificationController` to be more robust.
    - The filter logic now correctly reads dynamic input names from the form and applies `whereHas` conditions properly.