### PR TITLE
Refactor: Simplify TestCase by removing custom provider handling

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,20 +3,10 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
-use Spatie\Permission\PermissionServiceProvider; // เพิ่มบรรทัดนี้
 
 abstract class TestCase extends BaseTestCase
 {
-    /**
-     * The service providers that should be loaded for test purposes.
-     *
-     * @return array
-     */
-    protected function getPackageProviders($app)
-    {
-        return [
-            ...parent::getPackageProviders($app),
-            PermissionServiceProvider::class, // เพิ่มบรรทัดนี้
-        ];
-    }
+    // We are removing the custom getPackageProviders method
+    // to allow Laravel's default auto-discovery to handle all service providers,
+    // including the Spatie PermissionServiceProvider, correctly.
 }


### PR DESCRIPTION
The custom `getPackageProviders` method in `tests/TestCase.php` is no longer necessary.

This change removes the method to rely on Laravel's default package auto-discovery, which correctly handles the Spatie PermissionServiceProvider and other providers.