### PR TITLE
feat: Add name prefix and enhance employee filters

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -39,6 +39,14 @@ class EmployeeController extends Controller
             });
         }
 
+        if ($request->filled('nationality')) {
+            $query->where('employeeNationality', $request->input('nationality'));
+        }
+
+        if ($request->filled('mou_type')) {
+            $query->where('workPermitMOUGroup', $request->input('mou_type'));
+        }
+
         $employees = $query->paginate($currentPerPage)->withQueryString();
 
         return view('employees.index', compact(

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -20,11 +20,29 @@
             <form action="{{ route('employees.index') }}" method="GET" id="filter-form" class="d-flex flex-wrap gap-2 align-items-center">
                 <input type="text" name="search" class="form-control form-control-sm w-auto" placeholder="ค้นหา..." value="{{ request('search') }}">
 
-                <div class="btn-group btn-group-sm ms-md-auto">
-                    <input type="radio" class="btn-check" name="view" id="view-card" value="card" onchange="this.form.submit()" @checked($currentView === 'card')>
-                    <label class="btn btn-outline-primary" for="view-card"><i class="bi bi-grid-3x3-gap-fill"></i> การ์ด</label>
+                <select name="nationality" class="form-select form-select-sm w-auto">
+                    <option value="">-- ทุกสัญชาติ --</option>
+                    <option value="เมียนมา" @selected(request('nationality') == 'เมียนมา')>เมียนมา</option>
+                    <option value="ลาว" @selected(request('nationality') == 'ลาว')>ลาว</option>
+                    <option value="กัมพูชา" @selected(request('nationality') == 'กัมพูชา')>กัมพูชา</option>
+                    <option value="เวียดนาม" @selected(request('nationality') == 'เวียดนาม')>เวียดนาม</option>
+                </select>
 
-                    <input type="radio" class="btn-check" name="view" id="view-table" value="table" onchange="this.form.submit()" @checked($currentView === 'table')>
+                <select name="mou_type" class="form-select form-select-sm w-auto">
+                    <option value="">-- ทุกประเภท มติ. --</option>
+                    <option value="MOU" @selected(request('mou_type') == 'MOU')>MOU</option>
+                    <option value="มติต่ออายุในประเทศ" @selected(request('mou_type') == 'มติต่ออายุในประเทศ')>มติต่ออายุในประเทศ</option>
+                    <option value="มติขึ้นทะเบียน" @selected(request('mou_type') == 'มติขึ้นทะเบียน')>มติขึ้นทะเบียน</option>
+                    <option value="อื่นๆ" @selected(request('mou_type') == 'อื่นๆ')>อื่นๆ</option>
+                </select>
+
+                <button type="submit" class="btn btn-primary btn-sm">กรอง</button>
+                <a href="{{ route('employees.index') }}" class="btn btn-outline-secondary btn-sm">ล้างการกรอง</a>
+
+                <div class="btn-group btn-group-sm ms-md-auto">
+                    <input type="radio" class="btn-check" name="view" id="view-card" value="card" onchange="this.form.submit()" @checked(request('view', 'card') === 'card')>
+                    <label class="btn btn-outline-primary" for="view-card"><i class="bi bi-grid-3x3-gap-fill"></i> การ์ด</label>
+                    <input type="radio" class="btn-check" name="view" id="view-table" value="table" onchange="this.form.submit()" @checked(request('view') === 'table')>
                     <label class="btn btn-outline-primary" for="view-table"><i class="bi bi-table"></i> ตาราง</label>
                 </div>
 
@@ -33,8 +51,6 @@
                     <option value="{{ $option }}" @selected($currentPerPage == $option)>แสดง {{ $option }}</option>
                     @endforeach
                 </select>
-
-                <button type="submit" class="btn btn-primary btn-sm">ค้นหา</button>
             </form>
         </div>
     </div>

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -3,20 +3,16 @@
 @endphp
 <div id="employee-card-{{ $employee->id }}" class="list-group-item list-group-item-action employee-card">
     <div class="d-flex align-items-center">
-        {{-- Checkbox for Bulk Actions --}}
         <div class="me-3">
             <input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $employee->id }}" id="employee_checkbox_{{ $employee->id }}">
         </div>
-
-        {{-- Employee Photo (with inline style for guaranteed fix) --}}
         <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
              alt="Photo" class="employee-photo-thumb" style="width: 48px; height: 48px; object-fit: cover; border-radius: 50%; margin-right: 1rem;">
-
-        {{-- Employee Details --}}
         <div class="flex-grow-1">
             <div class="d-flex w-100 justify-content-between">
                 <h5 class="mb-1">
-                    {{ $employee->employeeNameEn ?? 'N/A' }}
+                    {{-- FIX: Added Name Prefix --}}
+                    {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
                     @if($employee->employeeNationality)
                         @php $flagCode = \App\Helpers\CountryHelper::getFlagCode($employee->employeeNationality); @endphp
                         @if($flagCode)
@@ -26,13 +22,12 @@
                 </h5>
                 <small class="text-muted" title="นายจ้าง">{{ $employerName }}</small>
             </div>
-            <p class="mb-1">{{ $employee->employeeNameTh ?? 'N/A' }} ({{ $employee->employeePosition ?? 'N/A' }})</p>
+            {{-- FIX: Added Name Prefix --}}
+            <p class="mb-1">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }} ({{ $employee->employeePosition ?? 'N/A' }})</p>
             <small class="text-muted d-block">Passport: {{ $employee->employeePassport ?? '-' }} (หมดอายุ: {{ $employee->passportExpiryDate ? $employee->passportExpiryDate->format('d/m/Y') : '-' }})</small>
             <small class="text-muted d-block">Work Permit: {{ $employee->employeeWorkPermit ?? '-' }} (หมดอายุ: {{ $employee->workPermitExpiryDate ? $employee->workPermitExpiryDate->format('d/m/Y') : '-' }})</small>
             <small class="text-muted d-block">Visa ({{ $employee->workPermitMOUGroup ?? '-' }}) | 90-Day: {{ $employee->ninetyDayReportDate ? $employee->ninetyDayReportDate->format('d/m/Y') : '-' }}</small>
         </div>
-
-        {{-- Action Buttons --}}
         <div class="ms-auto ps-3">
              <div class="btn-group-vertical btn-group-sm">
                  <a href="{{ route('employees.edit', ['employer' => $employee->employer_id, 'employee' => $employee->id]) }}" class="btn btn-outline-primary" title="แก้ไข"><i class="bi bi-pencil-fill"></i></a>


### PR DESCRIPTION
This commit introduces two main improvements to the employee list page:

1.  **Name Prefix Display**: The employee card now displays the name prefix (e.g., Mr., Miss, นาย, นางสาว) for both Thai and English names, providing more complete information at a glance.

2.  **Enhanced Filtering**:
    - Adds dropdown filters for "Nationality" and "MOU Type" to the employee list page.
    - Adds a "Clear Filter" button to easily reset the view.
    - The controller logic has been updated to handle these new filter parameters.