### PR TITLE
Fix: Import Bootstrap JavaScript module in bootstrap.js

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,3 +1,4 @@
+import 'bootstrap';
 import axios from 'axios';
 window.axios = axios;
 


### PR DESCRIPTION
The Bootstrap JavaScript library was not being imported in `resources/js/bootstrap.js`, preventing Bootstrap's JavaScript components (like modals) from functioning correctly.

This commit adds the required `import 'bootstrap';` statement at the top of the file to ensure the library is properly loaded and initialized by Vite, resolving the client-side errors.