### PR TITLE
Fix: Use camelCase for column names in CheckExpiries command

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use App\Models\Employee;
 use App\Models\Notification;
 use Carbon\Carbon;
-use Illuminate\Support\Str;
 
 class CheckExpiries extends Command
 {
@@ -34,11 +33,8 @@ class CheckExpiries extends Command
             $pastThreshold = $today->copy()->subDays(30);
             $futureThreshold = $today->copy()->addDays(90);
 
-            // FIX: Convert the camelCase property name to a snake_case column name for the DB query.
-            $columnName = Str::snake($dateField);
-
-            $employees = Employee::whereNotNull($columnName)
-                ->whereBetween($columnName, [$pastThreshold, $futureThreshold])
+            $employees = Employee::whereNotNull($dateField)
+                ->whereBetween($dateField, [$pastThreshold, $futureThreshold])
                 ->get();
 
             foreach ($employees as $employee) {


### PR DESCRIPTION
The CheckExpiries command was previously updated to use snake_case for column names, but the database schema actually uses camelCase.

This commit reverts the logic to use the camelCase dateField variable directly in the query, fixing the "Unknown Column" error. It also removes the unused `Illuminate\Support\Str` import.