### PR TITLE
Fix: Bulk action bar not showing on employer edit page

### DIFF
--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -224,7 +224,7 @@
 </div>
 
 {{-- NEW: Bulk Action Bar for Employer's Employee List --}}
-<div id="bulk-action-bar-employer" class="alert alert-info d-flex justify-content-between align-items-center my-3" style="display: none !important;">
+<div id="bulk-action-bar-employer" class="alert alert-info d-flex justify-content-between align-items-center my-3" style="display: none;">
     <div>
         <input class="form-check-input" type="checkbox" id="select-all-checkbox-employer">
         <label class="form-check-label ms-2" for="select-all-checkbox-employer">
@@ -1144,11 +1144,11 @@ document.addEventListener('DOMContentLoaded', function () {
             const count = selectedCheckboxes.length;
 
             if (count > 0) {
-                actionBar.style.display = 'flex !important';
+                actionBar.style.display = 'flex';
                 selectedCountSpan.textContent = count;
                 actionButton.disabled = false;
             } else {
-                actionBar.style.display = 'none !important';
+                actionBar.style.display = 'none';
                 selectedCountSpan.textContent = 0;
                 actionButton.disabled = true;
             }


### PR DESCRIPTION
Removes `!important` from the inline style and the corresponding JavaScript that controls the visibility of the bulk action bar. This was preventing the JavaScript from correctly showing the bar when checkboxes were selected.