### PR TITLE
Fix: Resolve trait conflict in TestCase

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,11 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Testing\CreatesApplication;
+use Illuminate\Foundation\Testing\RefreshDatabase; // เปลี่ยนจาก LazilyRefreshDatabase เป็น RefreshDatabase
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
-use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use LazilyRefreshDatabase;
+    use CreatesApplication, RefreshDatabase; // ใช้ RefreshDatabase แทน
 }


### PR DESCRIPTION
Updated `tests/TestCase.php` to use the `RefreshDatabase` trait directly instead of `LazilyRefreshDatabase`.

This change prevents potential trait conflicts and aligns the base test case with a more standard setup.