### PR TITLE
feat: Overhaul filtering logic in controllers

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -20,23 +20,39 @@ class EmployeeController extends Controller
 
 public function index(Request $request)
 {
-    // เปลี่ยนบรรทัดแรกให้มีการกรองข้อมูล
-    $query = Employee::query()->whereNull('terminated_at');
-    // ... filtering logic ...
+    $query = Employee::where('termination_date', null)->with('employer')->latest();
 
-    $totalEmployees = $query->count();
+    // Search functionality
+    $query->when($request->filled('search'), function ($q) use ($request) {
+        $searchTerm = $request->search;
+        $q->where(function ($subQuery) use ($searchTerm) {
+            $subQuery->where('employeeNameTh', 'like', "%{$searchTerm}%")
+                     ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
+                     ->orWhere('employeePassport', 'like', "%{$searchTerm}%")
+                     ->orWhere('personalId', 'like', "%{$searchTerm}%")
+                     ->orWhere('companyWorkerId', 'like', "%{$searchTerm}%");
+        });
+    });
 
-    $perPageOptions = [25, 50, 100];
-    $currentPerPage = $request->input('per_page', 25); // แก้ชื่อตัวแปรตรงนี้
+    // Filter functionality
+    $query->when($request->filled('nationality'), fn($q) => $q->where('employeeNationality', $request->nationality));
+    $query->when($request->filled('mou_type'), fn($q) => $q->where('workPermitMOUGroup', $request->mou_type));
+    $query->when($request->filled('pink_card_status'), function ($q) use ($request) {
+        if ($request->pink_card_status === 'yes') {
+            $q->whereNotNull('pinkCardNo')->where('pinkCardNo', '!=', '');
+        } elseif ($request->pink_card_status === 'no') {
+            $q->where(fn($sub) => $sub->whereNull('pinkCardNo')->orWhere('pinkCardNo', ''));
+        }
+    });
 
-    $employees = $query->with('employer')->latest()->paginate($currentPerPage);
+    $employees = $query->paginate(10)->withQueryString();
 
-    return view('employees.index', compact(
-        'employees',
-        'totalEmployees',
-        'perPageOptions',
-        'currentPerPage' // ส่งตัวแปรที่ถูกต้องไป
-    ))->with('currentView', $request->input('view', 'card'));
+    // Gender Counts
+    $totalEmployees = Employee::where('termination_date', null)->count();
+    $maleCount = Employee::where('termination_date', null)->whereIn('employeeTitleTh', ['นาย'])->count();
+    $femaleCount = Employee::where('termination_date', null)->whereIn('employeeTitleTh', ['นางสาว', 'นาง'])->count();
+
+    return view('employees.index', compact('employees', 'totalEmployees', 'maleCount', 'femaleCount'));
 }
 
 public function create(Request $request) // เพิ่ม Request $request เข้ามา

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -78,24 +78,42 @@ public function edit(Request $request, Employer $employer) // เพิ่ม Re
 {
     $jobOwners = JobOwner::orderBy('name')->get();
 
-    // --- เพิ่ม Logic ส่วนนี้เข้าไปทั้งหมด ---
-    $employeeQuery = $employer->employees()->whereNull('terminated_at');
-    // You can add filtering logic for employees here if needed based on $request
+    $jobOwners = JobOwner::orderBy('name')->get();
 
-    $perPageOptions = [10, 25, 50];
-    $currentPerPage = $request->input('per_page', 10);
-    $employees = $employeeQuery->paginate($currentPerPage); // เปลี่ยน $activeEmployees เป็น $employees และ paginate
-    $currentView = $request->input('view', 'card');
+    // Find the line that starts with "$employeesQuery = ..." and replace the entire filtering block
 
-    $terminatedEmployees = $employer->employees()->whereNotNull('terminated_at')->get();
+$employeesQuery = $employer->employees()->whereNull('termination_date');
+
+// Search functionality
+$employeesQuery->when($request->filled('search'), function ($q) use ($request) {
+    $searchTerm = $request->search;
+    $q->where(function ($subQuery) use ($searchTerm) {
+        $subQuery->where('employeeNameTh', 'like', "%{$searchTerm}%")
+                 ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
+                 ->orWhere('employeePassport', 'like', "%{$searchTerm}%");
+    });
+});
+
+// Filter functionality
+$employeesQuery->when($request->filled('nationality'), fn($q) => $q->where('employeeNationality', $request->nationality));
+$employeesQuery->when($request->filled('mou_type'), fn($q) => $q->where('workPermitMOUGroup', $request->mou_type));
+$employeesQuery->when($request->filled('pink_card_status'), function ($q) use ($request) {
+    if ($request->pink_card_status === 'yes') {
+        $q->whereNotNull('pinkCardNo')->where('pinkCardNo', '!=', '');
+    } elseif ($request->pink_card_status === 'no') {
+        $q->where(fn($sub) => $sub->whereNull('pinkCardNo')->orWhere('pinkCardNo', ''));
+    }
+});
+
+$employees = $employeesQuery->paginate(10, ['*'], 'employees_page')->withQueryString();
+
+    $terminatedEmployees = $employer->employees()->whereNotNull('termination_date')->get(); // Assuming you still need this for a modal or separate list
 
     return view('employers.edit', compact(
         'employer',
         'jobOwners',
-        'employees', // ส่งตัวแปรที่ถูกต้อง
-        'terminatedEmployees',
-        'perPageOptions', // ส่งตัวแปรที่ขาดไป
-        'currentView'     // ส่งตัวแปรที่ขาดไป
+        'employees',
+        'terminatedEmployees'
     ));
 }
 


### PR DESCRIPTION
Refactors the filtering and search logic in `EmployeeController@index` and `EmployerController@edit`.

- Implements robust, conditional filtering using `when()` for search terms, nationality, MOU type, and pink card status.
- Consolidates search logic to query across multiple relevant fields (names, IDs, passport numbers).
- Standardizes the pagination and data passed to the views for consistency.
- Removes outdated and less efficient filtering code.