### PR TITLE
feat: Link employer data to address modal

### DIFF
--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -147,7 +147,7 @@
 <div class="content-section mt-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h5 class="mb-0">ที่อยู่ตามทะเบียน</h5>
-        <button type="button" class="btn btn-sm btn-outline-success add-address-btn" data-bs-toggle="modal" data-bs-target="#addressModal" data-address-type="registered">
+        <button type="button" class="btn btn-sm btn-outline-primary add-address-btn" data-type="registered" data-addressable-id="{{ $employer->id }}" data-addressable-type="{{ get_class($employer) }}" data-bs-toggle="modal" data-bs-target="#addressModal">
             <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
         </button>
     </div>
@@ -181,7 +181,7 @@
 <div class="content-section mt-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h5 class="mb-0">ที่อยู่สถานที่ทำงาน</h5>
-        <button type="button" class="btn btn-sm btn-outline-success add-address-btn" data-bs-toggle="modal" data-bs-target="#addressModal" data-address-type="workplace">
+        <button type="button" class="btn btn-sm btn-outline-primary add-address-btn" data-type="workplace" data-addressable-id="{{ $employer->id }}" data-addressable-type="{{ get_class($employer) }}" data-bs-toggle="modal" data-bs-target="#addressModal">
             <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
         </button>
     </div>
@@ -738,6 +738,29 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         }
         updateActionBar();
+});
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const addressModal = document.getElementById('addressModal');
+    addressModal.addEventListener('show.bs.modal', function (event) {
+        // Button that triggered the modal
+        const button = event.relatedTarget;
+
+        // Extract info from data-* attributes
+        const addressableId = button.getAttribute('data-addressable-id');
+        const addressableType = button.getAttribute('data-addressable-type');
+        const addressType = button.getAttribute('data-type');
+
+        // Update the modal's hidden fields
+        const modalAddressableId = addressModal.querySelector('#addressableId');
+        const modalAddressableType = addressModal.querySelector('#addressableType');
+        const modalAddressType = addressModal.querySelector('#addressType');
+
+        modalAddressableId.value = addressableId;
+        modalAddressableType.value = addressableType;
+        modalAddressType.value = addressType;
+    });
 });
 </script>
 @endpush

--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -12,6 +12,8 @@
                     @csrf
                     <input type="hidden" id="addressId" name="id">
                     <input type="hidden" id="addressType" name="type">
+                    <input type="hidden" id="addressableId" name="addressable_id">
+                    <input type="hidden" id="addressableType" name="addressable_type">
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrNo" class="form-label">บ้านเลขที่ (ไทย)</label>


### PR DESCRIPTION
This commit implements the necessary changes to link an employer to the address creation modal.

- **Add Hidden Inputs:** The `_address_management` partial now includes hidden `addressable_id` and `addressable_type` input fields in the address form.
- **Update Buttons:** The 'Add Address' buttons on the employer edit page have been updated to include `data-addressable-id` and `data-addressable-type` attributes, which hold the employer's ID and class name.
- **Add JavaScript Logic:** A new JavaScript snippet has been added to the employer edit page. It listens for the modal's `show.bs.modal` event and populates the hidden fields with the data passed from the button that triggered the modal.