### PR TITLE
feat: Add export functionality for filtered data

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -249,4 +249,45 @@ class EmployeeController extends Controller
         $url = route('employers.edit', $employer) . '#employee-card-' . $employee->id;
         return redirect($url);
     }
+    public function export(Request $request)
+    {
+        $query = \App\Models\Employee::query()->with('employer')->latest();
+
+        $this->applyFilters($request, $query);
+
+        $employees = $query->get();
+        $fileName = "employees_" . date('Y-m-d') . ".csv";
+        $headers = [
+            "Content-type"        => "text/csv; charset=UTF-8",
+            "Content-Disposition" => "attachment; filename=\"$fileName\"",
+            "Pragma"              => "no-cache",
+            "Cache-Control"       => "must-revalidate, post-check=0, pre-check=0",
+            "Expires"             => "0"
+        ];
+
+        $columns = ['#', 'ชื่อ (TH)', 'ชื่อ (EN)', 'Passport', 'Work Permit', 'นายจ้าง', 'สัญชาติ', 'ประเภท MOU'];
+
+        $callback = function() use($employees, $columns) {
+            $file = fopen('php://output', 'w');
+            fputs($file, "\xEF\xBB\xBF");
+            fputcsv($file, $columns);
+
+            foreach ($employees as $index => $employee) {
+                $row = [
+                    $index + 1,
+                    $employee->employeeNameTh,
+                    $employee->employeeNameEn,
+                    $employee->employeePassport,
+                    $employee->employeeWorkPermit,
+                    $employee->employer->employerNameTh ?? 'N/A',
+                    $employee->employeeNationality,
+                    $employee->workPermitMOUGroup,
+                ];
+                fputcsv($file, $row);
+            }
+            fclose($file);
+        };
+
+        return new \Symfony\Component\HttpFoundation\StreamedResponse($callback, 200, $headers);
+    }
 }

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -442,4 +442,50 @@ public function edit(Request $request, Employer $employer)
 
         return $response;
     }
+
+    public function exportEmployees(Request $request, Employer $employer)
+    {
+        $employeesQuery = $employer->employees()->latest();
+
+        $this->applyEmployeeFilters($request, $employeesQuery);
+
+        $employees = $employeesQuery->get();
+
+        $csvHeader = [
+            '#', 'Thai Name', 'English Name', 'Position', 'Nationality', 'Passport No', 'Passport Expiry',
+            'Work Permit No', 'Work Permit Expiry', 'MOU Group', 'Visa Expiry', '90-Day Report'
+        ];
+        $fileName = "{$employer->employerId}_employees.csv";
+
+        $response = new StreamedResponse(function() use ($employees, $csvHeader) {
+            $handle = fopen('php://output', 'w');
+            fputs($handle, "\xEF\xBB\xBF");
+            fputcsv($handle, $csvHeader);
+
+            foreach ($employees as $index => $employee) {
+                $data = [
+                    $index + 1,
+                    $employee->employeeNameTh,
+                    $employee->employeeNameEn,
+                    $employee->employeePosition,
+                    $employee->employeeNationality,
+                    $employee->employeePassport,
+                    $employee->passportExpiryDate ? Carbon::parse($employee->passportExpiryDate)->format('d/m/Y') : '-',
+                    $employee->employeeWorkPermit,
+                    $employee->workPermitExpiryDate ? Carbon::parse($employee->workPermitExpiryDate)->format('d/m/Y') : '-',
+                    $employee->workPermitMOUGroup,
+                    $employee->visaExpiryDate ? Carbon::parse($employee->visaExpiryDate)->format('d/m/Y') : '-',
+                    $employee->ninetyDayReportDate ? Carbon::parse($employee->ninetyDayReportDate)->format('d/m/Y') : '-',
+                ];
+                fputcsv($handle, $data);
+            }
+
+            fclose($handle);
+        }, 200, [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => "attachment; filename=\"{$fileName}\"",
+        ]);
+
+        return $response;
+    }
 }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -199,7 +199,8 @@ class NotificationController extends Controller
             fclose($file);
         };
 
-        return new StreamedResponse($callback, 200, $headers);
+        return new StreamedResponse($callback, 200,.php
+headers);
     }
 
     /**
@@ -346,5 +347,49 @@ class NotificationController extends Controller
         // Add the URL hash to redirect and trigger the highlight
         $url = route('employers.edit', $employer) . '#employee-card-' . $employee->id;
         return redirect($url);
+    }
+    public function export(Request $request)
+    {
+        // Prioritize 'export_type' from the new buttons, fallback to 'active_tab' for compatibility.
+        $exportType = $request->input('export_type', $request->input('active_tab', 'ninety_day_report'));
+        $query = $this->getFilteredQuery($request, $exportType);
+        $notifications = $query->get(); // Get all matching records, not paginated
+
+        $fileName = "notifications_{$exportType}_" . date('Y-m-d') . ".csv";
+        $headers = [
+            "Content-type"        => "text/csv; charset=UTF-8",
+            "Content-Disposition" => "attachment; filename=\"$fileName\"",
+            "Pragma"              => "no-cache",
+            "Cache-Control"       => "must-revalidate, post-check=0, pre-check=0",
+            "Expires"             => "0"
+        ];
+
+        $columns = ['#', 'ชื่อลูกจ้าง (TH)', 'ชื่อลูกจ้าง (EN)', 'Passport', 'สัญชาติ', 'นายจ้าง', 'วันที่ครบกำหนด', 'ประเภท'];
+
+        $callback = function() use($notifications, $columns) {
+            $file = fopen('php://output', 'w');
+            fputs($file, "\xEF\xBB\xBF"); // Add BOM for UTF-8
+            fputcsv($file, $columns);
+
+            foreach ($notifications as $index => $notification) {
+                $employee = $notification->employee;
+                if (!$employee) continue; // Skip if no employee data
+
+                $row = [
+                    $index + 1,
+                    $employee->employeeNameTh,
+                    $employee->employeeNameEn,
+                    $employee->employeePassport,
+                    $employee->employeeNationality,
+                    $employee->employer->employerNameTh ?? 'N/A',
+                    $notification->due_date ? \Carbon\Carbon::parse($notification->due_date)->format('d/m/Y') : '-',
+                    $notification->type,
+                ];
+                fputcsv($file, $row);
+            }
+            fclose($file);
+        };
+
+        return new \Symfony\Component\HttpFoundation\StreamedResponse($callback, 200, $headers);
     }
 }

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -44,10 +44,7 @@
 
                 <button type="submit" class="btn btn-primary btn-sm">กรอง</button>
                 <a href="{{ route('employees.index') }}" class="btn btn-outline-secondary btn-sm">ล้างการกรอง</a>
-
-                {{-- Add this button --}}
-                <a href="{{ route('employees.export', request()->query()) }}" class="btn btn-outline-success btn-sm"><i class="bi bi-download"></i> Export</a>
-
+<a href="{{ route('employees.export', request()->query()) }}" class="btn btn-outline-success btn-sm"><i class="bi bi-download"></i> Export</a>
                 <div class="btn-group btn-group-sm ms-md-auto">
                     <input type="radio" class="btn-check" name="view" id="view-card" value="card" onchange="this.form.submit()" @checked(request('view', 'card') === 'card')>
                     <label class="btn btn-outline-primary" for="view-card"><i class="bi bi-grid-3x3-gap-fill"></i> การ์ด</label>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -221,7 +221,7 @@
     @endphp
     <h5>ข้อมูลลูกจ้าง (รวม: {{ $totalEmployees }} | ชาย: {{ $maleCount }} | หญิง: {{ $femaleCount }})</h5>
     <div class="d-flex gap-2">
-        <a href="{{ route('employers.exportEmployees', ['employer' => $employer->id] + request()->only(['search_employee', 'nationality', 'mou_type', 'pink_card'])) }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i> Export</a>
+        <a href="{{ route('employers.exportEmployees', ['employer' => $employer->id] + request()->query()) }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i> Export</a>
         <a href="{{ route('employees.create', ['employer_id' => $employer->id]) }}" class="btn btn-sm btn-outline-success"><i class="bi bi-person-plus"></i> เพิ่มพนักงาน</a>
     </div>
 </div>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -81,15 +81,11 @@
                     (ชาย: {{ $counts[$type]['male'] }} คน, หญิง: {{ $counts[$type]['female'] }} คน)
                 </div>
                 @endif
-
-    {{-- ADD THIS BLOCK --}}
-    <div class="d-flex justify-content-end mb-3">
-        <a href="{{ route('notifications.export', array_merge(request()->query(), ['export_type' => $type])) }}" class="btn btn-outline-success btn-sm">
-            <i class="bi bi-download"></i> Export ข้อมูล ({{ $tabs[$type] ?? 'รายการที่ยกเลิก' }})
-        </a>
-    </div>
-    {{-- END ADD BLOCK --}}
-                {{-- END: Gender Count Display --}}
+<div class="d-flex justify-content-end mb-3">
+    <a href="{{ route('notifications.export', array_merge(request()->query(), ['export_type' => $type])) }}" class="btn btn-outline-success btn-sm">
+        <i class="bi bi-download"></i> Export ข้อมูล ({{ $tabs[$type] ?? 'รายการที่ยกเลิก' }})
+    </a>
+</div>
 
                 @if($type === 'work_permit_mou')
                     @if($currentView == 'table')

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,10 @@ Route::middleware('auth')->group(function () {
     Route::resource('agents', AgentController::class);
     Route::resource('delegates', DelegateController::class);
 
+    Route::get('/notifications/export', [NotificationController::class, 'export'])->name('notifications.export');
+    Route::get('/employees/export', [EmployeeController::class, 'export'])->name('employees.export');
+    Route::get('/employers/{employer}/export-employees', [EmployerController::class, 'exportEmployees'])->name('employers.exportEmployees');
+
     Route::resource('job-owners', JobOwnerController::class)->only(['index', 'store', 'destroy']);
 
     Route::post('/addresses', [App\Http\Controllers\AddressController::class, 'store'])->name('addresses.store');
@@ -49,6 +53,5 @@ Route::middleware('auth')->group(function () {
     Route::post('/notifications/{notification}/renew', [NotificationController::class, 'renew'])->name('notifications.renew');
     Route::post('/notifications/{notification}/restore', [NotificationController::class, 'restore'])->name('notifications.restore');
     Route::delete('/notifications/{notification}/force-delete', [NotificationController::class, 'forceDelete'])->name('notifications.forceDelete');
-    Route::get('/notifications/export', [NotificationController::class, 'export'])->name('notifications.export');
 });
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Adds "Export" buttons to the Notifications, Employees, and Employer's Employees lists.

- The export buttons are added to the `notifications.index`, `employees.index`, and `employers.edit` views.
- The corresponding routes (`notifications.export`, `employees.export`, `employers.exportEmployees`) are added to handle the export requests.
- The controller methods reuse the existing filtering logic from their respective pages to ensure the exported CSV file contains the same data the user sees in the filtered view.