### PR TITLE
Refactor(tests): Improve test structure to prevent route caching issues

### DIFF
--- a/tests/Feature/Admin/RolesPermissionsPageTest.php
+++ b/tests/Feature/Admin/RolesPermissionsPageTest.php
@@ -7,41 +7,47 @@ use Tests\TestCase;
 use App\Models\User;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
-use Database\Seeders\RoleAndPermissionSeeder;
 
 class RolesPermissionsPageTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected $adminUser;
+    protected $staffUser;
+
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(RoleAndPermissionSeeder::class);
+
+        // Create roles and permissions
+        $adminRole = Role::create(['name' => 'admin']);
+        $staffRole = Role::create(['name' => 'staff']);
+
+        // Create a dummy user and assign roles
+        $this->adminUser = User::factory()->create();
+        $this->adminUser->assignRole($adminRole);
+
+        $this->staffUser = User::factory()->create();
+        $this->staffUser->assignRole($staffRole);
     }
 
     public function test_guests_cannot_access_admin_page()
     {
-        $response = $this->get(route('admin.roles_permissions.index'));
+        $response = $this->get('/admin/roles-permissions');
         $response->assertRedirect(route('login'));
     }
 
     public function test_non_admin_users_are_forbidden()
     {
-        $user = User::factory()->create();
-        $user->assignRole('staff');
-
-        $response = $this->actingAs($user)->get(route('admin.roles_permissions.index'));
+        $response = $this->actingAs($this->staffUser)->get('/admin/roles-permissions');
         $response->assertStatus(403);
     }
 
     public function test_admin_user_can_access_admin_page()
     {
-        $adminUser = User::factory()->create();
-        $adminUser->assignRole('admin');
-
-        $response = $this->actingAs($adminUser)->get(route('admin.roles_permissions.index'));
+        $response = $this->actingAs($this->adminUser)->get('/admin/roles-permissions');
 
         $response->assertStatus(200);
-        $response->assertSee('Manage Roles and Permissions');
+        $response->assertSeeText('Manage Roles and Permissions');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,10 +3,10 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\CreatesApplication;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use CreatesApplication, RefreshDatabase;
+    use CreatesApplication, LazilyRefreshDatabase;
 }


### PR DESCRIPTION
Resets `tests/TestCase.php` to use `LazilyRefreshDatabase` for better test performance and compatibility.

Updates `RolesPermissionsPageTest` to be self-contained by creating its own test data (roles and users) in the `setUp` method. This removes the dependency on the `RoleAndPermissionSeeder` and makes the test more robust and isolated.