### PR TITLE
Fix: Correct failing migration for english_prefix

### DIFF
--- a/database/migrations/2025_10_17_042000_add_english_prefix_to_employees_table.php
+++ b/database/migrations/2025_10_17_042000_add_english_prefix_to_employees_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('employees', function (Blueprint $table) {
-            $table->string('english_prefix', 20)->nullable()->after('prefix');
+            $table->string('english_prefix', 20)->nullable();
         });
     }
 


### PR DESCRIPTION
The `add_english_prefix_to_employees_table` migration was failing because it tried to add the `english_prefix` column after a non-existent `prefix` column.

This commit removes the `->after('prefix')` method call from the migration, allowing it to run successfully without depending on the position of another column.