### PR TITLE
feat: Synchronize title dropdowns and display on cards

### DIFF
--- a/resources/views/employees/create.blade.php
+++ b/resources/views/employees/create.blade.php
@@ -315,6 +315,26 @@ document.addEventListener('DOMContentLoaded', function () {
             employeePhotoPreview.src = URL.createObjectURL(file);
         }
     });
+
+    const titleTh = document.getElementById('employeeTitleTh');
+    const titleEn = document.getElementById('employeeTitleEn');
+
+    const thToEnMap = { 'นาย': 'Mr.', 'นางสาว': 'Miss', 'นาง': 'Mrs.' };
+    const enToThMap = { 'Mr.': 'นาย', 'Miss': 'นางสาว', 'Mrs.': 'นาง' };
+
+    titleTh.addEventListener('change', function() {
+        const selectedTh = this.value;
+        if (thToEnMap[selectedTh]) {
+            titleEn.value = thToEnMap[selectedTh];
+        }
+    });
+
+    titleEn.addEventListener('change', function() {
+        const selectedEn = this.value;
+        if (enToThMap[selectedEn]) {
+            titleTh.value = enToThMap[selectedEn];
+        }
+    });
 });
 </script>
 @endpush

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -354,6 +354,26 @@ document.addEventListener('DOMContentLoaded', function () {
             employeePhotoPreview.src = URL.createObjectURL(file);
         }
     });
+
+    const titleTh = document.getElementById('employeeTitleTh');
+    const titleEn = document.getElementById('employeeTitleEn');
+
+    const thToEnMap = { 'นาย': 'Mr.', 'นางสาว': 'Miss', 'นาง': 'Mrs.' };
+    const enToThMap = { 'Mr.': 'นาย', 'Miss': 'นางสาว', 'Mrs.': 'นาง' };
+
+    titleTh.addEventListener('change', function() {
+        const selectedTh = this.value;
+        if (thToEnMap[selectedTh]) {
+            titleEn.value = thToEnMap[selectedTh];
+        }
+    });
+
+    titleEn.addEventListener('change', function() {
+        const selectedEn = this.value;
+        if (enToThMap[selectedEn]) {
+            titleTh.value = enToThMap[selectedEn];
+        }
+    });
 });
 </script>
 @endpush

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -264,14 +264,14 @@ $nationalityFlags = [
                 <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}" class="employee-photo-thumb" alt="Employee Photo" style="width: 48px; height: 48px; object-fit: cover;">
                 <div class="flex-grow-1">
                     <p class="mb-0">
-                        <strong>{{ $loop->iteration }}. {{ $employee->employeeNameEn ?? 'No English Name' }}</strong>@if($nationality)
+                        <strong>{{ $loop->iteration }}. {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}</strong>@if($nationality)
     <span class="text-muted small"> - {{ $nationality }}</span>
     @if($flagCode)
         <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" class="ms-1" style="width: 20px; vertical-align: middle;">
     @endif
 @endif
                     </p>
-                    <p class="mb-1 text-muted small">{{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }} ({{ $employee->employeePosition ?? 'ไม่ระบุตำแหน่ง' }})</p>
+                    <p class="mb-1 text-muted small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }} ({{ $employee->employeePosition ?? 'ไม่ระบุตำแหน่ง' }})</p>
                     <p class="mb-1 text-muted small">Passport: {{ $employee->employeePassport ?? '-' }} (หมดอายุ: {{ $employee->passportExpiryDate ? \Carbon\Carbon::parse($employee->passportExpiryDate)->format('d M Y') : '-' }})</p>
                     <p class="mb-1 text-muted small">Work Permit: {{ $employee->employeeWorkPermit ?? '-' }} (หมดอายุ: {{ $employee->workPermitExpiryDate ? \Carbon\Carbon::parse($employee->workPermitExpiryDate)->format('d M Y') : '-' }})</p>
                     <p class="mb-0 text-muted small">Visa ({{ $employee->workPermitMOUGroup ?? '-' }}) หมดอายุ: {{ $employee->visaExpiryDate ? \Carbon\Carbon::parse($employee->visaExpiryDate)->format('d M Y') : '-' }} | 90-Day: {{ $employee->ninetyDayReportDate ? \Carbon\Carbon::parse($employee->ninetyDayReportDate)->format('d M Y') : '-' }}</p>

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -31,7 +31,7 @@
         <div class="d-flex justify-content-between align-items-start w-100">
             <div class="flex-grow-1">
                 <h5 class="alert-heading mb-1">
-                    {{ $loop->iteration }}. {{ $employee->employeeNameEn ?? 'N/A' }}
+                    {{ $loop->iteration }}. {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
                     @if($nationality)
                         <span class="text-muted fw-normal small">
                              - {{ $nationality }}
@@ -41,7 +41,7 @@
                         </span>
                     @endif
                 </h5>
-                <p class="mb-1 text-muted small">{{ $employee->employeeNameTh ?? '' }}</p>
+                <p class="mb-1 text-muted small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? '' }}</p>
                 <p class="mb-1"><strong>นายจ้าง:</strong> {{ $employer->employerNameTh ?? 'N/A' }}</p>
                 <p class="mb-0 small">
                     <strong>{{ $notification->title }}:</strong> {{ $dueDate->translatedFormat('d F Y') }}


### PR DESCRIPTION
This commit implements two features as per the task requirements.

Part A: Synchronize Title Dropdowns
- Added JavaScript to `resources/views/employees/create.blade.php` and `resources/views/employees/edit.blade.php`.
- This script ensures that when a user selects a title in the Thai dropdown (e.g., 'นาย'), the corresponding English title ('Mr.') is automatically selected in the English dropdown, and vice versa.
- The dropdowns were confirmed to have the required IDs (`employeeTitleTh` and `employeeTitleEn`) before adding the script.

Part B: Display Titles on Cards
- Modified `resources/views/notifications/_notification_item.blade.php` to prepend the employee's Thai and English titles to their names on the notification card.
- Modified `resources/views/employers/edit.blade.php` to prepend the employee's Thai and English titles to their names on the employee list card for an employer.
- Used the null coalescing operator (`?? ''`) to prevent errors if a title is not set.