### PR TITLE
Fix: Ensure job_owner_id is saved for employers

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -55,7 +55,7 @@ class EmployerController extends Controller
      */
     public function store(Request $request)
     {
-        $request->validate([
+        $validatedData = $request->validate([
             'employerNameTh' => 'required',
             'employerNameEn' => 'nullable',
             'employerId' => 'required|unique:employers',
@@ -70,12 +70,12 @@ class EmployerController extends Controller
             'document_company_registration' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:2048',
             'document_vat_registration' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:2048',
             'document_map' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:2048',
+            'job_owner_id' => 'nullable|exists:job_owners,id',
         ]);
 
-        DB::transaction(function () use ($request) {
-            $data = $request->except(['document_company_registration', 'document_vat_registration', 'document_map', 'registered_addresses', 'workplace_addresses']);
-
-            $employer = Employer::create($data);
+        DB::transaction(function () use ($request, $validatedData) {
+            $employerData = collect($validatedData)->except(['document_company_registration', 'document_vat_registration', 'document_map'])->all();
+            $employer = Employer::create($employerData);
 
             if ($request->hasFile('document_company_registration')) {
                 $path = $request->file('document_company_registration')->store("employer_documents/{$employer->id}", 'public');
@@ -141,7 +141,7 @@ class EmployerController extends Controller
      */
     public function update(Request $request, Employer $employer)
     {
-        $request->validate([
+        $validatedData = $request->validate([
             'employerNameTh' => 'required',
             'employerNameEn' => 'nullable',
             'employerId' => 'required|unique:employers,employerId,' . $employer->id,
@@ -156,9 +156,10 @@ class EmployerController extends Controller
             'document_company_registration' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:2048',
             'document_vat_registration' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:2048',
             'document_map' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:2048',
+            'job_owner_id' => 'nullable|exists:job_owners,id',
         ]);
 
-        $data = $request->except(['document_company_registration', 'document_vat_registration', 'document_map']);
+        $data = collect($validatedData)->except(['document_company_registration', 'document_vat_registration', 'document_map'])->all();
 
         if ($request->hasFile('document_company_registration')) {
             $path = $request->file('document_company_registration')->store("employer_documents/{$employer->id}", 'public');

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -24,6 +24,7 @@ class Employer extends Model
         'document_company_registration',
         'document_vat_registration',
         'document_map',
+        'job_owner_id',
     ];
 
     public function employees()


### PR DESCRIPTION
This commit fixes a bug where the job_owner_id was not being saved to the database when creating or updating an employer record.

The following changes were made:
- The `job_owner_id` field has been added to the `$fillable` array in the `Employer` model to allow mass assignment.
- The `store` and `update` methods in the `EmployerController` have been refactored to correctly validate and pass the `job_owner_id` to the database. The methods now use the validated data from the request, ensuring the field is included in the data passed to the `create` and `update` operations.