### PR TITLE
Fix: Resolve BadMethodCallException in notifications view

### DIFF
--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -31,7 +31,7 @@
         <div class="d-flex justify-content-between align-items-start w-100">
             <div class="flex-grow-1">
                 <h5 class="alert-heading mb-1">
-                    {{ $loop->iteration + ($notifications->perPage() * ($notifications->currentPage() - 1)) }}. {{ $notification->employee->employeeNameEn ?? 'N/A' }}
+                    {{ $itemNumber }}. {{ $notification->employee->employeeNameEn ?? 'N/A' }}
                     @if($flagCode)
                         <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" title="{{ $nationality }}">
                     @endif

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -12,7 +12,7 @@
 @endphp
 
 <tr>
-    <td>{{ $loop->iteration + ($notifications->perPage() * ($notifications->currentPage() - 1)) }}</td>
+    <td>{{ $itemNumber }}</td>
     <td>
         <div>{{ $notification->employee->employeeNameEn ?? 'N/A' }}</div>
         <div class="small text-muted">{{ $notification->employee->employeeNameTh ?? 'N/A' }}</div>

--- a/resources/views/notifications/_work_permit_mou_pane.blade.php
+++ b/resources/views/notifications/_work_permit_mou_pane.blade.php
@@ -14,7 +14,7 @@
         <h4 class="mb-3 border-bottom pb-2">ขอต่อ ({{ $forRenewal->count() }} รายการ)</h4>
         <div class="vstack gap-3">
             @forelse($forRenewal as $notification)
-                @include('notifications._notification_item', ['notification' => $notification, 'loop' => $loop])
+                @include('notifications._notification_item', ['notification' => $notification, 'itemNumber' => $loop->iteration])
             @empty
                 <p class="text-muted">ไม่มีรายการที่ต้องดำเนินการ</p>
             @endforelse
@@ -26,7 +26,7 @@
         <h4 class="mb-3 border-bottom pb-2">ขอรับใหม่ ({{ $forNewApplication->count() }} รายการ)</h4>
         <div class="vstack gap-3">
             @forelse($forNewApplication as $notification)
-                 @include('notifications._notification_item', ['notification' => $notification, 'loop' => $loop])
+                 @include('notifications._notification_item', ['notification' => $notification, 'itemNumber' => $loop->iteration])
             @empty
                  <p class="text-muted">ไม่มีรายการที่หมดอายุ</p>
             @endforelse

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -82,7 +82,10 @@
                                 </thead>
                                 <tbody>
                                     @forelse($notifications as $notification)
-                                        @include('notifications._notification_table_row', ['notification' => $notification, 'loop' => $loop, 'notifications' => $notifications])
+                                        @php
+                                            $itemNumber = $loop->iteration + ($notifications->perPage() * ($notifications->currentPage() - 1));
+                                        @endphp
+                                        @include('notifications._notification_table_row', ['notification' => $notification, 'itemNumber' => $itemNumber])
                                     @empty
                                         <tr><td colspan="6" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
                                     @endforelse
@@ -91,13 +94,19 @@
                         </div>
                     @else {{-- Card View --}}
                         @forelse($notifications as $notification)
-                            @include('notifications._notification_item', ['notification' => $notification, 'loop' => $loop])
+                            @php
+                                $itemNumber = $loop->iteration + ($notifications->perPage() * ($notifications->currentPage() - 1));
+                            @endphp
+                            @include('notifications._notification_item', ['notification' => $notification, 'itemNumber' => $itemNumber])
                         @empty
                             <p class="text-center text-muted">ไม่พบข้อมูล</p>
                         @endforelse
                     @endif
+
                     <div class="mt-4">
-                        {{ $notifications->links() }}
+                        @if($notifications->hasPages())
+                            {{ $notifications->links() }}
+                        @endif
                     </div>
                 @endif
             </div>


### PR DESCRIPTION
Refactored the notification views to fix a `BadMethodCallException`.

The error occurred because a partial view (`_notification_item`) was attempting to call paginator methods (`perPage`, `currentPage`) on a standard Laravel Collection, which was passed from the `_work_permit_mou_pane` view after filtering.

The solution involves:
- Calculating the item number in the parent views (`index.blade.php` and `_work_permit_mou_pane.blade.php`) based on whether the data is paginated or a simple collection.
- Passing the pre-calculated `$itemNumber` to the partial views (`_notification_item.blade.php` and `_notification_table_row.blade.php`).
- Updating the partials to simply display the `$itemNumber` variable, removing the calculation logic from them.

This change makes the partial views more reusable and robust, and it resolves the exception.