### PR TITLE
Fix: Correct restore method and add missing MOU filter

### DIFF
--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -55,7 +55,6 @@
                     @if($notification->status == 'cancelled')
                         <form action="{{ route('notifications.restore', $notification) }}" method="POST" class="d-inline">
                             @csrf
-                            @method('PATCH')
                             <button type="submit" class="btn btn-success" title="นำกลับ">
                                 <i class="bi bi-arrow-counterclockwise"></i>
                             </button>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -19,6 +19,7 @@
         <div class="card-body">
             <form action="{{ route('notifications.index') }}" method="GET" class="d-flex flex-wrap gap-2 align-items-center">
                 <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหาชื่อลูกจ้าง..." value="{{ request('search') }}" style="width: 200px;">
+
                 <select name="nationality" class="form-select form-select-sm" style="width: 150px;">
                     <option value="">-- ทุกสัญชาติ --</option>
                     <option value="เมียนมา" @selected(request('nationality') == 'เมียนมา')>เมียนมา</option>
@@ -26,6 +27,16 @@
                     <option value="กัมพูชา" @selected(request('nationality') == 'กัมพูชา')>กัมพูชา</option>
                     <option value="เวียดนาม" @selected(request('nationality') == 'เวียดนาม')>เวียดนาม</option>
                 </select>
+
+                {{-- ADDED THIS MISSING DROPDOWN --}}
+                <select name="mou_type" class="form-select form-select-sm" style="width: 200px;">
+                    <option value="">-- ทุกประเภท มติ. --</option>
+                    <option value="MOU" @selected(request('mou_type') == 'MOU')>MOU</option>
+                    <option value="มติต่ออายุในประเทศ" @selected(request('mou_type') == 'มติต่ออายุในประเทศ')>มติต่ออายุในประเทศ</option>
+                    <option value="มติขึ้นทะเบียน" @selected(request('mou_type') == 'มติขึ้นทะเบียน')>มติขึ้นทะเบียน</option>
+                    <option value="อื่นๆ" @selected(request('mou_type') == 'อื่นๆ')>อื่นๆ</option>
+                </select>
+
                 <button type="submit" class="btn btn-primary btn-sm">กรอง</button>
                 <a href="{{ route('notifications.index') }}" class="btn btn-secondary btn-sm">ล้างค่า</a>
             </form>


### PR DESCRIPTION
This commit addresses two issues on the notifications page:

1.  **Fix Restore Button Method:** The restore button form was using an incorrect method, causing an error. The directive has been removed, allowing the form to correctly submit, which matches the route definition.

2.  **Add Missing MOU Type Dropdown:** The 'MOU Type' filter dropdown was missing from the filter controls. It has been re-added to the form to allow users to filter notifications by this criterion.