### PR TITLE
Fix: Correct z-index for main content area

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -139,7 +139,7 @@
             </div>
         </aside>
 
-        <main id="main-content">
+        <main id="main-content" style="position: relative; z-index: 1;">
             @if (session('success'))
                 <div class="alert alert-success">
                     {{ session('success') }}


### PR DESCRIPTION
The action buttons (Edit, Delete) on index pages were unclickable because the main content area was being overlapped by another layout element.

This commit resolves the issue by adding `position: relative` and `z-index: 1` to the `<main id="main-content">` element in the main application layout file (`resources/views/layouts/app.blade.php`). This establishes a new stacking context for the main content, ensuring it is positioned above other elements and that all its children, including action buttons, are clickable.