### PR TITLE
Fix: Correct Blade Template Structure

### DIFF
--- a/jules-scratch/verification/verify_blade_structure.py
+++ b/jules-scratch/verification/verify_blade_structure.py
@@ -1,0 +1,39 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Register a new user
+    page.goto("http://localhost:5173/register")
+    page.get_by_label("Name").fill("Test User")
+    page.get_by_label("Email Address").fill("test@example.com")
+    page.get_by_label("Password", exact=True).fill("password")
+    page.get_by_label("Confirm Password").fill("password")
+    page.get_by_role("button", name="Register").click()
+
+    # Log in
+    page.goto("http://localhost:5173/login")
+    page.get_by_label("Email").fill("test@example.com")
+    page.get_by_label("Password").fill("password")
+    page.get_by_role("button", name="Log in").click()
+
+    # Verify login by checking for dashboard URL
+    expect(page).to_have_url("http://localhost:5173/dashboard")
+
+    # Navigate to create employer page and take screenshot
+    page.goto("http://localhost:5173/employers/create")
+    page.screenshot(path="jules-scratch/verification/create_employer.png")
+
+    # For the edit page, we need an employer.
+    # Let's assume an employer with ID 1 exists for verification purposes.
+    # If this fails, I'll need to create one first.
+    page.goto("http://localhost:5173/employers/1/edit")
+    page.screenshot(path="jules-scratch/verification/edit_employer.png")
+
+    context.close()
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -183,9 +183,9 @@
         </div>
     </form>
 </div>
-@endsection
 
 @include('partials._address_management')
+@endsection
 
 @push('scripts')
 <script>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -371,10 +371,9 @@
     </button>
 </div>
 
+    @include('partials._address_management')
+    @include('partials._employee_action_modals')
 @endsection
-
-@include('partials._address_management')
-@include('partials._employee_action_modals')
 
 @push('scripts')
 <script>


### PR DESCRIPTION
This commit corrects the Blade template structure in `resources/views/employers/create.blade.php` and `resources/views/employers/edit.blade.php`. The `@include` directives for partial views have been moved inside the `@section('content')` block to ensure they are rendered correctly within the application's layout.