### PR TITLE
feat: Implement soft deletes and restore nationality flags

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Employee extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     // The $fillable array is correct as it matches the camelCase schema.
     protected $fillable = [

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -88,6 +88,7 @@
                     <tr>
                         <th style="width: 1%;"><input class="form-check-input" type="checkbox" id="table-select-all-checkbox"></th>
                         <th scope="col">Employee</th>
+                        <th scope="col">สัญชาติ</th>
                         <th scope="col">Employer</th>
                         <th scope="col">Passport</th>
                         <th scope="col">Work Permit</th>
@@ -108,17 +109,28 @@
                                 </div>
                             </div>
                         </td>
+                        <td>
+                            @php
+                                $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
+                            @endphp
+                            @if($countryCode)
+                                <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 16px; height: 12px; margin-right: 5px; vertical-align: middle;">
+                                {{ $employee->employeeNationality }}
+                            @else
+                                {{ $employee->employeeNationality ?? '-' }}
+                            @endif
+                        </td>
                         <td class="text-muted">{{ $employee->employer->employerNameTh ?? 'N/A' }}</td>
                         <td>{{ $employee->employeePassport ?? '-' }}</td>
                         <td>{{ $employee->employeeWorkPermit ?? '-' }}</td>
                         <td>{{ $employee->ninetyDayReportDate ? $employee->ninetyDayReportDate->format('d/m/Y') : '-' }}</td>
-            <td class="text-nowrap">
-                <x-employee-action-buttons :employee="$employee" :show-locate-button="true" />
-            </td>
+                        <td class="text-nowrap">
+                            <x-employee-action-buttons :employee="$employee" :show-locate-button="true" />
+                        </td>
                     </tr>
                     @empty
                     <tr>
-                        <td colspan="7" class="text-center text-muted">ไม่พบข้อมูลลูกจ้าง</td>
+                        <td colspan="8" class="text-center text-muted">ไม่พบข้อมูลลูกจ้าง</td>
                     </tr>
                     @endforelse
                 </tbody>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -324,7 +324,7 @@
                         <th style="width: 25%;">Name (EN)</th>
                         <th style="width: 25%;">Name (TH)</th>
                         <th style="width: 15%;">Passport</th>
-                        <th style="width: 10%;">Nationality</th>
+                        <th style="width: 10%;">สัญชาติ</th>
                         <th style="width: 10%;">Actions</th>
                     </tr>
                 </thead>
@@ -347,18 +347,14 @@
                             <td>{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }}<br><small class="text-muted">{{ $employee->employeePosition ?? 'ไม่ระบุตำแหน่ง' }}</small></td>
                             <td>{{ $employee->employeePassport ?? '-' }}</td>
                             <td>
-                                @if($employee->employeeNationality)
-                                    @php
-                                        $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
-                                    @endphp
-                                    @if($countryCode)
-                                        <span class="flag-icon flag-icon-{{ $countryCode }}"></span>
-                                        {{ $employee->employeeNationality }}
-                                    @else
-                                        {{ $employee->employeeNationality }}
-                                    @endif
+                                @php
+                                    $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
+                                @endphp
+                                @if($countryCode)
+                                    <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 16px; height: 12px; margin-right: 5px; vertical-align: middle;">
+                                    {{ $employee->employeeNationality }}
                                 @else
-                                    -
+                                    {{ $employee->employeeNationality ?? '-' }}
                                 @endif
                             </td>
                             <td>

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -27,7 +27,7 @@
                 @endphp
                 @if($countryCode)
                     <span class="badge bg-light text-dark ms-2">
-                        <span class="flag-icon flag-icon-{{ $countryCode }}"></span>
+                        <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 16px; height: 12px; margin-right: 5px; vertical-align: middle;">
                         {{ $employee->employeeNationality }}
                     </span>
                 @endif


### PR DESCRIPTION
This commit addresses the final two polishing tasks:

1.  **Fix Employee Termination Logic:**
    - Implemented the `SoftDeletes` trait in the `Employee` model.
    - Employee terminations now correctly perform a soft delete by setting the `deleted_at` timestamp instead of permanently removing the record from the database.

2.  **Restore Nationality Flag UI:**
    - Restored the nationality flag icon in all employee list views (card view, main employee table, and employer's employee table).
    - The `<img>` tag is now correctly rendered, dynamically pointing to the flag image based on the employee's nationality.
    - Updated table headers to include a "สัญชาติ" (Nationality) column where appropriate.