### PR TITLE
fix: Correct employee nationality alignment and restore button

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -114,8 +114,10 @@
                                 $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
                             @endphp
                             @if($countryCode)
-                                <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 16px; height: 12px; margin-right: 5px; vertical-align: middle;">
-                                {{ $employee->employeeNationality }}
+                                <div class="d-flex align-items-center">
+                                    <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" class="me-2" style="width: 20px;">
+                                    <span>{{ $employee->employeeNationality }}</span>
+                                </div>
                             @else
                                 {{ $employee->employeeNationality ?? '-' }}
                             @endif

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -248,6 +248,11 @@
     <h5 class="mb-0">
         ข้อมูลลูกจ้าง (รวม: {{ $totalEmployees }} | ชาย: {{ $maleCount }} | หญิง: {{ $femaleCount }})
     </h5>
+    @can('create-employees')
+    <a href="{{ route('employees.create', ['employer_id' => $employer->id]) }}" class="btn btn-primary">
+        <i class="bi bi-plus-circle me-1"></i> เพิ่มลูกจ้าง
+    </a>
+    @endcan
 </div>
 
 <div class="card p-3 mb-3">
@@ -351,8 +356,10 @@
                                     $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
                                 @endphp
                                 @if($countryCode)
-                                    <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 16px; height: 12px; margin-right: 5px; vertical-align: middle;">
-                                    {{ $employee->employeeNationality }}
+                                    <div class="d-flex align-items-center">
+                                        <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" class="me-2" style="width: 20px;">
+                                        <span>{{ $employee->employeeNationality }}</span>
+                                    </div>
                                 @else
                                     {{ $employee->employeeNationality ?? '-' }}
                                 @endif

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -26,9 +26,9 @@
                     $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
                 @endphp
                 @if($countryCode)
-                    <span class="badge bg-light text-dark ms-2">
-                        <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 16px; height: 12px; margin-right: 5px; vertical-align: middle;">
-                        {{ $employee->employeeNationality }}
+                    <span class="badge bg-light text-dark ms-2 d-inline-flex align-items-center">
+                        <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 16px; height: 12px; margin-right: 5px;">
+                        <span>{{ $employee->employeeNationality }}</span>
                     </span>
                 @endif
             @endif


### PR DESCRIPTION
- Wraps the nationality flag image and text in a flex container (`d-flex align-items-center`) across all relevant views (`_employee_card.blade.php`, `employees/index.blade.php`, `employers/edit.blade.php`) to ensure they always render on the same line.
- Restores the missing 'Add New Employee' button to the `employers/edit.blade.php` view, ensuring it's correctly linked and guarded by the `create-employees` permission.