### PR TITLE
Fix(JS/CSS): Implement definitive modal stacking solution

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -19,6 +19,14 @@
     z-index: 1050;
 }
 
+/*
+ * Definitive Modal Stacking Fix Helper
+ * Temporarily sends a modal behind the backdrop to allow another to appear on top.
+ */
+.modal-behind {
+    z-index: 1040;
+}
+
 .modal.show {
     z-index: 1070 !important;
 }

--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -191,25 +191,22 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
 
-    // --- MODAL STACKING FIX ---
-    // When a confirmation modal is shown, prevent the main history modal from enforcing focus.
-    const onSubModalShow = () => {
-        const historyModalInstance = bootstrap.Modal.getInstance(historyModalEl);
-        if (historyModalInstance) {
-            historyModalInstance._config.focus = false;
-        }
-    };
+    // --- DEFINITIVE MODAL STACKING FIX ---
+    // When a confirmation modal is shown, add 'modal-behind' to the main history modal
+    // to lower its z-index, allowing the new modal to appear on top.
+    restoreModalEl.addEventListener('show.bs.modal', function () {
+        historyModalEl.classList.add('modal-behind');
+    });
+    forceDeleteModalEl.addEventListener('show.bs.modal', function () {
+        historyModalEl.classList.add('modal-behind');
+    });
 
-    // When a confirmation modal is hidden, restore focus enforcement on the main history modal.
-    const onSubModalHide = () => {
-        const historyModalInstance = bootstrap.Modal.getInstance(historyModalEl);
-        if (historyModalInstance) {
-            historyModalInstance._config.focus = true;
-        }
-    };
-
-    restoreModalEl.addEventListener('show.bs.modal', onSubModalShow);
-    restoreModalEl.addEventListener('hidden.bs.modal', onSubModalHide);
-    forceDeleteModalEl.addEventListener('show.bs.modal', onSubModalShow);
-    forceDeleteModalEl.addEventListener('hidden.bs.modal', onSubModalHide);
+    // When a confirmation modal is hidden, remove the 'modal-behind' class to restore
+    // the main history modal's original z-index.
+    restoreModalEl.addEventListener('hidden.bs.modal', function () {
+        historyModalEl.classList.remove('modal-behind');
+    });
+    forceDeleteModalEl.addEventListener('hidden.bs.modal', function () {
+        historyModalEl.classList.remove('modal-behind');
+    });
 });


### PR DESCRIPTION
This commit resolves the persistent issue where confirmation modals (e.g., restore, delete) would appear behind the main employment history modal's backdrop.

The previous fix, which manipulated the modal's `focus` configuration, was not consistently effective. This new solution is more robust:

1.  **CSS:** A new helper class `.modal-behind` is added to `resources/css/app.css`. This class sets a lower `z-index` (1040), ensuring any element with this class is rendered behind the standard modal backdrop (z-index 1050).

2.  **JavaScript:** The logic in `resources/js/employment-history.js` is updated.
    - When a secondary confirmation modal is about to be shown (`show.bs.modal`), the `.modal-behind` class is added to the primary history modal.
    - When the confirmation modal is hidden (`hidden.bs.modal`), the class is removed, restoring the primary modal's original `z-index`.

This ensures the correct visual hierarchy is always maintained, providing a reliable user experience.