### PR TITLE
Refactor terminate modal to be controlled by JavaScript

### DIFF
--- a/jules-scratch/verification/verify_terminate_modal.py
+++ b/jules-scratch/verification/verify_terminate_modal.py
@@ -1,0 +1,68 @@
+import re
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    # --- SETUP ---
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # --- SCRIPT ---
+
+    # 1. Go to login page
+    # Since I cannot run the server, I will assume it's running on localhost:8000
+    # and the user will run it before I run the script.
+    # The user mentioned they will handle artisan commands.
+    # I will inform the user to run the servers before I execute this script.
+    try:
+        page.goto("http://localhost:8000/login")
+
+        # 2. Log in
+        page.get_by_label("อีเมล").fill("test@example.com")
+        page.get_by_label("รหัสผ่าน").fill("password")
+        page.get_by_role("button", name="เข้าสู่ระบบ").click()
+
+        # Wait for navigation to the dashboard or employees page
+        expect(page).to_url(re.compile(r".*/dashboard|.*/employees"))
+        print("Login successful.")
+
+        # 3. Navigate to employees page
+        page.goto("http://localhost:8000/employees")
+        expect(page).to_have_title(re.compile("Employees"))
+        print("Navigated to employees page.")
+
+        # 4. Find and click the first "แจ้งออก" (Terminate) button
+        # The button has the class 'js-terminate-btn'
+        first_terminate_button = page.locator(".js-terminate-btn").first
+        expect(first_terminate_button).to_be_visible()
+        print("Found the terminate button.")
+        first_terminate_button.click()
+        print("Clicked the terminate button.")
+
+        # 5. Wait for the modal to appear and take a screenshot
+        terminate_modal = page.locator("#terminateEmployeeModal")
+        expect(terminate_modal).to_be_visible()
+
+        # Check for the modal title
+        modal_title = terminate_modal.locator(".modal-title")
+        expect(modal_title).to_have_text("แจ้งออก / เลิกจ้าง")
+        print("Modal is visible with the correct title.")
+
+        # Take screenshot
+        screenshot_path = "jules-scratch/verification/verification.png"
+        page.screenshot(path=screenshot_path)
+        print(f"Screenshot saved to {screenshot_path}")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        # Take a screenshot on error to help debug
+        page.screenshot(path="jules-scratch/verification/error.png")
+        raise
+
+    finally:
+        # --- TEARDOWN ---
+        context.close()
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/resources/views/partials/_employee_action_modals.blade.php
+++ b/resources/views/partials/_employee_action_modals.blade.php
@@ -76,26 +76,32 @@ document.addEventListener('DOMContentLoaded', function () {
     const showSuccess = (message) => Swal.fire('สำเร็จ!', message, 'success');
     const showError = (message) => Swal.fire('ผิดพลาด!', message, 'error');
 
-    // --- Terminate Modal Logic ---
-    const terminateModal = document.getElementById('terminateEmployeeModal');
-    if (terminateModal) {
-        terminateModal.addEventListener('show.bs.modal', function (event) {
-            const button = event.relatedTarget;
-            const employeeId = button.getAttribute('data-employee-id');
-            const url = `{{ url('employees') }}/${employeeId}/terminate`;
-            const form = document.getElementById('terminate-form');
-            form.setAttribute('action', url);
-        });
-    }
+    // --- MANUAL MODAL CONTROL ---
+    const terminateModalEl = document.getElementById('terminateEmployeeModal');
+    const terminateModal = terminateModalEl ? new bootstrap.Modal(terminateModalEl) : null;
+    const terminateForm = document.getElementById('terminate-form');
+
+    // ... (โค้ดสำหรับ History Modal สามารถเพิ่มตรงนี้ได้ในอนาคต) ...
 
     // --- Event Delegation for ALL Action Buttons ---
     document.body.addEventListener('click', function(e) {
+        // Find the closest button or link that was clicked
         const target = e.target.closest('button, a');
         if (!target) return;
 
         const employeeId = target.dataset.employeeId;
 
-        // Restore Employee
+        // --- Handle Terminate Button Click ---
+        if (target.matches('.js-terminate-btn')) {
+            e.preventDefault();
+            if (terminateModal && terminateForm) {
+                const url = `{{ url('employees') }}/${employeeId}/terminate`;
+                terminateForm.setAttribute('action', url);
+                terminateModal.show();
+            }
+        }
+
+        // --- Handle Restore Button Click ---
         if (target.matches('.btn-restore')) {
             e.preventDefault();
             Swal.fire({
@@ -122,7 +128,7 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         }
 
-        // Force Delete Employee
+        // --- Handle Force Delete Button Click ---
         if (target.matches('.btn-force-delete')) {
             e.preventDefault();
              Swal.fire({

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -51,9 +51,7 @@
                 @endif
 
                 @can('terminate-employees')
-                <button type="button" class="btn btn-sm btn-outline-danger"
-                        data-bs-toggle="modal"
-                        data-bs-target="#terminateEmployeeModal"
+                <button type="button" class="btn btn-sm btn-outline-danger js-terminate-btn" title="Terminate"
                         data-employee-id="{{ $employee->id }}">
                     <i class="bi bi-person-x-fill"></i> แจ้งออก
                 </button>


### PR DESCRIPTION
This commit refactors the employee termination functionality.

- Removed Bootstrap's `data-bs-*` attributes from the terminate button in the employee card view (`_employee_card.blade.php`).
- Added a `js-terminate-btn` class to the button for JavaScript targeting.
- Updated the JavaScript in `_employee_action_modals.blade.php` to manually control the terminate modal.
- A new event listener now handles clicks on `.js-terminate-btn`, sets the correct form action, and shows the modal using Bootstrap's JavaScript API.

This change decouples the button from the modal implementation, making the system more modular and easier to maintain.