### PR TITLE
Fix: Correct oversized employee photo in card view

### DIFF
--- a/resources/views/employees/_card.blade.php
+++ b/resources/views/employees/_card.blade.php
@@ -8,7 +8,10 @@
 <div class="card employee-card mb-3" id="employee-card-{{ $employee->id }}">
     <div class="card-body d-flex justify-content-between align-items-start gap-3">
         <div class="d-flex align-items-center flex-grow-1">
-            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}" class="employee-photo-thumb" alt="Photo">
+            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
+     class="employee-photo-thumb"
+     style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover; margin-right: 1rem;"
+     alt="Photo">
             <div class="flex-grow-1">
                 <p class="mb-0">
                     <strong>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}</strong>


### PR DESCRIPTION
The employee photo in the global employee card view (`employees/_card.blade.php`) was displaying at its original size instead of as a thumbnail.

This was caused by a missing inline `style` attribute on the `<img>` tag. This commit adds the necessary styles for width, height, border-radius, object-fit, and margin to ensure the photo is displayed correctly as a 48x48 circular thumbnail.