### PR TITLE
Configure the Employee model to use the 'terminated_at' column for it…

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -10,6 +10,8 @@ class Employee extends Model
 {
     use HasFactory, SoftDeletes;
 
+    const DELETED_AT = 'terminated_at';
+
     // The $fillable array is correct as it matches the camelCase schema.
     protected $fillable = [
         'employer_id',


### PR DESCRIPTION
…s soft delete functionality.

The Laravel SoftDeletes trait defaults to using a database column named 'deleted_at'. This application's 'employees' table uses a custom column named 'terminated_at' for this purpose.

This change adds the DELETED_AT constant to the Employee model to override the default soft delete timestamp column name, ensuring that the standard restore() method works as intended.