### PR TITLE
Fix: Correct JavaScript asset loading in main layout

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -222,8 +222,6 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
-
     {{-- Job Owner Management Modal --}}
     <div class="modal fade" id="jobOwnerModal" tabindex="-1" aria-labelledby="jobOwnerModalLabel" aria-hidden="true">
         <div class="modal-dialog">
@@ -266,6 +264,8 @@
                 </div>
         </div>
     </div>
+
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
This commit addresses an issue where the application's compiled JavaScript was not being loaded correctly.

- Replaced the hardcoded Bootstrap JS CDN link in `resources/views/layouts/app.blade.php` with the `@vite` directive.
- The `@vite` directive now correctly loads both `resources/css/app.css` and `resources/js/app.js`, ensuring that all bundled JavaScript, including the Bootstrap library imported in `resources/js/bootstrap.js`, is properly initialized.

This change ensures that JavaScript-dependent components, such as Bootstrap modals, will function as expected throughout the application.