### PR TITLE
Refactor: Overhaul address management and update history modal

### DIFF
--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -151,8 +151,11 @@
             <div class="content-section mt-4">
                 <div class="d-flex justify-content-between align-items-center mb-3">
                     <h5 class="mb-0">ที่อยู่ตามทะเบียน</h5>
-                    <button type="button" class="btn btn-sm btn-outline-success add-address-btn" data-bs-toggle="modal" data-bs-target="#addAddressModal" data-address-type="registered">
-                        <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
+                    <button type="button" class="btn btn-sm btn-primary add-address-btn"
+                            data-bs-toggle="modal"
+                            data-bs-target="#addressModal"
+                            data-type="registered">
+                        + เพิ่มที่อยู่
                     </button>
                 </div>
                 <div id="registeredAddressList" class="vstack gap-3">
@@ -164,8 +167,11 @@
             <div class="content-section mt-4">
                 <div class="d-flex justify-content-between align-items-center mb-3">
                     <h5 class="mb-0">ที่อยู่สถานที่ทำงาน</h5>
-                    <button type="button" class="btn btn-sm btn-outline-success add-address-btn" data-bs-toggle="modal" data-bs-target="#addAddressModal" data-address-type="workplace">
-                        <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
+                    <button type="button" class="btn btn-sm btn-primary add-address-btn"
+                            data-bs-toggle="modal"
+                            data-bs-target="#addressModal"
+                            data-type="workplace">
+                        + เพิ่มที่อยู่
                     </button>
                 </div>
                 <div id="workplaceAddressList" class="vstack gap-3">
@@ -197,10 +203,10 @@ document.addEventListener('DOMContentLoaded', function () {
     const registeredAddressList = document.getElementById('registeredAddressList');
     const workplaceAddressList = document.getElementById('workplaceAddressList');
     const mainForm = document.getElementById('saveEmployerForm');
-    const addressModalEl = document.getElementById('addAddressModal');
+    const addressModalEl = document.getElementById('addressModal');
     const addressModal = new bootstrap.Modal(addressModalEl);
     const addressForm = document.getElementById('addressForm');
-    const saveAddressButton = document.getElementById('saveAddress');
+    const saveAddressButton = document.getElementById('saveAddressBtn');
     const originalSaveButtonText = saveAddressButton.innerHTML;
 
     // This is the create page, so we override the default AJAX save behavior
@@ -377,8 +383,8 @@ document.addEventListener('DOMContentLoaded', function () {
      // Set address type when "Add Address" is clicked
     document.querySelectorAll('.add-address-btn').forEach(button => {
         button.addEventListener('click', function() {
-            const addressType = this.getAttribute('data-address-type');
-            document.getElementById('addressType').value = addressType;
+            const addressType = this.getAttribute('data-type');
+            document.getElementById('address_type').value = addressType;
         });
     });
 });

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -151,8 +151,12 @@
     <div class="content-section mt-4">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h5 class="mb-0">ที่อยู่ตามทะเบียน</h5>
-            <button type="button" class="btn btn-sm btn-outline-primary add-address-btn" data-type="registered" data-addressable-id="{{ $employer->id }}" data-addressable-type="employer" data-bs-toggle="modal" data-bs-target="#addAddressModal">
-                <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
+            <button type="button" class="btn btn-sm btn-primary add-address-btn"
+                    data-bs-toggle="modal"
+                    data-bs-target="#addressModal"
+                    data-type="registered"
+                    data-addressable-id="{{ $employer->id }}">
+                + เพิ่มที่อยู่
             </button>
         </div>
         <div id="registeredAddressList" class="vstack gap-3">
@@ -171,7 +175,13 @@
                         </p>
                     </div>
                     <div class="btn-group btn-group-sm">
-                        <button type="button" class="btn btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
+                        <button type="button" class="btn btn-sm btn-warning edit-address-btn"
+                                data-bs-toggle="modal"
+                                data-bs-target="#addressModal"
+                                data-address-id="{{ $address->id }}">
+                            แก้ไข
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
                     </div>
                 </div>
             @empty
@@ -184,8 +194,12 @@
     <div class="content-section mt-4">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h5 class="mb-0">ที่อยู่สถานที่ทำงาน</h5>
-            <button type="button" class="btn btn-sm btn-outline-primary add-address-btn" data-type="workplace" data-addressable-id="{{ $employer->id }}" data-addressable-type="employer" data-bs-toggle="modal" data-bs-target="#addAddressModal">
-                <i class="bi bi-plus-lg"></i> เพิ่มที่อยู่
+            <button type="button" class="btn btn-sm btn-primary add-address-btn"
+                    data-bs-toggle="modal"
+                    data-bs-target="#addressModal"
+                    data-type="workplace"
+                    data-addressable-id="{{ $employer->id }}">
+                + เพิ่มที่อยู่
             </button>
         </div>
         <div id="workplaceAddressList" class="vstack gap-3">
@@ -204,7 +218,13 @@
                         </p>
                     </div>
                     <div class="btn-group btn-group-sm">
-                        <button type="button" class="btn btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
+                        <button type="button" class="btn btn-sm btn-warning edit-address-btn"
+                                data-bs-toggle="modal"
+                                data-bs-target="#addressModal"
+                                data-address-id="{{ $address->id }}">
+                            แก้ไข
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
                     </div>
                 </div>
             @empty

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -479,6 +479,224 @@
     </script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     @stack('scripts')
+
+<script>
+// Full-Featured Address Management Script
+document.addEventListener('DOMContentLoaded', function () {
+    // --- Configuration & Global State ---
+    const thaiDataUrl = "/thai-addresses"; // Hardcoded URL
+    let thaiAddressData = [];
+    let dataLoaded = false;
+    const addressModalEl = document.getElementById('addressModal');
+    if (!addressModalEl) return; // Exit if the modal isn't on the page
+
+    const addressModal = new bootstrap.Modal(addressModalEl);
+    const addressForm = document.getElementById('addressForm');
+    const saveBtn = document.getElementById('saveAddressBtn');
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+    // --- Form Fields ---
+    const fields = {
+        id: document.getElementById('address_id'),
+        addressable_id: document.getElementById('addressable_id'),
+        addressable_type: document.getElementById('addressable_type'),
+        type: document.getElementById('address_type'),
+        addrNo: document.getElementById('addrNo'),
+        addrNoEn: document.getElementById('addrNoEn'),
+        addrMoo: document.getElementById('addrMoo'),
+        addrMooEn: document.getElementById('addrMooEn'),
+        addrSoi: document.getElementById('addrSoi'),
+        addrSoiEn: document.getElementById('addrSoiEn'),
+        addrRoad: document.getElementById('addrRoad'),
+        addrRoadEn: document.getElementById('addrRoadEn'),
+        addrProvince: document.getElementById('addrProvince'),
+        addrProvinceEn: document.getElementById('addrProvinceEn'),
+        addrDistrict: document.getElementById('addrDistrict'),
+        addrDistrictEn: document.getElementById('addrDistrictEn'),
+        addrSubDistrict: document.getElementById('addrSubDistrict'),
+        addrSubDistrictEn: document.getElementById('addrSubDistrictEn'),
+        addrZipCode: document.getElementById('addrZipCode')
+    };
+
+    // --- Data Loading ---
+    async function fetchThaiAddressData() {
+        if (dataLoaded) return;
+        try {
+            const response = await fetch(thaiDataUrl);
+            if (!response.ok) throw new Error('Network response was not ok.');
+            thaiAddressData = await response.json();
+            dataLoaded = true;
+            populateProvinces();
+        } catch (error) {
+            console.error('Failed to fetch Thai address data:', error);
+            showToast('ไม่สามารถโหลดข้อมูลที่อยู่ได้', 'danger');
+        }
+    }
+
+    // --- Dropdown Population ---
+    function populateProvinces() {
+        fields.addrProvince.innerHTML = '<option value="">-- เลือกจังหวัด --</option>';
+        const uniqueProvinces = [...new Map(thaiAddressData.map(item => [item['province_th'], item])).values()];
+        uniqueProvinces.sort((a, b) => a.province_th.localeCompare(b.province_th, 'th'));
+        uniqueProvinces.forEach(item => {
+            const option = new Option(item.province_th, item.province_th);
+            fields.addrProvince.add(option);
+        });
+    }
+
+    function populateDistricts(province) {
+        fields.addrDistrict.innerHTML = '<option value="">-- เลือกอำเภอ/เขต --</option>';
+        fields.addrSubDistrict.innerHTML = '<option value="">-- เลือกตำบล/แขวง --</option>'; // Reset sub-districts
+        if (!province) return;
+
+        const districts = [...new Set(thaiAddressData.filter(d => d.province_th === province).map(d => d.district_th))];
+        districts.sort((a, b) => a.localeCompare(b, 'th'));
+        districts.forEach(district => {
+            const option = new Option(district, district);
+            fields.addrDistrict.add(option);
+        });
+    }
+
+    function populateSubDistricts(province, district) {
+        fields.addrSubDistrict.innerHTML = '<option value="">-- เลือกตำบล/แขวง --</option>';
+        if (!province || !district) return;
+
+        const subDistricts = thaiAddressData.filter(d => d.province_th === province && d.district_th === district);
+        subDistricts.sort((a, b) => a.subdistrict_th.localeCompare(b.subdistrict_th, 'th'));
+        subDistricts.forEach(sub => {
+            const option = new Option(sub.subdistrict_th, sub.subdistrict_th);
+            fields.addrSubDistrict.add(option);
+        });
+    }
+
+    // --- Event Listeners for Dropdowns ---
+    fields.addrProvince.addEventListener('change', function() {
+        populateDistricts(this.value);
+        const selectedData = thaiAddressData.find(d => d.province_th === this.value);
+        fields.addrProvinceEn.value = selectedData ? selectedData.province_en : '';
+        fields.addrDistrictEn.value = '';
+        fields.addrSubDistrictEn.value = '';
+        fields.addrZipCode.value = '';
+    });
+
+    fields.addrDistrict.addEventListener('change', function() {
+        populateSubDistricts(fields.addrProvince.value, this.value);
+        const selectedData = thaiAddressData.find(d => d.province_th === fields.addrProvince.value && d.district_th === this.value);
+        fields.addrDistrictEn.value = selectedData ? selectedData.district_en : '';
+        fields.addrSubDistrictEn.value = '';
+        fields.addrZipCode.value = '';
+    });
+
+    fields.addrSubDistrict.addEventListener('change', function() {
+        const selectedData = thaiAddressData.find(d =>
+            d.province_th === fields.addrProvince.value &&
+            d.district_th === fields.addrDistrict.value &&
+            d.subdistrict_th === this.value
+        );
+        if (selectedData) {
+            fields.addrSubDistrictEn.value = selectedData.subdistrict_en;
+            fields.addrZipCode.value = selectedData.zip_code;
+        }
+    });
+
+    // --- Modal Opening Logic ---
+    addressModalEl.addEventListener('show.bs.modal', async function(e) {
+        await fetchThaiAddressData();
+        const button = e.relatedTarget;
+        if (!button) return;
+
+        const isAddButton = button.matches('.add-address-btn');
+        const isEditButton = button.matches('.edit-address-btn');
+
+        if (isAddButton) {
+            addressForm.reset();
+            fields.id.value = '';
+            fields.addressable_id.value = button.dataset.addressableId;
+            fields.addressable_type.value = 'App\\Models\\Employer';
+            fields.type.value = button.dataset.type;
+            document.getElementById('addressModalLabel').textContent = 'เพิ่มที่อยู่ใหม่';
+        } else if (isEditButton) {
+            const addressId = button.dataset.addressId;
+            document.getElementById('addressModalLabel').textContent = 'กำลังโหลด...';
+            try {
+                const response = await fetch(`/addresses/${addressId}`);
+                if (!response.ok) throw new Error('Failed to fetch address data.');
+                const data = await response.json();
+
+                addressForm.reset();
+                for (const key in data) {
+                    if (fields[key]) {
+                       fields[key].value = data[key];
+                    }
+                }
+
+                populateDistricts(data.addrProvince);
+                fields.addrDistrict.value = data.addrDistrict;
+                populateSubDistricts(data.addrProvince, data.addrDistrict);
+                fields.addrSubDistrict.value = data.addrSubDistrict;
+
+                document.getElementById('addressModalLabel').textContent = 'แก้ไขที่อยู่';
+            } catch (error) {
+                console.error('Error fetching address for edit:', error);
+                showToast('ไม่สามารถโหลดข้อมูลที่อยู่เพื่อแก้ไขได้', 'danger');
+                addressModal.hide();
+            }
+        }
+    });
+
+    // --- Save Logic ---
+    saveBtn.addEventListener('click', async function() {
+        const formData = new FormData(addressForm);
+        const addressId = fields.id.value;
+        const url = addressId ? `/addresses/${addressId}` : '/addresses';
+        const method = 'POST';
+
+        if (addressId) {
+            formData.append('_method', 'PUT');
+        }
+
+        try {
+            saveBtn.disabled = true;
+            saveBtn.innerHTML = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> กำลังบันทึก...`;
+
+            const response = await fetch(url, {
+                method: method,
+                body: formData,
+                headers: { 'X-CSRF-TOKEN': csrfToken, 'Accept': 'application/json' }
+            });
+
+            const result = await response.json();
+
+            if (!response.ok) {
+                if (response.status === 422 && result.errors) {
+                     let errorMsg = Object.values(result.errors).flat().join('\\n');
+                     throw new Error(errorMsg);
+                }
+                throw new Error(result.message || 'An unknown error occurred.');
+            }
+
+            showToast(result.message || 'บันทึกที่อยู่เรียบร้อยแล้ว', 'success');
+            addressModal.hide();
+
+            setTimeout(() => location.reload(), 1500);
+
+        } catch (error) {
+            console.error('Save address error:', error);
+            showToast(error.message || 'เกิดข้อผิดพลาดในการบันทึก', 'danger');
+        } finally {
+            saveBtn.disabled = false;
+            saveBtn.innerHTML = 'บันทึก';
+        }
+    });
+
+    addressModalEl.addEventListener('hidden.bs.modal', function () {
+        addressForm.reset();
+        populateDistricts('');
+        document.getElementById('addressModalLabel').textContent = 'เพิ่ม/แก้ไขที่อยู่';
+    });
+});
+</script>
+
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     const selectAllCheckbox = document.getElementById('select-all-checkbox');

--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -1,5 +1,4 @@
-{{-- Add/Edit Address Modal HTML --}}
-<div x-ignore class="modal fade" id="addAddressModal" tabindex="-1" aria-labelledby="addressModalLabel" aria-hidden="true">
+<div class="modal fade" id="addressModal" tabindex="-1" aria-labelledby="addressModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
@@ -7,13 +6,14 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <div id="address-errors" class="alert alert-danger" style="display: none;"></div>
-                <form id="addressForm" data-url="{{ route('addresses.thai_data') }}">
+                <form id="addressForm">
                     @csrf
-                    <input type="hidden" id="addressId" name="id">
-                    <input type="hidden" id="addressType" name="type">
-                    <input type="hidden" id="addressableId" name="addressable_id">
-                    <input type="hidden" id="addressableType" name="addressable_type">
+                    <input type="hidden" id="address_id" name="id">
+                    <input type="hidden" id="addressable_id" name="addressable_id">
+                    <input type="hidden" id="addressable_type" name="addressable_type" value="App\Models\Employer">
+                    <input type="hidden" id="address_type" name="type">
+
+                    {{-- Row 1: No --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrNo" class="form-label">บ้านเลขที่ (ไทย)</label>
@@ -24,7 +24,8 @@
                             <input type="text" class="form-control" id="addrNoEn" name="addrNoEn">
                         </div>
                     </div>
-                     <div class="row mb-3">
+                    {{-- Row 2: Moo --}}
+                    <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrMoo" class="form-label">หมู่ (ไทย)</label>
                             <input type="text" class="form-control" id="addrMoo" name="addrMoo">
@@ -34,6 +35,7 @@
                             <input type="text" class="form-control" id="addrMooEn" name="addrMooEn">
                         </div>
                     </div>
+                    {{-- Row 3: Soi --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrSoi" class="form-label">ซอย (ไทย)</label>
@@ -44,6 +46,7 @@
                             <input type="text" class="form-control" id="addrSoiEn" name="addrSoiEn">
                         </div>
                     </div>
+                    {{-- Row 4: Road --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrRoad" class="form-label">ถนน (ไทย)</label>
@@ -54,192 +57,57 @@
                             <input type="text" class="form-control" id="addrRoadEn" name="addrRoadEn">
                         </div>
                     </div>
+                    {{-- Row 5: Province --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrProvince" class="form-label">จังหวัด (Thai)</label>
                             <select class="form-select" id="addrProvince" name="addrProvince">
-                                <option selected disabled>--- เลือกจังหวัด ---</option>
+                                <option selected disabled>-- เลือกจังหวัด --</option>
                             </select>
                         </div>
                         <div class="col-md-6">
                             <label for="addrProvinceEn" class="form-label">Province (EN)</label>
-                            <input type="text" class="form-control" id="addrProvinceEn" name="addrProvinceEn" disabled>
-                            <!-- <select class="form-select" id="addrProvinceEn" name="addrProvinceEn" disabled>
-                                <option selected disabled>--- Province ---</option>
-                            </select> -->
+                            <input type="text" class="form-control" id="addrProvinceEn" name="addrProvinceEn" readonly>
                         </div>
                     </div>
+                    {{-- Row 6: District --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrDistrict" class="form-label">อำเภอ/เขต (Thai)</label>
-                            <select class="form-select" id="addrDistrict" name="addrDistrict" disabled>
-                                <option selected disabled>--- เลือกอำเภอ/เขต ---</option>
+                            <select class="form-select" id="addrDistrict" name="addrDistrict">
+                                <option selected disabled>-- เลือกอำเภอ/เขต --</option>
                             </select>
                         </div>
-                         <div class="col-md-6">
+                        <div class="col-md-6">
                             <label for="addrDistrictEn" class="form-label">District (EN)</label>
-                            <input type="text" class="form-control" id="addrDistrictEn" name="addrDistrictEn" disabled>
-                            <!-- <select class="form-select" id="addrDistrictEn" name="addrDistrictEn" disabled>
-                                <option selected disabled>--- District ---</option>
-                            </select> -->
+                            <input type="text" class="form-control" id="addrDistrictEn" name="addrDistrictEn" readonly>
                         </div>
                     </div>
+                    {{-- Row 7: SubDistrict --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrSubDistrict" class="form-label">ตำบล/แขวง (Thai)</label>
-                            <select class="form-select" id="addrSubDistrict" name="addrSubDistrict" disabled>
-                                <option selected disabled>--- เลือกตำบล/แขวง ---</option>
+                            <select class="form-select" id="addrSubDistrict" name="addrSubDistrict">
+                                <option selected disabled>-- เลือกตำบล/แขวง --</option>
                             </select>
                         </div>
                         <div class="col-md-6">
                             <label for="addrSubDistrictEn" class="form-label">Sub-district (EN)</label>
-                            <input type="text" class="form-control" id="addrSubDistrictEn" name="addrSubDistrictEn" disabled>
-                            <!-- <select class="form-select" id="addrSubDistrictEn" name="addrSubDistrictEn" disabled>
-                                <option selected disabled>--- Sub-district ---</option>
-                            </select> -->
+                            <input type="text" class="form-control" id="addrSubDistrictEn" name="addrSubDistrictEn" readonly>
                         </div>
                     </div>
                      <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="addrZipCode" class="form-label">รหัสไปรษณีย์</label>
                             <input type="text" class="form-control" id="addrZipCode" name="addrZipCode" readonly>
-                            <input type="hidden" id="addrZipCodeEn" name="addrZipCodeEn">
                         </div>
                     </div>
                 </form>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
-                <button type="button" class="btn btn-primary" id="saveAddress">บันทึก</button>
+                <button type="button" class="btn btn-primary" id="saveAddressBtn">บันทึก</button>
             </div>
         </div>
     </div>
 </div>
-
-@push('scripts')
-<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        const addressModalEl = document.getElementById('addAddressModal');
-        if (!addressModalEl) return;
-
-        // --- Element Declarations ---
-        const provinceSelect = document.getElementById('addrProvince');
-        const districtSelect = document.getElementById('addrDistrict');
-        const subDistrictSelect = document.getElementById('addrSubDistrict');
-        const zipCodeInput = document.getElementById('addrZipCode');
-        const provinceEnInput = document.getElementById('addrProvinceEn');
-        const districtEnInput = document.getElementById('addrDistrictEn');
-        const subDistrictEnInput = document.getElementById('addrSubDistrictEn');
-        const form = addressModalEl.querySelector('form');
-        let thaiAddressData = [];
-
-        // --- Event Listeners ---
-
-        // 1. DEFINITIVE BACKDROP FIX: On modal show, find the backdrop and force it to the back.
-        addressModalEl.addEventListener('shown.bs.modal', function () {
-            const backdrop = document.querySelector('.modal-backdrop');
-            if (backdrop) {
-                backdrop.style.zIndex = '1050'; // Force backdrop z-index
-            }
-            addressModalEl.style.zIndex = '1070'; // Ensure modal is on top
-        });
-
-        // 2. Fetch data only once when the modal is first shown
-        addressModalEl.addEventListener('show.bs.modal', function() {
-            if (thaiAddressData.length === 0) {
-                fetchAddressData();
-            }
-        }, { once: true });
-
-        // 3. Handle dropdown changes
-        provinceSelect.addEventListener('change', handleProvinceChange);
-        districtSelect.addEventListener('change', handleDistrictChange);
-        subDistrictSelect.addEventListener('change', handleSubDistrictChange);
-
-        // --- Main Functions ---
-
-        async function fetchAddressData() {
-            const dataUrl = form.dataset.url;
-            try {
-                const response = await fetch(dataUrl);
-                if (!response.ok) throw new Error('Network response was not ok');
-                thaiAddressData = await response.json();
-                populateProvinces();
-            } catch (error) {
-                console.error('Failed to fetch address data:', error);
-            }
-        }
-
-        function handleProvinceChange() {
-            const selectedProvinceData = thaiAddressData.find(p => p.name_th === provinceSelect.value);
-            resetDistricts();
-            resetSubDistricts();
-            if (selectedProvinceData) {
-                provinceEnInput.value = selectedProvinceData.name_en;
-                populateDistricts(selectedProvinceData.districts);
-                districtSelect.disabled = false; // <-- RE-ADDED THIS FIX
-            }
-        }
-
-        function handleDistrictChange() {
-            const selectedProvinceData = thaiAddressData.find(p => p.name_th === provinceSelect.value);
-            const selectedDistrictData = selectedProvinceData?.districts.find(d => d.name_th === districtSelect.value);
-            resetSubDistricts();
-            if (selectedDistrictData) {
-                districtEnInput.value = selectedDistrictData.name_en;
-                populateSubDistricts(selectedDistrictData.sub_districts);
-                subDistrictSelect.disabled = false; // <-- RE-ADDED THIS FIX
-            }
-        }
-
-        function handleSubDistrictChange() {
-            const selectedProvinceData = thaiAddressData.find(p => p.name_th === provinceSelect.value);
-            const selectedDistrictData = selectedProvinceData?.districts.find(d => d.name_th === districtSelect.value);
-            const selectedSubDistrictData = selectedDistrictData?.sub_districts.find(s => s.name_th === subDistrictSelect.value);
-            zipCodeInput.value = '';
-            subDistrictEnInput.value = '';
-            if (selectedSubDistrictData) {
-                subDistrictEnInput.value = selectedSubDistrictData.name_en;
-                zipCodeInput.value = selectedSubDistrictData.zip_code;
-            }
-        }
-
-        // --- Helper Functions (No changes needed here) ---
-
-        function populateProvinces() {
-            provinceSelect.innerHTML = '<option value="">-- เลือกจังหวัด --</option>';
-            thaiAddressData.forEach(province => {
-                const option = new Option(province.name_th, province.name_th);
-                provinceSelect.add(option);
-            });
-        }
-
-        function populateDistricts(districts) {
-            districts.forEach(district => {
-                const option = new Option(district.name_th, district.name_th);
-                districtSelect.add(option);
-            });
-        }
-
-        function populateSubDistricts(subDistricts) {
-            subDistricts.forEach(subDistrict => {
-                const option = new Option(subDistrict.name_th, subDistrict.name_th);
-                subDistrictSelect.add(option);
-            });
-        }
-
-        function resetDistricts() {
-            districtSelect.innerHTML = '<option value="">-- เลือกอำเภอ/เขต --</option>';
-            districtSelect.disabled = false;
-            districtEnInput.value = '';
-        }
-
-        function resetSubDistricts() {
-            subDistrictSelect.innerHTML = '<option value="">-- เลือกตำบล/แขวง --</option>';
-            subDistrictSelect.disabled = true;
-            subDistrictEnInput.value = '';
-            zipCodeInput.value = '';
-        }
-    });
-</script>
-@endpush

--- a/resources/views/partials/_employee_action_modals.blade.php
+++ b/resources/views/partials/_employee_action_modals.blade.php
@@ -41,22 +41,26 @@
                 <button type="button" class="btn-close ms-2" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <table class="table table-hover">
-                    <thead>
-                        <tr>
-                            <th>ชื่อพนักงาน</th>
-                            <th>วันที่แจ้งออก</th>
-                            <th>เหตุผล</th>
-                            <th>จัดการ</th>
-                        </tr>
-                    </thead>
-                    <tbody id="history-body">
-                        {{-- Terminated employees will be loaded here via JavaScript --}}
-                        <tr>
-                            <td colspan="4" class="text-center">กำลังโหลด...</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div id="terminated-employees-list" class="table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>พนักงาน</th>
+                                <th>ตำแหน่ง</th>
+                                <th>วันที่แจ้งออก</th>
+                                <th>เหตุผล</th>
+                                <th>จัดการ</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{-- Data will be loaded here by JavaScript --}}
+                            <tr>
+                                <td colspan="6" class="text-center">กำลังโหลดข้อมูล...</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>


### PR DESCRIPTION
This commit introduces a complete overhaul of the address management system and updates the employment history modal.

**Address Management System:**
- Replaced the old address modal with a new, comprehensive one in `_address_management.blade.php`, featuring a complete set of fields.
- Implemented a new, global JavaScript controller in `layouts/app.blade.php`. This script manages all AJAX-based address operations:
  - Fetches Thai address data from a dedicated endpoint.
  - Dynamically populates chained dropdowns for province, district, and sub-district.
  - Handles both creating new addresses and fetching data to edit existing ones.
  - Submits data via AJAX for both store and update actions.
- Updated all "Add Address" and "Edit Address" buttons in `employers/create.blade.php` and `employers/edit.blade.php` with the correct `data-` attributes to trigger the new modal.
- Corrected local JavaScript in `create.blade.php` to align with the new modal's element IDs.

**Employment History Modal:**
- Updated the table structure within the "Employment History" modal in `_employee_action_modals.blade.php` to match the new design specifications.