### PR TITLE
Fix notification titles and add nationality text

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -39,6 +39,20 @@ class NotificationController extends Controller
             $query = $this->getFilteredNotificationsQuery($request, $type, $formPrefix);
             $pageName = str_replace('_', '', $type) . '_page';
             $notifications = $query->with('employee.employer')->paginate(10, ['*'], $pageName)->withQueryString();
+
+            $notifications->getCollection()->transform(function ($notification) {
+                $notification->title = match ($notification->type) {
+                    'ninety_day_report' => 'รายงานตัว 90 วัน',
+                    'passport_expiry' => 'Passport หมดอายุ',
+                    'work_permit_expiry' => 'ใบอนุญาตทำงานหมดอายุ',
+                    'visa_expiry' => 'วีซ่าหมดอายุ',
+                    'ci_renewal' => 'กำหนดต่ออายุ CI',
+                    'resolution_renewal' => 'กำหนดต่ออายุมติ',
+                    default => 'การแจ้งเตือน',
+                };
+                return $notification;
+            });
+
             $groupedNotifications->put($type, $notifications);
         }
 

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -251,8 +251,11 @@ $nationalityFlags = [
                 <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}" class="employee-photo-thumb" alt="Employee Photo" style="width: 48px; height: 48px; object-fit: cover;">
                 <div class="flex-grow-1">
                     <p class="mb-0">
-                        <strong>{{ $employee->employeeNameEn ?? 'No English Name' }}</strong>@if($flagCode)
-    <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" class="ms-2" style="width: 20px; vertical-align: middle;">
+                        <strong>{{ $employee->employeeNameEn ?? 'No English Name' }}</strong>@if($nationality)
+    <span class="text-muted small"> - {{ $nationality }}</span>
+    @if($flagCode)
+        <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" class="ms-1" style="width: 20px; vertical-align: middle;">
+    @endif
 @endif
                     </p>
                     <p class="mb-1 text-muted small">{{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }} ({{ $employee->employeePosition ?? 'ไม่ระบุตำแหน่ง' }})</p>


### PR DESCRIPTION
- Add a `title` attribute to notification objects in `NotificationController` to display human-readable titles on the frontend.
- Add nationality text next to the employee's name on the employer edit page.