### PR TITLE
Remove unused jQuery script tag from the main layout file.

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -248,8 +248,6 @@
         </div>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-
     {{-- Toast Notification Container --}}
     <div class="toast-container position-fixed top-0 end-0 p-3">
         <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
The project's JavaScript assets have been analyzed, and no dependencies on the jQuery library were found. The existing scripts use vanilla JavaScript or Bootstrap 5's bundled JavaScript, which does not require jQuery.

Removing this unnecessary library call simplifies the asset loading process and eliminates a potential source of conflicts.