### PR TITLE
Fix: Move @stack('scripts') to the end of the body tag

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -232,7 +232,6 @@
     </div>
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    @stack('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             const renewModal = document.getElementById('renewNotificationModal');
@@ -423,5 +422,6 @@
         }
     });
     </script>
+    @stack('scripts')
 </body>
 </html>


### PR DESCRIPTION
This change moves the @stack('scripts') directive to the end of the <body> tag in the main application layout file. This ensures that any scripts pushed from child views are loaded after all other JavaScript libraries, which is the correct and intended behavior for proper script execution.