### PR TITLE
Fix Termination Data Saving and Finalize History UI

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -24,9 +24,20 @@ class EmployeeController extends Controller
     /**
      * Soft delete the specified employee.
      */
-    public function terminate(Employee $employee)
+    public function terminate(Request $request, Employee $employee)
     {
-        $employee->delete();
+        $validated = $request->validate([
+            'terminated_at' => 'required|date',
+            'termination_reason' => 'nullable|string|max:255',
+        ]);
+        // Update employee with termination details
+        $employee->termination_reason = $validated['termination_reason'];
+        $employee->save();
+        // Perform the soft delete which sets the terminated_at timestamp
+        $employee->delete(); // This will use the default timestamp
+        // To use the user-defined date, we update it *after* the delete
+        $employee->terminated_at = $validated['terminated_at'];
+        $employee->save();
         return back()->with('success', 'Employee terminated successfully.');
     }
 

--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -86,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         <div class="d-flex align-items-center">
                             <img src="${employee.employeePhoto ? `/storage/${employee.employeePhoto}` : '/images/default-avatar.png'}" alt="Photo" class="employee-photo-thumb">
                             <div>
-                                <strong>${employee.employeeNameEn || 'No English Name'}</strong>
+                                <strong>${employee.employeeTitleEn || ''} ${employee.employeeNameEn || 'No English Name'}</strong>
                                 <div class="text-muted small">${employee.employeeTitleTh || ''} ${employee.employeeNameTh || 'N/A'} (${employee.employeePosition || 'N/A'})</div>
                                 <div class="text-muted small">Passport: ${employee.employeePassport || 'N/A'}</div>
                                 <div class="text-muted small d-flex align-items-center">${flagHTML} ${employee.employeeNationality || ''}</div>


### PR DESCRIPTION
Repairs the termination process to correctly save the user-provided date and reason. The `terminate()` method in `EmployeeController` now processes the request data.

Also finalizes the history modal UI by adding the English gender prefix (`employeeTitleEn`) to the employee's name in the `employment-history.js` script.