### PR TITLE
Add debug panel to employer edit view for troubleshooting.

### DIFF
--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -1,6 +1,27 @@
 {{-- DEFINITIVE MASTER FIX: This is the user's full original file with the final corrections. --}}
 @extends('layouts.app')
 
+{{-- ===== เพิ่มโค้ด DEBUG ชั่วคราวเข้าไปตรงนี้ ===== --}}
+@section('debug-tracker')
+<div class="alert alert-warning m-3">
+    <h4 class="alert-heading">-- DEBUG MODE --</h4>
+    @if (Auth::check())
+        <p><strong>User Logged In:</strong> {{ Auth::user()->name }} (ID: {{ Auth::user()->id }})</p>
+        <p><strong>Roles:</strong> {{ Auth::user()->getRoleNames()->implode(', ') }}</p>
+        <hr>
+        <p><strong>Checking for 'create-employees' permission...</strong></p>
+        @if (Auth::user()->hasPermissionTo('create-employees'))
+            <p class="text-success fw-bold">RESULT: PERMISSION FOUND! (User should see the button)</p>
+        @else
+            <p class="text-danger fw-bold">RESULT: PERMISSION NOT FOUND! (This is why the button is hidden)</p>
+        @endif
+    @else
+        <p class="text-danger fw-bold">ERROR: User is not logged in.</p>
+    @endif
+</div>
+@endsection
+{{-- ===== สิ้นสุดโค้ด DEBUG ชั่วคราว ===== --}}
+
 @push('styles')
 <style>
     .highlight {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -159,6 +159,7 @@
         </aside>
 
         <main id="main-content" style="position: relative; z-index: 1;">
+            @yield('debug-tracker')
             @if (session('success'))
                 <div class="alert alert-success">
                     {{ session('success') }}


### PR DESCRIPTION
This change introduces a debug panel at the top of the `resources/views/employers/edit.blade.php` file as requested.

- Added a new `@section('debug-tracker')` to `edit.blade.php` containing the user-provided debug code.
- Added a corresponding `@yield('debug-tracker')` to the main layout `resources/views/layouts/app.blade.php` to ensure the panel is rendered.

Additionally, created a `.env` file and an empty `database/database.sqlite` file to configure the application environment, which was necessary to attempt frontend verification.