### PR TITLE
Fix: Harden notification view against null employee data

### DIFF
--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -1,73 +1,80 @@
-@php
-    $days_remaining = $notification->days_remaining;
-    $is_overdue = $days_remaining < 0;
+@if($notification->employee)
+    @php
+        $days_remaining = $notification->days_remaining;
+        $is_overdue = $days_remaining < 0;
 
-    $card_class = '';
-    $badge_class = 'bg-info text-dark';
-    if ($is_overdue) {
-        $card_class = 'alert-dark';
-        $badge_class = 'bg-dark';
-    } elseif ($days_remaining <= 30) {
-        $card_class = 'alert-danger';
-        $badge_class = 'bg-danger';
-    } elseif ($days_remaining <= 60) {
-        $card_class = 'alert-warning';
-        $badge_class = 'bg-warning text-dark';
-    }
+        $card_class = '';
+        $badge_class = 'bg-info text-dark';
+        if ($is_overdue) {
+            $card_class = 'alert-dark';
+            $badge_class = 'bg-dark';
+        } elseif ($days_remaining <= 30) {
+            $card_class = 'alert-danger';
+            $badge_class = 'bg-danger';
+        } elseif ($days_remaining <= 60) {
+            $card_class = 'alert-warning';
+            $badge_class = 'bg-warning text-dark';
+        }
 
-    $flagMap = ['เมียนมา' => 'mm', 'ลาว' => 'la', 'กัมพูชา' => 'kh', 'เวียดนาม' => 'vn'];
-    $nationality = $notification->employee->employeeNationality ?? '';
-    $flagCode = $flagMap[$nationality] ?? null;
-@endphp
+        $flagMap = ['เมียนมา' => 'mm', 'ลาว' => 'la', 'กัมพูชา' => 'kh', 'เวียดนาม' => 'vn'];
+        $nationality = $notification->employee->employeeNationality ?? '';
+        $flagCode = $flagMap[$nationality] ?? null;
+    @endphp
 
-<div class="alert {{ $card_class }} notification-item">
-    <div class="d-flex align-items-center gap-3">
-        <input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $notification->employee->id }}" id="notification_checkbox_{{ $notification->id }}">
-        {{-- FINAL FIX: Use Tailwind classes for robust styling --}}
-        <img src="{{ $notification->employee->employeePhoto ? asset('storage/' . $notification->employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
-             alt="Photo"
-             class="w-12 h-12 object-cover rounded-full bg-light flex-shrink-0"
-             style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover;">
+    <div class="alert {{ $card_class }} notification-item">
+        <div class="d-flex align-items-center gap-3">
+            <input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $notification->employee->id }}" id="notification_checkbox_{{ $notification->id }}">
+            {{-- FINAL FIX: Use Tailwind classes for robust styling --}}
+            <img src="{{ $notification->employee->employeePhoto ? asset('storage/' . $notification->employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
+                 alt="Photo"
+                 class="w-12 h-12 object-cover rounded-full bg-light flex-shrink-0"
+                 style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover;">
 
-        <div class="d-flex justify-content-between align-items-start w-100">
-            <div class="flex-grow-1">
-                <h5 class="alert-heading mb-1">
-                    {{ $itemNumber }}. {{ $notification->employee->employeeTitleEn ?? '' }} {{ $notification->employee->employeeNameEn ?? 'N/A' }}
-                    @if($flagCode)
-                        <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" title="{{ $nationality }}">
-                    @endif
-                </h5>
-                <p class="mb-1 small">{{ $notification->employee->employeeTitleTh ?? '' }} {{ $notification->employee->employeeNameTh ?? 'N/A' }}</p>
-                <p class="mb-1 small"><strong>นายจ้าง:</strong> {{ $notification->employee->employer->employerNameTh ?? 'N/A' }}</p>
-                <p class="mb-0 small"><strong>วันครบกำหนด:</strong> {{ \Carbon\Carbon::parse($notification->due_date)->translatedFormat('d F Y') }}</p>
-            </div>
-            <div class="text-end flex-shrink-0 ms-2">
-                <span class="badge {{ $badge_class }} mb-2 d-block text-nowrap fs-6">
-                    @if($is_overdue)
-                        หมดอายุ {{ abs($days_remaining) }} วัน
-                    @else
-                        เหลือ {{ $days_remaining }} วัน
-                    @endif
-                </span>
-                <div class="btn-group btn-group-sm">
-    @if($notification->status === 'cancelled')
-        <form action="{{ route('notifications.restore', $notification->id) }}" method="POST" class="d-inline">
-            @csrf
-            <button type="submit" class="btn btn-info" title="กู้คืน"><i class="bi bi-arrow-counterclockwise"></i> กู้คืน</button>
-        </form>
-        <form action="{{ route('notifications.forceDelete', $notification->id) }}" method="POST" class="d-inline" onsubmit="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้อย่างถาวร?');">
-            @csrf
-            @method('DELETE')
-            <button type="submit" class="btn btn-danger" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
-        </form>
-    @else
-        <a href="#" class="btn btn-info" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
-        <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
-        <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ดูข้อมูล"><i class="bi bi-search"></i></a>
-        <a href="#" class="btn btn-warning" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
-    @endif
-</div>
+            <div class="d-flex justify-content-between align-items-start w-100">
+                <div class="flex-grow-1">
+                    <h5 class="alert-heading mb-1">
+                        {{ $itemNumber }}. {{ $notification->employee->employeeTitleEn ?? '' }} {{ $notification->employee->employeeNameEn ?? 'N/A' }}
+                        @if($flagCode)
+                            <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $nationality }}" title="{{ $nationality }}">
+                        @endif
+                    </h5>
+                    <p class="mb-1 small">{{ $notification->employee->employeeTitleTh ?? '' }} {{ $notification->employee->employeeNameTh ?? 'N/A' }}</p>
+                    <p class="mb-1 small"><strong>นายจ้าง:</strong> {{ $notification->employee->employer->employerNameTh ?? 'N/A' }}</p>
+                    <p class="mb-0 small"><strong>วันครบกำหนด:</strong> {{ \Carbon\Carbon::parse($notification->due_date)->translatedFormat('d F Y') }}</p>
+                </div>
+                <div class="text-end flex-shrink-0 ms-2">
+                    <span class="badge {{ $badge_class }} mb-2 d-block text-nowrap fs-6">
+                        @if($is_overdue)
+                            หมดอายุ {{ abs($days_remaining) }} วัน
+                        @else
+                            เหลือ {{ $days_remaining }} วัน
+                        @endif
+                    </span>
+                    <div class="btn-group btn-group-sm">
+        @if($notification->status === 'cancelled')
+            <form action="{{ route('notifications.restore', $notification->id) }}" method="POST" class="d-inline">
+                @csrf
+                <button type="submit" class="btn btn-info" title="กู้คืน"><i class="bi bi-arrow-counterclockwise"></i> กู้คืน</button>
+            </form>
+            <form action="{{ route('notifications.forceDelete', $notification->id) }}" method="POST" class="d-inline" onsubmit="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้อย่างถาวร?');">
+                @csrf
+                @method('DELETE')
+                <button type="submit" class="btn btn-danger" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
+            </form>
+        @else
+            <a href="#" class="btn btn-info" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
+            <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
+            <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ดูข้อมูล"><i class="bi bi-search"></i></a>
+            <a href="#" class="btn btn-warning" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
+        @endif
+    </div>
+                </div>
             </div>
         </div>
     </div>
-</div>
+@else
+    {{-- Fallback for deleted employee --}}
+    <div class="alert alert-secondary notification-item-deleted" role="alert">
+        การแจ้งเตือนนี้เกี่ยวข้องกับข้อมูลลูกจ้างที่ถูกลบออกจากระบบไปแล้ว
+    </div>
+@endif


### PR DESCRIPTION
The notifications page at `notifications.index` would crash if it encountered a notification linked to an employee who had been permanently deleted from the database. This was because the `_notification_item.blade.php` partial unconditionally tried to access properties on the `employee` relationship, which would be `null` in this scenario.

This commit wraps the content of the partial in an `@if($notification->employee)` directive. If the employee exists, the notification is displayed as normal. If the employee is `null`, a fallback alert is shown, informing the user that the related employee data has been deleted. This prevents the view from rendering and makes the page more robust.