### PR TITLE
Fix: Resolve Address Modal and Controller Issues

### DIFF
--- a/app/Http/Controllers/AddressController.php
+++ b/app/Http/Controllers/AddressController.php
@@ -87,6 +87,8 @@ class AddressController extends Controller
             return response()->json(['error' => 'Address data file not found.'], 404);
         }
 
-        return response()->file($path);
+        $json = json_decode(file_get_contents($path), true);
+
+        return response()->json($json);
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -19,6 +19,6 @@
     z-index: 1050;
 }
 
-.modal {
-    z-index: 1060 !important;
+.modal.show {
+    z-index: 1070 !important;
 }

--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -180,6 +180,7 @@
             subDistrictSelect.innerHTML = '<option value="">-- เลือกตำบล/แขวง --</option>';
             zipCodeInput.value = '';
             if (provinceName && thaiAddressData[provinceName]) {
+                districtSelect.disabled = false;
                 Object.keys(thaiAddressData[provinceName].districts).sort().forEach(district => {
                     const option = new Option(district, district);
                     districtSelect.add(option);
@@ -191,6 +192,7 @@
             subDistrictSelect.innerHTML = '<option value="">-- เลือกตำบล/แขวง --</option>';
             zipCodeInput.value = '';
             if (provinceName && districtName && thaiAddressData[provinceName]?.districts[districtName]) {
+                subDistrictSelect.disabled = false;
                 const subDistricts = thaiAddressData[provinceName].districts[districtName].sub_districts;
                 Object.keys(subDistricts).sort().forEach(subDistrict => {
                     const option = new Option(subDistrict, subDistrict);


### PR DESCRIPTION
This commit applies a complete fix for several issues related to the address management modal and its corresponding controller logic.

1.  **CSS Z-index Conflict:** The modal backdrop (`.modal-backdrop`) was conflicting with other elements. The CSS has been updated to set a higher z-index (`1070`) specifically for the `.modal.show` class, ensuring it appears above all other content as intended.

2.  **Controller Data Type Error:** The `AddressController@getThaiAddressData` method was incorrectly returning a file stream (`response()->file()`) instead of a JSON object. This caused the frontend JavaScript to fail when parsing the address data. The method has been corrected to read the JSON file, decode it into a PHP array, and return a proper JSON response (`response()->json()`).

3.  **Disabled JavaScript Dropdowns:** The district and sub-district dropdowns in the address modal were not being enabled after a province was selected. The `populateDistricts` and `populateSubDistricts` JavaScript functions have been modified to explicitly set the `disabled` property of the respective select elements to `false` when they are populated with options.