### PR TITLE
feat: Create global all employees index page and menu

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -12,42 +12,42 @@ class EmployeeController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request)
-    {
-        // Define options for items per page
-        $cardPerPageOptions = [10, 15, 20];
-        $tablePerPageOptions = [25, 50, 100];
+public function index(Request $request)
+{
+    // Define options for items per page
+    $cardPerPageOptions = [10, 15, 20];
+    $tablePerPageOptions = [25, 50, 100];
 
-        // Determine the current view, default to 'card'
-        $currentView = $request->input('view', 'card');
+    // Determine the current view, default to 'card'
+    $currentView = $request->input('view', 'card');
 
-        // Determine per_page based on the current view
-        $defaultPerPage = ($currentView === 'card') ? $cardPerPageOptions[0] : $tablePerPageOptions[0];
-        $currentPerPage = $request->input('per_page', $defaultPerPage);
+    // Determine per_page based on the current view
+    $defaultPerPage = ($currentView === 'card') ? $cardPerPageOptions[0] : $tablePerPageOptions[0];
+    $currentPerPage = $request->input('per_page', $defaultPerPage);
 
-        // Determine which set of options to pass to the view
-        $perPageOptions = ($currentView === 'card') ? $cardPerPageOptions : $tablePerPageOptions;
+    // Determine which set of options to pass to the view
+    $perPageOptions = ($currentView === 'card') ? $cardPerPageOptions : $tablePerPageOptions;
 
-        // Build the query
-        $query = Employee::with(['employer', 'documents']); // Eager load relationships
+    // Build the query for ALL employees
+    $query = Employee::with('employer')->latest(); // Eager load employer relationship
 
-        // Handle search if present
-        if ($request->has('search') && $request->input('search') != '') {
-            $search = $request->input('search');
-            $query->where(function($q) use ($search) {
-                $q->where('employeeNameTh', 'like', "%{$search}%")
-                  ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                  ->orWhere('employeePassport', 'like', "%{$search}%")
-                  ->orWhereHas('employer', function($q_employer) use ($search) {
-                      $q_employer->where('employerNameTh', 'like', "%{$search}%");
-                  });
-            });
-        }
-
-        $employees = $query->latest()->paginate($currentPerPage)->withQueryString();
-
-        return view('employees.index', compact('employees', 'currentView', 'currentPerPage', 'perPageOptions'));
+    // Handle search if present
+    if ($request->filled('search')) {
+        $search = $request->input('search');
+        $query->where(function($q) use ($search) {
+            $q->where('employeeNameTh', 'like', "%{$search}%")
+              ->orWhere('employeeNameEn', 'like', "%{$search}%")
+              ->orWhere('employeePassport', 'like', "%{$search}%")
+              ->orWhereHas('employer', function($q_employer) use ($search) {
+                  $q_employer->where('employerNameTh', 'like', "%{$search}%");
+              });
+        });
     }
+
+    $employees = $query->paginate($currentPerPage)->withQueryString();
+
+    return view('employees.index', compact('employees', 'currentView', 'currentPerPage', 'perPageOptions'));
+}
 
     /**
      * Show the form for creating a new resource.

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -121,6 +121,9 @@
                 </a>
                 <hr>
                 <a href="{{ route('employers.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('employers.*') ? 'active' : '' }}"><i class="bi bi-person-vcard-fill me-2"></i>ข้อมูลนายจ้าง</a>
+                <a href="{{ route('employees.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('employees.*') ? 'active' : '' }}">
+                    <i class="bi bi-people-fill me-2"></i>ข้อมูลลูกจ้าง
+                </a>
                 <a href="{{ route('importers.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('importers.*') ? 'active' : '' }}"><i class="bi bi-box-arrow-in-down-left me-2"></i>ข้อมูลบริษัทนำเข้า</a>
                 <a href="{{ route('agents.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('agents.*') ? 'active' : '' }}"><i class="bi bi-person-square me-2"></i>ข้อมูลเอเจนซี่</a>
                 <a href="{{ route('delegates.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('delegates.*') ? 'active' : '' }}"><i class="bi bi-people-fill me-2"></i>ข้อมูลพนักงาน</a>


### PR DESCRIPTION
This commit introduces a new top-level "All Employees" page and a corresponding sidebar menu item.

- Adds a "ข้อมูลลูกจ้าง" (All Employees) link to the main sidebar navigation in `resources/views/layouts/app.blade.php`.
- Updates the `EmployeeController@index` method to fetch, search, and paginate all employees from all employers, creating a global employee directory.
- The new page at `/employees` leverages the existing view switcher (card/table), search, and pagination functionality.