### PR TITLE
Fix: Resolve fatal error and implement table bulk actions

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -127,7 +127,8 @@ public function edit(Request $request, Employer $employer)
         'employees',
         'terminatedEmployees',
         'perPageOptions',
-        'currentView'
+        'currentView',
+        'currentPerPage'
     ));
 }
 

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -83,7 +83,7 @@
             <table class="table table-hover align-middle">
                 <thead class="table-light">
                     <tr>
-                        <th scope="col" style="width: 1rem;"></th>
+                        <th style="width: 1%;"><input class="form-check-input" type="checkbox" id="table-select-all-checkbox"></th>
                         <th scope="col">Employee</th>
                         <th scope="col">Employer</th>
                         <th scope="col">Passport</th>
@@ -95,7 +95,7 @@
                 <tbody>
                     @forelse($employees as $employee)
                     <tr>
-                        <td><input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $employee->id }}"></td>
+                        <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}"></td>
                         <td>
                             <div class="d-flex align-items-center">
                                 <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}" alt="Photo" class="employee-photo-thumb" style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; margin-right: 0.75rem;">

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -295,7 +295,7 @@
             <table class="table table-hover table-sm align-middle">
                 <thead>
                     <tr>
-                        <th style="width: 1rem;"><!-- Checkbox --></th>
+                        <th style="width: 1%;"><input class="form-check-input" type="checkbox" id="table-select-all-checkbox"></th>
                         <th style="width: 5%;">#</th>
                         <th style="width: 10%;">Photo</th>
                         <th style="width: 25%;">Name (EN)</th>
@@ -309,7 +309,7 @@
                     @forelse($employees as $employee)
                         <tr id="employee-row-{{ $employee->id }}">
                             {{-- DEFINITIVE FIX: Add checkbox for bulk actions --}}
-                            <td><input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $employee->id }}"></td>
+                            <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}"></td>
                             <td>{{ $employees->firstItem() + $loop->index }}</td>
                             <td class="align-middle text-center" style="width: 60px;">
                                 @if($employee->employeePhoto)


### PR DESCRIPTION
- Patches EmployerController@edit to include `currentPerPage` in the view's compact(), fixing a fatal error when changing the items per page in the table view.
- Adds 'select all' and individual row checkboxes to the employee table view in `employees/index.blade.php`.
- Adds 'select all' and individual row checkboxes to the employee table view in `employers/edit.blade.php`.
- Standardizes the checkbox class to `employee-checkbox` to align with the existing global JavaScript handler for bulk actions.