### PR TITLE
Refactor: Relocate Spatie middleware registration to bootstrap/app.php

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,10 +54,5 @@ class Kernel extends HttpKernel
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-
-        // ย้าย Middleware ของ Spatie มาไว้ที่นี่ทั้งหมด
-        'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
-        'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
-        'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
     ];
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,9 +10,13 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
-    ->withMiddleware(function (Middleware $middleware): void {
+    ->withExceptions(function (Exceptions $exceptions) {
         //
     })
-    ->withExceptions(function (Exceptions $exceptions): void {
-        //
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->alias([
+            'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+            'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+            'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+        ]);
     })->create();


### PR DESCRIPTION
- Moves the Spatie Permission middleware aliases (`role`, `permission`, `role_or_permission`) from `app/Http/Kernel.php` to `bootstrap/app.php`.
- This change aligns with the middleware registration conventions of newer Laravel versions.
- Cleans up the `$middlewareAliases` array in `app/Http/Kernel.php` by removing the now-redundant Spatie middleware definitions.