### PR TITLE
Refactor: Separate termination and trash states for Employee model

### DIFF
--- a/app/Console/Commands/PruneSoftDeletes.php
+++ b/app/Console/Commands/PruneSoftDeletes.php
@@ -8,6 +8,7 @@ use App\Models\Agent;
 use App\Models\Importer;
 use App\Models\Delegate;
 use App\Models\Address;
+use App\Models\Employee;
 
 class PruneSoftDeletes extends Command
 {
@@ -53,6 +54,10 @@ class PruneSoftDeletes extends Command
         // Prune Addresses
         $addressCount = Address::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
         $this->info("Pruned $addressCount Addresses.");
+
+        // Prune Trashed Employees (using default 'deleted_at' column)
+        $employeeCount = Employee::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
+        $this->info("Pruned $employeeCount Trashed Employees.");
 
         $this->info('Soft delete pruning complete.');
         return 0;

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -10,8 +10,6 @@ class Employee extends Model
 {
     use HasFactory, SoftDeletes;
 
-    const DELETED_AT = 'terminated_at';
-
     // The $fillable array is correct as it matches the camelCase schema.
     protected $fillable = [
         'employer_id',


### PR DESCRIPTION
- Removes the `DELETED_AT` constant from the Employee model to revert to the default `deleted_at` column for soft deletes.
- Updates the `PruneSoftDeletes` command to correctly prune trashed Employees based on the `deleted_at` column.
- This change allows the application to distinguish between a terminated employee (kept indefinitely) and a trashed employee (pruned after 30 days).