### PR TITLE
feat: Add cache buster to address data URL

### DIFF
--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -134,7 +134,7 @@ document.addEventListener('DOMContentLoaded', function () {
     async function fetchAddressData() {
         if (addressData.length > 0) return;
         try {
-            const dataUrl = `{{ asset('storage/data/thai-address-data.json') }}?v=${new Date().getTime()}`;
+            const dataUrl = `{{ asset('storage/data/thai-address-data.json') }}?v=${Date.now()}`;
             const response = await fetch(dataUrl);
             if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
             addressData = await response.json();


### PR DESCRIPTION
Replaced `new Date().getTime()` with the more concise `Date.now()` to generate a unique timestamp for the `thai-address-data.json` URL. This prevents the browser from using a cached version of the file.