### PR TITLE
Fix: Correct CSRF token variable scope in employment-history.js

### DIFF
--- a/jules-scratch/verification/verify_csrf_fix.py
+++ b/jules-scratch/verification/verify_csrf_fix.py
@@ -1,0 +1,39 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Login
+    page.goto("http://localhost:5173/login")
+    page.fill('input[name="email"]', "admin@example.com")
+    page.fill('input[name="password"]', "admin_password_1234")
+    page.click('button[type="submit"]')
+    page.wait_for_url("http://localhost:5173/dashboard")
+
+    # Go to employers page
+    page.goto("http://localhost:5173/employers")
+
+    # Click first employer
+    page.click('a.btn.btn-info.btn-sm')
+
+    # Click employment history
+    page.click('button[data-bs-target="#employmentHistoryModal"]')
+
+    # Wait for modal to be visible
+    page.wait_for_selector('#employmentHistoryModal.show')
+
+    # Click the restore button
+    page.click('#historyTableBody .js-restore-form button')
+
+    # Wait for the confirmation modal to be visible
+    page.wait_for_selector('#restoreConfirmationModal.show')
+
+    # Take screenshot
+    page.screenshot(path="jules-scratch/verification/verification.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const historyModalEl = document.getElementById('employmentHistoryModal');
     if (!historyModalEl) return;
 
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     const tableBody = document.getElementById('historyTableBody');
     const searchInput = document.getElementById('history-search-input');
     let currentEmployerId = null;
@@ -55,8 +56,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     tableBody.innerHTML = `<tr><td colspan="5" class="text-center">No employment history found ${searchTerm ? 'matching search' : ''}.</td></tr>`;
                     return;
                 }
-
-                const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
                 data.data.forEach((employee, index) => {
                     const terminatedDate = employee.terminated_at ? new Date(employee.terminated_at).toLocaleDateString('th-TH', { year: 'numeric', month: 'long', day: 'numeric' }) : 'N/A';


### PR DESCRIPTION
Moves the `csrfToken` variable declaration to the top-level scope of the `DOMContentLoaded` event listener. This ensures the token is accessible to the `submitForm` function, fixing the "419 CSRF Token Error" that occurred when submitting forms from the history modal.