### PR TITLE
feat: Add employee filters and fix bulk actions UI

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -39,6 +39,14 @@ class EmployeeController extends Controller
             });
         }
 
+        if ($request->filled('nationality')) {
+            $query->where('employeeNationality', $request->input('nationality'));
+        }
+
+        if ($request->filled('mou_type')) {
+            $query->where('workPermitMOUGroup', $request->input('mou_type'));
+        }
+
         $employees = $query->paginate($currentPerPage)->withQueryString();
 
         return view('employees.index', compact(

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -20,6 +20,30 @@
             <form action="{{ route('employees.index') }}" method="GET" id="filter-form" class="d-flex flex-wrap gap-2 align-items-center">
                 <input type="text" name="search" class="form-control form-control-sm w-auto" placeholder="ค้นหา..." value="{{ request('search') }}">
 
+                {{-- NEW: Nationality Filter --}}
+                <select name="nationality" class="form-select form-select-sm w-auto">
+                    <option value="">-- ทุกสัญชาติ --</option>
+                    <option value="เมียนมา" @selected(request('nationality') == 'เมียนมา')>เมียนมา</option>
+                    <option value="ลาว" @selected(request('nationality') == 'ลาว')>ลาว</option>
+                    <option value="กัมพูชา" @selected(request('nationality') == 'กัมพูชา')>กัมพูชา</option>
+                    <option value="เวียดนาม" @selected(request('nationality') == 'เวียดนาม')>เวียดนาม</option>
+                </select>
+
+                {{-- NEW: MOU Type Filter --}}
+                <select name="mou_type" class="form-select form-select-sm w-auto">
+                    <option value="">-- ทุกประเภท มติ. --</option>
+                    <option value="MOU" @selected(request('mou_type') == 'MOU')>MOU</option>
+                    <option value="มติต่ออายุในประเทศ" @selected(request('mou_type') == 'มติต่ออายุในประเทศ')>มติต่ออายุในประเทศ</option>
+                    <option value="มติขึ้นทะเบียน" @selected(request('mou_type') == 'มติขึ้นทะเบียน')>มติขึ้นทะเบียน</option>
+                    <option value="อื่นๆ" @selected(request('mou_type') == 'อื่นๆ')>อื่นๆ</option>
+                </select>
+
+                <button type="submit" class="btn btn-primary btn-sm">กรอง</button>
+
+                {{-- NEW: Clear Filter Button --}}
+                <a href="{{ route('employees.index') }}" class="btn btn-outline-secondary btn-sm">ล้างการกรอง</a>
+
+                {{-- View switcher and per page options remain at the end --}}
                 <div class="btn-group btn-group-sm ms-md-auto">
                     <input type="radio" class="btn-check" name="view" id="view-card" value="card" onchange="this.form.submit()" @checked($currentView === 'card')>
                     <label class="btn btn-outline-primary" for="view-card"><i class="bi bi-grid-3x3-gap-fill"></i> การ์ด</label>
@@ -27,14 +51,11 @@
                     <input type="radio" class="btn-check" name="view" id="view-table" value="table" onchange="this.form.submit()" @checked($currentView === 'table')>
                     <label class="btn btn-outline-primary" for="view-table"><i class="bi bi-table"></i> ตาราง</label>
                 </div>
-
                 <select name="per_page" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
                     @foreach($perPageOptions as $option)
                     <option value="{{ $option }}" @selected($currentPerPage == $option)>แสดง {{ $option }}</option>
                     @endforeach
                 </select>
-
-                <button type="submit" class="btn btn-primary btn-sm">ค้นหา</button>
             </form>
         </div>
     </div>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -43,7 +43,7 @@
 </div>
 
 {{-- Bulk Action Bar --}}
-<div id="bulk-action-bar-employer" class="alert alert-info d-flex justify-content-between align-items-center my-3" style="display: none !important;">
+<div id="bulk-action-bar-employer" class="alert alert-info d-flex justify-content-between align-items-center my-3" style="display: none;">
     <div>
         <input class="form-check-input" type="checkbox" id="select-all-checkbox-employer">
         <label class="form-check-label ms-2" for="select-all-checkbox-employer">
@@ -102,11 +102,11 @@
             const count = selectedCheckboxes.length;
 
             if (count > 0) {
-                actionBar.style.display = 'flex !important';
+                actionBar.style.display = 'flex';
                 selectedCountSpan.textContent = count;
                 actionButton.disabled = false;
             } else {
-                actionBar.style.display = 'none !important';
+                actionBar.style.display = 'none';
                 selectedCountSpan.textContent = 0;
                 actionButton.disabled = true;
             }


### PR DESCRIPTION
- Implements nationality and MOU type filters on the employee index page.
- Adds a 'Clear Filter' button to reset the view.
- Fixes a bug on the employer edit page where the bulk action bar was not appearing due to an overly restrictive CSS `!important` rule.