### PR TITLE
Refactor RolesPermissionsPageTest for clarity and efficiency

### DIFF
--- a/tests/Feature/Admin/RolesPermissionsPageTest.php
+++ b/tests/Feature/Admin/RolesPermissionsPageTest.php
@@ -6,17 +6,25 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\User;
 use Spatie\Permission\Models\Role;
-use Spatie\Permission\Models\Permission;
 use Database\Seeders\RoleAndPermissionSeeder;
 
 class RolesPermissionsPageTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected $adminUser;
+    protected $staffUser;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->seed(RoleAndPermissionSeeder::class);
+
+        $this->adminUser = User::factory()->create();
+        $this->adminUser->assignRole('admin');
+
+        $this->staffUser = User::factory()->create();
+        $this->staffUser->assignRole('staff');
     }
 
     public function test_guests_cannot_access_admin_page()
@@ -27,44 +35,19 @@ class RolesPermissionsPageTest extends TestCase
 
     public function test_non_admin_users_are_forbidden()
     {
-        $user = User::factory()->create();
-        $user->assignRole('staff');
-
-        $response = $this->actingAs($user)->get(route('admin.roles_permissions.index'));
+        $response = $this->actingAs($this->staffUser)->get(route('admin.roles_permissions.index'));
         $response->assertStatus(403);
     }
 
-    public function test_admin_user_can_access_admin_page()
+    public function test_admin_user_can_access_admin_page_and_see_content()
     {
-        // สร้าง Admin User ขึ้นมาใหม่สำหรับ Test นี้โดยเฉพาะ
-        $adminUser = User::factory()->create();
-        $adminUser->assignRole('admin');
-
-        // --- โค้ดนักสืบ ---
-        // ตรวจสอบว่า User คนนี้มี Role 'admin' จริงหรือไม่
-        if (! $adminUser->hasRole('admin')) {
-            $this->fail('Assertion failed: The created user does not have the "admin" role.');
-        }
-
-        // ตรวจสอบว่า Role 'admin' มี Permission อะไรบ้าง
-        $adminRole = Role::findByName('admin');
-        dump('Admin Role Permissions:', $adminRole->permissions->pluck('name')->toArray());
-
-        // ตรวจสอบว่า User คนนี้มี Permission โดยตรงหรือไม่ (ถ้ามี)
-        dump('Direct User Permissions:', $adminUser->getDirectPermissions()->pluck('name')->toArray());
-
-        // ตรวจสอบ Permission ทั้งหมดของ User (ทั้งทางตรงและผ่าน Role)
-        dump('All User Permissions (via roles):', $adminUser->getAllPermissions()->pluck('name')->toArray());
-        // --- สิ้นสุดโค้ดนักสืบ ---
-
-        $response = $this->actingAs($adminUser)->get(route('admin.roles_permissions.index'));
-
-        // หาก Test ล้มเหลว ให้แสดงเนื้อหาของหน้าที่ได้รับกลับมาทั้งหมดเพื่อดูว่ามันคือหน้าอะไร
-        if ($response->status() !== 200) {
-            $response->dump();
-        }
+        $response = $this->actingAs($this->adminUser)->get(route('admin.roles_permissions.index'));
 
         $response->assertStatus(200);
-        $response->assertSeeText('Manage Roles and Permissions');
+        $response->assertSee('Roles'); // Check for the "Roles" table heading
+        $response->assertSee('All Permissions'); // Check for the "All Permissions" section heading
+        $response->assertSee('admin'); // Check if the admin role name is displayed
+        $response->assertSee('staff'); // Check if the staff role name is displayed
+        $response->assertSee('manage-users'); // Check if a permission name is displayed
     }
 }


### PR DESCRIPTION
This commit completely updates the `tests/Feature/Admin/RolesPermissionsPageTest.php` file.

The new implementation refactors the test by:
- Introducing a `setUp()` method to seed necessary roles and permissions and create reusable admin and staff users.
- Streamlining the tests for guest access, non-admin access, and admin access.
- Improving assertions to specifically check for the presence of key text elements like 'Roles', 'All Permissions', 'admin', 'staff', and 'manage-users' on the page, ensuring the view is rendered correctly.