### PR TITLE
feat: Implement Grand UI Overhaul

### DIFF
--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -53,15 +53,15 @@ class RoleAndPermissionSeeder extends Seeder
             // Create Staff Role and assign specific permissions
             $staffRole = Role::firstOrCreate(['name' => 'staff']);
             $staffPermissions = [
-                'view-employers', 'create-employers', 'edit-employers', 'delete-employers',
+                'view-employers', 'create-employers', 'edit-employers',
                 'view-employees', 'create-employees', 'edit-employees', 'terminate-employees',
-                'view-agents', 'create-agents', 'edit-agents', 'delete-agents',
-                'view-importers', 'create-importers', 'edit-importers', 'delete-importers',
-                'view-delegates', 'create-delegates', 'edit-delegates', 'delete-delegates',
-                'view-addresses', 'create-addresses', 'edit-addresses', 'delete-addresses',
-                'view-notifications', 'cancel-notifications', 'renew-notifications', 'restore-notifications',
+                'view-agents', 'create-agents', 'edit-agents',
+                'view-importers', 'create-importers', 'edit-importers',
+                'view-delegates', 'create-delegates', 'edit-delegates',
+                'view-addresses', 'create-addresses', 'edit-addresses',
+                'view-notifications', 'cancel-notifications', 'renew-notifications',
             ];
-            $staffRole->givePermissionTo($staffPermissions);
+            $staffRole->syncPermissions($staffPermissions);
 
             // Create or find Admin User
             $adminUser = User::firstOrCreate(

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -2,6 +2,7 @@ import './bootstrap';
 import './employment-history.js';
 import './terminate-employee.js';
 import './address-handler.js';
+import './central-delete-handler.js';
 
 import Alpine from 'alpinejs';
 

--- a/resources/js/central-delete-handler.js
+++ b/resources/js/central-delete-handler.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const deleteModal = document.getElementById('centralDeleteConfirmationModal');
+    if (!deleteModal) {
+        return;
+    }
+
+    const deleteForm = document.getElementById('centralDeleteForm');
+    const deleteModalMessage = document.getElementById('deleteModalMessage');
+    const confirmBtn = document.getElementById('confirmCentralDeleteBtn');
+
+    deleteModal.addEventListener('show.bs.modal', function (event) {
+        const button = event.relatedTarget;
+
+        const action = button.getAttribute('data-action');
+        const message = button.getAttribute('data-message');
+        const isForceDelete = button.getAttribute('data-is-force-delete') === 'true';
+
+        // Set the form action
+        if (action) {
+            deleteForm.setAttribute('action', action);
+        }
+
+        // Set the modal message
+        if (message) {
+            deleteModalMessage.innerHTML = message;
+        } else {
+            deleteModalMessage.innerHTML = 'คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้?';
+        }
+
+        // Adjust button for force delete
+        if (isForceDelete) {
+            confirmBtn.classList.remove('btn-danger');
+            confirmBtn.classList.add('btn-warning');
+            confirmBtn.textContent = 'ยืนยันการลบถาวร';
+        } else {
+            confirmBtn.classList.remove('btn-warning');
+            confirmBtn.classList.add('btn-danger');
+            confirmBtn.textContent = 'ยืนยันการลบ';
+        }
+    });
+});

--- a/resources/views/admin/trash.blade.php
+++ b/resources/views/admin/trash.blade.php
@@ -34,11 +34,14 @@
                                 </form>
                             @endcan
                             @can('force-delete-employers')
-                                <form action="{{ route('admin.trash.forceDelete', ['model' => 'employer', 'id' => $item->id]) }}" method="POST" onsubmit="return confirm('PERMANENTLY DELETE? This cannot be undone.');">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-sm btn-danger">Force Delete</button>
-                                </form>
+                                <button type="button" class="btn btn-sm btn-danger btn-trigger-delete-modal"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#centralDeleteConfirmationModal"
+                                        data-action="{{ route('admin.trash.forceDelete', ['model' => 'employer', 'id' => $item->id]) }}"
+                                        data-message="คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลนายจ้าง '{{ $item->employerNameTh }}' อย่างถาวร? การกระทำนี้ไม่สามารถย้อนกลับได้"
+                                        data-is-force-delete="true">
+                                    Force Delete
+                                </button>
                             @endcan
                         </td>
                     </tr>
@@ -70,11 +73,14 @@
                                 </form>
                             @endcan
                             @can('force-delete-agents')
-                                <form action="{{ route('admin.trash.forceDelete', ['model' => 'agent', 'id' => $item->id]) }}" method="POST" onsubmit="return confirm('PERMANENTLY DELETE? This cannot be undone.');">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-sm btn-danger">Force Delete</button>
-                                </form>
+                                <button type="button" class="btn btn-sm btn-danger btn-trigger-delete-modal"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#centralDeleteConfirmationModal"
+                                        data-action="{{ route('admin.trash.forceDelete', ['model' => 'agent', 'id' => $item->id]) }}"
+                                        data-message="คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลเอเจนซี่ '{{ $item->agentNameEn }}' อย่างถาวร? การกระทำนี้ไม่สามารถย้อนกลับได้"
+                                        data-is-force-delete="true">
+                                    Force Delete
+                                </button>
                             @endcan
                         </td>
                     </tr>

--- a/resources/views/agents/index.blade.php
+++ b/resources/views/agents/index.blade.php
@@ -30,12 +30,18 @@
                         <td>{{ $agent->agentLicense }}</td>
                         <td>{{ $agent->agentPhone }}</td>
                         <td class="text-center">
+                            @can('edit-agents')
                             <a href="{{ route('agents.edit', $agent) }}" class="btn btn-sm btn-outline-primary">แก้ไข</a>
-                            <form action="{{ route('agents.destroy', $agent) }}" method="POST" class="d-inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้?')">ลบ</button>
-                            </form>
+                            @endcan
+                            @can('delete-agents')
+                            <button type="button" class="btn btn-sm btn-outline-danger btn-trigger-delete-modal"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#centralDeleteConfirmationModal"
+                                    data-action="{{ route('agents.destroy', $agent) }}"
+                                    data-message="คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลเอเจนซี่ '{{ $agent->agentNameEn }}'?">
+                                ลบ
+                            </button>
+                            @endcan
                         </td>
                     </tr>
                 @empty

--- a/resources/views/components/employee-action-buttons.blade.php
+++ b/resources/views/components/employee-action-buttons.blade.php
@@ -32,8 +32,12 @@
     
     {{-- Force Delete Button (Red) - Admin Only --}}
     @can('force-delete-employees')
-         <button type="button" class="btn btn-sm btn-danger js-force-delete-btn" title="Force Delete"
-                data-employee-id="{{ $employee->id }}">
+        <button type="button" class="btn btn-sm btn-danger btn-trigger-delete-modal" title="Force Delete"
+                data-bs-toggle="modal"
+                data-bs-target="#centralDeleteConfirmationModal"
+                data-action="{{ route('employees.forceDelete', $employee->id) }}"
+                data-message="คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลพนักงาน '{{ $employee->employeeNameTh }}' อย่างถาวร? การกระทำนี้ไม่สามารถย้อนกลับได้"
+                data-is-force-delete="true">
             <i class="bi bi-trash3-fill"></i>
         </button>
     @endcan

--- a/resources/views/delegates/index.blade.php
+++ b/resources/views/delegates/index.blade.php
@@ -39,12 +39,18 @@
                         <td>{{ $delegate->delegateNameTh }}</td>
                         <td>{{ $delegate->delegateId }}</td>
                         <td>
+                            @can('edit-delegates')
                             <a href="{{ route('delegates.edit', $delegate->id) }}" class="btn btn-sm btn-primary">Edit</a>
-                            <form action="{{ route('delegates.destroy', $delegate->id) }}" method="POST" style="display:inline-block;" onsubmit="return confirm('Are you sure you want to delete this delegate?');">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-sm btn-danger">Delete</button>
-                            </form>
+                            @endcan
+                            @can('delete-delegates')
+                            <button type="button" class="btn btn-sm btn-danger btn-trigger-delete-modal"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#centralDeleteConfirmationModal"
+                                    data-action="{{ route('delegates.destroy', $delegate->id) }}"
+                                    data-message="Are you sure you want to delete delegate '{{ $delegate->delegateNameTh }}'?">
+                                Delete
+                            </button>
+                            @endcan
                         </td>
                     </tr>
                     @endforeach

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -175,7 +175,15 @@
                         </p>
                     </div>
                     <div class="btn-group btn-group-sm">
-                        <button type="button" class="btn btn-sm btn-danger btn-delete-address" data-address-id="{{ $address->id }}">Delete</button>
+                        @can('delete-addresses')
+                        <button type="button" class="btn btn-sm btn-danger btn-trigger-delete-modal"
+                                data-bs-toggle="modal"
+                                data-bs-target="#centralDeleteConfirmationModal"
+                                data-action="{{ route('addresses.destroy', $address->id) }}"
+                                data-message="คุณแน่ใจหรือไม่ว่าต้องการลบที่อยู่นี้?">
+                            Delete
+                        </button>
+                        @endcan
                     </div>
                 </div>
             @empty
@@ -212,7 +220,15 @@
                         </p>
                     </div>
                     <div class="btn-group btn-group-sm">
-                        <button type="button" class="btn btn-sm btn-danger btn-delete-address" data-address-id="{{ $address->id }}">Delete</button>
+                        @can('delete-addresses')
+                        <button type="button" class="btn btn-sm btn-danger btn-trigger-delete-modal"
+                                data-bs-toggle="modal"
+                                data-bs-target="#centralDeleteConfirmationModal"
+                                data-action="{{ route('addresses.destroy', $address->id) }}"
+                                data-message="คุณแน่ใจหรือไม่ว่าต้องการลบที่อยู่นี้?">
+                            Delete
+                        </button>
+                        @endcan
                     </div>
                 </div>
             @empty

--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -52,11 +52,13 @@
                             <a href="{{ route('employers.edit', $employer) }}" class="btn btn-sm btn-outline-primary">แก้ไข</a>
                             @endcan
                             @can('delete-employers')
-                            <form action="{{ route('employers.destroy', $employer) }}" method="POST" class="d-inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้?')">ลบ</button>
-                            </form>
+                            <button type="button" class="btn btn-sm btn-outline-danger btn-trigger-delete-modal"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#centralDeleteConfirmationModal"
+                                    data-action="{{ route('employers.destroy', $employer) }}"
+                                    data-message="คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลนายจ้าง '{{ $employer->employerNameTh }}'?">
+                                ลบ
+                            </button>
                             @endcan
                         </td>
                     </tr>

--- a/resources/views/importers/index.blade.php
+++ b/resources/views/importers/index.blade.php
@@ -35,12 +35,18 @@
                         <td>{{ $importer->importerId }}</td>
                         <td>{{ $importer->importerLicenseNo }}</td>
                         <td class="text-center">
+                            @can('edit-importers')
                             <a href="{{ route('importers.edit', $importer->id) }}" class="btn btn-sm btn-outline-primary">แก้ไข</a>
-                            <form action="{{ route('importers.destroy', $importer->id) }}" method="POST" class="d-inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้?')">ลบ</button>
-                            </form>
+                            @endcan
+                            @can('delete-importers')
+                            <button type="button" class="btn btn-sm btn-outline-danger btn-trigger-delete-modal"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#centralDeleteConfirmationModal"
+                                    data-action="{{ route('importers.destroy', $importer->id) }}"
+                                    data-message="คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลบริษัทนำเข้า '{{ $importer->importerNameTh }}'?">
+                                ลบ
+                            </button>
+                            @endcan
                         </td>
                     </tr>
                 @empty

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -257,25 +257,29 @@
         </div>
     </div>
 
-    {{-- START: Delete Address Confirmation Modal --}}
-<div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
+{{-- START: Central Delete Confirmation Modal --}}
+<div class="modal fade" id="centralDeleteConfirmationModal" tabindex="-1" aria-labelledby="centralDeleteConfirmationModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="deleteConfirmModalLabel">Confirm Deletion</h5>
+                <h5 class="modal-title" id="centralDeleteConfirmationModalLabel">ยืนยันการลบ</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                Are you sure you want to delete this address? This action cannot be undone.
+                <p id="deleteModalMessage">คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้?</p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-danger" id="confirmDeleteBtn">Confirm Delete</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                <form id="centralDeleteForm" method="POST" style="display: inline;">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger" id="confirmCentralDeleteBtn">ยืนยันการลบ</button>
+                </form>
             </div>
         </div>
     </div>
 </div>
-{{-- END: Delete Address Confirmation Modal --}}
+{{-- END: Central Delete Confirmation Modal --}}
 
     {{-- Toast Notification Container --}}
     <div class="toast-container position-fixed top-0 end-0 p-3">


### PR DESCRIPTION
This commit introduces a major UI and security enhancement by addressing three key issues:

1.  **Security: Corrected Staff Permissions:**
    - Modified the `RoleAndPermissionSeeder` to use `syncPermissions`, ensuring the 'staff' role has a strict, limited set of permissions.
    - Removed all unauthorized `delete-`, `restore-`, and `force-delete-` permissions from the staff role.
    - Wrapped all delete and edit buttons throughout the application's views with the appropriate `@can` directives to enforce authorization at the UI level.

2.  **UI: Centralized Deletion Modal:**
    - Replaced all JavaScript `confirm()` dialogs with a single, centralized Bootstrap modal (`#centralDeleteConfirmationModal`).
    - Created a global JavaScript handler (`central-delete-handler.js`) to dynamically populate and manage the modal for all delete and force-delete actions across the application.
    - This provides a consistent and improved user experience for all destructive actions.

3.  **Feature: Upgraded Employee & Address Buttons:**
    - Upgraded the "Force Delete" button for employees to use the new central modal system.
    - Updated the address deletion buttons in the employer edit view to integrate with the new modal, fixing a previously broken feature.
    - Ensured all action buttons are protected by their respective permissions.