### PR TITLE
Fix: Apply final patches for EmployerController and routes

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -119,13 +119,16 @@ class EmployerController extends Controller
         }
         $terminatedEmployees = $historyQuery->paginate($perPage, ['*'], 'history_page')->appends($request->except('history_page'));
 
+        $jobOwners = \App\Models\JobOwner::orderBy('name')->get();
+
         return view('employers.edit', compact(
             'employer',
             'employees',
             'terminatedEmployees',
             'nationalities',
             'male_count',
-            'female_count'
+            'female_count',
+            'jobOwners'
         ));
     }
 


### PR DESCRIPTION
- In `EmployerController@edit`, added the missing `$jobOwners` query and passed the variable to the view to fix an 'Undefined variable' error.
- Verified that the `employees.restore` and `employees.forceDelete` routes in `routes/web.php` correctly use `withTrashed()` to prevent 404 errors on soft-deleted models.