### PR TITLE
Refactor employee action modals to use delegated JavaScript

### DIFF
--- a/resources/views/components/employee-action-buttons.blade.php
+++ b/resources/views/components/employee-action-buttons.blade.php
@@ -22,9 +22,7 @@
 
     {{-- Terminate Button (Orange) --}}
     @can('terminate-employees')
-        <button type="button" class="btn btn-sm btn-outline-warning me-1" title="Terminate"
-                data-bs-toggle="modal"
-                data-bs-target="#terminateEmployeeModal"
+        <button type="button" class="btn btn-sm btn-outline-warning me-1 js-terminate-btn" title="Terminate"
                 data-employee-id="{{ $employee->id }}">
             <i class="bi bi-person-x-fill"></i>
         </button>
@@ -32,7 +30,7 @@
 
     {{-- Force Delete Button (Red) - Admin Only --}}
     @can('force-delete-employees')
-         <button type="button" class="btn btn-sm btn-danger btn-force-delete" title="Force Delete"
+         <button type="button" class="btn btn-sm btn-danger js-force-delete-btn" title="Force Delete"
                 data-employee-id="{{ $employee->id }}">
             <i class="bi bi-trash3-fill"></i>
         </button>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -399,9 +399,9 @@ document.addEventListener('DOMContentLoaded', function () {
                         historyBody.innerHTML = '<tr><td colspan="4" class="text-center">ไม่พบประวัติการจ้างงาน</td></tr>';
                     } else {
                         data.forEach(employee => {
-                            // Use data-employee-id to work with the centralized SweetAlert script
-                            const restoreButton = employee.can_restore ? `<button class="btn btn-sm btn-success btn-restore" data-employee-id="${employee.id}">กู้คืน</button>` : '';
-                            const deleteButton = employee.can_force_delete ? `<button class="btn btn-sm btn-danger btn-force-delete" data-employee-id="${employee.id}">ลบถาวร</button>` : '';
+                            // Use data-employee-id and js-* classes to work with the centralized SweetAlert script
+                            const restoreButton = employee.can_restore ? `<button class="btn btn-sm btn-success js-restore-btn" data-employee-id="${employee.id}">กู้คืน</button>` : '';
+                            const deleteButton = employee.can_force_delete ? `<button class="btn btn-sm btn-danger js-force-delete-btn" data-employee-id="${employee.id}">ลบถาวร</button>` : '';
 
                             const row = `
                                 <tr id="history-row-${employee.id}">

--- a/resources/views/partials/_employee_action_modals.blade.php
+++ b/resources/views/partials/_employee_action_modals.blade.php
@@ -100,22 +100,15 @@ document.addEventListener('DOMContentLoaded', function () {
     const showSuccess = (message) => showToast(message, 'success');
     const showError = (message) => showToast(message, 'error');
 
-    // --- Terminate Modal Logic ---
+    // --- Modal and Form Element References ---
     const terminateModalEl = document.getElementById('terminateEmployeeModal');
-    if (terminateModalEl) {
-        const terminateForm = document.getElementById('terminate-form');
+    const terminateModal = terminateModalEl ? new bootstrap.Modal(terminateModalEl) : null;
+    const terminateForm = document.getElementById('terminate-form');
 
-        // 1. Set form action when modal is shown
-        terminateModalEl.addEventListener('show.bs.modal', function (event) {
-            const button = event.relatedTarget;
-            const employeeId = button.getAttribute('data-employee-id');
-            if (employeeId) {
-                const url = `{{ url('employees') }}/${employeeId}/terminate`;
-                terminateForm.setAttribute('action', url);
-            }
-        });
-
-        // 2. Handle form submission with Fetch API for a smoother experience
+    // --- AJAX form submission for Terminate Modal ---
+    // This listener is separate because it handles a form 'submit' event, not a button 'click'.
+    // It will be triggered after the terminate modal is shown and the user confirms.
+    if (terminateForm) {
         terminateForm.addEventListener('submit', function(e) {
             e.preventDefault();
             const formData = new FormData(this);
@@ -131,8 +124,10 @@ document.addEventListener('DOMContentLoaded', function () {
             })
             .then(response => response.json())
             .then(data => {
-                const modalInstance = bootstrap.Modal.getInstance(terminateModalEl);
-                modalInstance.hide();
+                if (terminateModal) {
+                    const modalInstance = bootstrap.Modal.getInstance(terminateModalEl);
+                    modalInstance.hide();
+                }
                 if (data.success) {
                     Swal.fire('สำเร็จ!', data.message, 'success').then(() => location.reload());
                 } else {
@@ -146,16 +141,27 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    // --- Delegated Event Listeners for Dynamic Buttons (Restore, Force Delete) ---
+    // --- CENTRALIZED EVENT DELEGATION FOR ALL ACTION BUTTONS ---
     document.body.addEventListener('click', function(e) {
-        const button = e.target.closest('.btn-restore, .btn-force-delete');
+        // Find the closest button with an action class
+        const button = e.target.closest('.js-terminate-btn, .js-restore-btn, .js-force-delete-btn');
         if (!button) return;
 
         e.preventDefault();
         const employeeId = button.dataset.employeeId;
+        if (!employeeId) return;
+
+        // --- Handle Terminate Button Click (Show Modal) ---
+        if (button.matches('.js-terminate-btn')) {
+            if (terminateModal && terminateForm) {
+                const url = `{{ url('employees') }}/${employeeId}/terminate`;
+                terminateForm.setAttribute('action', url);
+                terminateModal.show();
+            }
+        }
 
         // --- Handle Restore Button Click ---
-        if (button.matches('.btn-restore')) {
+        if (button.matches('.js-restore-btn')) {
             Swal.fire({
                 title: 'คุณต้องการกู้คืนพนักงานคนนี้ใช่หรือไม่?',
                 text: 'พนักงานจะกลับสู่สถานะ "กำลังจ้างงาน"',
@@ -175,7 +181,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     .then(data => {
                         if (data.success) {
                             showSuccess(data.message);
-                            // Remove row from history modal and reload the page for full update
                             document.getElementById(`history-row-${employeeId}`)?.remove();
                             setTimeout(() => location.reload(), 1500);
                         } else {
@@ -187,7 +192,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         // --- Handle Force Delete Button Click ---
-        if (button.matches('.btn-force-delete')) {
+        if (button.matches('.js-force-delete-btn')) {
              Swal.fire({
                 title: 'คุณแน่ใจหรือไม่?',
                 html: "การกระทำนี้จะลบข้อมูลพนักงานและเอกสารที่เกี่ยวข้องทั้งหมดอย่าง<b>ถาวร</b><br>และไม่สามารถย้อนกลับได้!",
@@ -207,7 +212,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     .then(data => {
                         if (data.success) {
                             showSuccess(data.message);
-                            // Just remove the row from the UI, no need to reload
                             document.getElementById(`history-row-${employeeId}`)?.remove();
                             document.getElementById(`employee-card-${employeeId}`)?.remove();
                             document.getElementById(`employee-row-${employeeId}`)?.remove();


### PR DESCRIPTION
This commit refactors the JavaScript that handles employee actions (terminate, restore, force-delete) to use a centralized, delegated event listener.

Key changes:
- Replaced direct Bootstrap `data-bs-*` attributes for triggering the terminate modal with a JavaScript-based approach.
- Centralized all employee action button clicks (`terminate`, `restore`, `force-delete`) into a single event listener in `_employee_action_modals.blade.php`.
- Updated button components and dynamically generated buttons to use consistent `js-*` class names (`js-terminate-btn`, `js-restore-btn`, `js-force-delete-btn`) for the new event listener to target.
- Preserved all existing functionality, including AJAX form submission for termination and SweetAlert2 confirmations for all actions.