### PR TITLE
Hotfix: Add missing 'message' field to Notification creation

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -17,25 +17,19 @@ class CheckExpiries extends Command
         $this->info('Starting expiry check process...');
         $today = now()->startOfDay();
 
-        // EXPLANATION: Step 1 - Clean up very old notifications first.
-        // This removes notifications for documents that expired more than a year ago.
         $this->info('Cleaning up old notifications...');
         Notification::where('due_date', '<', $today->copy()->subYear())->delete();
 
-        // Define document types and their corresponding notification types
         $documentChecks = [
             'passportExpiryDate'   => 'passport_expiry',
             'workPermitExpiryDate' => 'work_permit_expiry',
             'visaExpiryDate'       => 'visa_expiry',
             'ninetyDayReportDate'  => 'ninety_day_report',
-            // We can add more special checks later here
         ];
 
         foreach ($documentChecks as $dateField => $notificationType) {
             $this->info("Checking: {$notificationType}...");
 
-            // EXPLANATION: Step 2 - Expand the search range.
-            // We now look for documents that expired up to 30 days ago AND will expire in the next 90 days.
             $pastThreshold = $today->copy()->subDays(30);
             $futureThreshold = $today->copy()->addDays(90);
 
@@ -45,26 +39,19 @@ class CheckExpiries extends Command
 
             foreach ($employees as $employee) {
                 if ($employee->is_cancelled) {
-                    continue; // Skip cancelled employees
+                    continue;
                 }
 
                 $expiryDate = Carbon::parse($employee->{$dateField});
-
-                // EXPLANATION: Step 3 - The calculation logic is now more robust.
-                // diffInDays will be positive for future dates, negative for past dates.
                 $daysRemaining = $today->diffInDays($expiryDate, false);
-
-                // For special MOU renewal types, we create separate notifications
                 $currentNotificationType = $notificationType;
-                if ($notificationType === 'work_permit_expiry') {
-                     if ($employee->workPermitMOUGroup === 'มติต่ออายุในประเทศ' || $employee->workPermitMOUGroup === 'มติขึ้นทะเบียน') {
-                        $currentNotificationType = 'resolution_renewal';
-                    }
+
+                if ($notificationType === 'work_permit_expiry' && in_array($employee->workPermitMOUGroup, ['มติต่ออายุในประเทศ', 'มติขึ้นทะเบียน'])) {
+                    $currentNotificationType = 'resolution_renewal';
                 }
-                 if ($notificationType === 'passport_expiry' && $employee->passportType === 'CI') {
+                if ($notificationType === 'passport_expiry' && $employee->passportType === 'CI') {
                     $currentNotificationType = 'ci_renewal';
                 }
-
 
                 Notification::updateOrCreate(
                     [
@@ -74,8 +61,10 @@ class CheckExpiries extends Command
                     [
                         'due_date' => $expiryDate,
                         'days_remaining' => $daysRemaining,
-                        'status' => 'unread', // Reset status in case it was cancelled before
-                        'danger_threshold' => 15, // e.g., show as critical if less than 15 days
+                        'status' => 'unread',
+                        'danger_threshold' => 15,
+                        // FIX: Added the 'message' field to match the database schema requirement.
+                        'message' => 'Automated expiry check.',
                     ]
                 );
             }


### PR DESCRIPTION
This commit fixes a 'General error: 1364 Field 'message' doesn't have a default value' that occurred when running the `app:check-expiries` command.

The error was caused by the `Notification::updateOrCreate` call in `app/Console/Commands/CheckExpiries.php` not providing a value for the `message` field, which is a required field in the `notifications` table.

This fix adds the required 'message' field with a default value of 'Automated expiry check.' to resolve the issue.