### PR TITLE
feat(employee-card): Add missing document expiry details

### DIFF
--- a/resources/views/employers/_employee_card.blade.php
+++ b/resources/views/employers/_employee_card.blade.php
@@ -1,8 +1,10 @@
 @php
+    // This logic is now inside the component for reusability
     $flagCodes = ['เมียนมา' => 'mm', 'ลาว' => 'la', 'กัมพูชา' => 'kh', 'เวียดนาม' => 'vn'];
     $nationality = $employee->employeeNationality ?? null;
     $flagCode = $nationality ? ($flagCodes[$nationality] ?? null) : null;
 @endphp
+
 <div class="employee-card d-flex justify-content-between align-items-start gap-3 mb-3" id="employee-card-{{ $employee->id }}">
     <div class="d-flex align-items-center flex-grow-1">
         <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
@@ -10,7 +12,7 @@
              style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover; margin-right: 1rem;"
              alt="Photo">
         <div class="flex-grow-1">
-             <p class="mb-0">
+            <p class="mb-0">
                 <strong>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}</strong>
                 @if($nationality)
                     <span class="text-muted small"> - {{ $nationality }}</span>
@@ -20,8 +22,11 @@
                 @endif
             </p>
             <p class="mb-1 text-muted small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }} ({{ $employee->employeePosition ?? 'ไม่ระบุตำแหน่ง' }})</p>
-            <p class="mb-1 text-muted small">Passport: {{ $employee->employeePassport ?? '-' }}</p>
-        </div>
+
+            <p class="mb-1 text-muted small">Passport: {{ $employee->employeePassport ?? '-' }} (หมดอายุ: {{ $employee->passportExpiryDate ? \Carbon\Carbon::parse($employee->passportExpiryDate)->format('d/m/Y') : '-' }})</p>
+            <p class="mb-1 text-muted small">Work Permit: {{ $employee->employeeWorkPermit ?? '-' }} (หมดอายุ: {{ $employee->workPermitExpiryDate ? \Carbon\Carbon::parse($employee->workPermitExpiryDate)->format('d/m/Y') : '-' }})</p>
+            <p class="mb-0 text-muted small">Visa ({{ $employee->workPermitMOUGroup ?? '-' }}) หมดอายุ: {{ $employee->visaExpiryDate ? \Carbon\Carbon::parse($employee->visaExpiryDate)->format('d/m/Y') : '-' }} | 90-Day: {{ $employee->ninetyDayReportDate ? \Carbon\Carbon::parse($employee->ninetyDayReportDate)->format('d/m/Y') : '-' }}</p>
+            </div>
     </div>
     <div class="btn-group btn-group-sm">
         <a href="{{ route('employees.edit', $employee->id) }}" class="btn btn-outline-primary" title="แก้ไข"><i class="bi bi-pencil-fill"></i></a>


### PR DESCRIPTION
Updates the employee card component to display Work Permit, Visa, and 90-Day report details and their respective expiry dates, aligning the component with the design specifications.

This change modifies the `_employee_card.blade.php` partial to include:
- Work Permit number and expiry date.
- Visa expiry date, including the MOU group.
- 90-Day report date.

The new fields are safely rendered using the null coalescing operator to prevent errors when data is missing.