### PR TITLE
Fix: Correct pagination and data passing in controllers

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -21,20 +21,20 @@ class EmployeeController extends Controller
 public function index(Request $request)
 {
     $query = Employee::query();
-
-    // ... (ส่วนของการกรองข้อมูล ถ้ามี) ...
+    // ... filtering logic ...
 
     $totalEmployees = $query->count();
 
     $perPageOptions = [25, 50, 100];
-    $perPage = $request->input('per_page', 25);
-    $employees = $query->with('employer')->latest()->paginate($perPage);
+    $currentPerPage = $request->input('per_page', 25); // แก้ชื่อตัวแปรตรงนี้
 
-    // ส่งข้อมูลที่จำเป็นไป แต่ไม่รวม male/female count แล้ว
+    $employees = $query->with('employer')->latest()->paginate($currentPerPage);
+
     return view('employees.index', compact(
         'employees',
         'totalEmployees',
-        'perPageOptions'
+        'perPageOptions',
+        'currentPerPage' // ส่งตัวแปรที่ถูกต้องไป
     ))->with('currentView', $request->input('view', 'card'));
 }
 

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -73,14 +73,30 @@ class EmployerController extends Controller
         return redirect()->route('employers.index')->with('success', 'Employer created successfully.');
     }
 
-    public function edit(Employer $employer)
-    {
-        $jobOwners = JobOwner::orderBy('name')->get();
-        $activeEmployees = $employer->employees()->whereNull('terminated_at')->get();
-        $terminatedEmployees = $employer->employees()->whereNotNull('terminated_at')->get();
+public function edit(Request $request, Employer $employer) // เพิ่ม Request $request
+{
+    $jobOwners = JobOwner::orderBy('name')->get();
 
-        return view('employers.edit', compact('employer', 'jobOwners', 'activeEmployees', 'terminatedEmployees'));
-    }
+    // --- เพิ่ม Logic ส่วนนี้เข้าไปทั้งหมด ---
+    $employeeQuery = $employer->employees()->whereNull('terminated_at');
+    // You can add filtering logic for employees here if needed based on $request
+
+    $perPageOptions = [10, 25, 50];
+    $currentPerPage = $request->input('per_page', 10);
+    $employees = $employeeQuery->paginate($currentPerPage); // เปลี่ยน $activeEmployees เป็น $employees และ paginate
+    $currentView = $request->input('view', 'card');
+
+    $terminatedEmployees = $employer->employees()->whereNotNull('terminated_at')->get();
+
+    return view('employers.edit', compact(
+        'employer',
+        'jobOwners',
+        'employees', // ส่งตัวแปรที่ถูกต้อง
+        'terminatedEmployees',
+        'perPageOptions', // ส่งตัวแปรที่ขาดไป
+        'currentView'     // ส่งตัวแปรที่ขาดไป
+    ));
+}
 
     public function update(Request $request, Employer $employer)
     {


### PR DESCRIPTION
This commit addresses two bugs in the Employee and Employer controllers.

In `EmployeeController@index`, the `per_page` input variable was incorrectly named, causing pagination to fail. This has been corrected to `currentPerPage` and passed to the view.

In `EmployerController@edit`, the method was updated to support pagination and view switching for the employee list. The `Request` object is now injected, and the necessary variables (`employees`, `perPageOptions`, `currentView`) are passed to the view to enable this functionality.