### PR TITLE
Fix: Correct restore button URL in History Modal

### DIFF
--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const terminatedDate = employee.terminated_at ? new Date(employee.terminated_at).toLocaleDateString('th-TH', { year: 'numeric', month: 'long', day: 'numeric' }) : 'N/A';
 
                     const restoreForm = employee.can_restore ? `
-                        <form action="/employees/${employee.id}/restore" method="POST" class="d-inline js-restore-form">
+                        <form action="/employees/${employee.id}/reinstate" method="POST" class="d-inline js-restore-form">
                             <input type="hidden" name="_token" value="${csrfToken}">
                             <button type="submit" class="btn btn-sm btn-success" title="Restore">
                                 <i class="bi bi-arrow-counterclockwise"></i>


### PR DESCRIPTION
The "Restore" button's form action in the "Employment History" modal was incorrectly pointing to the soft-delete restore route (`.../restore`). This change corrects the URL to point to the `.../reinstate` route, which is the correct action for restoring an employee from the 'terminated' (History) state, as opposed to the 'trashed' state.

This aligns the button's functionality with the intended two-column workflow for employee status management.