### PR TITLE
Feat: Add employee export button and list numbering

### DIFF
--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -220,7 +220,10 @@
         $femaleCount = $employer->employees()->whereIn('employeeTitleTh', ['นางสาว', 'นาง'])->count();
     @endphp
     <h5>ข้อมูลลูกจ้าง (รวม: {{ $totalEmployees }} | ชาย: {{ $maleCount }} | หญิง: {{ $femaleCount }})</h5>
-    <a href="{{ route('employees.create', ['employer_id' => $employer->id]) }}" class="btn btn-sm btn-outline-success"><i class="bi bi-person-plus"></i> เพิ่มพนักงาน</a>
+    <div class="d-flex gap-2">
+        <a href="{{ route('employers.exportEmployees', ['employer' => $employer->id, 'search_employee' => request('search_employee'), 'nationality' => request('nationality'), 'mou_type' => request('mou_type')]) }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i> Export</a>
+        <a href="{{ route('employees.create', ['employer_id' => $employer->id]) }}" class="btn btn-sm btn-outline-success"><i class="bi bi-person-plus"></i> เพิ่มพนักงาน</a>
+    </div>
 </div>
 
 {{-- NEW: Bulk Action Bar for Employer's Employee List --}}
@@ -279,7 +282,7 @@
         <div class="list-group">
         @forelse($employees as $employee)
             {{-- DEFINITIVE FIX: Use the single, unified partial --}}
-            @include('partials._employee_card', ['employee' => $employee])
+            @include('partials._employee_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees])
         @empty
             <p class="text-center text-muted">ไม่พบข้อมูลลูกจ้างที่ตรงกับเงื่อนไข</p>
         @endforelse

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -9,16 +9,23 @@
         <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
              alt="Photo" class="employee-photo-thumb" style="width: 48px; height: 48px; object-fit: cover; border-radius: 50%; margin-right: 1rem;">
         <div class="flex-grow-1">
-            <h5 class="mb-1">
-                {{-- FIX: Added Name Prefix --}}
-                {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
+            <p class="mb-0">
+                <strong>
+                    {{-- Calculate the correct item number based on pagination --}}
+                    @if(isset($pagination) && $pagination instanceof \Illuminate\Pagination\LengthAwarePaginator)
+                        {{ ($pagination->currentPage() - 1) * $pagination->perPage() + $loop->iteration }}.
+                    @else
+                        {{ $loop->iteration }}.
+                    @endif
+                    {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}
+                </strong>
                 @if($employee->employeeNationality)
                     @php $flagCode = \App\Helpers\CountryHelper::getFlagCode($employee->employeeNationality); @endphp
                     @if($flagCode)
                         <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $employee->employeeNationality }}" title="{{ $employee->employeeNationality }}">
                     @endif
                 @endif
-            </h5>
+            </p>
             {{-- FIX: Added Name Prefix --}}
             <p class="mb-1">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }} ({{ $employee->employeePosition ?? 'N/A' }})</p>
             <small class="text-muted d-block" title="นายจ้าง">นายจ้าง: {{ $employerName }}</small>


### PR DESCRIPTION
- Adds an "Export" button to the employer edit page to allow exporting a filtered list of employees.
- Adds sequential numbering to the employee cards on the employer edit page.
- The numbering is aware of pagination and displays the correct absolute number for each employee across pages.