### PR TITLE
feat(tests): Update Spatie permission tests

### DIFF
--- a/tests/Feature/Database/RbacStructureTest.php
+++ b/tests/Feature/Database/RbacStructureTest.php
@@ -10,23 +10,18 @@ class RbacStructureTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * Remove the deprecated "@test" annotation and use the "test" keyword in the method name
-     * or use the #[Test] attribute for PHPUnit 10+. For now, we'll rename the method.
-     */
-    public function test_it_has_the_correct_rbac_tables_and_columns()
+    public function test_it_has_the_correct_spatie_permission_tables()
     {
-        // Since we use RefreshDatabase, the migrations are already run before this test executes.
-        // We no longer need to check if the table doesn't exist, or run migrate manually.
-        // We just need to assert that the final state is correct.
-
+        // Assert that the tables from the Spatie package migrations exist.
         $this->assertTrue(Schema::hasTable('roles'), 'The "roles" table is missing.');
         $this->assertTrue(Schema::hasTable('permissions'), 'The "permissions" table is missing.');
-        $this->assertTrue(Schema::hasTable('role_user'), 'The "role_user" pivot table is missing.');
-        $this->assertTrue(Schema::hasTable('permission_role'), 'The "permission_role" pivot table is missing.');
+        $this->assertTrue(Schema::hasTable('model_has_permissions'), 'The "model_has_permissions" table is missing.');
+        $this->assertTrue(Schema::hasTable('model_has_roles'), 'The "model_has_roles" table is missing.');
+        $this->assertTrue(Schema::hasTable('role_has_permissions'), 'The "role_has_permissions" table is missing.');
 
+        // Assert that the 'roles' table has the columns defined by the Spatie package.
         $this->assertTrue(Schema::hasColumns('roles', [
-            'id', 'name', 'description', 'created_at', 'updated_at'
+            'id', 'name', 'guard_name', 'created_at', 'updated_at'
         ]), 'The "roles" table is missing required columns.');
     }
 }

--- a/tests/Feature/Seeder/RoleAndPermissionSeederTest.php
+++ b/tests/Feature/Seeder/RoleAndPermissionSeederTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature\Seeder;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\Role;
-use App\Models\Permission;
+use Spatie\Permission\Models\Role; // Use the Spatie Model
+use Spatie\Permission\Models\Permission; // Use the Spatie Model
 use App\Models\User;
 
 class RoleAndPermissionSeederTest extends TestCase
@@ -15,13 +15,13 @@ class RoleAndPermissionSeederTest extends TestCase
     public function test_role_and_permission_seeder_runs_correctly()
     {
         // 1. Create the initial user that the seeder expects to find
-        $user = User::factory()->create([
+        User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
 
-        // 2. Run the specific seeder
-        $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+        // 2. Run our main seeder which includes the RoleAndPermissionSeeder
+        $this->seed();
 
         // 3. Assert that roles were created
         $this->assertDatabaseHas('roles', ['name' => 'admin']);
@@ -37,6 +37,7 @@ class RoleAndPermissionSeederTest extends TestCase
         $this->assertCount($allPermissionsCount, $adminRole->permissions);
 
         // 6. Assert that the test user was assigned the admin role
+        $user = User::whereEmail('test@example.com')->first();
         $this->assertTrue($user->hasRole('admin'));
     }
 }


### PR DESCRIPTION
Updates `RbacStructureTest` and `RoleAndPermissionSeederTest` to correctly reference the tables and models from the Spatie Permission package.

- `RbacStructureTest` now asserts the existence of the correct Spatie tables (`roles`, `permissions`, `model_has_permissions`, etc.).
- `RoleAndPermissionSeederTest` now uses the `Spatie\Permission\Models\Role` and `Spatie\Permission\Models\Permission` models for its assertions.