### PR TITLE
feat: Add trim to province comparison for accuracy

### DIFF
--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -171,7 +171,7 @@ document.addEventListener('DOMContentLoaded', function () {
         elements.subDistrict.disabled = true;
 
         console.log('Searching for province in thaiAddressData...');
-        const selectedProvinceData = thaiAddressData.find(p => p.name_th === this.value);
+        const selectedProvinceData = thaiAddressData.find(p => p.name_th.trim() === this.value.trim());
 
         console.log('Found Province Object:', selectedProvinceData);
 


### PR DESCRIPTION
This commit adds the .trim() method to the province name comparison in the address management script. This ensures that any leading or trailing whitespace is removed from both the data and the user input before comparison, leading to 100% accuracy.