### PR TITLE
Create Seeder for RBAC Roles and Permissions

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,13 +12,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
+        // Create a default user
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
 
-        $this->call(CounterSeeder::class);
+        // Call the other seeders
+        $this->call([
+            CounterSeeder::class,
+            RoleAndPermissionSeeder::class, // เพิ่มบรรทัดนี้เข้ามา
+        ]);
     }
 }

--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Role;
+use App\Models\Permission;
+use App\Models\User;
+
+class RoleAndPermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reset cached roles and permissions
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+
+        // Create Permissions
+        $permissions = [
+            'view-dashboard',
+            'manage-users',
+            'manage-roles',
+            'view-employers',
+            'create-employers',
+            'edit-employers',
+            'delete-employers',
+            'view-employees',
+            'create-employees',
+            'edit-employees',
+            'delete-employees',
+            'manage-settings'
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::create(['name' => $permission]);
+        }
+
+        // Create Roles and assign existing permissions
+        $adminRole = Role::create(['name' => 'admin', 'description' => 'Administrator with all permissions']);
+        $adminRole->givePermissionTo(Permission::all());
+
+        $staffRole = Role::create(['name' => 'staff', 'description' => 'Staff member with limited permissions']);
+        $staffRole->givePermissionTo(['view-employers', 'view-employees', 'edit-employees']);
+
+        // Assign Admin role to the test user
+        $user = User::where('email', 'test@example.com')->first();
+        if ($user) {
+            $user->assignRole($adminRole);
+        }
+    }
+}

--- a/tests/Feature/Seeder/RoleAndPermissionSeederTest.php
+++ b/tests/Feature/Seeder/RoleAndPermissionSeederTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Seeder;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Role;
+use App\Models\Permission;
+use App\Models\User;
+
+class RoleAndPermissionSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_role_and_permission_seeder_runs_correctly()
+    {
+        // 1. Create the initial user that the seeder expects to find
+        $user = User::factory()->create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+
+        // 2. Run the specific seeder
+        $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+
+        // 3. Assert that roles were created
+        $this->assertDatabaseHas('roles', ['name' => 'admin']);
+        $this->assertDatabaseHas('roles', ['name' => 'staff']);
+
+        // 4. Assert that permissions were created
+        $this->assertDatabaseHas('permissions', ['name' => 'manage-users']);
+        $this->assertDatabaseHas('permissions', ['name' => 'view-employees']);
+
+        // 5. Assert that the admin role has all permissions
+        $adminRole = Role::whereName('admin')->first();
+        $allPermissionsCount = Permission::count();
+        $this->assertCount($allPermissionsCount, $adminRole->permissions);
+
+        // 6. Assert that the test user was assigned the admin role
+        $this->assertTrue($user->hasRole('admin'));
+    }
+}


### PR DESCRIPTION
This commit introduces a new database seeder for setting up the initial roles and permissions for the application's Role-Based Access Control (RBAC) system.

- Creates `RoleAndPermissionSeeder` to define permissions and create 'admin' and 'staff' roles.
- The 'admin' role is granted all permissions.
- The 'staff' role is granted a limited set of permissions.
- The seeder assigns the 'admin' role to the user with the email 'test@example.com'.
- Updates `DatabaseSeeder` to call the new `RoleAndPermissionSeeder`.
- Adds a feature test `RoleAndPermissionSeederTest` to ensure the seeder functions correctly by verifying the creation of roles, permissions, and role assignments.