### PR TITLE
Fix: Correct EmployeeController@create method signature

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -52,8 +52,13 @@ class EmployeeController extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create(Employer $employer)
+    public function create(Request $request)
     {
+        $employer_id = $request->query('employer_id');
+
+        // Use findOrFail to automatically handle cases where the employer is not found
+        $employer = Employer::findOrFail($employer_id);
+
         return view('employees.create', compact('employer'));
     }
 


### PR DESCRIPTION
The `create` method in `EmployeeController` expected an `Employer` object via route model binding, but the `employees.create` route did not provide this parameter, leading to a `UrlGenerationException`.

This commit modifies the `create` method to accept the `Request` object, retrieve the `employer_id` from the query string, and use `findOrFail` to fetch the employer. This aligns the controller with the route definition and resolves the exception.