### PR TITLE
Final Polish for Notification Workflow

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -31,6 +31,9 @@ class CheckExpiries extends Command
             ];
 
             foreach ($standardChecks as $type => $expiryDateString) {
+                if ($type === 'passport_expiry' && $employee->passportType === 'CI') {
+                    continue; // Skip standard passport check for CI employees
+                }
                 if ($expiryDateString) {
                     $expiryDate = Carbon::parse($expiryDateString)->startOfDay();
                     $thresholdDate = $today->copy()->addDays(45);

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -93,27 +93,29 @@ class NotificationController extends Controller
 
         // Update the corresponding employee field
         $employee = $notification->employee;
+        $updateField = null;
+
         switch ($notification->type) {
             case 'passport_expiry':
-                $employee->passport_expiry_date = $newDueDate;
+                $updateField = 'passport_expiry_date';
                 break;
             case 'ninety_day_report':
-                $employee->ninety_day_report_date = $newDueDate;
+                $updateField = 'ninety_day_report_date';
                 break;
             case 'visa_expiry':
-                $employee->visa_expiry_date = $newDueDate;
+                $updateField = 'visa_expiry_date';
                 break;
-             case 'work_permit_expiry':
-                // This might need more specific logic if work_permit_expiry is a generic type
-                // For now, assuming it updates a general work permit date.
-                // Adjust field name if necessary, e.g., 'work_permit_expiry_date'
-                 if (isset($employee->work_permit_expiry_date)) {
-                    $employee->work_permit_expiry_date = $newDueDate;
-                 }
+            case 'work_permit_expiry':
+                $updateField = 'work_permit_expiry_date';
                 break;
-            // Add other cases as needed for ci_renewal, etc.
+            // No default case needed, handled by the if below
         }
-        $employee->save();
+
+        if ($updateField) {
+            $employee->update([
+                $updateField => $newDueDate,
+            ]);
+        }
 
         return back()->with('success', 'การแจ้งเตือนได้รับการต่ออายุเรียบร้อยแล้ว');
     }

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -1011,6 +1011,20 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }
     });
+
+    // Highlight employee card from URL hash
+    if (window.location.hash) {
+        try {
+            const elementId = window.location.hash.substring(1);
+            const element = document.getElementById(elementId);
+            if (element && element.classList.contains('employee-card')) {
+                element.classList.add('highlight');
+                element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+        } catch (e) {
+            console.error("Error handling URL hash for highlighting:", e);
+        }
+    }
 });
 </script>
 @endpush

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -102,6 +102,10 @@
             letter-spacing: 0.05em;
             font-weight: 600;
         }
+        .employee-card.highlight {
+            border: 2px solid var(--bs-primary-dark);
+            box-shadow: 0 0 12px rgba(var(--bs-primary-rgb), 0.4);
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
This commit applies final polishing touches to the notification and employee management workflow.

- Part 1: Fix Renew Functionality Error
  - Refactored the `renew()` method in `NotificationController` to use a single, robust `update()` call.
  - Ensures that all column names are explicitly in `snake_case` when updating the employee model, resolving a recurring bug.

- Part 2: Correct Notification Generation Logic
  - Updated the `CheckExpiries` command to skip the standard 45-day passport expiry check for employees with a 'CI' passport type.
  - This prevents duplicate or incorrect notifications for CI renewals, which have a separate, longer-term check.

- Part 3: Implement Employee Card Highlighting
  - Added JavaScript to the employer edit page to detect a URL hash (e.g., `#employee-card-123`).
  - When a hash is present, the corresponding employee card is highlighted with a new `.highlight` CSS class and scrolled into the center of the view for better visibility.