### PR TITLE
Fix: Correct notification card display and add missing flag

### DIFF
--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -239,15 +239,21 @@ $nationalityFlags = [
         {{-- THE ONLY CRITICAL CHANGE IS HERE: Using the correct $employees variable --}}
         {{-- ========================================================================= --}}
         @forelse ($employees as $employee)
+@php
+    $flagCodes = [
+        'เมียนมา' => 'mm', 'ลาว' => 'la', 'กัมพูชา' => 'kh', 'เวียดนาม' => 'vn',
+    ];
+    $nationality = $employee->employeeNationality ?? null;
+    $flagCode = $nationality ? ($flagCodes[$nationality] ?? null) : null;
+@endphp
         <div class="employee-card d-flex justify-content-between align-items-start gap-3" id="employee-card-{{ $employee->id }}">
             <div class="d-flex align-items-center flex-grow-1">
                 <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}" class="employee-photo-thumb" alt="Employee Photo" style="width: 48px; height: 48px; object-fit: cover;">
                 <div class="flex-grow-1">
                     <p class="mb-0">
-                        @if (isset($employee->nationality) && array_key_exists($employee->nationality, $nationalityFlags))
-                            <img src="https://flagcdn.com/w20/{{ $nationalityFlags[$employee->nationality] }}.png" srcset="https://flagcdn.com/w40/{{ $nationalityFlags[$employee->nationality] }}.png 2x" width="20" alt="{{ $employee->nationality }}" class="me-2" style="vertical-align: middle;">
-                        @endif
-                        <strong>{{ $employee->employeeNameEn ?? 'No English Name' }}</strong>
+                        <strong>{{ $employee->employeeNameEn ?? 'No English Name' }}</strong>@if($flagCode)
+    <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" class="ms-2" style="width: 20px; vertical-align: middle;">
+@endif
                     </p>
                     <p class="mb-1 text-muted small">{{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }} ({{ $employee->employeePosition ?? 'ไม่ระบุตำแหน่ง' }})</p>
                     <p class="mb-1 text-muted small">Passport: {{ $employee->employeePassport ?? '-' }} (หมดอายุ: {{ $employee->passportExpiryDate ? \Carbon\Carbon::parse($employee->passportExpiryDate)->format('d M Y') : '-' }})</p>

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -4,7 +4,6 @@
     $daysRemaining = $notification->days_remaining;
     $dueDate = \Carbon\Carbon::parse($notification->due_date);
 
-    // Set locale to Thai for date formatting
     \Carbon\Carbon::setLocale('th');
 
     $alertClass = 'alert-secondary';
@@ -14,12 +13,8 @@
         $alertClass = 'alert-danger';
     }
 
-    // Nationality to Flag code mapping
     $flagCodes = [
-        'เมียนมา' => 'mm',
-        'ลาว' => 'la',
-        'กัมพูชา' => 'kh',
-        'เวียดนาม' => 'vn',
+        'เมียนมา' => 'mm', 'ลาว' => 'la', 'กัมพูชา' => 'kh', 'เวียดนาม' => 'vn',
     ];
     $nationality = $employee->employeeNationality ?? null;
     $flagCode = $nationality ? ($flagCodes[$nationality] ?? null) : null;
@@ -37,16 +32,16 @@
             <div class="flex-grow-1">
                 <h5 class="alert-heading mb-1">
                     {{ $loop->iteration }}. {{ $employee->employeeNameEn ?? 'N/A' }}
-
                     @if($nationality)
                         <span class="text-muted fw-normal small">
-                            {{ $nationality }}
+                             - {{ $nationality }}
                             @if($flagCode)
                                 <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" class="ms-1" style="width: 20px; vertical-align: middle;">
                             @endif
                         </span>
                     @endif
                 </h5>
+                <p class="mb-1 text-muted small">{{ $employee->employeeNameTh ?? '' }}</p>
                 <p class="mb-1"><strong>นายจ้าง:</strong> {{ $employer->employerNameTh ?? 'N/A' }}</p>
                 <p class="mb-0 small">
                     <strong>{{ $notification->title }}:</strong> {{ $dueDate->translatedFormat('d F Y') }}


### PR DESCRIPTION
This commit addresses two display issues:

1. Updates `_notification_item.blade.php` to display the employee's Thai name and the notification title, ensuring the card matches the design reference.

2. Modifies `edit.blade.php` to add the national flag icon next to the employee's name on the employer edit page. This replaces the previous incorrect implementation and uses the `employeeNationality` field.