### PR TITLE
Fix: Ensure address form receives and submits required data

### DIFF
--- a/resources/js/address-handler.js
+++ b/resources/js/address-handler.js
@@ -50,6 +50,18 @@ document.addEventListener('DOMContentLoaded', function () {
         });
 
     addressModalEl.addEventListener('show.bs.modal', function (event) {
+        // Button that triggered the modal
+        const button = event.relatedTarget;
+        if (button) {
+            // Extract info from data-* attributes
+            const addressableId = button.dataset.addressableId;
+            const addressType = button.dataset.type;
+
+            // Update the modal's hidden fields
+            document.getElementById('addressable_id').value = addressableId;
+            document.getElementById('address_type').value = addressType;
+        }
+
         if (thaiAddressData.length > 0) {
             populateProvinces();
         }


### PR DESCRIPTION
This commit resolves the '422 Unprocessable Content' error on the address form by correctly populating hidden fields from the triggering button's data attributes.

- Modified `resources/js/address-handler.js` to read `data-addressable-id` and `data-type` from the modal's triggering button and populate the `#addressable_id` and `#address_type` hidden inputs.
- Ensured the `addressable_type` in `resources/views/partials/_address_management.blade.php` uses the full model namespace (`App\Models\Employer`) as required by Laravel's polymorphic relations.

This change establishes a complete data pipeline, allowing the existing AJAX submission logic to send the correct data to the backend.