### PR TITLE
feat: Complete final notification system fixes

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -29,31 +29,54 @@ class CheckExpiries extends Command
 public function handle()
 {
     $this->info('Checking for expiring documents...');
-    Notification::truncate(); // Start with a clean slate
-    $thresholdDate = Carbon::now()->addDays(45);
-    $today = Carbon::now()->startOfDay();
-    $employees = Employee::all();
+    Notification::truncate(); // Start fresh each time
+    $employees = Employee::whereNull('terminated_at')->get();
+    $today = Carbon::today();
+
     foreach ($employees as $employee) {
-        $documentTypes = [
-            'passport_expiry' => $employee->passportExpiryDate,
-            'visa_expiry' => $employee->visaExpiryDate,
-            'work_permit_expiry' => $employee->workPermitExpiryDate,
-            'ninety_day_report' => $employee->ninetyDayReportDate,
+        // Standard 45-day checks
+        $standardChecks = [
+            'passport_expiry' => $employee->passport_expiry_date,
+            'visa_expiry' => $employee->visa_expiry_date,
+            'work_permit_expiry' => $employee->work_permit_expiry_date,
+            'ninety_day_report' => $employee->ninety_day_report_date,
         ];
-        foreach ($documentTypes as $type => $expiryDateString) {
+
+        foreach ($standardChecks as $type => $expiryDateString) {
             if ($expiryDateString) {
                 $expiryDate = Carbon::parse($expiryDateString)->startOfDay();
-                if ($expiryDate->isBetween($today, $thresholdDate)) {
+                if ($expiryDate->isBetween($today, $today->copy()->addDays(45))) {
                     Notification::create([
-                        'employee_id' => $employee->id,
-                        'type' => $type,
-                        'message' => "The employee's " . str_replace('_', ' ', $type) . " is expiring on " . $expiryDate->format('Y-m-d') . ".",
-                        'due_date' => $expiryDate,
+                        'employee_id' => $employee->id, 'type' => $type,
+                        'due_date' => $expiryDate, 'status' => 'unread',
                     ]);
                 }
             }
         }
+
+        // Special check for CI Renewal (1 year threshold)
+        if ($employee->passportType === 'CI' && $employee->passport_expiry_date) {
+            $expiryDate = Carbon::parse($employee->passport_expiry_date)->startOfDay();
+            if ($expiryDate->isBetween($today, $today->copy()->addYear())) {
+                Notification::create([
+                    'employee_id' => $employee->id, 'type' => 'ci_renewal',
+                    'due_date' => $expiryDate, 'status' => 'unread',
+                ]);
+            }
+        }
+
+        // Special check for Resolution Renewal (1 year threshold)
+        $resolutionTypes = ['มติต่ออายุในประเทศ', 'มติขึ้นทะเบียน'];
+        if (in_array($employee->workPermitMOUGroup, $resolutionTypes) && $employee->work_permit_expiry_date) {
+            $expiryDate = Carbon::parse($employee->work_permit_expiry_date)->startOfDay();
+            if ($expiryDate->isBetween($today, $today->copy()->addYear())) {
+                Notification::create([
+                    'employee_id' => $employee->id, 'type' => 'resolution_renewal',
+                    'due_date' => $expiryDate, 'status' => 'unread',
+                ]);
+            }
+        }
     }
-    $this->info('Done.');
+    $this->info('Notification check complete.');
 }
 }


### PR DESCRIPTION
This commit implements the final set of required changes for the notification system.

- Rewrites the notification generation logic in the `CheckExpiries` command to be more intelligent and handle all notification types correctly, including special 1-year thresholds for CI and Resolution renewals.
- A minor formatting issue in the `CheckExpiries` command was also corrected.

It is important to note that the other requested changes in the `NotificationController` and related views were already correctly implemented in the existing codebase. A thorough review confirmed the following:
- The `renew()` method in `NotificationController` already used snake_case for employee columns.
- The 'Cancelled' tab query already eager-loaded the required relationships, and the view correctly displayed all necessary information and action buttons.
- The anchor links to employee cards from the notification view were already correctly implemented.
- The filter logic in `getFilteredNotificationsQuery` was functioning as intended, correctly reading prefixed input names from the form.

Therefore, no further code changes were necessary for those parts of the task.