### PR TITLE
Refactor Thai address data endpoint to use web.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+/public/data/thai-address-data.json

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@
 
 Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
 
+## Project Setup
+
+### Address Data
+
+This project requires a data file containing Thai address information. To download this file, run the following Artisan command:
+
+```bash
+php artisan address:download-data
+```
+
+This command will download the necessary file and store it in `public/data/thai-address-data.json`. This file is required for the address selection functionality to work correctly.
+
 - [Simple, fast routing engine](https://laravel.com/docs/routing).
 - [Powerful dependency injection container](https://laravel.com/docs/container).
 - Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.

--- a/app/Console/Commands/DownloadAddressData.php
+++ b/app/Console/Commands/DownloadAddressData.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+
+class DownloadAddressData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'address:download-data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Downloads the Thai address data from the source repository.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $url = 'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api/v1/province_with_amphure_tambon.json';
+        $directory = public_path('data');
+        $filePath = $directory . '/thai-address-data.json';
+
+        $this->info('Starting download of Thai address data...');
+
+        // Ensure the directory exists
+        if (!File::isDirectory($directory)) {
+            File::makeDirectory($directory, 0755, true, true);
+            $this->comment('Created directory: ' . $directory);
+        }
+
+        try {
+            $response = Http::timeout(300)->get($url);
+
+            if ($response->successful()) {
+                File::put($filePath, $response->body());
+                $this->info('Successfully downloaded and saved address data to: ' . $filePath);
+            } else {
+                $this->error('Failed to download address data. Server responded with status code: ' . $response->status());
+                return 1; // Indicate failure
+            }
+        } catch (\Exception $e) {
+            $this->error('An error occurred during download: ' . $e->getMessage());
+            return 1; // Indicate failure
+        }
+
+        return 0; // Indicate success
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         \App\Console\Commands\CheckExpiries::class,
+        \App\Console\Commands\DownloadAddressData::class,
     ];
 
     /**

--- a/app/Http/Controllers/AddressController.php
+++ b/app/Http/Controllers/AddressController.php
@@ -78,4 +78,15 @@ class AddressController extends Controller
 
         return response()->json(['success' => true]);
     }
+
+    public function getThaiAddressData()
+    {
+        $path = public_path('data/thai-address-data.json');
+
+        if (!file_exists($path)) {
+            return response()->json(['error' => 'Address data file not found.'], 404);
+        }
+
+        return response()->file($path);
+    }
 }

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -569,7 +569,7 @@ let thaiAddressData = [];
 
 async function fetchAddressData() {
     try {
-        const response = await fetch('https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_province_with_amphure_tambon.json');
+        const response = await fetch("{{ route('addresses.thai_data') }}");
         if (!response.ok) throw new Error('Network response was not ok');
         thaiAddressData = await response.json();
         populateProvinces();

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,9 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\JobOwnerController;
 use App\Http\Controllers\JobController;
+use App\Http\Controllers\AddressController;
+
+Route::get('/thai-addresses', [AddressController::class, 'getThaiAddressData'])->name('addresses.thai_data');
 Route::get('/', function () {
     return view('welcome');
 });


### PR DESCRIPTION
- Moves the Thai address data endpoint from `api.php` to `routes/web.php` to avoid potential API-related issues.
- Creates a new route `/thai-addresses` and a corresponding `AddressController@getThaiAddressData` method to serve a local JSON file.
- Updates the frontend JavaScript to fetch data from the new endpoint.
- Adds a new Artisan command `address:download-data` to download the required address data file from the source repository.
- Updates `.gitignore` to exclude the downloaded data file.
- Updates `README.md` with instructions on how to use the new command.