### PR TITLE
feat: Configure Laravel pagination to use Bootstrap 5

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Pagination\Paginator;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Paginator::useBootstrapFive();
     }
 }


### PR DESCRIPTION
Configures Laravel's pagination to use the built-in Bootstrap 5 views. This is done by calling `Paginator::useBootstrapFive()` in the `AppServiceProvider`.

This change ensures that pagination controls are correctly styled in the Bootstrap 5 project, resolving issues with unstyled SVG icons.