### PR TITLE
feat: Implement AJAX address form submission

### DIFF
--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -236,6 +236,85 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         // ... rest of modal logic for add/edit ...
     });
+
+    // --- 6. Save Address Logic (NEW CODE) ---
+    const saveAddressButton = document.getElementById('saveAddress');
+    const addressForm = document.getElementById('addressForm');
+    const addressModal = new bootstrap.Modal(addressModalEl);
+    const addressErrors = document.getElementById('address-errors');
+
+    saveAddressButton.addEventListener('click', async function() {
+        // Prepare form data
+        const formData = new FormData(addressForm);
+        const addressId = document.getElementById('addressId').value;
+
+        // Determine URL and Method
+        let url = '{{ route('addresses.store') }}';
+        let method = 'POST';
+
+        if (addressId) {
+            url = `/addresses/${addressId}`;
+            // For Laravel, PUT method is simulated via a hidden field
+            formData.append('_method', 'PUT');
+        }
+
+        // Disable button to prevent double-click
+        saveAddressButton.disabled = true;
+        saveAddressButton.innerHTML = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> กำลังบันทึก...`;
+        addressErrors.style.display = 'none';
+        addressErrors.innerHTML = '';
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST', // Always POST for FormData, Laravel handles PUT/PATCH via _method field
+                body: formData,
+                headers: {
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                    'Accept': 'application/json',
+                }
+            });
+
+            const result = await response.json();
+
+            if (!response.ok) {
+                // Handle validation errors from Laravel
+                if (response.status === 422 && result.errors) {
+                    let errorHtml = '<ul>';
+                    for (const key in result.errors) {
+                        result.errors[key].forEach(error => {
+                            errorHtml += `<li>${error}</li>`;
+                        });
+                    }
+                    errorHtml += '</ul>';
+                    addressErrors.innerHTML = errorHtml;
+                    addressErrors.style.display = 'block';
+                } else {
+                    throw new Error(result.message || 'An unknown error occurred.');
+                }
+            } else {
+                // Success
+                addressModal.hide();
+                // We need a function to refresh the address lists on the main page
+                if (typeof window.refreshAddressLists === 'function') {
+                    window.refreshAddressLists();
+                } else {
+                    // Fallback if the function doesn't exist yet
+                    window.location.reload();
+                }
+                // You might want a nicer notification system later
+                alert('บันทึกที่อยู่เรียบร้อยแล้ว');
+            }
+
+        } catch (error) {
+            console.error('Save Address Error:', error);
+            addressErrors.innerHTML = `เกิดข้อผิดพลาดในการเชื่อมต่อ: ${error.message}`;
+            addressErrors.style.display = 'block';
+        } finally {
+            // Re-enable button
+            saveAddressButton.disabled = false;
+            saveAddressButton.innerHTML = 'บันทึก';
+        }
+    });
 });
 
 


### PR DESCRIPTION
Adds JavaScript to handle the saving of address data from the modal form using an asynchronous fetch request.

Key features:
- Handles both creating new addresses (POST) and updating existing ones (PUT).
- Disables the save button during the request to prevent double submissions.
- Displays a loading indicator to provide user feedback.
- Renders validation errors returned from the server.
- Reloads the page on success to reflect the changes.

Note: The change was applied to `resources/views/partials/_address_management.blade.php` as the path specified in the prompt (`resources/views/employers/_address_management.blade.php`) did not exist. Frontend verification could not be completed as the PHP development server failed to start.