### PR TITLE
Fix(bug): Correct DB query column names and image sizing

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use App\Models\Employee;
 use App\Models\Notification;
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 class CheckExpiries extends Command
 {
@@ -33,9 +34,11 @@ class CheckExpiries extends Command
             $pastThreshold = $today->copy()->subDays(30);
             $futureThreshold = $today->copy()->addDays(90);
 
-            // Get employees who have an expiry date within our target window
-            $employees = Employee::whereNotNull($dateField)
-                ->whereBetween($dateField, [$pastThreshold, $futureThreshold])
+            // FIX: Convert the camelCase property name to a snake_case column name for the DB query.
+            $columnName = Str::snake($dateField);
+
+            $employees = Employee::whereNotNull($columnName)
+                ->whereBetween($columnName, [$pastThreshold, $futureThreshold])
                 ->get();
 
             foreach ($employees as $employee) {

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -21,9 +21,9 @@
 
 <div class="alert alert-secondary notification-item">
     <div class="d-flex align-items-center gap-3">
-        {{-- FIX: The employee photo now uses the correct CSS class from app.css --}}
-        <img src="{{ $notification->employee->employeePhoto ? asset('storage/' . $notification->employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
-             class="employee-photo-thumb" alt="Photo" style="margin-right: 0;">
+<img src="{{ $notification->employee->employeePhoto ? asset('storage/' . $notification->employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
+     alt="Photo"
+     class="w-12 h-12 object-cover rounded-full bg-gray-200 flex-shrink-0">
 
         <div class="d-flex justify-content-between align-items-start w-100">
             <div class="flex-grow-1">


### PR DESCRIPTION
This commit addresses two critical bugs:

1.  **Database Query:** In the `CheckExpiries` command, database queries were failing because they used camelCase property names (`passportExpiryDate`) instead of the required snake_case column names (`passport_expiry_date`). This has been fixed by converting the property name to snake_case using `Str::snake()` before the query is executed.

2.  **Image Sizing:** The employee photo in the notification view was not displaying at the correct size. The CSS has been updated to use Tailwind CSS utility classes (`w-12 h-12 object-cover rounded-full`) to enforce a fixed size, ensuring a consistent and proper layout.