### PR TITLE
feat: Create EmployerEmployeeSeeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,9 @@ class DatabaseSeeder extends Seeder
             'email' => 'test@example.com',
         ]);
 
-        $this->call(CounterSeeder::class);
+        $this->call([
+            CounterSeeder::class,
+            EmployerEmployeeSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/EmployerEmployeeSeeder.php
+++ b/database/seeders/EmployerEmployeeSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Employer;
+use App\Models\Employee;
+
+class EmployerEmployeeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // สร้างนายจ้างจำนวน 10 ราย
+        // สำหรับนายจ้างแต่ละราย ให้สร้างลูกจ้างแบบสุ่มจำนวน 5 ถึง 15 คน
+        // และผูกข้อมูลลูกจ้างเข้ากับนายจ้างรายนั้นๆ โดยอัตโนมัติ
+        Employer::factory()
+            ->has(Employee::factory()->count(rand(5, 15)))
+            ->count(10)
+            ->create();
+    }
+}


### PR DESCRIPTION
This change introduces a new database seeder, EmployerEmployeeSeeder, to populate the database with sample data for employers and their associated employees.

The seeder creates 10 employers, and for each employer, it generates a random number of employees (between 5 and 15). This is useful for development and testing purposes.

The main DatabaseSeeder has been updated to call this new seeder.