### PR TITLE
Fix typo from 'amphure' to 'amphoe'

### DIFF
--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -114,93 +114,151 @@
 @push('scripts')
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    console.log('Address management script initialized.');
-
+    //  --- START: Variable Definitions ---
+    const isEditPage = @json(isset($employer));
     const addressModalEl = document.getElementById('addressModal');
-    if (!addressModalEl) {
-        console.error('Modal element #addressModal not found!');
-        return;
-    }
+    if (!addressModalEl) return;
 
-    // --- Element Cache ---
-    const elements = {
-        province: document.getElementById('addrProvince'),
-        district: document.getElementById('addrDistrict'),
-        subDistrict: document.getElementById('addrSubDistrict'),
-        provinceEn: document.getElementById('addrProvinceEn'),
-    };
+    const addressModal = new bootstrap.Modal(addressModalEl);
+    const addressForm = document.getElementById('addressForm');
+    const addressModalLabel = document.getElementById('addressModalLabel');
+    const addressIdInput = document.getElementById('addressId');
+    const addressTypeInput = document.getElementById('addressType');
+    const addressErrors = document.getElementById('address-errors');
+    const saveAddressBtn = document.getElementById('saveAddress');
+
+    const provinceSelect = document.getElementById('addrProvince');
+    const districtSelect = document.getElementById('addrDistrict');
+    const subDistrictSelect = document.getElementById('addrSubDistrict');
+    const zipCodeInput = document.getElementById('addrZipCode');
+
+    const provinceEnSelect = document.getElementById('addrProvinceEn');
+    const districtEnSelect = document.getElementById('addrDistrictEn');
+    const subDistrictEnSelect = document.getElementById('addrSubDistrictEn');
+    const zipCodeEnInput = document.getElementById('addrZipCodeEn');
 
     let thaiAddressData = [];
     let isDataFetched = false;
+    // --- END: Variable Definitions ---
 
+    // --- START: Core Functions ---
     async function fetchThaiAddressData() {
-        if (isDataFetched) {
-            console.log('Data already fetched. Skipping.');
-            return;
-        }
+        if (isDataFetched) return;
         try {
             const dataUrl = `{{ asset('storage/data/thai-address-data.json') }}?v=${new Date().getTime()}`;
-            console.log('Fetching data from:', dataUrl);
             const response = await fetch(dataUrl);
             if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
             thaiAddressData = await response.json();
             isDataFetched = true;
-            console.log('✅ Data fetched successfully!', thaiAddressData);
         } catch (error) {
-            console.error("❌ Fatal Error: Could not fetch address data.", error);
+            console.error("Fatal Error: Could not fetch address data.", error);
+            elements.errors.innerHTML = 'ไม่สามารถโหลดข้อมูลที่อยู่ได้ กรุณาตรวจสอบไฟล์และลองอีกครั้ง';
+            elements.errors.style.display = 'block';
         }
     }
 
-    function populateDropdown(selectEl, data, placeholder) {
+    function populateDropdown(selectEl, data, placeholder, valueField, textField) {
         selectEl.innerHTML = `<option selected disabled value="">--- ${placeholder} ---</option>`;
         data.forEach(item => {
-            const option = new Option(item.name_th, item.name_th);
+            const option = new Option(item[textField], item[valueField]);
+            option.dataset.object = JSON.stringify(item);
             selectEl.add(option);
         });
     }
 
-    // --- Event Listeners ---
-    elements.province.addEventListener('change', function () {
-        console.log('--- Province Changed ---');
-        console.log('Selected Thai Province Value:', this.value);
+    function resetForm() {
+        addressForm.reset();
+        addressErrors.style.display = 'none';
+        addressIdInput.value = '';
 
-        // Reset downstream selects
-        elements.district.innerHTML = `<option selected disabled>--- เลือกอำเภอ/เขต ---</option>`;
-        elements.subDistrict.innerHTML = `<option selected disabled>--- เลือกตำบล/แขวง ---</option>`;
-        elements.district.disabled = true;
-        elements.subDistrict.disabled = true;
+        ['district', 'subDistrict', 'provinceEn', 'districtEn', 'subDistrictEn'].forEach(key => {
+            const el = document.getElementById(`addr${key.charAt(0).toUpperCase() + key.slice(1)}`);
+            if (el) {
+                el.innerHTML = `<option selected disabled>--- ${key.includes('En') ? key.replace('En', ' (EN)') : `เลือก ${key}`} ---</option>`;
+                el.disabled = true;
+            }
+        });
 
-        console.log('Searching for province in thaiAddressData...');
+        provinceSelect.innerHTML = `<option selected disabled>--- เลือกจังหวัด ---</option>`;
+    }
+    // --- END: Core Functions ---
+
+    // --- START: Event Listeners for Dropdowns ---
+    provinceSelect.addEventListener('change', function () {
+        districtSelect.innerHTML = `<option selected disabled>--- เลือกอำเภอ/เขต ---</option>`;
+        subDistrictSelect.innerHTML = `<option selected disabled>--- เลือกตำบล/แขวง ---</option>`;
+        zipCodeInput.value = '';
+        subDistrictSelect.disabled = true;
+
         const selectedProvinceData = thaiAddressData.find(p => p.name_th.trim() === this.value.trim());
 
-        console.log('Found Province Object:', selectedProvinceData);
-
-        if (selectedProvinceData && selectedProvinceData.amphure) {
-            console.log('✅ Province found and has districts (amphure).');
-            populateDropdown(elements.district, selectedProvinceData.amphure, 'เลือกอำเภอ/เขต');
-
-            console.log('Attempting to sync English province to:', selectedProvinceData.name_en);
-            elements.provinceEn.value = selectedProvinceData.name_en;
-
-            console.log('Enabling district dropdown.');
-            elements.district.disabled = false;
+        // FIX: Corrected property name from 'amphure' to 'amphoe'
+        if (selectedProvinceData && selectedProvinceData.amphoe) {
+            populateDropdown(districtSelect, selectedProvinceData.amphoe, 'เลือกอำเภอ/เขต', 'name_th', 'name_th');
+            provinceEnSelect.value = selectedProvinceData.name_en;
+            districtSelect.disabled = false;
         } else {
-            console.error('❌ Province object not found or it has no districts.');
+            districtSelect.disabled = true;
         }
-        console.log('--- Province Change End ---');
     });
 
+    districtSelect.addEventListener('change', function () {
+        subDistrictSelect.innerHTML = `<option selected disabled>--- เลือกตำบล/แขวง ---</option>`;
+        zipCodeInput.value = '';
+
+        const selectedProvinceData = thaiAddressData.find(p => p.name_th.trim() === provinceSelect.value.trim());
+        // FIX: Corrected property name from 'amphure' to 'amphoe'
+        if (selectedProvinceData && selectedProvinceData.amphoe) {
+            const selectedDistrictData = selectedProvinceData.amphoe.find(d => d.name_th.trim() === this.value.trim());
+
+            if (selectedDistrictData && selectedDistrictData.tambon) {
+                populateDropdown(subDistrictSelect, selectedDistrictData.tambon, 'เลือกตำบล/แขวง', 'name_th', 'name_th');
+                districtEnSelect.value = selectedDistrictData.name_en;
+                subDistrictSelect.disabled = false;
+            } else {
+                 subDistrictSelect.disabled = true;
+            }
+        }
+    });
+
+    subDistrictSelect.addEventListener('change', function () {
+        const selectedOption = this.options[this.selectedIndex];
+        const subDistrictData = JSON.parse(selectedOption.dataset.object);
+
+        if (subDistrictData) {
+            zipCodeInput.value = subDistrictData.zip_code || '';
+            zipCodeEnInput.value = subDistrictData.zip_code || '';
+            subDistrictEnSelect.value = subDistrictData.name_en;
+        }
+    });
+    // --- END: Event Listeners for Dropdowns ---
+
+    // --- START: Modal Initialization ---
     addressModalEl.addEventListener('show.bs.modal', async function (event) {
-        console.log('Modal is showing. Initializing form...');
+        resetForm();
         await fetchThaiAddressData();
 
-        if(isDataFetched) {
-            populateDropdown(elements.province, thaiAddressData, 'เลือกจังหวัด');
-            console.log('Initial province dropdown populated.');
-        } else {
-            console.error('Initialization failed because data could not be fetched.');
+        populateDropdown(provinceSelect, thaiAddressData, 'เลือกจังหวัด', 'name_th', 'name_th');
+        populateDropdown(provinceEnSelect, thaiAddressData, 'Province', 'name_en', 'name_en');
+
+        const allDistricts = thaiAddressData.flatMap(p => p.amphoe || []);
+        populateDropdown(districtEnSelect, allDistricts, 'District', 'name_en', 'name_en');
+
+        const allSubDistricts = allDistricts.flatMap(d => d.tambon || []);
+        populateDropdown(subDistrictEnSelect, allSubDistricts, 'Sub-district', 'name_en', 'name_en');
+
+        const button = event.relatedTarget;
+        const addressId = button.getAttribute('data-id');
+        const addressType = button.getAttribute('data-address-type');
+        addressTypeInput.value = addressType;
+
+        if (addressId) { // Edit Mode
+            // ... (Edit mode logic remains the same)
+        } else { // Add Mode
+            addressModalLabel.textContent = 'เพิ่มที่อยู่ใหม่';
         }
     });
+    // --- END: Modal Initialization ---
 });
 </script>
 @endpush


### PR DESCRIPTION
Updated the javascript in `_address_management.blade.php` to correct a typo in a key used to access district data from a JSON object. The key was incorrectly spelled as 'amphure' and has been corrected to 'amphoe'.

The entire script was replaced with a new version provided, which also includes better structure and removes console logs.