### PR TITLE
feat: Polish and fix employee index page

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -17,19 +17,23 @@ public function index(Request $request)
     // Define options for items per page
     $cardPerPageOptions = [10, 15, 20];
     $tablePerPageOptions = [25, 50, 100];
-
-    // Determine the current view, default to 'card'
     $currentView = $request->input('view', 'card');
-
-    // Determine per_page based on the current view
     $defaultPerPage = ($currentView === 'card') ? $cardPerPageOptions[0] : $tablePerPageOptions[0];
     $currentPerPage = $request->input('per_page', $defaultPerPage);
-
-    // Determine which set of options to pass to the view
     $perPageOptions = ($currentView === 'card') ? $cardPerPageOptions : $tablePerPageOptions;
 
-    // Build the query for ALL employees
-    $query = Employee::with('employer')->latest(); // Eager load employer relationship
+    // Build the base query for ALL employees
+    $query = Employee::query();
+
+    // --- START: COUNTING LOGIC ---
+    // Calculate counts before filtering for search
+    $totalEmployees = $query->count();
+    $maleCount = (clone $query)->whereIn('employeeTitleTh', ['นาย'])->count();
+    $femaleCount = (clone $query)->whereIn('employeeTitleTh', ['นางสาว', 'นาง'])->count();
+    // --- END: COUNTING LOGIC ---
+
+    // Eager load employer relationship
+    $query->with('employer')->latest();
 
     // Handle search if present
     if ($request->filled('search')) {
@@ -46,7 +50,10 @@ public function index(Request $request)
 
     $employees = $query->paginate($currentPerPage)->withQueryString();
 
-    return view('employees.index', compact('employees', 'currentView', 'currentPerPage', 'perPageOptions'));
+    return view('employees.index', compact(
+        'employees', 'currentView', 'currentPerPage', 'perPageOptions',
+        'totalEmployees', 'maleCount', 'femaleCount' // Pass new variables
+    ));
 }
 
     /**

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -23,7 +23,10 @@
 <div class="p-4 p-md-5 content-section">
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
         <h2 class="mb-3 mb-md-0">รายการข้อมูลลูกจ้างทั้งหมด</h2>
-        <a href="{{ route('employees.create') }}" class="btn btn-primary"><i class="bi bi-plus-circle me-1"></i> เพิ่มข้อมูลใหม่</a>
+        <h2 class="h5 text-muted fw-normal">
+            (รวม: {{ $totalEmployees }} | ชาย: {{ $maleCount }} | หญิง: {{ $femaleCount }})
+        </h2>
+        <a href="{{ route('employers.index') }}" class="btn btn-primary"><i class="bi bi-plus-circle me-1"></i> เพิ่มข้อมูลใหม่</a>
     </div>
 
     <div class="card mb-4">
@@ -83,7 +86,7 @@
                             {{-- ADDED .employee-photo-thumb class --}}
                             <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
                                  class="employee-photo-thumb"
-                                 style="width: 48px; height: 48px;"
+                                 style="width: 48px; height: 48px; border-radius: 50%;"
                                  alt="Photo">
                         </td>
                         <td>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn }}</td>


### PR DESCRIPTION
This commit addresses three issues on the employee list page:

1.  **Fix "Add New" Button:** The "Add New" button now correctly links to the employers list page (`employers.index`) instead of the employee creation form, allowing the user to select an employer first.

2.  **Style Employee Photo:** Employee photos in the table view are now styled with `border-radius: 50%` to render as circles, matching the design of the card view.

3.  **Add Employee Counts:** The page now displays a detailed count of total, male, and female employees. The calculation logic has been added to the `EmployeeController`.