### PR TITLE
feat: Improve address deletion UX with SweetAlert2

### DIFF
--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -168,14 +168,6 @@
                         </p>
                     </div>
                     <div class="btn-group btn-group-sm">
-                        <button type="button" class="btn btn-outline-secondary edit-address-btn"
-                                data-id="{{ $address->id }}"
-                                data-addressable-id="{{ $employer->id }}"
-                                data-addressable-type="employer"
-                                data-bs-toggle="modal"
-                                data-bs-target="#addressModal">
-                            <i class="bi bi-pencil"></i>
-                        </button>
                         <button type="button" class="btn btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
                     </div>
                 </div>
@@ -209,14 +201,6 @@
                         </p>
                     </div>
                     <div class="btn-group btn-group-sm">
-                        <button type="button" class="btn btn-outline-secondary edit-address-btn"
-                                data-id="{{ $address->id }}"
-                                data-addressable-id="{{ $employer->id }}"
-                                data-addressable-type="employer"
-                                data-bs-toggle="modal"
-                                data-bs-target="#addressModal">
-                            <i class="bi bi-pencil"></i>
-                        </button>
                         <button type="button" class="btn btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
                     </div>
                 </div>
@@ -869,9 +853,20 @@ document.addEventListener('DOMContentLoaded', function() {
         const deleteBtn = e.target.closest('.delete-address-btn');
         if (deleteBtn) {
             const addressId = deleteBtn.getAttribute('data-id');
-            if (confirm('คุณแน่ใจหรือไม่ว่าต้องการลบที่อยู่นี้?')) {
-                deleteAddress(addressId);
-            }
+            Swal.fire({
+                title: 'ยืนยันการลบ',
+                text: "คุณแน่ใจหรือไม่ว่าต้องการลบที่อยู่นี้? การกระทำนี้ไม่สามารถย้อนกลับได้",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#6c757d',
+                confirmButtonText: 'ใช่, ลบเลย!',
+                cancelButtonText: 'ยกเลิก'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    deleteAddress(addressId);
+                }
+            });
         }
     });
 });

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,6 +17,8 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
+
     <style>
         :root {
             --bs-primary: #F97316;
@@ -234,6 +236,7 @@
     </div>
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.all.min.js"></script>
 
     {{-- Toast Notification Container --}}
     <div class="toast-container position-fixed top-0 end-0 p-3">


### PR DESCRIPTION
This commit introduces two main improvements to the employer address management interface:

1.  **Integrate SweetAlert2:** The SweetAlert2 library is now included in the main application layout, making it available for use across the application for improved user notifications and modals.

2.  **Enhance Delete Confirmation:** The standard browser `confirm()` dialog for deleting an address has been replaced with a more user-friendly and visually appealing SweetAlert2 modal. This provides a better user experience by clearly confirming the irreversible nature of the action.

Additionally, the "Edit" button for addresses on the employer edit page has been removed as per the requirements.