### PR TITLE
Fix: Apply inline style to employee photo on employer's employee card

### DIFF
--- a/resources/views/employers/_employee_card.blade.php
+++ b/resources/views/employers/_employee_card.blade.php
@@ -5,7 +5,10 @@
 @endphp
 <div class="employee-card d-flex justify-content-between align-items-start gap-3 mb-3" id="employee-card-{{ $employee->id }}">
     <div class="d-flex align-items-center flex-grow-1">
-        <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}" class="employee-photo-thumb" alt="Photo">
+        <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
+             class="employee-photo-thumb"
+             style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover; margin-right: 1rem;"
+             alt="Photo">
         <div class="flex-grow-1">
              <p class="mb-0">
                 <strong>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}</strong>


### PR DESCRIPTION
This change applies a protective inline style to the employee photo on the employer's employee card to ensure it always displays at the correct size. This resolves a recurring CSS conflict.