### PR TITLE
fix: Include soft-deleted employees in history query

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -196,7 +196,7 @@ public function edit(Request $request, Employer $employer)
 
     public function filterHistory(Request $request, Employer $employer)
     {
-        $query = $employer->employees()->whereNotNull('terminated_at');
+        $query = $employer->employees()->withTrashed()->whereNotNull('terminated_at');
 
         // Implement search
         if ($request->filled('search')) {


### PR DESCRIPTION
This change addresses an issue where terminated (soft-deleted) employees were not appearing in the employment history view.

The `filterHistory` method in `EmployerController` has been updated to use the `withTrashed()` Eloquent method. This ensures that soft-deleted employee records are included in the query results, making the history view complete.

The second part of the original task, fixing the flag image paths, could not be completed as the image files are missing from the repository.