### PR TITLE
Refactor: Finalize Notification Module and Add Action Hub

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -52,11 +52,12 @@ class CheckExpiries extends Command
                 // --- NEW LOGIC: Determine notification type based on workPermitMOUGroup ---
                 if ($notificationType === 'work_permit_expiry') {
                     if ($employee->workPermitMOUGroup === 'MOU') {
-                        $currentNotificationType = 'work_permit_mou'; // New specific type for MOU
-                    } elseif (in_array($employee->workPermitMOUGroup, ['มติต่ออายุในประเทศ', 'มติขึ้นทะเบียน'])) {
+                        $currentNotificationType = 'work_permit_mou';
+                    } elseif ($employee->workPermitMOUGroup === 'มติต่ออายุในประเทศ') {
                         $currentNotificationType = 'resolution_renewal';
+                    } elseif ($employee->workPermitMOUGroup === 'มติขึ้นทะเบียน') {
+                        $currentNotificationType = 'new_registration_renewal'; // New, specific type
                     }
-                    // If it's another type, it will just remain 'work_permit_expiry' and won't show in new tabs
                 }
 
                 if ($notificationType === 'passport_expiry' && $employee->passportType === 'CI') {

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -18,14 +18,14 @@ class NotificationController extends Controller
         $perPageOptions = ($currentView === 'card') ? [10, 15, 20] : [25, 50, 100];
         $perPage = $request->input('per_page', $perPageOptions[0]);
 
-        // --- UPDATED TABS ---
         $tabs = [
             'ninety_day_report' => 'รายงานตัว 90 วัน',
             'passport_expiry' => 'Passport',
-            'work_permit_mou' => 'ใบอนุญาตทำงาน (MOU)', // Changed name and key
+            'work_permit_mou' => 'ใบอนุญาตทำงาน (MOU)',
             'visa_expiry' => 'วีซ่า',
             'ci_renewal' => 'ต่ออายุ CI',
-            'resolution_renewal' => 'ต่ออายุมติ', // This now has its own dedicated logic
+            'resolution_renewal' => 'ต่ออายุมติ',
+            'new_registration_renewal' => 'มติขึ้นทะเบียนใหม่', // New Tab
         ];
 
         $notificationsData = [];

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -59,6 +59,7 @@
             <button type="submit" class="btn btn-danger" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
         </form>
     @else
+        <a href="#" class="btn btn-success" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
         <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
         <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ดูข้อมูล"><i class="bi bi-search"></i></a>
         <a href="#" class="btn btn-warning" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -39,9 +39,10 @@
             <button type="submit" class="btn btn-danger btn-sm" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
         </form>
     @else
-        <a href="#" class="btn btn-success btn-sm" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
-        <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary btn-sm" title="ดูข้อมูล"><i class="bi bi-search"></i></a>
-        <a href="#" class="btn btn-warning btn-sm" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
+        <a href="#" class="btn btn-success" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
+        <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
+        <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ดูข้อมูล"><i class="bi bi-search"></i></a>
+        <a href="#" class="btn btn-warning" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
     @endif
 </div>
     </td>

--- a/resources/views/notifications/_work_permit_mou_table.blade.php
+++ b/resources/views/notifications/_work_permit_mou_table.blade.php
@@ -1,0 +1,34 @@
+@php
+    $forRenewal = $notifications->filter(fn($n) => $n->days_remaining >= 0 && $n->days_remaining <= 50);
+    $forNewApplication = $notifications->filter(fn($n) => $n->days_remaining < 0);
+@endphp
+
+<div class="table-responsive">
+    <table class="table table-hover table-sm">
+        {{-- Section 1: For Renewal --}}
+        <thead class="table-light">
+            <tr><th colspan="6">ขอต่อ ({{ $forRenewal->count() }} รายการ)</th></tr>
+            <tr><th>#</th><th>ชื่อลูกจ้าง</th><th>นายจ้าง</th><th>วันที่ครบกำหนด</th><th>สถานะ</th><th class="text-center">จัดการ</th></tr>
+        </thead>
+        <tbody>
+            @forelse($forRenewal as $notification)
+                @include('notifications._notification_table_row', ['notification' => $notification, 'itemNumber' => $loop->iteration])
+            @empty
+                <tr><td colspan="6" class="text-center text-muted">ไม่มีรายการที่ต้องดำเนินการ</td></tr>
+            @endforelse
+        </tbody>
+
+        {{-- Section 2: For New Application --}}
+        <thead class="table-light mt-4">
+            <tr><th colspan="6">ขอรับใหม่ ({{ $forNewApplication->count() }} รายการ)</th></tr>
+             <tr><th>#</th><th>ชื่อลูกจ้าง</th><th>นายจ้าง</th><th>วันที่ครบกำหนด</th><th>สถานะ</th><th class="text-center">จัดการ</th></tr>
+        </thead>
+        <tbody>
+            @forelse($forNewApplication as $notification)
+                @include('notifications._notification_table_row', ['notification' => $notification, 'itemNumber' => $loop->iteration])
+            @empty
+                <tr><td colspan="6" class="text-center text-muted">ไม่มีรายการที่หมดอายุ</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -62,9 +62,12 @@
         @foreach($notificationsData as $type => $notifications)
             <div class="tab-pane fade {{ $loop->first ? 'show active' : '' }}" id="{{ $type }}-pane" role="tabpanel">
 
-                {{-- NEW LOGIC: Check if this is the special tab --}}
                 @if($type === 'work_permit_mou')
-                    @include('notifications._work_permit_mou_pane', ['notifications' => $notifications])
+                    @if($currentView == 'table')
+                        @include('notifications._work_permit_mou_table', ['notifications' => $notifications])
+                    @else
+                        @include('notifications._work_permit_mou_pane', ['notifications' => $notifications])
+                    @endif
                 @else
                     {{-- Standard rendering for all other tabs --}}
                     @if($currentView == 'table')


### PR DESCRIPTION
This commit introduces the final requested changes to the notification module.

- **New 'New Registration Resolution' Tab:**
  - A new notification type `new_registration_renewal` is created in the `CheckExpiries` command for employees with `workPermitMOUGroup` set to 'มติขึ้นทะเบียน'.
  - The `NotificationController` is updated to include a new tab for this notification type.

- **Table View for MOU Work Permits:**
  - The main notification view `index.blade.php` now conditionally renders a table or card view for the 'ใบอนุญาตทำงาน (MOU)' tab.
  - A new partial, `_work_permit_mou_table.blade.php`, is created to display these notifications in a two-part table: 'For Renewal' and 'For New Application'.

- **Action Hub 'Create Job' Button:**
  - A new 'Create Job' button has been added to the action buttons in both the card view (`_notification_item.blade.php`) and the table row view (`_notification_table_row.blade.php`).