### PR TITLE
feat: Set definitive test passwords in seeders

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,7 +17,7 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'password' => Hash::make('รหัสผ่านสำหรับ Admin ที่คุณ Wing ต้องการ'),
+    'password' => Hash::make('admin_password_1234'),
         ]);
 
         // Call the other seeders

--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -52,7 +52,7 @@ class RoleAndPermissionSeeder extends Seeder
         $staffUser = User::factory()->create([
             'name' => 'Staff User',
             'email' => 'staff@example.com',
-            'password' => Hash::make('รหัสผ่านสำหรับ Staff ที่คุณ Wing ต้องการ'),
+    'password' => Hash::make('staff_password_1234'),
         ]);
         $staffUser->assignRole($staffRole);
         $this->command->info('Staff User (staff@example.com) created and assigned to staff role.');


### PR DESCRIPTION
Replaces the placeholder password text in the database seeders with fixed, definitive passwords for the admin and staff test users.

- The admin user password is set to 'admin_password_1234'.
- The staff user password is set to 'staff_password_1234'.

This follows the instructions to make the test user credentials predictable for development and testing.