### PR TITLE
Refactor: Modify redirects to return to employer page

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -111,6 +111,9 @@ public function create(Request $request) // เพิ่ม Request $request เ
         }
 
         Employee::create($validated);
+        if ($request->has('source_employer_id')) {
+            return redirect()->route('employers.edit', $request->source_employer_id)->with('success', 'Employee created successfully.');
+        }
         return redirect()->route('employees.index')->with('success', 'Employee created successfully.');
     }
 
@@ -186,6 +189,9 @@ public function create(Request $request) // เพิ่ม Request $request เ
         }
 
         $employee->update($validated);
+        if ($request->has('source_employer_id')) {
+            return redirect()->route('employers.edit', $request->source_employer_id)->with('success', 'Employee updated successfully.');
+        }
         return redirect()->route('employees.index')->with('success', 'Employee updated successfully.');
     }
 

--- a/resources/views/employees/create.blade.php
+++ b/resources/views/employees/create.blade.php
@@ -22,6 +22,9 @@
 
     <form action="{{ route('employees.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
+    @if(request()->has('employer_id'))
+        <input type="hidden" name="source_employer_id" value="{{ request('employer_id') }}">
+    @endif
         @if(isset($employer) && $employer)
             <input type="hidden" name="employer_id" value="{{ $employer->id }}">
         @else

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -24,6 +24,7 @@
         @csrf
         @method('PUT')
 
+        <input type="hidden" name="source_employer_id" value="{{ $employee->employer_id }}">
         <input type="hidden" name="employer_id" value="{{ $employee->employer_id }}">
 
         {{-- Personal Information --}}

--- a/resources/views/employees/history.blade.php
+++ b/resources/views/employees/history.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.app')
+
+@section('title', 'ประวัติการจ้างงาน')
+
+@section('content')
+<div class="content-section">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2 class="mb-0">ประวัติการจ้างงาน</h2>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Photo</th>
+                    <th scope="col">Name (EN / TH)</th>
+                    <th scope="col">Passport</th>
+                    <th scope="col">Nationality</th>
+                    <th scope="col">Employer</th>
+                    <th scope="col">Termination Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($terminatedEmployees as $employee)
+                    <tr>
+                        <th scope="row">{{ $loop->iteration }}</th>
+                        <td class="align-middle text-center" style="width: 60px;">
+                            @if($employee->employeePhoto)
+                                <img src="{{ asset('storage/' . $employee->employeePhoto) }}" alt="Photo" class="img-fluid rounded-circle" style="width: 40px; height: 40px; object-fit: cover;">
+                            @else
+                                <div class="bg-secondary rounded-circle d-flex justify-content-center align-items-center text-white" style="width: 40px; height: 40px;">
+                                    <i class="bi bi-person-fill"></i>
+                                </div>
+                            @endif
+                        </td>
+                        <td class="align-middle">
+                            <div class="fw-bold">{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}</div>
+                            <div class="text-muted small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }}</div>
+                        </td>
+                        <td class="align-middle">{{ $employee->employeePassport ?? '-' }}</td>
+                        <td class="align-middle">{{ $employee->employeeNationality ?? '-' }}</td>
+                        <td class="align-middle">{{ $employee->employer->employerNameTh ?? 'N/A' }}</td>
+                        <td class="align-middle">{{ $employee->termination_date ? \Carbon\Carbon::parse($employee->termination_date)->format('d/m/Y') : 'N/A' }}</td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="7" class="text-center text-muted py-4">ไม่พบข้อมูลพนักงานที่ถูกเลิกจ้าง</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+     <div class="mt-4">
+        {{ $terminatedEmployees->links() }}
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
- After creating or updating an employee from the employer's detail page, the user is now redirected back to the employer's detail page instead of the main employee index.
- This is achieved by passing a `source_employer_id` in the forms and checking for it in the `EmployeeController`.

Feat: Overhaul the employment history page

- Replaced the old employment history page with a new, detailed table-based layout.
- The new table displays key employee information, including their photo, name, passport number, nationality, employer, and termination date.
- Added pagination to the history page.