### PR TITLE
Fix: Update EmployeeController and RoleAndPermissionSeeder

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -19,30 +19,24 @@ class EmployeeController extends Controller
     }
 
 public function index(Request $request)
-    {
-    // Start building the query
+{
     $query = Employee::query();
 
-    // Handle filtering (assuming you have this logic)
-    // ... filtering logic based on $request ...
+    // ... (ส่วนของการกรองข้อมูล ถ้ามี) ...
 
     $totalEmployees = $query->count();
-    $maleCount = $query->clone()->where('gender', 'male')->count(); // Assuming you have a 'gender' column
-    $femaleCount = $totalEmployees - $maleCount;
 
     $perPageOptions = [25, 50, 100];
     $perPage = $request->input('per_page', 25);
-
     $employees = $query->with('employer')->latest()->paginate($perPage);
 
+    // ส่งข้อมูลที่จำเป็นไป แต่ไม่รวม male/female count แล้ว
     return view('employees.index', compact(
         'employees',
         'totalEmployees',
-        'maleCount',
-        'femaleCount',
-        'perPageOptions',
+        'perPageOptions'
     ))->with('currentView', $request->input('view', 'card'));
-    }
+}
 
     public function create()
     {

--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -30,7 +30,8 @@ class RoleAndPermissionSeeder extends Seeder
         $staffRole = Role::create(['name' => 'staff']);
         $staffRole->givePermissionTo([
             'view-employers',
-            'create-employers', // <-- เพิ่มสิทธิ์นี้เข้าไป
+            'create-employers',
+            'edit-employers', // <-- เพิ่มสิทธิ์นี้เข้าไป
             'view-employees',
             'edit-employees'
         ]);

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -10,7 +10,7 @@
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
         <h2 class="mb-3 mb-md-0">รายการข้อมูลลูกจ้างทั้งหมด</h2>
         <h2 class="h5 text-muted fw-normal">
-            (รวม: {{ $totalEmployees }} | ชาย: {{ $maleCount }} | หญิง: {{ $femaleCount }})
+            (รวม: {{ $totalEmployees }})
         </h2>
         @can('create-employees')
         <a href="{{ route('employers.index') }}" class="btn btn-primary" title="ไปที่หน้านายจ้างเพื่อเพิ่มลูกจ้างใหม่"><i class="bi bi-plus-circle me-1"></i> เพิ่มข้อมูลใหม่</a>


### PR DESCRIPTION
- Updated the `EmployeeController@index` method to remove the calculation and passing of male/female employee counts to the view.
- Updated the corresponding `employees.index.blade.php` view to remove the display of these counts, preventing a rendering error.
- Updated the `RoleAndPermissionSeeder` to grant the 'staff' role the 'edit-employers' permission.