### PR TITLE
feat: Create backend for centralized trash system

### DIFF
--- a/app/Http/Controllers/Admin/TrashController.php
+++ b/app/Http/Controllers/Admin/TrashController.php
@@ -1,0 +1,98 @@
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+
+class TrashController extends Controller
+{
+    // Protect the entire controller with the permission we just added
+    public function __construct()
+    {
+        $this->middleware('permission:view-trash');
+    }
+
+    /**
+     * Display a list of all soft-deleted items.
+     */
+    public function index()
+    {
+        $trashedData = [];
+
+        $models = $this->getPrunableModels();
+
+        foreach ($models as $modelName => $modelClass) {
+            $trashedData[$modelName] = $modelClass::onlyTrashed()->get();
+        }
+
+        // This view does not exist yet. We will create it in Brief 10.
+        return view('admin.trash.index', compact('trashedData'));
+    }
+
+    /**
+     * Restore a specific soft-deleted item.
+     */
+    public function restore(Request $request, $model, $id)
+    {
+        $modelClass = $this->getModelClass($model);
+        $permission = 'restore-' . Str::plural(strtolower($model)); // e.g., 'restore-employers'
+
+        if (Gate::denies($permission)) {
+            return response()->json(['error' => 'You do not have permission to restore this item.'], 403);
+        }
+
+        $item = $modelClass::onlyTrashed()->findOrFail($id);
+        $item->restore();
+
+        return response()->json(['success' => ucfirst($model) . ' restored successfully.']);
+    }
+
+    /**
+     * Permanently delete a specific soft-deleted item.
+     */
+    public function forceDelete(Request $request, $model, $id)
+    {
+        $modelClass = $this->getModelClass($model);
+        $permission = 'force-delete-' . Str::plural(strtolower($model)); // e.g., 'force-delete-employers'
+
+        if (Gate::denies($permission)) {
+            return response()->json(['error' => 'You do not have permission to permanently delete this item.'], 403);
+        }
+
+        $item = $modelClass::onlyTrashed()->findOrFail($id);
+        $item->forceDelete();
+
+        return response()->json(['success' => ucfirst($model) . ' permanently deleted successfully.']);
+    }
+
+    /**
+     * Helper function to get all models that use SoftDeletes (based on Seeder).
+     */
+    private function getPrunableModels(): array
+    {
+        return [
+            'employees' => \App\Models\Employee::class,
+            'employers' => \App\Models\Employer::class,
+            'agents' => \App\Models\Agent::class,
+            'importers' => \App\Models\Importer::class,
+            'delegates' => \App\Models\Delegate::class,
+            'addresses' => \App\Models\Address::class,
+        ];
+    }
+
+    /**
+     * Helper function to safely get a model class from a string.
+     */
+    private function getModelClass($modelName): string
+    {
+        $map = $this->getPrunableModels();
+        $modelNameLower = strtolower($modelName); // Use the plural form from the URL
+
+        if (!array_key_exists($modelNameLower, $map)) {
+            abort(404, 'Model not found.');
+        }
+
+        return $map[$modelNameLower];
+    }
+}

--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -23,6 +23,7 @@ class RoleAndPermissionSeeder extends Seeder
         $permissions = [
             'view-dashboard',
             'manage-users', 'manage-roles', 'manage-settings',
+            'view-trash', //
             'view-employers', 'create-employers', 'edit-employers', 'delete-employers',
             'view-employees', 'create-employees', 'edit-employees', 'delete-employees',
             'terminate-employees',

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,4 +67,19 @@ Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->grou
 });
 // === สิ้นสุดส่วนที่ต้องเพิ่ม ===
 
+// --- Central Trash System ---
+Route::middleware(['auth', 'permission:view-trash'])->prefix('admin')->name('admin.')->group(function () {
+
+    Route::get('/trash', [\App\Http\Controllers\Admin\TrashController::class, 'index'])
+         ->name('trash.index');
+
+    Route::post('/trash/{model}/{id}/restore', [\App\Http\Controllers\Admin\TrashController::class, 'restore'])
+         ->name('trash.restore')
+         ->withTrashed(); // Important for finding soft-deleted models
+
+    Route::delete('/trash/{model}/{id}/force-delete', [\App\Http\Controllers\Admin\TrashController::class, 'forceDelete'])
+         ->name('trash.forceDelete')
+         ->withTrashed(); // Important for finding soft-deleted models
+});
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
This commit introduces the backend infrastructure for the centralized trash system.

- Adds the 'view-trash' permission to the RoleAndPermissionSeeder.
- Creates the TrashController to handle viewing, restoring, and force-deleting soft-deleted models.
- Registers the necessary routes in web.php under the admin prefix, protected by the 'view-trash' permission.