### PR TITLE
feat(address): Implement delete and fix create workflow

### DIFF
--- a/resources/js/address-handler.js
+++ b/resources/js/address-handler.js
@@ -240,4 +240,58 @@ document.addEventListener('DOMContentLoaded', function () {
         saveButton.disabled = false;
         saveButton.innerHTML = 'บันทึก';
     });
+
+    // START: Add Delete Functionality
+    document.addEventListener('click', function(e) {
+        // Check if the clicked element is a delete button
+        if (e.target && (e.target.classList.contains('btn-delete-address') || e.target.closest('.btn-delete-address'))) {
+
+            e.preventDefault();
+
+            const button = e.target.closest('.btn-delete-address');
+            const addressId = button.dataset.addressId;
+            const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+            if (!addressId || !token) {
+                console.error('Delete button is missing address ID or CSRF token is not found.');
+                alert('An error occurred. Please refresh the page.');
+                return;
+            }
+
+            // Show confirmation dialog
+            if (!confirm('Are you sure you want to delete this address? This action cannot be undone.')) {
+                return; // User cancelled
+            }
+
+            // Perform the fetch request to the delete endpoint
+            fetch(`/addresses/${addressId}`, {
+                method: 'DELETE',
+                headers: {
+                    'X-CSRF-TOKEN': token,
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json'
+                }
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok. Status: ' + response.status);
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (data.success) {
+                    alert('Address deleted successfully.');
+                    // Reload the page to show the updated address list
+                    window.location.reload();
+                } else {
+                    throw new Error('Server reported an error: ' + (data.message || 'Unknown error'));
+                }
+            })
+            .catch(error => {
+                console.error('Error deleting address:', error);
+                alert('Failed to delete address. Please check the console for details.');
+            });
+        }
+    });
+    // END: Add Delete Functionality
 });

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -154,7 +154,9 @@
                     <button type="button" class="btn btn-sm btn-primary add-address-btn"
                             data-bs-toggle="modal"
                             data-bs-target="#addressModal"
-                            data-type="registered">
+                            data-type="registered"
+                            disabled
+                            title="You must save the employer first before adding an address.">
                         + เพิ่มที่อยู่
                     </button>
                 </div>
@@ -170,7 +172,9 @@
                     <button type="button" class="btn btn-sm btn-primary add-address-btn"
                             data-bs-toggle="modal"
                             data-bs-target="#addressModal"
-                            data-type="workplace">
+                            data-type="workplace"
+                            disabled
+                            title="You must save the employer first before adding an address.">
                         + เพิ่มที่อยู่
                     </button>
                 </div>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -181,7 +181,7 @@
                                 data-address-id="{{ $address->id }}">
                             แก้ไข
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
+                        <button type="button" class="btn btn-sm btn-danger ms-2 btn-delete-address" data-address-id="{{ $address->id }}">Delete</button>
                     </div>
                 </div>
             @empty
@@ -224,7 +224,7 @@
                                 data-address-id="{{ $address->id }}">
                             แก้ไข
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-danger delete-address-btn" data-id="{{ $address->id }}"><i class="bi bi-trash"></i></button>
+                        <button type="button" class="btn btn-sm btn-danger ms-2 btn-delete-address" data-address-id="{{ $address->id }}">Delete</button>
                     </div>
                 </div>
             @empty


### PR DESCRIPTION
Implements a holistic fix for the address management feature.

- Disables the 'Add Address' buttons on the employer create page to enforce the correct workflow where an employer must exist before an address can be added. A title attribute is added to explain the disabled state.
- Adds 'Delete' buttons next to each existing address on the employer edit page, allowing for address removal.
- Implements the corresponding JavaScript fetch request with the 'DELETE' method to handle the deletion logic, including a confirmation dialog.
- Ensures the master layout contains the CSRF token required for secure AJAX requests.