### PR TITLE
feat: Add days_remaining column to notifications table

### DIFF
--- a/database/migrations/2025_09_14_091500_add_days_remaining_to_notifications_table.php
+++ b/database/migrations/2025_09_14_091500_add_days_remaining_to_notifications_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->integer('days_remaining')->default(0)->after('due_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->dropColumn('days_remaining');
+        });
+    }
+};


### PR DESCRIPTION
This adds the `days_remaining` integer column to the `notifications` table.

This column is necessary to store the pre-calculated number of days remaining for a notification's due date, fixing a bug where this value was not displayed correctly on the frontend.