### PR TITLE
feat: Update employment history modal display

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -13,6 +13,7 @@ class Employee extends Model
     // The $fillable array is correct as it matches the camelCase schema.
     protected $fillable = [
         'employer_id',
+        'english_prefix',
         'employeeNameTh',
         'employeeNameEn',
         'employeeNationality',

--- a/database/migrations/2025_10_17_042000_add_english_prefix_to_employees_table.php
+++ b/database/migrations/2025_10_17_042000_add_english_prefix_to_employees_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->string('english_prefix', 20)->nullable()->after('prefix');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('english_prefix');
+        });
+    }
+};

--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -82,11 +82,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     const countryCode = flagMap[employee.employeeNationality];
                     const flagHTML = countryCode ? `<img src="/images/flags/${countryCode}.png" alt="${employee.employeeNationality}" style="width: 16px; height: 11px; margin-right: 4px; border-radius: 2px;">` : '';
 
+                    const employeeNameEnWithPrefix = [employee.english_prefix, employee.employeeNameEn].filter(Boolean).join(' ');
+
                     const employeeCellHTML = `
                         <div class="d-flex align-items-center">
                             <img src="${employee.employeePhoto ? `/storage/${employee.employeePhoto}` : '/images/default-avatar.png'}" alt="Photo" class="employee-photo-thumb">
                             <div>
-                                <strong>${employee.employeeNameEn || 'No English Name'}</strong>
+                                <strong>${employeeNameEnWithPrefix || 'No English Name'}</strong>
                                 <div class="text-muted small">${employee.employeeTitleTh || ''} ${employee.employeeNameTh || 'N/A'} (${employee.employeePosition || 'N/A'})</div>
                                 <div class="text-muted small">Passport: ${employee.employeePassport || 'N/A'}</div>
                                 <div class="text-muted small d-flex align-items-center">${flagHTML} ${employee.employeeNationality || ''}</div>


### PR DESCRIPTION
- Create a migration to add 'english_prefix' to the employees table.
- Update the Employee model to include 'english_prefix' in the fillable array.
- Modify the employment history JavaScript to display the English prefix with the employee's name.
- Verify that termination date and reason are displayed correctly.