### PR TITLE
fix(history): Correct query and add reinstate route for history modal

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -196,7 +196,7 @@ public function edit(Request $request, Employer $employer)
 
     public function filterHistory(Request $request, Employer $employer)
     {
-        $query = $employer->employees()->onlyTrashed();
+        $query = $employer->employees()->whereNotNull('terminated_at');
 
         // Implement search
         if ($request->filled('search')) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/employers/{employer}/employees/filter', [EmployerController::class, 'filterEmployees'])->name('employers.employees.filter');
     Route::get('employers/{employer}/history', [EmployerController::class, 'filterHistory'])->name('employers.history.filter');
     Route::post('employees/{employee}/terminate', [EmployeeController::class, 'terminate'])->name('employees.terminate');
+    Route::post('employees/{employee}/reinstate', [EmployeeController::class, 'reinstate'])->name('employees.reinstate');
     Route::post('/employees/{employee}/restore', [EmployeeController::class, 'restore'])->name('employees.restore')->withTrashed();
     Route::delete('/employees/{employee}/force-delete', [EmployeeController::class, 'forceDelete'])->name('employees.forceDelete')->withTrashed();
     Route::get('/employees/{employee}/locate', [EmployeeController::class, 'locate'])->name('employees.locate');


### PR DESCRIPTION
- Updates the `filterHistory` method in `EmployerController` to query for employees with a non-null `terminated_at` timestamp, aligning it with the new termination logic.
- Adds the `employees.reinstate` route to `web.php` to enable the restore functionality from the history modal.