### PR TITLE
feat: Implement dynamic view and pagination for employees page

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -12,9 +12,41 @@ class EmployeeController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-        // Not used for now
+        // Define options for items per page
+        $cardPerPageOptions = [10, 15, 20];
+        $tablePerPageOptions = [25, 50, 100];
+
+        // Determine the current view, default to 'card'
+        $currentView = $request->input('view', 'card');
+
+        // Determine per_page based on the current view
+        $defaultPerPage = ($currentView === 'card') ? $cardPerPageOptions[0] : $tablePerPageOptions[0];
+        $currentPerPage = $request->input('per_page', $defaultPerPage);
+
+        // Determine which set of options to pass to the view
+        $perPageOptions = ($currentView === 'card') ? $cardPerPageOptions : $tablePerPageOptions;
+
+        // Build the query
+        $query = Employee::with(['employer', 'documents']); // Eager load relationships
+
+        // Handle search if present
+        if ($request->has('search') && $request->input('search') != '') {
+            $search = $request->input('search');
+            $query->where(function($q) use ($search) {
+                $q->where('employeeNameTh', 'like', "%{$search}%")
+                  ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                  ->orWhere('employeePassport', 'like', "%{$search}%")
+                  ->orWhereHas('employer', function($q_employer) use ($search) {
+                      $q_employer->where('employerNameTh', 'like', "%{$search}%");
+                  });
+            });
+        }
+
+        $employees = $query->latest()->paginate($currentPerPage)->withQueryString();
+
+        return view('employees.index', compact('employees', 'currentView', 'currentPerPage', 'perPageOptions'));
     }
 
     /**

--- a/resources/views/employees/_card.blade.php
+++ b/resources/views/employees/_card.blade.php
@@ -1,0 +1,36 @@
+@php
+    // This logic is now inside the component for reusability
+    $flagCodes = ['เมียนมา' => 'mm', 'ลาว' => 'la', 'กัมพูชา' => 'kh', 'เวียดนาม' => 'vn'];
+    $nationality = $employee->employeeNationality ?? null;
+    $flagCode = $nationality ? ($flagCodes[$nationality] ?? null) : null;
+@endphp
+
+<div class="card employee-card mb-3" id="employee-card-{{ $employee->id }}">
+    <div class="card-body d-flex justify-content-between align-items-start gap-3">
+        <div class="d-flex align-items-center flex-grow-1">
+            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}" class="employee-photo-thumb" alt="Photo">
+            <div class="flex-grow-1">
+                <p class="mb-0">
+                    <strong>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}</strong>
+                    @if($nationality)
+                        <span class="text-muted small"> - {{ $nationality }}</span>
+                        @if($flagCode)
+                            <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" class="ms-1" style="width: 20px; vertical-align: middle;">
+                        @endif
+                    @endif
+                </p>
+                <p class="mb-1 text-muted small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }}</p>
+                <p class="mb-1 text-muted small"><strong>นายจ้าง:</strong> {{ $employee->employer->employerNameTh ?? 'N/A' }}</p>
+                <p class="mb-0 text-muted small">Passport: {{ $employee->employeePassport ?? '-' }}</p>
+            </div>
+        </div>
+        <div class="btn-group btn-group-sm">
+            <a href="{{ route('employers.employees.edit', ['employer' => $employee->employer, 'employee' => $employee]) }}" class="btn btn-outline-primary" title="แก้ไข">
+                <i class="bi bi-pencil-fill"></i>
+            </a>
+            <button type="button" class="btn btn-outline-danger delete-employee-btn" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal" data-delete-url="{{ route('employers.employees.destroy', ['employer' => $employee->employer, 'employee' => $employee]) }}" title="ลบ">
+                <i class="bi bi-trash-fill"></i>
+            </button>
+        </div>
+    </div>
+</div>

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -1,0 +1,111 @@
+@extends('layouts.app')
+@section('title', 'ข้อมูลลูกจ้าง')
+
+@push('styles')
+<style>
+    .employee-card {
+        background-color: #ffffff;
+        border: 1px solid #e2e8f0;
+        transition: all 0.2s ease-in-out;
+    }
+    .employee-card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 4px 10px rgba(0,0,0,0.07);
+    }
+    .employee-photo-thumb {
+        width: 48px; height: 48px; object-fit: cover; border-radius: 50%;
+        margin-right: 1rem; background-color: #e2e8f0;
+    }
+</style>
+@endpush
+
+@section('content')
+<div class="p-4 p-md-5 content-section">
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+        <h2 class="mb-3 mb-md-0">รายการข้อมูลลูกจ้างทั้งหมด</h2>
+        <a href="{{ route('employers.index') }}" class="btn btn-primary"><i class="bi bi-plus-circle me-1"></i> เพิ่มข้อมูลใหม่</a>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-body">
+            <form action="{{ route('employees.index') }}" method="GET" id="filter-form" class="d-flex flex-wrap gap-2 align-items-center">
+                <input type="text" name="search" class="form-control form-control-sm w-auto" placeholder="ค้นหา..." value="{{ request('search') }}">
+
+                <div class="btn-group btn-group-sm ms-md-auto">
+                    <input type="radio" class="btn-check" name="view" id="view-card" value="card" onchange="this.form.submit()" @checked($currentView === 'card')>
+                    <label class="btn btn-outline-primary" for="view-card"><i class="bi bi-grid-3x3-gap-fill"></i> การ์ด</label>
+
+                    <input type="radio" class="btn-check" name="view" id="view-table" value="table" onchange="this.form.submit()" @checked($currentView === 'table')>
+                    <label class="btn btn-outline-primary" for="view-table"><i class="bi bi-table"></i> ตาราง</label>
+                </div>
+
+                <select name="per_page" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                    @foreach($perPageOptions as $option)
+                    <option value="{{ $option }}" @selected($currentPerPage == $option)>แสดง {{ $option }}</option>
+                    @endforeach
+                </select>
+
+                <button type="submit" class="btn btn-primary btn-sm">ค้นหา</button>
+            </form>
+        </div>
+    </div>
+
+    @if($currentView === 'card')
+        {{-- Card View --}}
+        <div class="card-view">
+            @forelse($employees as $employee)
+                @include('employees._card', ['employee' => $employee])
+            @empty
+                <p class="text-center text-muted">ไม่พบข้อมูลลูกจ้าง</p>
+            @endforelse
+        </div>
+    @else
+        {{-- Table View --}}
+        <div class="table-responsive">
+            <table class="table table-hover align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th>#</th>
+                        <th>รูป</th>
+                        <th>ชื่อ (อังกฤษ)</th>
+                        <th>ชื่อ (ไทย)</th>
+                        <th>สัญชาติ</th>
+                        <th>Passport</th>
+                        <th>นายจ้าง</th>
+                        <th class="text-center">จัดการ</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($employees as $employee)
+                    <tr>
+                        <td>{{ $loop->iteration + $employees->firstItem() - 1 }}</td>
+                        <td>
+                            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}"
+                                 class="employee-photo-thumb" style="width: 40px; height: 40px; margin-right: 0;" alt="Photo">
+                        </td>
+                        <td>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn }}</td>
+                        <td>{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh }}</td>
+                        <td>{{ $employee->employeeNationality }}</td>
+                        <td>{{ $employee->employeePassport }}</td>
+                        <td>{{ $employee->employer->employerNameTh ?? 'N/A' }}</td>
+                        <td class="text-center">
+                            <a href="{{ route('employers.employees.edit', ['employer' => $employee->employer, 'employee' => $employee]) }}" class="btn btn-sm btn-outline-primary" title="แก้ไข"><i class="bi bi-pencil-fill"></i></a>
+                            <button type="button" class="btn btn-sm btn-outline-danger delete-employee-btn" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal" data-delete-url="{{ route('employers.employees.destroy', ['employer' => $employee->employer, 'employee' => $employee]) }}" title="ลบ"><i class="bi bi-trash-fill"></i></button>
+                        </td>
+                    </tr>
+                    @empty
+                    <tr>
+                        <td colspan="8" class="text-center text-muted">ไม่พบข้อมูลลูกจ้าง</td>
+                    </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    @endif
+
+    <div class="mt-4">
+        {{ $employees->links() }}
+    </div>
+
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,8 @@ Route::middleware('auth')->group(function () {
     Route::post('employees/{employee}/terminate', [EmployerController::class, 'terminate'])->name('employees.terminate');
     Route::post('/employees/{employee}/restore', [EmployerController::class, 'restoreEmployee'])->name('employees.restore');
     Route::delete('/employees/{employee}/force-delete', [EmployerController::class, 'forceDeleteEmployee'])->name('employees.forceDelete');
-    Route::resource('employers.employees', EmployeeController::class);
+    Route::get('/employees', [EmployeeController::class, 'index'])->name('employees.index');
+    Route::resource('employers.employees', EmployeeController::class)->except(['index']);
     Route::resource('importers', ImporterController::class);
     Route::resource('agents', AgentController::class);
     Route::resource('delegates', DelegateController::class);


### PR DESCRIPTION
This commit overhauls the employee index page to provide a more flexible user experience.

Key changes include:
- A new top-level route `/employees` is created to display a list of all employees across all employers.
- The `EmployeeController@index` method is updated to handle query parameters for view type (`card`/`table`) and items per page.
- A reusable Blade component `_card.blade.php` is created for the employee card view.
- The main `employees/index.blade.php` view is replaced with a new version that includes UI controls for switching between card and table views, and for selecting the number of items per page. The pagination options are dynamically updated based on the selected view.
- All action routes (edit, delete, create) have been corrected to use the proper nested route helpers, ensuring full functionality of the page.