### PR TITLE
Refactor: Final Polish on Forms and Notification Logic

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -30,30 +30,27 @@ class CheckExpiries extends Command
         foreach ($documentChecks as $dateField => $notificationType) {
             $this->info("Checking: {$notificationType}...");
 
-            $pastThreshold = $today->copy()->subDays(365); // Check for items expired up to a year ago
-            $futureThreshold = $today->copy()->addDays(45); // Check for items expiring in the next 45 days
+            $pastThreshold = $today->copy()->subDays(365);
+            $futureThreshold = $today->copy()->addDays(45);
 
-            // --- FIX: This query now uses the correct camelCase column name ---
             $employees = Employee::whereNotNull($dateField)
                 ->whereBetween($dateField, [$pastThreshold, $futureThreshold])
                 ->get();
 
+            $this->info("Found {$employees->count()} employees for notification type [{$notificationType}].");
+
             foreach ($employees as $employee) {
-                if ($employee->is_cancelled ?? false) { // Use null coalescing for safety
+                if ($employee->is_cancelled ?? false) {
                     continue;
                 }
 
-                // Ensure we have a Carbon instance for calculation
                 $expiryDate = Carbon::parse($employee->{$dateField});
                 $daysRemaining = $today->diffInDays($expiryDate, false);
-                $currentNotificationType = $notificationType;
 
-                if ($notificationType === 'work_permit_expiry' && in_array($employee->workPermitMOUGroup, ['มติต่ออายุในประเทศ', 'มติขึ้นทะเบียน'])) {
-                    $currentNotificationType = 'resolution_renewal';
-                }
-                if ($notificationType === 'passport_expiry' && $employee->passportType === 'CI') {
-                    $currentNotificationType = 'ci_renewal';
-                }
+                // --- SIMPLIFIED LOGIC: No longer re-routing notifications ---
+                // All passport expiries will create a 'passport_expiry' notification.
+                // All work permit expiries will create a 'work_permit_expiry' notification.
+                $currentNotificationType = $notificationType;
 
                 Notification::updateOrCreate(
                     [

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -85,7 +85,7 @@ class EmployeeController extends Controller
 
     public function update(Request $request, Employee $employee)
     {
-        $validated = $request->validate([
+        $request->validate([
             'employeeNameTh' => 'required|string|max:255',
             'employeeNameEn' => 'nullable|string|max:255',
             'employeePassport' => ['required', 'string', 'max:255', Rule::unique('employees')->ignore($employee->id)],
@@ -120,15 +120,27 @@ class EmployeeController extends Controller
             'document_4' => 'nullable|file|max:5120',
             'document_5' => 'nullable|file|max:5120',
             'document_6' => 'nullable|file|max:5120',
+            'document_7' => 'nullable|file|max:5120',
+            'document_8' => 'nullable|file|max:5120',
+            'document_description_3' => 'nullable|string|max:255',
+            'document_description_4' => 'nullable|string|max:255',
+            'document_description_5' => 'nullable|string|max:255',
         ]);
 
-        // --- DEFINITIVE FIX FOR SAVING DATA ---
-        // 1. Fill the model with all data from the request, excluding files.
-        $employee->fill($request->except(['employeePhoto', 'document_1', 'document_2', 'document_3', 'document_4', 'document_5', 'document_6']));
+        $employee->fill($request->except(['_token', '_method']));
 
-        // 2. Handle all file uploads.
-        $fileFields = ['employeePhoto', 'document_1', 'document_2', 'document_3', 'document_4', 'document_5', 'document_6'];
+        $fileFields = ['employeePhoto', 'document_1', 'document_2', 'document_3', 'document_4', 'document_5', 'document_6', 'document_7', 'document_8'];
         foreach ($fileFields as $field) {
+            $remove_field = 'remove_' . $field;
+            // --- FIX: Logic to handle file DELETION ---
+            if ($request->has($remove_field)) {
+                if ($employee->{$field}) {
+                    Storage::disk('public')->delete($employee->{$field});
+                }
+                $employee->{$field} = null;
+            }
+
+            // --- Logic to handle file UPLOAD ---
             if ($request->hasFile($field)) {
                 if ($employee->{$field}) {
                     Storage::disk('public')->delete($employee->{$field});
@@ -138,7 +150,6 @@ class EmployeeController extends Controller
             }
         }
 
-        // 3. Save all changes to the database.
         $employee->save();
 
         $employer = $employee->employer;

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -122,38 +122,46 @@
             <div class="col-md-4"><label for="nature_of_work" class="form-label">ลักษณะงาน (Nature of Work)</label><input type="text" class="form-control" id="nature_of_work" name="nature_of_work" value="{{ old('nature_of_work', $employee->nature_of_work) }}"></div>
         </div>
 
-        <hr class="my-4">
-        <h5>เอกสารแนบ</h5>
-        <div class="row g-3">
-            @for ($i = 1; $i <= 6; $i++)
-                @php
-                    $doc_field = 'document_' . $i;
-                    $desc_field = 'document_description_' . $i;
-                    $default_label = "เอกสารแนบ " . $i;
-                    $labels = [
-                        1 => '1. passport/visa/workpermit',
-                        2 => '2. บัตรชมพู',
-                        3 => '3. สัญญาจ้างงาน',
-                        4 => '4. บัตรประชาชนเมียนมา/ทะเบียนบ้าน',
-                        5 => '5. Myanmar ID',
-                        6 => '6. Myanmar House Reg'
-                    ];
-                @endphp
-                <div class="col-md-4">
-                    <label for="{{ $doc_field }}" class="form-label">{{ $labels[$i] ?? $default_label }}</label>
-                    @if($employee->{$doc_field})
-                        <a href="{{ asset('storage/'.$employee->{$doc_field}) }}" target="_blank" class="small d-block mb-1">ดูไฟล์ปัจจุบัน</a>
-                    @endif
-                    <input type="file" class="form-control form-control-sm" id="{{ $doc_field }}" name="{{ $doc_field }}">
-                     @if($employee->{$doc_field})
-                        <div class="form-check mt-1">
-                            <input class="form-check-input" type="checkbox" name="remove_{{ $doc_field }}" id="remove_{{ $doc_field }}">
-                            <label class="form-check-label small" for="remove_{{ $doc_field }}">ลบไฟล์นี้</label>
-                        </div>
-                    @endif
-                </div>
-            @endfor
-        </div>
+    <hr class="my-4">
+    <h5>เอกสารแนบ</h5>
+    <div class="row g-3">
+        @for ($i = 1; $i <= 8; $i++)
+            @php
+                $doc_field = 'document_' . $i;
+                $desc_field = 'document_description_' . $i;
+                $default_label = "เอกสารแนบ " . $i;
+                $labels = [
+                    1 => '1. passport/visa/workpermit',
+                    2 => '2. บัตรชมพู',
+                    3 => '3. สัญญาจ้างงาน',
+                    4 => '4. บัตรประชาชนเมียนมา/ทะเบียนบ้าน',
+                    5 => '5. Myanmar ID',
+                    6 => '6. Myanmar House Reg',
+                    7 => '7. เอกสารแนบ 7',
+                    8 => '8. เอกสารแนบ 8'
+                ];
+                $has_description = in_array($i, [3, 4, 5]);
+            @endphp
+            <div class="col-md-4">
+                <label for="{{ $doc_field }}" class="form-label fw-bold">{{ $labels[$i] ?? $default_label }}</label>
+                @if($employee->{$doc_field})
+                    <a href="{{ asset('storage/'.$employee->{$doc_field}) }}" target="_blank" class="small d-block mb-1 text-success"><i class="bi bi-file-earmark-text"></i> ดูไฟล์ปัจจุบัน</a>
+                @endif
+                <input type="file" class="form-control form-control-sm" id="{{ $doc_field }}" name="{{ $doc_field }}">
+
+                @if($has_description)
+                <input type="text" class="form-control form-control-sm mt-2" name="{{ $desc_field }}" value="{{ old($desc_field, $employee->{$desc_field}) }}" placeholder="ระบุประเภทเอกสาร...">
+                @endif
+
+                 @if($employee->{$doc_field})
+                    <div class="form-check mt-1">
+                        <input class="form-check-input" type="checkbox" name="remove_{{ $doc_field }}" id="remove_{{ $doc_field }}">
+                        <label class="form-check-label small text-danger" for="remove_{{ $doc_field }}">ลบไฟล์นี้</label>
+                    </div>
+                @endif
+            </div>
+        @endfor
+    </div>
 
         <div class="mt-5 text-end">
             <button type="submit" class="btn btn-primary px-4">บันทึกข้อมูล</button>


### PR DESCRIPTION
This commit applies the final set of changes to complete the form and notification features.

1.  **Simplify Notification Logic (`CheckExpiries.php`)**: The command for checking expiries has been simplified. It no longer contains conditional logic to reroute notifications. Each document type now maps directly to its own notification type (e.g., passport expiry creates a `passport_expiry` notification).

2.  **Enhance Employee Edit Form (`edit.blade.php`)**: The employee edit form has been updated to support up to 8 document uploads. New description fields have been added for specific documents, and a "delete file" checkbox is now available for each existing document, improving user experience.

3.  **Implement File Deletion Logic (`EmployeeController.php`)**: The `update` method in the `EmployeeController` now includes logic to handle file deletions. When a "delete file" checkbox is checked, the corresponding file is removed from storage, and the database record is updated to null. Validation has also been extended to cover the new fields.