### PR TITLE
Fix: Correct route names for employee actions

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -89,8 +89,8 @@
                         <td>{{ $employee->employeePassport }}</td>
                         <td>{{ $employee->employer->employerNameTh ?? 'N/A' }}</td>
                         <td class="text-center">
-                            <a href="{{ route('employers.employees.edit', ['employer' => $employee->employer, 'employee' => $employee]) }}" class="btn btn-sm btn-outline-primary" title="แก้ไข"><i class="bi bi-pencil-fill"></i></a>
-                            <button type="button" class="btn btn-sm btn-outline-danger delete-employee-btn" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal" data-delete-url="{{ route('employers.employees.destroy', ['employer' => $employee->employer, 'employee' => $employee]) }}" title="ลบ"><i class="bi bi-trash-fill"></i></button>
+                            <a href="{{ route('employees.edit', $employee->id) }}" class="btn btn-sm btn-outline-primary" title="แก้ไข"><i class="bi bi-pencil-fill"></i></a>
+                            <button type="button" class="btn btn-sm btn-outline-danger delete-employee-btn" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal" data-delete-url="{{ route('employees.destroy', $employee->id) }}" title="ลบ"><i class="bi bi-trash-fill"></i></button>
                         </td>
                     </tr>
                     @empty


### PR DESCRIPTION
The "Edit" and "Delete" buttons on the global employee index page (`/employees`) were using incorrect, nested route names (`employers.employees.edit` and `employers.employees.destroy`). This caused a `RouteNotFoundException`.

This commit corrects the `route()` helper calls to use the proper, non-nested route names: `employees.edit` and `employees.destroy`.