### PR TITLE
feat: Add view switcher and per-page selector to notifications

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -12,66 +12,71 @@ use Carbon\Carbon;
 
 class NotificationController extends Controller
 {
-    public function index(Request $request)
-    {
-        $tabs = [
-            'ninety_day_report', 'passport_expiry', 'work_permit_expiry',
-            'visa_expiry', 'ci_renewal', 'resolution_renewal'
-        ];
+public function index(Request $request)
+{
+    // --- View & Pagination Logic ---
+    $currentView = $request->input('view', 'card');
+    $cardPerPageOptions = [10, 15, 20];
+    $tablePerPageOptions = [25, 50, 100];
+    $perPageOptions = ($currentView === 'card') ? $cardPerPageOptions : $tablePerPageOptions;
+    $perPage = $request->input('per_page', $perPageOptions[0]);
 
-        $notificationsData = [];
-        $counts = [];
+    // --- Define Tabs ---
+    $tabs = [
+        'ninety_day_report' => 'รายงานตัว 90 วัน',
+        'passport_expiry' => 'Passport',
+        'work_permit_expiry' => 'ใบอนุญาตทำงาน',
+        'visa_expiry' => 'วีซ่า',
+        'ci_renewal' => 'ต่ออายุ CI',
+        'resolution_renewal' => 'ต่ออายุมติ',
+    ];
 
-        // Calculate counts for all tabs first
-        foreach ($tabs as $type) {
-            $counts[$type] = $this->getFilteredQuery($request, $type)->count();
-        }
-        $counts['cancelled'] = $this->getFilteredQuery($request, 'cancelled')->count();
+    $notificationsData = [];
+    $counts = [];
 
-        // Paginate the data for each tab separately
-        foreach ($tabs as $type) {
-            $notificationsData[$type] = $this->getFilteredQuery($request, $type)
-                                             ->paginate(10, ['*'], $type . '_page')
-                                             ->withQueryString();
-        }
-        $notificationsData['cancelled'] = $this->getFilteredQuery($request, 'cancelled')
-                                                ->paginate(10, ['*'], 'cancelled_page')
-                                                ->withQueryString();
-
-        return view('notifications.index', compact('notificationsData', 'counts'));
+    foreach ($tabs as $type => $title) {
+        $query = $this->getFilteredQuery($request, $type);
+        $counts[$type] = (clone $query)->count();
+        $notificationsData[$type] = $query->paginate($perPage, ['*'], $type . '_page')->withQueryString();
     }
 
-    private function getFilteredQuery(Request $request, string $type)
-    {
-        $query = Notification::with('employee.employer');
+    // Handle cancelled items separately
+    $cancelledQuery = $this->getFilteredQuery($request, 'cancelled');
+    $counts['cancelled'] = (clone $cancelledQuery)->count();
+    $notificationsData['cancelled'] = $cancelledQuery->paginate($perPage, ['*'], 'cancelled_page')->withQueryString();
 
-        if ($type === 'cancelled') {
-            $query->where('status', 'cancelled')->latest('updated_at');
-        } else {
-            $query->where('status', '!=', 'cancelled')->where('type', $type)->latest('due_date');
-        }
+    return view('notifications.index', compact('notificationsData', 'counts', 'currentView', 'perPageOptions'));
+}
 
-        // Apply shared filters
-        if ($request->filled('search')) {
-            $search = $request->input('search');
-            $query->whereHas('employee', function ($q) use ($search) {
-                $q->where('employeeNameTh', 'like', "%{$search}%")
-                  ->orWhere('employeeNameEn', 'like', "%{$search}%");
-            });
-        }
-        if ($request->filled('nationality')) {
-            $query->whereHas('employee', function ($q) use ($request) {
-                $q->where('employeeNationality', $request->input('nationality'));
-            });
-        }
-        if ($request->filled('mou_type')) {
-            $query->whereHas('employee', function ($q) use ($request) {
-                $q->where('workPermitMOUGroup', $request->input('mou_type'));
-            });
-        }
+private function getFilteredQuery(Request $request, string $type)
+{
+    $query = \App\Models\Notification::with('employee.employer');
 
-        return $query;
+    if ($type === 'cancelled') {
+        $query->where('status', 'cancelled')->latest('updated_at');
+    } else {
+        $query->where('status', '!=', 'cancelled')->where('type', $type)->latest('due_date');
     }
+
+    if ($request->filled('search')) {
+        $search = $request->input('search');
+        $query->whereHas('employee', function ($q) use ($search) {
+            $q->where('employeeNameTh', 'like', "%{$search}%")
+              ->orWhere('employeeNameEn', 'like', "%{$search}%");
+        });
+    }
+    if ($request->filled('nationality')) {
+        $query->whereHas('employee', function ($q) use ($request) {
+            $q->where('employeeNationality', $request->input('nationality'));
+        });
+    }
+    if ($request->filled('mou_type')) {
+        $query->whereHas('employee', function ($q) use ($request) {
+            $q->where('workPermitMOUGroup', $request->input('mou_type'));
+        });
+    }
+    return $query;
+}
 
     /**
      * Restore a cancelled notification.

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -11,39 +11,21 @@
     } elseif ($daysRemaining <= $notification->danger_threshold) {
         $rowClass = 'table-danger';
     }
-
-    $flagCodes = [
-        'เมียนมา' => 'mm', 'ลาว' => 'la', 'กัมพูชา' => 'kh', 'เวียดนาม' => 'vn',
-    ];
-    $nationality = $employee->employeeNationality ?? null;
-    $flagCode = $nationality ? ($flagCodes[$nationality] ?? null) : null;
 @endphp
-
 <tr class="{{ $rowClass }}">
-    <td>{{ $loop->iteration }}</td>
+    <td>{{ $loop->iteration + $notifications->firstItem() - 1 }}</td>
     <td>
-        <div>{{ $employee->employeeNameEn ?? 'N/A' }}</div>
-        <div class="small text-muted">{{ $employee->employeeNameTh ?? '' }}</div>
-    </td>
-    <td>
-        @if($nationality)
-            {{ $nationality }}
-            @if($flagCode)
-                <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" class="ms-1" style="width: 20px; vertical-align: middle;">
-            @endif
-        @else
-            N/A
-        @endif
+        <div>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}</div>
+        <div class="small text-muted">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? '' }}</div>
     </td>
     <td>{{ $employer->employerNameTh ?? 'N/A' }}</td>
-    <td>{{ $notification->title }}</td>
     <td>{{ $dueDate->translatedFormat('d M Y') }}</td>
     <td>
         <span class="badge {{ $daysRemaining < 0 ? 'bg-dark' : 'bg-secondary' }}">
             {{ $daysRemaining < 0 ? 'เลยกำหนด ' . abs($daysRemaining) . ' วัน' : 'เหลือ ' . $daysRemaining . ' วัน' }}
         </span>
     </td>
-    <td>
+    <td class="text-center">
         <div class="btn-group btn-group-sm">
             @if($notification->status == 'cancelled')
                 <form action="{{ route('notifications.restore', $notification) }}" method="POST" class="d-inline">

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -25,6 +25,20 @@
                 </select>
                 <button type="submit" class="btn btn-primary btn-sm">กรอง</button>
                 <a href="{{ route('notifications.index') }}" class="btn btn-secondary btn-sm">ล้างค่า</a>
+
+                {{-- VIEW CONTROLS --}}
+                <div class="btn-group btn-group-sm ms-md-auto">
+                    <input type="radio" class="btn-check" name="view" id="view-card" value="card" onchange="this.form.submit()" @checked(request('view', 'card') === 'card')>
+                    <label class="btn btn-outline-primary" for="view-card"><i class="bi bi-grid-3x3-gap-fill"></i></label>
+
+                    <input type="radio" class="btn-check" name="view" id="view-table" value="table" onchange="this.form.submit()" @checked(request('view') === 'table')>
+                    <label class="btn btn-outline-primary" for="view-table"><i class="bi bi-table"></i></label>
+                </div>
+                <select name="per_page" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                    @foreach($perPageOptions as $option)
+                    <option value="{{ $option }}" @selected(request('per_page', $perPageOptions[0]) == $option)>แสดง {{ $option }}</option>
+                    @endforeach
+                </select>
             </form>
         </div>
     </div>
@@ -68,15 +82,41 @@
     </ul>
 
     <div class="tab-content pt-4" id="notificationTabContent">
-        @foreach($notificationsData as $type => $paginatedNotifications)
+        @foreach($notificationsData as $type => $notifications)
             <div class="tab-pane fade {{ $loop->first ? 'show active' : '' }}" id="{{ $type }}-pane" role="tabpanel">
-                @forelse($paginatedNotifications as $notification)
-                    @include('notifications._notification_item', ['notification' => $notification, 'loop' => $loop])
-                @empty
-                    <p class="text-center text-muted">ไม่พบการแจ้งเตือนในหมวดนี้</p>
-                @endforelse
+
+                @if($currentView == 'table')
+                    <div class="table-responsive">
+                        <table class="table table-hover table-sm">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>ชื่อลูกจ้าง</th>
+                                    <th>นายจ้าง</th>
+                                    <th>วันที่ครบกำหนด</th>
+                                    <th>สถานะ</th>
+                                    <th class="text-center">จัดการ</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($notifications as $notification)
+                                    @include('notifications._notification_table_row', ['notification' => $notification, 'loop' => $loop, 'notifications' => $notifications])
+                                @empty
+                                    <tr><td colspan="6" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                @else {{-- Card View --}}
+                    @forelse($notifications as $notification)
+                        @include('notifications._notification_item', ['notification' => $notification, 'loop' => $loop])
+                    @empty
+                        <p class="text-center text-muted">ไม่พบข้อมูล</p>
+                    @endforelse
+                @endif
+
                 <div class="mt-4">
-                    {{ $paginatedNotifications->links() }}
+                    {{ $notifications->links() }}
                 </div>
             </div>
         @endforeach


### PR DESCRIPTION
Re-implements the view switcher (Card/Table) and items-per-page selector on the notifications page.

- Updates NotificationController to handle `view` and `per_page` state.
- Adds a new table layout for displaying notifications.
- The main notifications view is updated to include the new controls and conditionally renders either the card or table layout.
- Preserves existing filter and tab functionality.
- Restores action buttons and row styling to the new table view to avoid regressions.