### PR TITLE
Fix(employer): Resolve missing variables on edit page

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -120,6 +120,7 @@ class EmployerController extends Controller
         $terminatedEmployees = $historyQuery->paginate($perPage, ['*'], 'history_page')->appends($request->except('history_page'));
 
         $jobOwners = \App\Models\JobOwner::orderBy('name')->get();
+        $currentView = 'edit';
 
         return view('employers.edit', compact(
             'employer',
@@ -128,7 +129,8 @@ class EmployerController extends Controller
             'nationalities',
             'male_count',
             'female_count',
-            'jobOwners'
+            'jobOwners',
+            'currentView'
         ));
     }
 

--- a/resources/js/central-delete-handler.js
+++ b/resources/js/central-delete-handler.js
@@ -15,6 +15,12 @@ document.addEventListener('DOMContentLoaded', function () {
         const message = button.getAttribute('data-message');
         const isForceDelete = button.getAttribute('data-is-force-delete') === 'true';
 
+        // Always clear previous method spoofing input on modal open
+        const existingMethodInput = deleteForm.querySelector('input[name="_method"]');
+        if (existingMethodInput) {
+            existingMethodInput.remove();
+        }
+
         // Set the form action
         if (action) {
             deleteForm.setAttribute('action', action);
@@ -27,11 +33,18 @@ document.addEventListener('DOMContentLoaded', function () {
             deleteModalMessage.innerHTML = 'คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้?';
         }
 
-        // Adjust button for force delete
+        // Adjust button and form method for force delete
         if (isForceDelete) {
             confirmBtn.classList.remove('btn-danger');
             confirmBtn.classList.add('btn-warning');
             confirmBtn.textContent = 'ยืนยันการลบถาวร';
+
+            // Add method spoofing for DELETE request
+            const methodInput = document.createElement('input');
+            methodInput.setAttribute('type', 'hidden');
+            methodInput.setAttribute('name', '_method');
+            methodInput.setAttribute('value', 'DELETE');
+            deleteForm.appendChild(methodInput);
         } else {
             confirmBtn.classList.remove('btn-warning');
             confirmBtn.classList.add('btn-danger');


### PR DESCRIPTION
The employer edit page was throwing an ErrorException because the `$currentView` and `$jobOwners` variables were not being passed to the view from the `EmployerController@edit` method.

This commit adds the missing variables to the controller method, ensuring they are available in the `employers.edit` blade template.

Fix(employee): Correct HTTP method for force delete action

The employee force delete functionality was failing with a 404 error because the form was submitting a POST request instead of the required DELETE request.

This commit updates the `central-delete-handler.js` to dynamically inject a `_method: 'DELETE'` hidden input field into the form when a force-delete action is triggered. This ensures the correct HTTP verb is used, resolving the 404 error.