### PR TITLE
feat: Implement employee termination functionality

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -7,6 +7,7 @@ use App\Models\JobOwner;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
+use App\Models\Employee; // <-- เพิ่มบรรทัดนี้
 
 class EmployerController extends Controller
 {
@@ -158,5 +159,22 @@ public function edit(Request $request, Employer $employer) // เพิ่ม Re
         return redirect()->route('employers.index')->with('success', 'Employer deleted successfully.');
     }
 
-    // Other methods like export, filter, terminate etc.
+    // --- เพิ่ม Method ใหม่นี้เข้าไปก่อนบรรทัดสุดท้ายของคลาส ---
+    public function terminate(Request $request, Employee $employee)
+    {
+        $validated = $request->validate([
+            'terminated_at' => 'required|date',
+            'termination_reason' => 'nullable|string',
+        ]);
+
+        $employee->update([
+            'terminated_at' => $validated['terminated_at'],
+            'termination_reason' => $validated['termination_reason'],
+        ]);
+
+        return redirect()->back()->with('success', 'Employee has been terminated.');
+    }
+    // --- สิ้นสุดส่วนที่ต้องเพิ่ม ---
+
+    // Other methods like export, filter etc.
 }

--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -14,8 +14,6 @@ class RoleAndPermissionSeeder extends Seeder
     {
         // Reset cached roles and permissions
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
-
-        // Inform the user that the seeder has started
         $this->command->info('Seeding Roles and Permissions...');
 
         // Create Permissions
@@ -23,9 +21,9 @@ class RoleAndPermissionSeeder extends Seeder
             'view-dashboard',
             'manage-users', 'manage-roles', 'manage-settings',
             'view-employers', 'create-employers', 'edit-employers', 'delete-employers',
-            'view-employees', 'create-employees', 'edit-employees', 'delete-employees'
+            'view-employees', 'create-employees', 'edit-employees', 'delete-employees',
+            'terminate-employees' // <-- เพิ่ม Permission ใหม่
         ];
-
         foreach ($permissions as $permission) {
             Permission::create(['name' => $permission]);
         }
@@ -34,12 +32,9 @@ class RoleAndPermissionSeeder extends Seeder
         // Create Staff Role and assign permissions
         $staffRole = Role::create(['name' => 'staff']);
         $staffPermissions = [
-            'view-employers',
-            'create-employers',
-            'edit-employers',
-            'view-employees',
-            'edit-employees',
-            'create-employees' // Ensure it's explicitly here
+            'view-employers', 'create-employers', 'edit-employers',
+            'view-employees', 'edit-employees', 'create-employees',
+            'terminate-employees' // <-- มอบสิทธิ์ใหม่ให้ Staff
         ];
         $staffRole->givePermissionTo($staffPermissions);
         $this->command->info('Staff role created and assigned permissions.');

--- a/jules-scratch/verification/verify_termination_button.py
+++ b/jules-scratch/verification/verify_termination_button.py
@@ -1,0 +1,35 @@
+import re
+from playwright.sync_api import Page, expect
+
+def test_termination_button_is_visible_for_staff(page: Page):
+    """
+    This test verifies that a staff user can see the new 'Terminate' button
+    on an employee card, confirming the 'terminate-employees' permission is working.
+    """
+    # 1. Arrange: Go to the login page.
+    # The APP_URL is http://127.0.0.1:8000, which is where `php artisan serve` runs.
+    page.goto("http://127.0.0.1:8000/login")
+
+    # 2. Act: Log in as the staff user.
+    # The seeder creates 'staff@example.com'. The default password is 'password'.
+    page.get_by_label("อีเมล").fill("staff@example.com")
+    page.get_by_label("รหัสผ่าน").fill("password")
+    page.get_by_role("button", name="เข้าสู่ระบบ").click()
+
+    # 3. Assert: Ensure we are on the dashboard after login.
+    expect(page).to_have_url(re.compile(r".*/dashboard"))
+
+    # 4. Act: Navigate to the first employer's edit page to see employee cards.
+    # We assume an employer with ID 1 exists from the seeders.
+    page.goto("http://127.0.0.1:8000/employers/1/edit")
+
+    # 5. Assert: Check that the "Terminate" button is visible.
+    # We locate the button by its unique title attribute.
+    terminate_button = page.get_by_title("แจ้งออก/เลิกจ้าง")
+
+    # Ensure at least one such button exists and is visible on the page.
+    expect(terminate_button.first).to_be_visible()
+
+    # 6. Screenshot: Capture the result for visual confirmation.
+    # We'll screenshot the whole page to provide context.
+    page.screenshot(path="jules-scratch/verification/verification.png")

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -50,7 +50,7 @@
                     </a>
                 @endif
 
-                @can('delete-employees')
+                @can('terminate-employees')
                 <button type="button" class="btn btn-outline-warning terminate-employee-btn" data-id="{{ $employee->id }}" title="แจ้งออก/เลิกจ้าง">
                     <i class="bi bi-person-dash-fill"></i>
                 </button>


### PR DESCRIPTION
This commit introduces the ability for authorized users to terminate an employee.

- Adds a new `terminate-employees` permission.
- Assigns the new permission to the `staff` and `admin` roles in the `RoleAndPermissionSeeder`.
- Adds a `terminate()` method to the `EmployerController` to handle the employee termination logic.
- Updates the employee card view to use the new `terminate-employees` permission to show the termination button.