### PR TITLE
Fix "Route Not Found" error for viewing notifications

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -43,7 +43,7 @@ Route::middleware('auth')->group(function () {
     Route::delete('/addresses/{address}', [App\Http\Controllers\AddressController::class, 'destroy'])->name('addresses.destroy');
 
     Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
-    Route::get('/notifications/{notificationId}/view', [NotificationController::class, 'viewEmployee'])->name('notifications.viewEmployee');
+    Route::get('/notifications/{notification}/view-employee', [NotificationController::class, 'viewEmployee'])->name('notifications.view-employee');
     Route::post('/notifications/{notification}/cancel', [NotificationController::class, 'cancel'])->name('notifications.cancel');
     Route::post('/notifications/{notification}/renew', [NotificationController::class, 'renew'])->name('notifications.renew');
     Route::post('/notifications/{notification}/restore', [NotificationController::class, 'restore'])->name('notifications.restore');


### PR DESCRIPTION
The route for viewing an employee from a notification was incorrectly defined, causing a "Route [notifications.view-employee] not defined" error.

This commit aligns the route definition in `routes/web.php` with the application's expectations by:
1.  Renaming the route from `notifications.viewEmployee` to `notifications.view-employee`.
2.  Updating the URI from `/notifications/{notificationId}/view` to `/notifications/{notification}/view-employee`.
3.  Changing the route parameter to `{notification}` to follow Laravel's convention for route model binding.

These changes resolve the error and ensure the "View Data" button functions correctly.