### PR TITLE
Fix: Correct modal z-index to appear above backdrop

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -10,3 +10,14 @@
     margin-right: 1rem;
     background-color: #e2e8f0;
 }
+
+/*
+ * Modal Z-index Fix
+ * Ensures modals always appear on top of their backdrops.
+ */
+.modal-backdrop {
+    z-index: 1050;
+}
+.modal {
+    z-index: 1060;
+}


### PR DESCRIPTION
The Bootstrap modals on the notifications page were appearing underneath the .modal-backdrop overlay, which made them unclickable. This was due to a z-index stacking issue.

This commit adds a CSS override to `resources/css/app.css` to explicitly set the z-index for both the `.modal` and `.modal-backdrop` classes, ensuring that the modal always displays on top of the backdrop.