### PR TITLE
feat: Implement dynamic action for termination modal

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,6 @@
 import './bootstrap';
 import './employment-history.js';
+import './terminate-employee.js';
 
 import Alpine from 'alpinejs';
 

--- a/resources/js/terminate-employee.js
+++ b/resources/js/terminate-employee.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const terminateEmployeeModal = document.getElementById('terminateEmployeeModal');
+    if (terminateEmployeeModal) {
+        terminateEmployeeModal.addEventListener('show.bs.modal', function (event) {
+            // Button that triggered the modal
+            const button = event.relatedTarget;
+            // Extract info from data-* attributes
+            const employeeId = button.getAttribute('data-employee-id');
+
+            // Update the modal's content.
+            const form = terminateEmployeeModal.querySelector('#terminate-form');
+            if (form) {
+                let actionUrl = form.getAttribute('action');
+                // Replace the placeholder {employeeId} with the actual ID
+                form.action = `/employees/${employeeId}/terminate`;
+            }
+        });
+    }
+});


### PR DESCRIPTION
- Create `resources/js/terminate-employee.js` to dynamically set the form action URL for the termination modal.
- The script listens for the modal's `show.bs.modal` event, gets the employee ID from the trigger button, and constructs the correct URL.
- Import the new script into `resources/js/app.js` to ensure it's loaded globally.

This fixes the `MethodNotAllowedHttpException` that occurred due to the form having an empty `action` attribute.