### PR TITLE
feat: Implement address management and add employee credentials

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -144,6 +144,8 @@ public function create(Request $request) // เพิ่ม Request $request เ
             'designatedHospital' => 'nullable|string|max:255',
             'startDate' => 'nullable|date',
             'employeePhone' => 'nullable|string|max:255',
+            'email' => 'nullable|email|max:255|unique:employees,email',
+            'password' => 'nullable|string|min:8',
             'employeePosition' => 'nullable|string|max:255',
             'workPermitMOUGroup' => 'nullable|string|max:255',
             'workPermitMOUGroupOther' => 'nullable|string|max:255',
@@ -168,6 +170,10 @@ public function create(Request $request) // เพิ่ม Request $request เ
             if ($request->hasFile("document_$i")) {
                 $validated["document_$i"] = $request->file("document_$i")->store("employee_documents", 'public');
             }
+        }
+
+        if (empty($validated['password'])) {
+            unset($validated['password']);
         }
 
         Employee::create($validated);
@@ -216,6 +222,8 @@ public function create(Request $request) // เพิ่ม Request $request เ
             'designatedHospital' => 'nullable|string|max:255',
             'startDate' => 'nullable|date',
             'employeePhone' => 'nullable|string|max:255',
+            'email' => 'nullable|email|max:255|unique:employees,email,' . $employee->id,
+            'password' => 'nullable|string|min:8',
             'employeePosition' => 'nullable|string|max:255',
             'workPermitMOUGroup' => 'nullable|string|max:255',
             'workPermitMOUGroupOther' => 'nullable|string|max:255',
@@ -246,6 +254,10 @@ public function create(Request $request) // เพิ่ม Request $request เ
                 }
                 $validated["document_$i"] = $request->file("document_$i")->store("employee_documents", 'public');
             }
+        }
+
+        if (empty($validated['password'])) {
+            unset($validated['password']);
         }
 
         $employee->update($validated);

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -40,6 +40,8 @@ class Employee extends Model
         'designatedHospital',
         'startDate',
         'employeePhone',
+        'email',
+        'password',
         'employeePosition',
         'workPermitMOUGroup',
         'workPermitMOUGroupOther',
@@ -72,6 +74,7 @@ class Employee extends Model
         'employeeDob' => 'date:Y-m-d',
         'startDate' => 'date:Y-m-d',
         'terminated_at' => 'datetime',
+        'password' => 'hashed',
     ];
 
     public function employer()

--- a/database/migrations/2025_10_17_063600_add_email_and_password_to_employees_table.php
+++ b/database/migrations/2025_10_17_063600_add_email_and_password_to_employees_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->string('email')->nullable()->unique()->after('employeePhone');
+            $table->string('password')->nullable()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('email');
+            $table->dropColumn('password');
+        });
+    }
+};

--- a/resources/js/address-handler.js
+++ b/resources/js/address-handler.js
@@ -1,0 +1,117 @@
+document.addEventListener('DOMContentLoaded', function () {
+    let thaiAddressData = [];
+    // Ensure we are on a page that has the address modal
+    const addressModalEl = document.getElementById('addressModal');
+    if (!addressModalEl) {
+        return;
+    }
+
+    const provinceSelect = document.getElementById('addrProvinceTh');
+    const districtSelect = document.getElementById('addrDistrictTh');
+    const subDistrictSelect = document.getElementById('addrSubDistrictTh');
+    const provinceEnInput = document.getElementById('addrProvinceEn');
+    const districtEnInput = document.getElementById('addrDistrictEn');
+    const subDistrictEnInput = document.getElementById('addrSubDistrictEn');
+    const zipCodeInput = document.getElementById('addrZipCode');
+
+    const resetSelect = (select, placeholder) => {
+        select.innerHTML = `<option value="" selected disabled>${placeholder}</option>`;
+        select.disabled = true;
+    };
+
+    const clearInputs = (...inputs) => {
+        inputs.forEach(input => input.value = '');
+    };
+
+    const populateProvinces = () => {
+        resetSelect(provinceSelect, '-- เลือกจังหวัด --');
+        thaiAddressData.forEach(province => {
+            const option = new Option(province.name_th, province.name_th);
+            provinceSelect.add(option);
+        });
+        provinceSelect.disabled = false;
+    };
+
+    // Fetch data on initial load
+    fetch('/api/thai-address-data')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.json();
+        })
+        .then(data => {
+            thaiAddressData = data;
+            // The modal's show event will trigger the population
+        })
+        .catch(error => {
+            console.error('Failed to fetch Thai address data:', error);
+            // Maybe disable the address functionality or show an error
+        });
+
+    addressModalEl.addEventListener('show.bs.modal', function (event) {
+        if (thaiAddressData.length > 0) {
+            populateProvinces();
+        }
+        resetSelect(districtSelect, '-- เลือกอำเภอ/เขต --');
+        resetSelect(subDistrictSelect, '-- เลือกตำบล/แขวง --');
+        clearInputs(provinceEnInput, districtEnInput, subDistrictEnInput, zipCodeInput);
+    });
+
+    provinceSelect.addEventListener('change', function () {
+        resetSelect(districtSelect, '-- เลือกอำเภอ/เขต --');
+        resetSelect(subDistrictSelect, '-- เลือกตำบล/แขวง --');
+        clearInputs(provinceEnInput, districtEnInput, subDistrictEnInput, zipCodeInput);
+
+        const selectedProvinceName = this.value;
+        if (!selectedProvinceName) return;
+
+        const selectedProvince = thaiAddressData.find(p => p.name_th === selectedProvinceName);
+        if (selectedProvince) {
+            provinceEnInput.value = selectedProvince.name_en;
+            districtSelect.innerHTML = '<option value="">-- เลือกอำเภอ/เขต --</option>';
+            selectedProvince.amphoe.forEach(district => {
+                const option = new Option(district.name_th, district.name_th);
+                districtSelect.add(option);
+            });
+            districtSelect.disabled = false;
+        }
+    });
+
+    districtSelect.addEventListener('change', function () {
+        resetSelect(subDistrictSelect, '-- เลือกตำบล/แขวง --');
+        clearInputs(districtEnInput, subDistrictEnInput, zipCodeInput);
+
+        const selectedProvince = thaiAddressData.find(p => p.name_th === provinceSelect.value);
+        const selectedDistrictName = this.value;
+        if (!selectedDistrictName || !selectedProvince) return;
+
+        const selectedDistrict = selectedProvince.amphoe.find(d => d.name_th === selectedDistrictName);
+        if (selectedDistrict) {
+            districtEnInput.value = selectedDistrict.name_en;
+            subDistrictSelect.innerHTML = '<option value="">-- เลือกตำบล/แขวง --</option>';
+            selectedDistrict.tambon.forEach(sub => {
+                const option = new Option(sub.name_th, sub.name_th);
+                subDistrictSelect.add(option);
+            });
+            subDistrictSelect.disabled = false;
+        }
+    });
+
+    subDistrictSelect.addEventListener('change', function () {
+        clearInputs(subDistrictEnInput, zipCodeInput);
+
+        const selectedProvince = thaiAddressData.find(p => p.name_th === provinceSelect.value);
+        if (!selectedProvince) return;
+        const selectedDistrict = selectedProvince.amphoe.find(d => d.name_th === districtSelect.value);
+        if (!selectedDistrict) return;
+        const selectedSubDistrictName = this.value;
+        if (!selectedSubDistrictName) return;
+
+        const selectedSubDistrict = selectedDistrict.tambon.find(s => s.name_th === selectedSubDistrictName);
+        if (selectedSubDistrict) {
+            subDistrictEnInput.value = selectedSubDistrict.name_en;
+            zipCodeInput.value = selectedSubDistrict.zip_code;
+        }
+    });
+});

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,7 @@
 import './bootstrap';
 import './employment-history.js';
 import './terminate-employee.js';
+import './address-handler.js';
 
 import Alpine from 'alpinejs';
 

--- a/resources/views/employees/create.blade.php
+++ b/resources/views/employees/create.blade.php
@@ -129,6 +129,16 @@
             </div>
         </div>
         <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="email" class="form-label">อีเมล</label>
+                <input type="email" class="form-control" id="email" name="email" value="{{ old('email') }}">
+            </div>
+            <div class="col-md-6">
+                <label for="password" class="form-label">รหัสผ่าน (ถ้าต้องการตั้ง)</label>
+                <input type="password" class="form-control" id="password" name="password">
+            </div>
+        </div>
+        <div class="row mb-3">
             <div class="col-md-4">
                 <label for="personalId" class="form-label">เลขประจำตัว</label>
                 <input type="text" class="form-control" id="personalId" name="personalId" value="{{ old('personalId') }}">

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -121,6 +121,8 @@
             <div class="col-md-4"><label for="ninetyDayReportDate" class="form-label">วันหมดอายุรายงานตัว 90 วัน</label><input type="date" class="form-control" id="ninetyDayReportDate" name="ninetyDayReportDate" value="{{ old('ninetyDayReportDate', optional($employee->ninetyDayReportDate)->format('Y-m-d')) }}"></div>
             <div class="col-md-4"><label for="startDate" class="form-label">วันเริ่มงาน</label><input type="date" class="form-control" id="startDate" name="startDate" value="{{ old('startDate', optional($employee->startDate)->format('Y-m-d')) }}"></div>
             <div class="col-md-4"><label for="employeePhone" class="form-label">เบอร์โทรศัพท์</label><input type="tel" class="form-control" id="employeePhone" name="employeePhone" value="{{ old('employeePhone', $employee->employeePhone) }}"></div>
+            <div class="col-md-4"><label for="email" class="form-label">อีเมล</label><input type="email" class="form-control" id="email" name="email" value="{{ old('email', $employee->email) }}"></div>
+            <div class="col-md-4"><label for="password" class="form-label">รหัสผ่านใหม่ (ปล่อยว่างถ้าไม่เปลี่ยน)</label><input type="password" class="form-control" id="password" name="password"></div>
             <div class="col-md-4"><label for="employeePosition" class="form-label">ตำแหน่ง</label><input type="text" class="form-control" id="employeePosition" name="employeePosition" value="{{ old('employeePosition', $employee->employeePosition) }}"></div>
             <div class="col-md-4"><label for="nature_of_work" class="form-label">ลักษณะงาน (Nature of Work)</label><input type="text" class="form-control" id="nature_of_work" name="nature_of_work" value="{{ old('nature_of_work', $employee->nature_of_work) }}"></div>
         </div>

--- a/resources/views/partials/_address_management.blade.php
+++ b/resources/views/partials/_address_management.blade.php
@@ -60,8 +60,8 @@
                     {{-- Row 5: Province --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
-                            <label for="addrProvince" class="form-label">จังหวัด (Thai)</label>
-                            <select class="form-select" id="addrProvince" name="addrProvince">
+                            <label for="addrProvinceTh" class="form-label">จังหวัด (Thai)</label>
+                            <select class="form-select" id="addrProvinceTh" name="addrProvince">
                                 <option selected disabled>-- เลือกจังหวัด --</option>
                             </select>
                         </div>
@@ -73,8 +73,8 @@
                     {{-- Row 6: District --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
-                            <label for="addrDistrict" class="form-label">อำเภอ/เขต (Thai)</label>
-                            <select class="form-select" id="addrDistrict" name="addrDistrict">
+                            <label for="addrDistrictTh" class="form-label">อำเภอ/เขต (Thai)</label>
+                            <select class="form-select" id="addrDistrictTh" name="addrDistrict">
                                 <option selected disabled>-- เลือกอำเภอ/เขต --</option>
                             </select>
                         </div>
@@ -86,8 +86,8 @@
                     {{-- Row 7: SubDistrict --}}
                     <div class="row mb-3">
                         <div class="col-md-6">
-                            <label for="addrSubDistrict" class="form-label">ตำบล/แขวง (Thai)</label>
-                            <select class="form-select" id="addrSubDistrict" name="addrSubDistrict">
+                            <label for="addrSubDistrictTh" class="form-label">ตำบล/แขวง (Thai)</label>
+                            <select class="form-select" id="addrSubDistrictTh" name="addrSubDistrict">
                                 <option selected disabled>-- เลือกตำบล/แขวง --</option>
                             </select>
                         </div>
@@ -111,187 +111,3 @@
         </div>
     </div>
 </div>
-
-@push('scripts')
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    let thaiAddressData = [];
-    const addressModalEl = document.getElementById('addressModal');
-    const form = document.getElementById('addressForm');
-    if (!form) return; // Exit if no address form on the page
-
-    // --- Form Input References ---
-    const provinceSelect = document.getElementById('addrProvince');
-    const districtSelect = document.getElementById('addrDistrict');
-    const subDistrictSelect = document.getElementById('addrSubDistrict');
-    const provinceEnInput = document.getElementById('addrProvinceEn');
-    const districtEnInput = document.getElementById('addrDistrictEn');
-    const subDistrictEnInput = document.getElementById('addrSubDistrictEn');
-    const zipCodeInput = document.getElementById('addrZipCode');
-    const saveBtn = document.getElementById('saveAddressBtn');
-
-    // --- Helper Functions ---
-    const resetSelect = (select, placeholder) => {
-        select.innerHTML = `<option value="">${placeholder}</option>`;
-        select.disabled = true;
-    };
-
-    const clearInputs = (...inputs) => {
-        inputs.forEach(input => input.value = '');
-    };
-
-    // 1. FETCH THAI ADDRESS DATA
-    const fetchAddressData = () => {
-        // Check if data is already fetched
-        if (thaiAddressData.length > 0) {
-            populateProvinces();
-            return;
-        }
-        fetch("{{ route('addresses.thai_data') }}")
-            .then(response => {
-                if (!response.ok) throw new Error('Network response was not ok');
-                return response.json();
-            })
-            .then(data => {
-                thaiAddressData = data;
-                populateProvinces();
-            }).catch(error => {
-                console.error('Error fetching address data:', error);
-                // Optionally disable the form or show an error message to the user
-            });
-    };
-
-    // 2. POPULATE DROPDOWNS
-    const populateProvinces = () => {
-        resetSelect(provinceSelect, '-- เลือกจังหวัด --');
-        thaiAddressData.forEach(province => {
-            const option = new Option(province.name_th, province.name_th);
-            provinceSelect.add(option);
-        });
-        provinceSelect.disabled = false;
-    };
-
-    provinceSelect.addEventListener('change', function () {
-        resetSelect(districtSelect, '-- เลือกอำเภอ/เขต --');
-        resetSelect(subDistrictSelect, '-- เลือกตำบล/แขวง --');
-        clearInputs(provinceEnInput, districtEnInput, subDistrictEnInput, zipCodeInput);
-
-        const selectedProvinceName = this.value;
-        if (!selectedProvinceName) return;
-
-        const selectedProvince = thaiAddressData.find(p => p.name_th === selectedProvinceName);
-        if (selectedProvince) {
-            provinceEnInput.value = selectedProvince.name_en;
-            districtSelect.innerHTML = '<option value="">-- เลือกอำเภอ/เขต --</option>'; // Reset
-            selectedProvince.amphoe.forEach(district => {
-                const option = new Option(district.name_th, district.name_th);
-                districtSelect.add(option);
-            });
-            districtSelect.disabled = false;
-        }
-    });
-
-    districtSelect.addEventListener('change', function () {
-        resetSelect(subDistrictSelect, '-- เลือกตำบล/แขวง --');
-        clearInputs(districtEnInput, subDistrictEnInput, zipCodeInput);
-
-        const selectedProvince = thaiAddressData.find(p => p.name_th === provinceSelect.value);
-        const selectedDistrictName = this.value;
-        if (!selectedDistrictName || !selectedProvince) return;
-
-        const selectedDistrict = selectedProvince.amphoe.find(d => d.name_th === selectedDistrictName);
-        if (selectedDistrict) {
-            districtEnInput.value = selectedDistrict.name_en;
-            subDistrictSelect.innerHTML = '<option value="">-- เลือกตำบล/แขวง --</option>'; // Reset
-            selectedDistrict.tambon.forEach(sub => {
-                const option = new Option(sub.name_th, sub.name_th);
-                subDistrictSelect.add(option);
-            });
-            subDistrictSelect.disabled = false;
-        }
-    });
-
-    subDistrictSelect.addEventListener('change', function () {
-        clearInputs(subDistrictEnInput, zipCodeInput);
-
-        const selectedProvince = thaiAddressData.find(p => p.name_th === provinceSelect.value);
-        if (!selectedProvince) return;
-        const selectedDistrict = selectedProvince.amphoe.find(d => d.name_th === districtSelect.value);
-        if (!selectedDistrict) return;
-        const selectedSubDistrictName = this.value;
-        if (!selectedSubDistrictName) return;
-
-        const selectedSubDistrict = selectedDistrict.tambon.find(s => s.name_th === selectedSubDistrictName);
-        if (selectedSubDistrict) {
-            subDistrictEnInput.value = selectedSubDistrict.name_en;
-            zipCodeInput.value = selectedSubDistrict.zip_code;
-        }
-    });
-
-    // 3. MODAL EVENT HANDLING
-    if (addressModalEl) {
-        addressModalEl.addEventListener('show.bs.modal', function(event) {
-            const button = event.relatedTarget;
-            if (!button) return; // Modal opened via JS, not a button click
-
-            form.reset();
-            clearInputs(provinceEnInput, districtEnInput, subDistrictEnInput, zipCodeInput);
-            resetSelect(districtSelect, '-- เลือกอำเภอ/เขต --');
-            resetSelect(subDistrictSelect, '-- เลือกตำบล/แขวง --');
-            fetchAddressData(); // Fetch data and populate provinces
-
-            const modalType = button.classList.contains('add-address-btn') ? 'add' : 'edit';
-            const addressableId = button.dataset.addressableId;
-            const addressType = button.dataset.type;
-
-            document.getElementById('addressModalLabel').textContent = 'เพิ่มที่อยู่ใหม่';
-            document.getElementById('addressable_id').value = addressableId;
-            document.getElementById('address_type').value = addressType;
-            document.getElementById('address_id').value = ''; // Clear ID for 'add' mode
-        });
-    }
-
-    // 4. SAVE ADDRESS LOGIC
-    if (saveBtn) {
-        saveBtn.addEventListener('click', function() {
-            const formData = new FormData(form);
-            const data = Object.fromEntries(formData.entries());
-            const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-
-            fetch("{{ route('addresses.store') }}", {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': csrfToken,
-                    'Accept': 'application/json'
-                },
-                body: JSON.stringify(data)
-            })
-            .then(response => response.json())
-            .then(result => {
-                const modalInstance = bootstrap.Modal.getInstance(addressModalEl);
-                if (result.success) {
-                    modalInstance.hide();
-                    Swal.fire({
-                        icon: 'success',
-                        title: 'สำเร็จ',
-                        text: result.message || 'บันทึกที่อยู่เรียบร้อยแล้ว',
-                        timer: 2000,
-                        showConfirmButton: false,
-                    }).then(() => location.reload()); // Reload to see changes
-                } else {
-                    let errorText = result.message || 'เกิดข้อผิดพลาดในการตรวจสอบข้อมูล';
-                    if (result.errors) {
-                        errorText = Object.values(result.errors).map(e => `<div>${e}</div>`).join('');
-                    }
-                    Swal.fire({ icon: 'error', title: 'ผิดพลาด!', html: errorText });
-                }
-            }).catch(error => {
-                console.error('Save Address Error:', error);
-                Swal.fire({ icon: 'error', title: 'ผิดพลาด!', text: 'ไม่สามารถส่งข้อมูลไปยังเซิร์ฟเวอร์ได้' });
-            });
-        });
-    }
-});
-</script>
-@endpush


### PR DESCRIPTION
This commit introduces two major features:

1.  **Employer Address Management System:**
    -   The address modal (`_address_management.blade.php`) has been updated with specific IDs for better JavaScript targeting.
    -   A new, dedicated JavaScript module (`address-handler.js`) now manages all front-end logic for the address modal, including fetching Thai address data and handling cascading dropdowns for provinces, districts, and sub-districts.
    -   The old, inline address script has been removed from the Blade partial and the new module is imported into the main `app.js`.

2.  **Employee Email and Password Fields:**
    -   A database migration has been added to include `email` and `password` columns in the `employees` table.
    -   The `Employee` model is updated to make these new fields fillable and to automatically hash passwords upon saving.
    -   The `create` and `edit` employee views now include fields for managing employee email and password.
    -   The `EmployeeController`'s `store` and `update` methods have been updated to handle the validation and persistence of the new credential fields.