### PR TITLE
fix: Correct table photo size and re-implement highlight feature

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -82,7 +82,9 @@
                         <td>
                             {{-- ADDED .employee-photo-thumb class --}}
                             <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
-                                 class="employee-photo-thumb" alt="Photo">
+                                 class="employee-photo-thumb"
+                                 style="width: 48px; height: 48px;"
+                                 alt="Photo">
                         </td>
                         <td>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn }}</td>
                         <td>{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh }}</td>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -1,6 +1,21 @@
 {{-- DEFINITIVE MASTER FIX: This is the user's full original file with the final corrections. --}}
 @extends('layouts.app')
 
+@push('styles')
+<style>
+    @keyframes highlight-fade {
+        from { background-color: #fef9c3; } /* A light yellow */
+        to { background-color: transparent; }
+    }
+    .highlight {
+        animation: highlight-fade 3s ease-out forwards;
+        border: 2px solid #f97316 !important; /* An orange border */
+        border-radius: 0.5rem; /* Match card/row radius */
+        box-shadow: 0 0 15px rgba(249, 115, 22, 0.5);
+    }
+</style>
+@endpush
+
 @section('title', 'แก้ไขข้อมูลนายจ้าง')
 
 @section('content')
@@ -1072,28 +1087,24 @@ document.addEventListener('DOMContentLoaded', function () {
         const elementToHighlight = document.getElementById(highlightId);
 
         if (elementToHighlight) {
-            // Scroll to the element
+            // Scroll the element into the middle of the view
             elementToHighlight.scrollIntoView({ behavior: 'smooth', block: 'center' });
 
-            // Add highlight class and remove it after animation
+            // Add the highlight class
             elementToHighlight.classList.add('highlight');
+
+            // Optional: Remove the class after the animation to clean up styles
             setTimeout(() => {
                 elementToHighlight.classList.remove('highlight');
-            }, 3000); // 3 seconds, matching the animation
+                // Also clear the hash from the URL for a cleaner experience
+                if (history.pushState) {
+                    history.pushState(null, null, window.location.pathname + window.location.search);
+                } else {
+                    window.location.hash = '';
+                }
+            }, 3100); // Slightly longer than the animation
         }
     }
 });
 </script>
-@endpush
-@push('styles')
-<style>
-    @keyframes highlight-fade {
-        from { background-color: #fef9c3; } /* yellow-100 */
-        to { background-color: transparent; }
-    }
-    .highlight {
-        animation: highlight-fade 3s ease-out;
-        border-color: #f97316 !important; /* orange-500 */
-    }
-</style>
 @endpush


### PR DESCRIPTION
This commit addresses two issues:

1.  **Fixes oversized employee photo:** Adds an inline style to the `<img>` tag in the employees table view (`employees.index.blade.php`) to ensure the photo is always displayed at 48x48 pixels.

2.  **Re-implements employee highlight:** Adds the correct CSS and JavaScript to the employer edit page (`employers.edit.blade.php`) to restore the scroll-and-highlight functionality. The new implementation correctly scrolls to the element and cleans the URL hash after the highlight animation.