### PR TITLE
Fix: Restore Terminate and Delete Workflows

### DIFF
--- a/resources/views/admin/trash/index.blade.php
+++ b/resources/views/admin/trash/index.blade.php
@@ -96,11 +96,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 .then(response => response.json())
                 .then(data => {
                     if (data.success) {
-                        showToast(data.message, 'success');
-                        const row = document.querySelector(config.rowSelector);
-                        if (row) {
-                            row.remove();
-                        }
+                        window.location.reload();
                     } else {
                         showToast(data.message || 'An error occurred.', 'danger');
                     }

--- a/resources/views/components/employee-action-buttons.blade.php
+++ b/resources/views/components/employee-action-buttons.blade.php
@@ -20,15 +20,27 @@
         </a>
     @endif
 
-    {{-- Standard Delete (Soft Delete) Button --}}
-    @can('delete-employees')
+    {{-- Terminate Button (Dark Grey) --}}
+    @can('terminate-employees')
         <button type="button"
-                class="btn btn-sm btn-danger btn-trigger-delete-modal"
-                title="Delete Employee"
-                data-action="{{ route('employees.destroy', $employee->id) }}"
-                data-message="Are you sure you want to move this employee to the Central Trash?"
-                data-is-force-delete="false">
-            <i class="bi bi-trash-fill"></i>
+                class="btn btn-sm btn-secondary me-1 btn-terminate"
+                title="Terminate Employment"
+                data-bs-toggle="modal"
+                data-bs-target="#terminateEmployeeModal"
+                data-employee-id="{{ $employee->id }}"
+                data-employee-name="{{ $employee->employeeNameTh }}">
+            <i class="bi bi-person-x-fill"></i>
         </button>
+    @endcan
+
+    {{-- Standard Delete (Soft Delete to Trash) Button --}}
+    @can('delete-employees')
+        <form action="{{ route('employees.destroy', $employee->id) }}" method="POST" class="d-inline delete-employee-form">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-sm btn-danger" title="Delete Employee (to Trash)">
+                <i class="bi bi-trash-fill"></i>
+            </button>
+        </form>
     @endcan
 </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -762,5 +762,52 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 });
 </script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.body.addEventListener('submit', function(e) {
+        if (e.target.matches('.delete-employee-form')) {
+            e.preventDefault();
+            const form = e.target;
+
+            Swal.fire({
+                title: 'Are you sure?',
+                text: "This will move the employee to the Central Trash. You can recover them later.",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#6c757d',
+                confirmButtonText: 'Yes, move to Trash!'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    const action = form.getAttribute('action');
+                    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+                    fetch(action, {
+                        method: 'POST',
+                        headers: {
+                            'X-CSRF-TOKEN': csrfToken,
+                            'Accept': 'application/json'
+                        },
+                        body: new FormData(form)
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.success) {
+                             window.location.reload();
+                        } else {
+                            showToast(data.message || 'An error occurred while trying to delete the employee.', 'danger');
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Delete Error:', error);
+                        showToast('A network error occurred. Please try again.', 'danger');
+                    });
+                }
+            });
+        }
+    });
+});
+</script>
 </body>
 </html>

--- a/resources/views/partials/_employee_action_modals.blade.php
+++ b/resources/views/partials/_employee_action_modals.blade.php
@@ -26,6 +26,45 @@
     </div>
 </div>
 
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const terminateModal = document.getElementById('terminateEmployeeModal');
+    if (terminateModal) {
+        const terminateForm = document.getElementById('terminateEmployeeForm');
+        const employeeNameEl = document.getElementById('terminateEmployeeName');
+
+        terminateModal.addEventListener('show.bs.modal', function (event) {
+            const button = event.relatedTarget;
+            const employeeId = button.getAttribute('data-employee-id');
+            const employeeName = button.getAttribute('data-employee-name');
+
+            const actionUrl = `/employees/${employeeId}/terminate`;
+            terminateForm.action = actionUrl;
+            employeeNameEl.textContent = employeeName;
+        });
+
+        terminateForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            Swal.fire({
+                title: 'Are you sure?',
+                text: "Do you really want to terminate this employee?",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#3085d6',
+                confirmButtonText: 'Yes, terminate them!'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    e.target.submit();
+                }
+            });
+        });
+    }
+});
+</script>
+@endpush
+
 {{-- All-purpose Employment History Modal --}}
 <div class="modal fade" id="employmentHistoryModal" tabindex="-1" aria-labelledby="employmentHistoryModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-xl">
@@ -58,6 +97,38 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
             </div>
+        </div>
+    </div>
+</div>
+
+{{-- Terminate Employee Modal --}}
+<div class="modal fade" id="terminateEmployeeModal" tabindex="-1" aria-labelledby="terminateEmployeeModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="terminateEmployeeForm" method="POST" action="">
+                @csrf
+                @method('PUT')
+                <div class="modal-header">
+                    <h5 class="modal-title" id="terminateEmployeeModalLabel">Terminate Employee</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Are you sure you want to terminate <strong id="terminateEmployeeName"></strong>?</p>
+                    <input type="hidden" id="terminate_employee_id" name="employee_id">
+                    <div class="mb-3">
+                        <label for="termination_date" class="form-label">Termination Date</label>
+                        <input type="date" class="form-control" id="termination_date" name="termination_date" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="termination_reason" class="form-label">Reason for Termination</label>
+                        <textarea class="form-control" id="termination_reason" name="termination_reason" rows="3"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Terminate</button>
+                </div>
+            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This commit addresses a critical regression by restoring the "Terminate" button and correctly implementing the "Delete" (to Trash) button, ensuring both have distinct functionalities as required.

- Restores the "Terminate" button, which opens a modal to set the `terminated_at` date for an employee. A SweetAlert confirmation has been added to this workflow.
- Implements a new "Delete" button that performs a soft delete, moving the employee to the Central Trash. This action is also protected by a SweetAlert confirmation.
- Fixes a UI refresh bug in the Central Trash view by reloading the page after a "Restore" or "Force Delete" action, ensuring the counts and tables are always accurate.