### PR TITLE
feat: Update UI for employee and notification views

### DIFF
--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -32,11 +32,12 @@
         <div class="d-flex justify-content-between align-items-start w-100">
             <div class="flex-grow-1">
                 <h5 class="alert-heading mb-1">
-                    {{ $itemNumber }}. {{ $notification->employee->employeeNameEn ?? 'N/A' }}
+                    {{ $itemNumber }}. {{ $notification->employee->employeeTitleEn ?? '' }} {{ $notification->employee->employeeNameEn ?? 'N/A' }}
                     @if($flagCode)
                         <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" title="{{ $nationality }}">
                     @endif
                 </h5>
+                <p class="mb-1 small">{{ $notification->employee->employeeTitleTh ?? '' }} {{ $notification->employee->employeeNameTh ?? 'N/A' }}</p>
                 <p class="mb-1 small"><strong>นายจ้าง:</strong> {{ $notification->employee->employer->employerNameTh ?? 'N/A' }}</p>
                 <p class="mb-0 small"><strong>วันครบกำหนด:</strong> {{ \Carbon\Carbon::parse($notification->due_date)->translatedFormat('d F Y') }}</p>
             </div>

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -15,8 +15,8 @@
     <td><input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $notification->employee->id }}" id="notification_table_checkbox_{{ $notification->id }}"></td>
     <td>{{ $itemNumber }}</td>
     <td>
-        <div>{{ $notification->employee->employeeNameEn ?? 'N/A' }}</div>
-        <div class="small text-muted">{{ $notification->employee->employeeNameTh ?? 'N/A' }}</div>
+        <div>{{ $notification->employee->employeeTitleEn ?? '' }} {{ $notification->employee->employeeNameEn ?? 'N/A' }}</div>
+        <div class="small text-muted">{{ $notification->employee->employeeTitleTh ?? '' }} {{ $notification->employee->employeeNameTh ?? 'N/A' }}</div>
     </td>
     <td>{{ $notification->employee->employer->employerNameTh ?? 'N/A' }}</td>
     <td>{{ \Carbon\Carbon::parse($notification->due_date)->translatedFormat('d M Y') }}</td>

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -9,21 +9,19 @@
         <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
              alt="Photo" class="employee-photo-thumb" style="width: 48px; height: 48px; object-fit: cover; border-radius: 50%; margin-right: 1rem;">
         <div class="flex-grow-1">
-            <div class="d-flex w-100 justify-content-between">
-                <h5 class="mb-1">
-                    {{-- FIX: Added Name Prefix --}}
-                    {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
-                    @if($employee->employeeNationality)
-                        @php $flagCode = \App\Helpers\CountryHelper::getFlagCode($employee->employeeNationality); @endphp
-                        @if($flagCode)
-                            <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $employee->employeeNationality }}" title="{{ $employee->employeeNationality }}">
-                        @endif
+            <h5 class="mb-1">
+                {{-- FIX: Added Name Prefix --}}
+                {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
+                @if($employee->employeeNationality)
+                    @php $flagCode = \App\Helpers\CountryHelper::getFlagCode($employee->employeeNationality); @endphp
+                    @if($flagCode)
+                        <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $employee->employeeNationality }}" title="{{ $employee->employeeNationality }}">
                     @endif
-                </h5>
-                <small class="text-muted" title="นายจ้าง">{{ $employerName }}</small>
-            </div>
+                @endif
+            </h5>
             {{-- FIX: Added Name Prefix --}}
             <p class="mb-1">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }} ({{ $employee->employeePosition ?? 'N/A' }})</p>
+            <small class="text-muted d-block" title="นายจ้าง">นายจ้าง: {{ $employerName }}</small>
             <small class="text-muted d-block">Passport: {{ $employee->employeePassport ?? '-' }} (หมดอายุ: {{ $employee->passportExpiryDate ? $employee->passportExpiryDate->format('d/m/Y') : '-' }})</small>
             <small class="text-muted d-block">Work Permit: {{ $employee->employeeWorkPermit ?? '-' }} (หมดอายุ: {{ $employee->workPermitExpiryDate ? $employee->workPermitExpiryDate->format('d/m/Y') : '-' }})</small>
             <small class="text-muted d-block">Visa ({{ $employee->workPermitMOUGroup ?? '-' }}) | 90-Day: {{ $employee->ninetyDayReportDate ? $employee->ninetyDayReportDate->format('d/m/Y') : '-' }}</small>


### PR DESCRIPTION
This commit addresses three UI update requests:

1. In `resources/views/partials/_employee_card.blade.php`, the employer's name is moved below the employee's name for a better layout.
2. In `resources/views/notifications/_notification_item.blade.php`, the employee's name prefix (title) in both Thai and English is added to the display.
3. In `resources/views/notifications/_notification_table_row.blade.php`, the employee's name prefix (title) in both Thai and English is added to the display.

These changes improve the clarity and organization of the information presented to the user.

Note: I was unable to run the test suite because the `php` executable could not be found in the environment. The changes are purely presentational and have been visually verified by reviewing the code.