### PR TITLE
feat: Implement server-side filtering and pagination for employers

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -20,21 +20,23 @@ class EmployerController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Employer::with('jobOwner');
+        $perPage = $request->input('per_page', 25);
+        $search = $request->input('search');
 
-        if ($request->filled('search')) {
-            $search = $request->input('search');
+        $query = Employer::with('jobOwner')->latest();
+
+        if ($search) {
             $query->where(function ($q) use ($search) {
                 $q->where('employerNameTh', 'like', "%{$search}%")
                   ->orWhere('employerNameEn', 'like', "%{$search}%")
-                  ->orWhere('employerId', 'like', "%{$search}%");
+                  ->orWhere('employerId', 'like', "%{$search}%")
+                  ->orWhere('employerTaxId', 'like', "%{$search}%");
             });
         }
 
-        $employers = $query->latest()->paginate(10);
-        $jobOwners = User::pluck('name', 'id');
+        $employers = $query->paginate($perPage)->withQueryString();
 
-        return view('employers.index', compact('employers', 'jobOwners'));
+        return view('employers.index', compact('employers'));
     }
 
     /**

--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -12,7 +12,15 @@
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
         <h2 class="mb-3 mb-md-0">รายการข้อมูลนายจ้าง</h2>
         <div class="d-flex gap-2">
-            <input type="text" name="search" id="employer-search-input" class="form-control form-control-sm" placeholder="ค้นหา..." value="{{ request('search') }}">
+            <form action="{{ route('employers.index') }}" method="GET" class="d-flex gap-2">
+                <select name="per_page" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                    <option value="25" @selected(request('per_page', 25) == 25)>25</option>
+                    <option value="50" @selected(request('per_page') == 50)>50</option>
+                    <option value="100" @selected(request('per_page') == 100)>100</option>
+                </select>
+                <input type="text" name="search" class="form-control form-control-sm w-auto" placeholder="ค้นหา..." value="{{ request('search') }}">
+                <button type="submit" class="btn btn-primary btn-sm">ค้นหา</button>
+            </form>
             <a href="{{ route('employers.export') }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i> Export</a>
             <a href="{{ route('employers.create') }}" class="btn btn-primary btn-sm"><i class="bi bi-plus-circle me-1"></i> เพิ่มข้อมูลใหม่</a>
         </div>
@@ -53,31 +61,9 @@
                 @endforelse
             </tbody>
         </table>
+        <div class="mt-4">
+            {{ $employers->links() }}
+        </div>
     </div>
 </div>
 @endsection
-
-@push('scripts')
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        const searchInput = document.getElementById('employer-search-input');
-        const tableBody = document.getElementById('employer-table-body');
-        if (searchInput && tableBody) {
-            const tableRows = tableBody.getElementsByTagName('tr');
-
-            searchInput.addEventListener('keyup', function() {
-                const searchTerm = searchInput.value.toLowerCase();
-                for (let row of tableRows) {
-                    // Check all cells in the row for the search term
-                    const rowText = row.textContent || row.innerText;
-                    if (rowText.toLowerCase().includes(searchTerm)) {
-                        row.style.display = ""; // Show row if it matches
-                    } else {
-                        row.style.display = "none"; // Hide row if it doesn't match
-                    }
-                }
-            });
-        }
-    });
-</script>
-@endpush


### PR DESCRIPTION
This commit refactors the employers list to handle data on the server-side, improving performance for large datasets.

- The `EmployerController`'s `index` method is updated to process search queries and pagination dynamically.
- The `employers.index` view is modified to replace the client-side live search with a form that supports server-side filtering and a "per page" selection.
- The old live-search JavaScript is removed.
- Pagination links are added to the view.