### PR TITLE
Fix: Unify Control and Bulk Action Bars

### DIFF
--- a/jules-scratch/verification/verify_bars.py
+++ b/jules-scratch/verification/verify_bars.py
@@ -1,0 +1,20 @@
+from playwright.sync_api import Page, expect
+
+def test_verify_bars(page: Page):
+    # Go to the employers edit page
+    page.goto("http://127.0.0.1:8000/employers/1/edit")
+
+    # Wait for the page to load
+    expect(page.get_by_text("แก้ไขข้อมูลนายจ้าง")).to_be_visible()
+
+    # Take a screenshot of the employers edit page
+    page.screenshot(path="jules-scratch/verification/employers-edit.png")
+
+    # Go to the employees index page
+    page.goto("http://127.0.0.1:8000/employees")
+
+    # Wait for the page to load
+    expect(page.get_by_text("รายการข้อมูลลูกจ้างทั้งหมด")).to_be_visible()
+
+    # Take a screenshot of the employees index page
+    page.screenshot(path="jules-scratch/verification/employees-index.png")

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -51,8 +51,13 @@
     </div>
 </div>
 
-<div class="bulk-action-bar mb-3">
-    <span>เลือกทั้งหมด (0)</span>
+<div class="bulk-action-bar mb-3" style="display: none;">
+    <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="select-all-checkbox">
+        <label class="form-check-label" for="select-all-checkbox">
+            เลือกทั้งหมด (<span id="selected-count">0</span>)
+        </label>
+    </div>
     <button class="btn btn-sm btn-outline-danger" disabled>ดำเนินการกับรายการที่เลือก</button>
 </div>
 

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -256,12 +256,28 @@
             <button type="submit" class="btn btn-sm btn-primary">กรอง</button>
             <a href="{{ route('employers.edit', $employer->id) }}" class="btn btn-sm btn-secondary">ล้างค่า</a>
         </form>
+        <div class="d-flex align-items-center gap-2">
+            <div class="btn-group btn-group-sm">
+                <a href="{{ route('employers.edit', ['employer' => $employer->id] + array_merge(request()->query(), ['view' => 'card'])) }}" class="btn {{ $currentView == 'card' ? 'btn-primary' : 'btn-outline-secondary' }}">การ์ด</a>
+                <a href="{{ route('employers.edit', ['employer' => $employer->id] + array_merge(request()->query(), ['view' => 'table'])) }}" class="btn {{ $currentView == 'table' ? 'btn-primary' : 'btn-outline-secondary' }}">ตาราง</a>
+            </div>
+            <div class="btn-group btn-group-sm">
+                @foreach($perPageOptions as $option)
+                    <a href="{{ route('employers.edit', ['employer' => $employer->id] + array_merge(request()->query(), ['per_page' => $option])) }}" class="btn {{ $currentPerPage == $option ? 'btn-primary' : 'btn-outline-secondary' }}">{{ $option }}</a>
+                @endforeach
+            </div>
+        </div>
     </div>
 </div>
 
-<div class="bulk-action-bar" style="display: none;">
-    <span id="selected-count">เลือกทั้งหมด (0)</span>
-    <button class="btn btn-sm btn-outline-danger">ดำเนินการกับรายการที่เลือก</button>
+<div class="bulk-action-bar mb-3" style="display: none;">
+    <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="select-all-checkbox">
+        <label class="form-check-label" for="select-all-checkbox">
+            เลือกทั้งหมด (<span id="selected-count">0</span>)
+        </label>
+    </div>
+    <button class="btn btn-sm btn-outline-danger" disabled>ดำเนินการกับรายการที่เลือก</button>
 </div>
 {{-- END: REPLACE UNTIL HERE --}}
 <div id="employeeList">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -479,5 +479,44 @@
     </script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     @stack('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const selectAllCheckbox = document.getElementById('select-all-checkbox');
+    const employeeCheckboxes = document.querySelectorAll('.employee-checkbox');
+    const bulkActionBar = document.querySelector('.bulk-action-bar');
+    const selectedCountSpan = document.getElementById('selected-count');
+    const bulkActionButton = bulkActionBar ? bulkActionBar.querySelector('button') : null;
+
+    if (!selectAllCheckbox) return; // Exit if controls are not on this page
+
+    function updateBulkActionBar() {
+        const selectedCheckboxes = document.querySelectorAll('.employee-checkbox:checked');
+        const count = selectedCheckboxes.length;
+
+        if (count > 0) {
+            bulkActionBar.style.display = 'flex';
+            selectedCountSpan.textContent = count;
+            bulkActionButton.disabled = false;
+            // Sync select-all checkbox
+            selectAllCheckbox.checked = (count === employeeCheckboxes.length);
+        } else {
+            bulkActionBar.style.display = 'none';
+            bulkActionButton.disabled = true;
+            selectAllCheckbox.checked = false;
+        }
+    }
+
+    selectAllCheckbox.addEventListener('change', function () {
+        employeeCheckboxes.forEach(checkbox => {
+            checkbox.checked = this.checked;
+        });
+        updateBulkActionBar();
+    });
+
+    employeeCheckboxes.forEach(checkbox => {
+        checkbox.addEventListener('change', updateBulkActionBar);
+    });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
This commit brings consistency to the Control Bar and Bulk Action Bar across the `employees/index.blade.php` and `employers/edit.blade.php` pages.

- **Control Bar:** The view and pagination controls from the employees index page have been added to the employers edit page, ensuring a consistent user experience for filtering and navigation.
- **Bulk Action Bar:** Both pages now use the same Bulk Action Bar, which includes a "Select All" checkbox and a selection counter for improved usability.
- **Global JavaScript:** A new JavaScript block has been added to the main `app.blade.php` layout to handle the "Select All" functionality globally, making the feature available on any page that uses the layout and has the appropriate checkboxes.