### PR TITLE
Fix: Correct multiple UI and logic bugs

### DIFF
--- a/jules-scratch/verification/verify_bug_fixes.py
+++ b/jules-scratch/verification/verify_bug_fixes.py
@@ -1,0 +1,30 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Log in
+    page.goto("http://localhost:8000/login")
+    page.get_by_label("Email address").fill("test@example.com")
+    page.get_by_label("Password").fill("admin_password_1234")
+    page.get_by_role("button", name="Log in").click()
+
+    # Go to employees page
+    page.goto("http://localhost:8000/employees")
+
+    # Verify the layout and bulk action checkbox
+    page.screenshot(path="jules-scratch/verification/employees_page.png")
+
+    # Go to an employer's edit page
+    page.goto("http://localhost:8000/employers/1/edit")
+
+    # Verify the fatal error fix and the layout
+    page.screenshot(path="jules-scratch/verification/employer_edit_page.png")
+
+    context.close()
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -20,30 +20,23 @@
 
 <div class="card p-3 mb-3">
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-3">
-        <form method="GET" action="{{ route('employees.index') }}" class="d-flex flex-wrap gap-2">
-            <input type="hidden" name="view" value="{{ $currentView }}">
-            <input type="hidden" name="per_page" value="{{ $currentPerPage }}">
-
-            <select name="nationality" class="form-select form-select-sm" onchange="this.form.submit()">
+        <form method="GET" action="{{ route('employees.index') }}" class="d-flex flex-wrap align-items-center gap-2">
+            <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหา..." value="{{ request('search') }}" style="width: 200px;">
+            <select name="nationality" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- ทุกสัญชาติ --</option>
                 <option value="เมียนมา" {{ request('nationality') == 'เมียนมา' ? 'selected' : '' }}>เมียนมา</option>
                 <option value="ลาว" {{ request('nationality') == 'ลาว' ? 'selected' : '' }}>ลาว</option>
                 <option value="กัมพูชา" {{ request('nationality') == 'กัมพูชา' ? 'selected' : '' }}>กัมพูชา</option>
                 <option value="เวียดนาม" {{ request('nationality') == 'เวียดนาม' ? 'selected' : '' }}>เวียดนาม</option>
             </select>
-
-            <select name="pink_card" class="form-select form-select-sm" onchange="this.form.submit()">
+            <select name="pink_card" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- บัตรชมพู --</option>
                 <option value="yes" {{ request('pink_card') == 'yes' ? 'selected' : '' }}>มีบัตรชมพู</option>
                 <option value="no" {{ request('pink_card') == 'no' ? 'selected' : '' }}>ไม่มีบัตรชมพู</option>
             </select>
-
-            <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหา..." value="{{ request('search') }}">
-
             <button type="submit" class="btn btn-sm btn-primary">กรอง</button>
             <a href="{{ route('employees.index') }}" class="btn btn-sm btn-secondary">ล้างค่า</a>
         </form>
-
         <div class="d-flex align-items-center gap-2">
             <div class="btn-group btn-group-sm">
                 <a href="{{ route('employees.index', array_merge(request()->query(), ['view' => 'card'])) }}" class="btn {{ $currentView == 'card' ? 'btn-primary' : 'btn-outline-secondary' }}">การ์ด</a>
@@ -58,7 +51,6 @@
     </div>
 </div>
 
-{{-- Bulk Action Bar --}}
 <div class="bulk-action-bar mb-3">
     <span>เลือกทั้งหมด (0)</span>
     <button class="btn btn-sm btn-outline-danger" disabled>ดำเนินการกับรายการที่เลือก</button>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -219,8 +219,8 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
     @php
         $totalEmployees = $employees->total();
-        $maleCount = $employer->employees()->where('gender', 'ชาย')->count();
-        $femaleCount = $employer->employees()->where('gender', 'หญิง')->count();
+        $maleCount = $employer->employees()->whereIn('employeeTitleTh', ['นาย'])->count();
+    $femaleCount = $employer->employees()->whereIn('employeeTitleTh', ['นางสาว', 'นาง'])->count();
     @endphp
     <h5 class="mb-0">
         ข้อมูลลูกจ้าง (รวม: {{ $totalEmployees }} | ชาย: {{ $maleCount }} | หญิง: {{ $femaleCount }})
@@ -228,39 +228,30 @@
     <div class="d-flex gap-2">
         <a href="{{ route('employers.exportEmployees', ['employer' => $employer->id] + request()->query()) }}" class="btn btn-sm btn-outline-success">Export</a>
         @can('create-employees')
-            <a href="{{ route('employees.create', ['employer_id' => $employer->id]) }}" class="btn btn-sm btn-success">
-                <i class="bi bi-plus-circle"></i> เพิ่มพนักงาน
-            </a>
+            <a href="{{ route('employees.create', ['employer_id' => $employer->id]) }}" class="btn btn-sm btn-success"><i class="bi bi-plus-circle"></i> เพิ่มพนักงาน</a>
         @endcan
     </div>
 </div>
 
 <div class="card p-3 mb-3">
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-3">
-         <form method="GET" action="{{ route('employers.edit', $employer->id) }}" class="d-flex flex-wrap gap-2">
-            <input type="hidden" name="view" value="{{ $currentView }}">
-            <input type="hidden" name="per_page" value="{{ $currentPerPage }}">
-
-            <select name="nationality" class="form-select form-select-sm" onchange="this.form.submit()">
+        <form method="GET" action="{{ route('employers.edit', $employer->id) }}" class="d-flex flex-wrap align-items-center gap-2">
+            <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหา..." value="{{ request('search') }}" style="width: 200px;">
+            <select name="nationality" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- ทุกสัญชาติ --</option>
                 <option value="เมียนมา" {{ request('nationality') == 'เมียนมา' ? 'selected' : '' }}>เมียนมา</option>
                 <option value="ลาว" {{ request('nationality') == 'ลาว' ? 'selected' : '' }}>ลาว</option>
                 <option value="กัมพูชา" {{ request('nationality') == 'กัมพูชา' ? 'selected' : '' }}>กัมพูชา</option>
                 <option value="เวียดนาม" {{ request('nationality') == 'เวียดนาม' ? 'selected' : '' }}>เวียดนาม</option>
             </select>
-
-            <select name="pink_card" class="form-select form-select-sm" onchange="this.form.submit()">
+            <select name="pink_card" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- บัตรชมพู --</option>
                 <option value="yes" {{ request('pink_card') == 'yes' ? 'selected' : '' }}>มีบัตรชมพู</option>
                 <option value="no" {{ request('pink_card') == 'no' ? 'selected' : '' }}>ไม่มีบัตรชมพู</option>
             </select>
-
-            <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหา..." value="{{ request('search') }}">
-
             <button type="submit" class="btn btn-sm btn-primary">กรอง</button>
             <a href="{{ route('employers.edit', $employer->id) }}" class="btn btn-sm btn-secondary">ล้างค่า</a>
         </form>
-
         <div class="d-flex align-items-center gap-2">
             <div class="btn-group btn-group-sm">
                 <a href="{{ route('employers.edit', ['employer' => $employer->id] + array_merge(request()->query(), ['view' => 'card'])) }}" class="btn {{ $currentView == 'card' ? 'btn-primary' : 'btn-outline-secondary' }}">การ์ด</a>
@@ -275,7 +266,6 @@
     </div>
 </div>
 
-{{-- Bulk Action Bar --}}
 <div class="bulk-action-bar mb-3">
     <span>เลือกทั้งหมด (0)</span>
     <button class="btn btn-sm btn-outline-danger" disabled>ดำเนินการกับรายการที่เลือก</button>

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -1,3 +1,4 @@
+<input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}">
 @php
     $employerName = $employee->employer->employerNameTh ?? 'N/A';
 @endphp


### PR DESCRIPTION
This commit addresses three separate issues:

1.  **Fatal Error in Gender Count:** The employee count by gender on the employer edit page was causing a fatal error. The logic was incorrectly trying to query a `gender` column and later had a typo (`employeeTitleT`). This has been corrected to query the `employeeTitleTh` column with the appropriate Thai titles ('นาย', 'นางสาว', 'นาง') to accurately count male and female employees.

2.  **Incorrect Control Bar Layout:** The control bars for filtering and view options on the main employee list (`employees/index`) and the employee list on the employer edit page (`employers/edit`) were using an outdated or incorrect layout. Both have been replaced with the correct, standardized control bar template.

3.  **Missing Bulk Action Checkbox:** The checkbox for selecting individual employees for bulk actions was missing from the employee card view. This has been restored by adding the necessary input to the `_employee_card.blade.php` partial.