### PR TITLE
Update RolesPermissionsPageTest for debugging

### DIFF
--- a/tests/Feature/Admin/RolesPermissionsPageTest.php
+++ b/tests/Feature/Admin/RolesPermissionsPageTest.php
@@ -6,22 +6,16 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\User;
 use Spatie\Permission\Models\Role;
-use Database\Seeders\RoleAndPermissionSeeder; // เพิ่มบรรทัดนี้
+use Spatie\Permission\Models\Permission;
+use Database\Seeders\RoleAndPermissionSeeder;
 
 class RolesPermissionsPageTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
     protected function setUp(): void
     {
         parent::setUp();
-
-        // Run the seeder that creates roles and permissions
         $this->seed(RoleAndPermissionSeeder::class);
     }
 
@@ -31,7 +25,7 @@ class RolesPermissionsPageTest extends TestCase
         $response->assertRedirect(route('login'));
     }
 
-    public function test_non_admin_users_cannot_access_admin_page()
+    public function test_non_admin_users_are_forbidden()
     {
         $user = User::factory()->create();
         $user->assignRole('staff');
@@ -42,14 +36,35 @@ class RolesPermissionsPageTest extends TestCase
 
     public function test_admin_user_can_access_admin_page()
     {
+        // สร้าง Admin User ขึ้นมาใหม่สำหรับ Test นี้โดยเฉพาะ
         $adminUser = User::factory()->create();
         $adminUser->assignRole('admin');
 
+        // --- โค้ดนักสืบ ---
+        // ตรวจสอบว่า User คนนี้มี Role 'admin' จริงหรือไม่
+        if (! $adminUser->hasRole('admin')) {
+            $this->fail('Assertion failed: The created user does not have the "admin" role.');
+        }
+
+        // ตรวจสอบว่า Role 'admin' มี Permission อะไรบ้าง
+        $adminRole = Role::findByName('admin');
+        dump('Admin Role Permissions:', $adminRole->permissions->pluck('name')->toArray());
+
+        // ตรวจสอบว่า User คนนี้มี Permission โดยตรงหรือไม่ (ถ้ามี)
+        dump('Direct User Permissions:', $adminUser->getDirectPermissions()->pluck('name')->toArray());
+
+        // ตรวจสอบ Permission ทั้งหมดของ User (ทั้งทางตรงและผ่าน Role)
+        dump('All User Permissions (via roles):', $adminUser->getAllPermissions()->pluck('name')->toArray());
+        // --- สิ้นสุดโค้ดนักสืบ ---
+
         $response = $this->actingAs($adminUser)->get(route('admin.roles_permissions.index'));
+
+        // หาก Test ล้มเหลว ให้แสดงเนื้อหาของหน้าที่ได้รับกลับมาทั้งหมดเพื่อดูว่ามันคือหน้าอะไร
+        if ($response->status() !== 200) {
+            $response->dump();
+        }
 
         $response->assertStatus(200);
         $response->assertSeeText('Manage Roles and Permissions');
-        $response->assertSeeText('admin');
-        $response->assertSeeText('staff');
     }
 }


### PR DESCRIPTION
Replaces the content of `tests/Feature/Admin/RolesPermissionsPageTest.php` with the user-provided version containing debugging code.

This change is intended to help diagnose an issue where a user with the 'admin' role is receiving a 403 Forbidden error when accessing an admin-only page. The new test code includes `dump()` statements to inspect the user's roles and permissions at runtime.