### PR TITLE
Fix: Correct restore/delete binding and add delete confirmation

### DIFF
--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -137,66 +137,86 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    const forceDeleteModalEl = document.getElementById('forceDeleteConfirmationModal');
+    const confirmDeleteBtn = document.getElementById('confirm-force-delete-btn');
+    let formToSubmit = null;
+
+    if (!forceDeleteModalEl || !confirmDeleteBtn) {
+        console.error('Force delete modal elements not found on this page.');
+        return;
+    }
+    const forceDeleteBootstrapModal = new bootstrap.Modal(forceDeleteModalEl);
+
+    /**
+     * Handles the AJAX submission for a given form (Restore or Force Delete).
+     * @param {HTMLFormElement} form - The form to submit.
+     */
+    const submitFormAndRefresh = (form) => {
+        const actionUrl = form.action;
+        const formData = new FormData(form);
+        const fetchOptions = {
+            method: 'POST',
+            body: formData,
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+            }
+        };
+
+        fetch(actionUrl, fetchOptions)
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    if (typeof showToast === 'function') {
+                        showToast(data.message, 'success');
+                    } else {
+                        alert(data.message);
+                    }
+                    // Refresh the history list to show the change
+                    fetchAndRenderHistory(currentEmployerId, searchInput.value.trim());
+                } else {
+                    if (typeof showToast === 'function') {
+                        showToast(data.message || 'An unknown error occurred.', 'danger');
+                    } else {
+                        alert(data.message || 'An unknown error occurred.');
+                    }
+                }
+            })
+            .catch(error => {
+                console.error('Error submitting form:', error);
+                if (typeof showToast === 'function') {
+                    showToast('An error occurred while communicating with the server.', 'danger');
+                } else {
+                    alert('An error occurred while communicating with the server.');
+                }
+            });
+    };
+
+    // Listener for the final confirmation button in the delete modal
+    confirmDeleteBtn.addEventListener('click', () => {
+        if (formToSubmit) {
+            submitFormAndRefresh(formToSubmit);
+            formToSubmit = null; // Clear the stored form
+            forceDeleteBootstrapModal.hide();
+        }
+    });
+
     // Delegated event listener for form submissions (Restore, Force Delete)
     if (tableBody) {
         tableBody.addEventListener('submit', function(event) {
-            // We are only interested in form submissions
             if (event.target.tagName !== 'FORM') {
                 return;
             }
-
             event.preventDefault();
             const form = event.target;
 
-            // Add a confirmation step for deletion
             if (form.classList.contains('js-delete-form')) {
-                if (!confirm('คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลนี้อย่างถาวร? การกระทำนี้ไม่สามารถย้อนกลับได้')) {
-                    return; // Stop if user cancels
-                }
+                // For delete, store the form and show the confirmation modal
+                formToSubmit = form;
+                forceDeleteBootstrapModal.show();
+            } else {
+                // For other actions (like restore), submit directly
+                submitFormAndRefresh(form);
             }
-
-            const actionUrl = form.action;
-            const formData = new FormData(form);
-            // The method is always POST from the form's perspective,
-            // but Laravel will correctly interpret it as DELETE if _method=DELETE is present.
-            const fetchOptions = {
-                method: 'POST',
-                body: formData,
-                headers: {
-                    // The CSRF token is in the form data, but we also need X-Requested-With for Laravel to know it's an AJAX call
-                    'X-Requested-With': 'XMLHttpRequest',
-                }
-            };
-
-            fetch(actionUrl, fetchOptions)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.success) {
-                        // Use the global toast function if it exists
-                        if (typeof showToast === 'function') {
-                            showToast(data.message, 'success');
-                        } else {
-                            alert(data.message); // Fallback
-                        }
-                        // Refresh the history list to show the change
-                        fetchAndRenderHistory(currentEmployerId, searchInput.value.trim());
-                    } else {
-                        // Handle errors, show a toast
-                        if (typeof showToast === 'function') {
-                            showToast(data.message || 'An unknown error occurred.', 'danger');
-                        } else {
-                            alert(data.message || 'An unknown error occurred.');
-                        }
-                    }
-                })
-                .catch(error => {
-                    console.error('Error submitting form:', error);
-                    if (typeof showToast === 'function') {
-                        showToast('An error occurred while communicating with the server.', 'danger');
-                    } else {
-                        alert('An error occurred while communicating with the server.');
-                    }
-                });
         });
     }
 });

--- a/resources/views/partials/_employee_action_modals.blade.php
+++ b/resources/views/partials/_employee_action_modals.blade.php
@@ -27,6 +27,25 @@
     </div>
 </div>
 
+{{-- Force Delete Confirmation Modal --}}
+<div class="modal fade" id="forceDeleteConfirmationModal" tabindex="-1" aria-labelledby="forceDeleteConfirmationModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="forceDeleteConfirmationModalLabel">ยืนยันการลบถาวร</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        คุณแน่ใจหรือไม่ที่จะลบข้อมูลพนักงานนี้อย่างถาวร? การกระทำนี้ไม่สามารถย้อนกลับได้
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+        <button type="button" class="btn btn-danger" id="confirm-force-delete-btn">ยืนยันการลบ</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 {{-- CORRECTED AND FINAL EMPLOYMENT HISTORY MODAL --}}
 <div class="modal fade" id="employmentHistoryModal" tabindex="-1" aria-labelledby="employmentHistoryModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-xl">

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,8 +31,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/employers/{employer}/employees/filter', [EmployerController::class, 'filterEmployees'])->name('employers.employees.filter');
     Route::get('employers/{employer}/history', [EmployerController::class, 'filterHistory'])->name('employers.history.filter');
     Route::post('employees/{employee}/terminate', [EmployeeController::class, 'terminate'])->name('employees.terminate');
-    Route::post('/employees/{employee}/restore', [EmployeeController::class, 'restore'])->name('employees.restore');
-    Route::delete('/employees/{employee}/force-delete', [EmployeeController::class, 'forceDelete'])->name('employees.forceDelete');
+    Route::post('/employees/{employee}/restore', [EmployeeController::class, 'restore'])->name('employees.restore')->withTrashed();
+    Route::delete('/employees/{employee}/force-delete', [EmployeeController::class, 'forceDelete'])->name('employees.forceDelete')->withTrashed();
     Route::get('/employees/{employee}/locate', [EmployeeController::class, 'locate'])->name('employees.locate');
     Route::get('/employees/{employee}/create-job', [JobController::class, 'createFromEmployee'])->name('jobs.create_from_employee');
     Route::get('/employees/export', [EmployeeController::class, 'export'])->name('employees.export');


### PR DESCRIPTION
- Applied `withTrashed()` to restore and force-delete routes in `routes/web.php` to enable Route Model Binding for soft-deleted employees.
- Replaced the native `confirm()` with a Bootstrap modal for a better user experience when force-deleting an employee from the history.
- Updated `employment-history.js` to handle the new modal confirmation flow, ensuring the AJAX request is only sent after user confirmation.