### PR TITLE
Fix: Correct route for employee update form

### DIFF
--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -16,7 +16,7 @@
         </div>
     @endif
 
-    <form action="{{ route('employers.employees.update', [$employer, $employee]) }}" method="POST" enctype="multipart/form-data">
+    <form action="{{ route('employees.update', $employee->id) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
 


### PR DESCRIPTION
The form on the employee edit page was pointing to an incorrect route 'employers.employees.update', which caused a RouteNotFoundException.

This commit corrects the form's action attribute to use the 'employees.update' route, which is the correct route for updating employee information. The `@method('PUT')` directive was already present and is correct for this action.