### PR TITLE
fix(js): Replace partial refresh with full reload on restore

### DIFF
--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -124,20 +124,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (data.success) {
                     showToast(data.message, 'success');
                     if (isRestoreAction) {
-                        const historyModal = bootstrap.Modal.getInstance(historyModalEl);
-                        if (historyModal) historyModal.hide();
-                        // Asynchronously refresh the main employee list container
-                        fetch(window.location.href)
-                            .then(res => res.text())
-                            .then(html => {
-                                const newDoc = new DOMParser().parseFromString(html, 'text/html');
-                                const newContainer = newDoc.getElementById('employee-list-container');
-                                const currentContainer = document.getElementById('employee-list-container');
-                                if (newContainer && currentContainer) {
-                                    currentContainer.innerHTML = newContainer.innerHTML;
-                                } else { window.location.reload(); } // Fallback
-                            })
-                            .catch(() => window.location.reload()); // Fallback
+                        // On successful restore, simply reload the page.
+                        // This is the most reliable way to ensure all data is refreshed correctly.
+                        window.location.reload();
                     } else {
                         // For delete, just refresh the history modal list
                         fetchAndRenderHistory(currentEmployerId, searchInput.value.trim());


### PR DESCRIPTION
Replaces the complex and failing asynchronous partial-refresh logic with a simple and reliable full-page reload (`window.location.reload()`) when an employee is restored from the employment history modal.

The previous implementation attempted to fetch the current page content and replace the employee list container. This was failing due to session/authentication issues with the `fetch` request, causing the server to return the login page's HTML instead of the employee list, making the restored employee seem to disappear.

This change simplifies the logic and ensures the UI state is always consistent and correct after a restore action.