### PR TITLE
Fix TypeError in employment history modal

### DIFF
--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -47,12 +47,12 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(data => {
                 tableBody.innerHTML = ''; // Clear loading state
 
-                if (!data || data.length === 0) {
+                if (!data.data || data.data.length === 0) {
                     tableBody.innerHTML = '<tr><td colspan="6" class="text-center">ไม่พบข้อมูลประวัติการจ้างงาน</td></tr>';
                     return;
                 }
 
-                data.forEach((employee, index) => {
+                data.data.forEach((employee, index) => {
                     const terminatedDate = employee.terminated_at ? new Date(employee.terminated_at).toLocaleDateString('th-TH', { year: 'numeric', month: 'long', day: 'numeric' }) : 'N/A';
 
                     // Conditionally create buttons based on permissions from the API response


### PR DESCRIPTION
The frontend JavaScript was attempting to iterate directly over the paginated response object from Laravel, which caused a `TypeError: data.forEach is not a function`.

This commit fixes the issue by accessing the nested `data` array within the JSON response (`response.data.data`) before iterating, aligning the frontend logic with the backend's paginated data structure. The check for an empty result is also updated to inspect `data.data.length`.