### PR TITLE
Fix: Correct address handling and upgrade notifications

### DIFF
--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 <div class="content-section">
     <h2 class="mb-4">เพิ่มข้อมูลนายจ้าง</h2>
-    <form action="{{ route('employers.store') }}" method="POST" enctype="multipart/form-data">
+    <form id="saveEmployerForm" action="{{ route('employers.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
 
         @if ($errors->any())
@@ -184,3 +184,120 @@
 @endsection
 
 @include('partials._address_management')
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    // --- Temporary Address Storage ---
+    let tempRegisteredAddresses = [];
+    let tempWorkplaceAddresses = [];
+
+    const registeredAddressList = document.getElementById('registeredAddressList');
+    const workplaceAddressList = document.getElementById('workplaceAddressList');
+    const mainForm = document.getElementById('saveEmployerForm');
+    const addressModalEl = document.getElementById('addressModal');
+    const addressModal = new bootstrap.Modal(addressModalEl);
+    const addressForm = document.getElementById('addressForm');
+    const saveAddressButton = document.getElementById('saveAddress');
+    const originalSaveButtonText = saveAddressButton.innerHTML;
+
+    // This is the create page, so we override the default AJAX save behavior
+    const isCreatePage = true; // Simple flag to confirm context
+
+    function renderAddressList(container, addresses, type) {
+        if (addresses.length === 0) {
+            container.innerHTML = '<p class="text-muted">ยังไม่มีที่อยู่</p>';
+            return;
+        }
+
+        container.innerHTML = ''; // Clear existing
+        addresses.forEach((address, index) => {
+            const card = document.createElement('div');
+            card.className = 'address-card d-flex justify-content-between align-items-start';
+            card.innerHTML = `
+                <div>
+                    <p class="mb-0">
+                        เลขที่ ${address.addrNo ?? ''} หมู่ ${address.addrMoo ?? ''} ซอย${address.addrSoi ?? ''} ถนน${address.addrRoad ?? ''}
+                        แขวง/ตำบล ${address.addrSubDistrict ?? ''} เขต/อำเภอ ${address.addrDistrict ?? ''}
+                        ${address.addrProvince ?? ''} ${address.addrZipCode ?? ''}
+                    </p>
+                </div>
+                <div class="btn-group btn-group-sm">
+                    <button type="button" class="btn btn-outline-danger remove-temp-address-btn" data-type="${type}" data-index="${index}"><i class="bi bi-trash"></i></button>
+                </div>
+            `;
+            container.appendChild(card);
+        });
+    }
+
+    function handleSaveAddressTemporarily() {
+        const formData = new FormData(addressForm);
+        const addressData = Object.fromEntries(formData.entries());
+        const addressType = document.getElementById('addressType').value;
+
+        // Basic validation check
+        if (!addressData.addrNo || !addressData.addrProvince || !addressData.addrDistrict || !addressData.addrSubDistrict) {
+             alert('กรุณากรอกข้อมูลที่อยู่ให้ครบถ้วน');
+             return;
+        }
+
+        if (addressType === 'registered') {
+            tempRegisteredAddresses.push(addressData);
+            renderAddressList(registeredAddressList, tempRegisteredAddresses, 'registered');
+        } else if (addressType === 'workplace') {
+            tempWorkplaceAddresses.push(addressData);
+            renderAddressList(workplaceAddressList, tempWorkplaceAddresses, 'workplace');
+        }
+
+        addressModal.hide();
+    }
+
+    // Override the save button's click event ONLY on this page
+    if (isCreatePage) {
+        // Clone and replace the button to remove existing event listeners from the partial
+        const newSaveAddressButton = saveAddressButton.cloneNode(true);
+        saveAddressButton.parentNode.replaceChild(newSaveAddressButton, saveAddressButton);
+        newSaveAddressButton.addEventListener('click', handleSaveAddressTemporarily);
+    }
+
+    // Handle removal of a temporary address
+    document.addEventListener('click', function(e) {
+        const removeBtn = e.target.closest('.remove-temp-address-btn');
+        if (removeBtn) {
+            const type = removeBtn.dataset.type;
+            const index = parseInt(removeBtn.dataset.index, 10);
+
+            if (type === 'registered') {
+                tempRegisteredAddresses.splice(index, 1);
+                renderAddressList(registeredAddressList, tempRegisteredAddresses, 'registered');
+            } else if (type === 'workplace') {
+                tempWorkplaceAddresses.splice(index, 1);
+                renderAddressList(workplaceAddressList, tempWorkplaceAddresses, 'workplace');
+            }
+        }
+    });
+
+    // Before submitting the main form, serialize the temp addresses into the hidden fields
+    mainForm.addEventListener('submit', function (e) {
+        document.getElementById('registered_addresses_json').value = JSON.stringify(tempRegisteredAddresses);
+        document.getElementById('workplace_addresses_json').value = JSON.stringify(tempWorkplaceAddresses);
+    });
+
+    // Reset form on modal close
+    addressModalEl.addEventListener('hidden.bs.modal', function () {
+        addressForm.reset();
+        // Reset dropdowns to their initial disabled state
+        document.getElementById('addrDistrict').disabled = true;
+        document.getElementById('addrSubDistrict').disabled = true;
+    });
+
+     // Set address type when "Add Address" is clicked
+    document.querySelectorAll('.add-address-btn').forEach(button => {
+        button.addEventListener('click', function() {
+            const addressType = this.getAttribute('data-address-type');
+            document.getElementById('addressType').value = addressType;
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -167,7 +167,14 @@
                     </p>
                 </div>
                 <div class="btn-group btn-group-sm">
-                    <button type="button" class="btn btn-outline-secondary edit-address-btn" data-id="{{ $address->id }}" data-bs-toggle="modal" data-bs-target="#addressModal"><i class="bi bi-pencil"></i></button>
+                    <button type="button" class="btn btn-outline-secondary edit-address-btn"
+                            data-id="{{ $address->id }}"
+                            data-addressable-id="{{ $employer->id }}"
+                            data-addressable-type="{{ get_class($employer) }}"
+                            data-bs-toggle="modal"
+                            data-bs-target="#addressModal">
+                        <i class="bi bi-pencil"></i>
+                    </button>
                     <button type="button" class="btn btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
                 </div>
             </div>
@@ -201,7 +208,14 @@
                     </p>
                 </div>
                 <div class="btn-group btn-group-sm">
-                    <button type="button" class="btn btn-outline-secondary edit-address-btn" data-id="{{ $address->id }}" data-bs-toggle="modal" data-bs-target="#addressModal"><i class="bi bi-pencil"></i></button>
+                    <button type="button" class="btn btn-outline-secondary edit-address-btn"
+                            data-id="{{ $address->id }}"
+                            data-addressable-id="{{ $employer->id }}"
+                            data-addressable-type="{{ get_class($employer) }}"
+                            data-bs-toggle="modal"
+                            data-bs-target="#addressModal">
+                        <i class="bi bi-pencil"></i>
+                    </button>
                     <button type="button" class="btn btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
                 </div>
             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -232,6 +232,20 @@
     </div>
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+
+    {{-- Toast Notification Container --}}
+    <div class="toast-container position-fixed top-0 end-0 p-3">
+        <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header">
+                <i class="bi bi-check-circle-fill rounded me-2 text-success"></i>
+                <strong class="me-auto">การแจ้งเตือน</strong>
+                <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+            <div class="toast-body" id="toast-body-content">
+                </div>
+        </div>
+    </div>
+
     @stack('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function () {
@@ -422,6 +436,29 @@
             newJobOwnerNameInput.classList.remove('is-invalid');
         }
     });
+    </script>
+    <script>
+    // Global Toast Function
+    function showToast(message, type = 'success') {
+        const toastLiveExample = document.getElementById('liveToast');
+        const toastBody = document.getElementById('toast-body-content');
+        const toastIcon = toastLiveExample.querySelector('.toast-header i');
+
+        toastBody.textContent = message;
+
+        // Customize icon based on type
+        toastIcon.className = 'rounded me-2'; // Reset classes
+        if (type === 'success') {
+            toastIcon.classList.add('bi', 'bi-check-circle-fill', 'text-success');
+        } else if (type === 'error') {
+            toastIcon.classList.add('bi', 'bi-x-circle-fill', 'text-danger');
+        } else {
+            toastIcon.classList.add('bi', 'bi-info-circle-fill', 'text-info');
+        }
+
+        const toast = new bootstrap.Toast(toastLiveExample);
+        toast.show();
+    }
     </script>
 </body>
 </html>

--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -303,8 +303,8 @@ document.addEventListener('DOMContentLoaded', function () {
                     // Fallback if the function doesn't exist yet
                     window.location.reload();
                 }
-                // You might want a nicer notification system later
-                alert('บันทึกที่อยู่เรียบร้อยแล้ว');
+                // Use the new, global toast notification system
+                showToast('บันทึกที่อยู่เรียบร้อยแล้ว');
             }
 
         } catch (error) {


### PR DESCRIPTION
This commit addresses two main issues:

1.  **Fixes Address Saving Logic:**
    - On the 'Edit Employer' page, the 'Edit Address' button was missing the `data-addressable-id` and `data-addressable-type` attributes. This prevented the address modal from correctly associating the address with the employer. These attributes have been added.
    - On the 'Create Employer' page, the address modal would attempt an AJAX save, which would fail as there was no employer ID yet. This has been corrected by implementing a client-side solution that temporarily stores new addresses in a JavaScript array. The array is then serialized and submitted with the main employer form.

2.  **Upgrades Alert System to Toast Notifications:**
    - Replaced the browser's default `alert()` with a more modern and less intrusive Bootstrap Toast notification.
    - Added the toast HTML structure to the main application layout.
    - Created a global `showToast(message, type)` JavaScript function for sitewide use.
    - Updated the address management script to call `showToast()` on successful save.