### PR TITLE
feat: Create Admin Section for Role and Permission Management

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class AdminController extends Controller
+{
+    /**
+     * Display a listing of the roles and permissions.
+     */
+    public function indexRolesAndPermissions()
+    {
+        $roles = Role::with('permissions')->get();
+        $permissions = Permission::all();
+
+        return view('admin.roles_permissions.index', compact('roles', 'permissions'));
+    }
+}

--- a/resources/views/admin/roles_permissions/index.blade.php
+++ b/resources/views/admin/roles_permissions/index.blade.php
@@ -1,0 +1,52 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Manage Roles and Permissions') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                <h3 class="text-lg font-medium text-gray-900">Roles</h3>
+                <div class="mt-4">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Permissions</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach ($roles as $role)
+                                <tr>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $role->name }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        @foreach ($role->permissions as $permission)
+                                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                                {{ $permission->name }}
+                                            </span>
+                                        @endforeach
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                <h3 class="text-lg font-medium text-gray-900">All Permissions</h3>
+                <div class="mt-4 flex flex-wrap gap-2">
+                    @foreach ($permissions as $permission)
+                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
+                            {{ $permission->name }}
+                        </span>
+                    @endforeach
+                </div>
+            </div>
+
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,4 +59,11 @@ Route::middleware('auth')->group(function () {
     Route::post('/notifications/{notification}/restore', [NotificationController::class, 'restore'])->name('notifications.restore');
     Route::delete('/notifications/{notification}/force-delete', [NotificationController::class, 'forceDelete'])->name('notifications.forceDelete');
 });
+
+// === เพิ่มโค้ดส่วนนี้เข้าไป ===
+Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->group(function () {
+    Route::get('/roles-permissions', [App\Http\Controllers\Admin\AdminController::class, 'indexRolesAndPermissions'])->name('roles_permissions.index');
+});
+// === สิ้นสุดส่วนที่ต้องเพิ่ม ===
+
 require __DIR__.'/auth.php';

--- a/tests/Feature/Admin/RolesPermissionsPageTest.php
+++ b/tests/Feature/Admin/RolesPermissionsPageTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+
+class RolesPermissionsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guests_cannot_access_admin_page()
+    {
+        $response = $this->get(route('admin.roles_permissions.index'));
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_non_admin_users_cannot_access_admin_page()
+    {
+        $this->seed(); // Run seeders to create roles
+
+        $user = User::factory()->create();
+        $user->assignRole('staff'); // Assign a non-admin role
+
+        $response = $this->actingAs($user)->get(route('admin.roles_permissions.index'));
+        $response->assertStatus(403); // Forbidden
+    }
+
+    public function test_admin_user_can_access_admin_page()
+    {
+        $this->seed(); // Run seeders to create roles
+
+        $adminUser = User::whereEmail('test@example.com')->first(); // Our seeder makes this user an admin
+
+        $response = $this->actingAs($adminUser)->get(route('admin.roles_permissions.index'));
+
+        $response->assertStatus(200);
+        $response->assertSeeText('Manage Roles and Permissions');
+        $response->assertSeeText('admin');
+        $response->assertSeeText('staff');
+        $response->assertSeeText('manage-users');
+    }
+}


### PR DESCRIPTION
This commit introduces a new section for administrators to manage user roles and permissions.

The following changes were made:
- Added an `AdminController` to handle the logic for displaying roles and permissions.
- Registered a new route group under the `/admin` prefix, protected by the `auth` and `role:admin` middleware.
- Created a new view to display a list of roles with their assigned permissions, and a list of all available permissions.
- Added a feature test to ensure that only authenticated admin users can access this new section, while guests and non-admin users are denied access.