### PR TITLE
fix(employer): Generate new employer ID on create form

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -30,7 +30,15 @@ class EmployerController extends Controller
     public function create()
     {
         $jobOwners = JobOwner::orderBy('name')->get();
-        return view('employers.create', compact('jobOwners'));
+
+        // --- เพิ่มโค้ดส่วนนี้เข้าไป ---
+        // สร้างรหัสนายจ้างใหม่ที่ไม่ซ้ำใคร
+        $lastEmployer = Employer::orderBy('id', 'desc')->first();
+        $nextId = $lastEmployer ? $lastEmployer->id + 1 : 1;
+        $newEmployerId = 'EMP-' . str_pad($nextId, 5, '0', STR_PAD_LEFT);
+        // --- สิ้นสุดส่วนที่ต้องเพิ่ม ---
+
+        return view('employers.create', compact('jobOwners', 'newEmployerId')); // เพิ่ม 'newEmployerId' เข้าไป
     }
 
     public function store(Request $request)


### PR DESCRIPTION
This commit addresses a bug where a new employer ID was not being generated and pre-filled on the employer creation page.

- The `create()` method in `EmployerController` has been updated to:
  - Fetch the last employer record.
  - Increment the ID to generate a new sequential ID.
  - Format the ID as `EMP-` followed by a zero-padded number (e.g., `EMP-00001`).
  - Pass this new ID to the `employers.create` view.

The `create.blade.php` view was already configured to display this ID in a `readonly` input field, so no changes were needed on the frontend template.

Verification was performed by code inspection and a successful automated code review, as the testing environment lacks a `php` executable, preventing the execution of the test suite.