### PR TITLE
Hotfix: Remove references to non-existent danger_threshold column

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -69,7 +69,6 @@ class CheckExpiries extends Command
                         'due_date' => $expiryDate,
                         'days_remaining' => $daysRemaining, // This value will now be correct
                         'status' => 'unread',
-                        'danger_threshold' => 15,
                         'message' => 'Automated expiry check.',
                     ]
                 );

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -21,7 +21,6 @@ class Notification extends Model
         'due_date',
         'status',
         'days_remaining', // FIX: Added this field to allow mass assignment
-        'danger_threshold',
     ];
 
     /**


### PR DESCRIPTION
This commit resolves the 'Unknown column 'danger_threshold'' error by removing the field from the Notification model's fillable attributes and the creation logic in the CheckExpiries command.