### PR TITLE
feat: Implement universal soft deletes for core models

### DIFF
--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Address extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'type',

--- a/app/Models/Agent.php
+++ b/app/Models/Agent.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Agent extends Model
 {
+    use SoftDeletes;
+
     protected $fillable = [
         'agentNameEn',
         'agentLicense',

--- a/app/Models/Delegate.php
+++ b/app/Models/Delegate.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Delegate extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'delegateNameTh',

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -4,11 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\JobOwner;
 
 class Employer extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'employerNameTh',

--- a/app/Models/Importer.php
+++ b/app/Models/Importer.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Importer extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/database/migrations/2025_10_18_080500_add_soft_deletes_to_core_models.php
+++ b/database/migrations/2025_10_18_080500_add_soft_deletes_to_core_models.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add softDeletes column to 5 core tables
+        Schema::table('employers', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+        Schema::table('agents', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+        Schema::table('importers', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+        Schema::table('delegates', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+        Schema::table('addresses', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Remove softDeletes column from 5 core tables
+        Schema::table('employers', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+        Schema::table('agents', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+        Schema::table('importers', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+        Schema::table('delegates', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+        Schema::table('addresses', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};


### PR DESCRIPTION
- Creates a new migration to add the `deleted_at` column to the `employers`, `agents`, `importers`, `delegates`, and `addresses` tables.
- Updates the corresponding models (`Employer`, `Agent`, `Importer`, `Delegate`, `Address`) to use the `SoftDeletes` trait, enabling soft delete functionality across these core entities.