### PR TITLE
Fix: Reinstate function now returns JSON

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -57,7 +57,7 @@ public function reinstate(Employee $employee)
     $this->authorize('terminate-employees'); // Re-using permission, or create a new 'reinstate-employees' if needed
     $employee->update(['terminated_at' => null]);
 
-    return back()->with('success', 'Employee reinstated successfully.');
+    return response()->json(['success' => 'Employee reinstated successfully.']);
 }
 
     public function index(Request $request)


### PR DESCRIPTION
The reinstate method in EmployeeController was returning a redirect, which caused an error with the AJAX call from the frontend. This has been changed to return a JSON response to correctly handle the AJAX request.