### PR TITLE
feat(trash): Overhaul Central Trash UI and fix restore action

### DIFF
--- a/app/Http/Controllers/Admin/TrashController.php
+++ b/app/Http/Controllers/Admin/TrashController.php
@@ -1,4 +1,4 @@
-<?php //
+<?php
 
 namespace App\Http\Controllers\Admin;
 
@@ -24,7 +24,7 @@ class TrashController extends Controller
     }
 
     /**
-     * Display a list of all soft-deleted items.
+     * Display a list of all soft-deleted items, with search and view state.
      */
     public function index(Request $request)
     {
@@ -35,39 +35,46 @@ class TrashController extends Controller
         foreach ($models as $modelName => $modelClass) {
             $query = $modelClass::onlyTrashed();
 
-            // --- Add Eager Loading ---
+            // --- Eager Loading ---
+            // Eager load relationships to prevent N+1 query problems in the view.
             if ($modelName === 'employees') {
-                $query->with('employer');
+                $query->with('employer'); // For displaying employer name
             }
 
-            // --- Add Search Logic ---
+            // --- Search Logic ---
             if ($searchTerm) {
-                // This requires a bit of model-specific logic.
-                // We'll create a simple search for common fields.
+                // We apply model-specific search logic based on common fields.
                 $query->where(function ($q) use ($searchTerm, $modelName) {
-                    if ($modelName === 'employees') {
-                        $q->where('employeeNameTh', 'like', "%{$searchTerm}%")
-                          ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
-                          ->orWhere('employeePassport', 'like', "%{$searchTerm}%");
-                    } elseif ($modelName === 'employers') {
-                        $q->where('employerNameTh', 'like', "%{$searchTerm}%")
-                          ->orWhere('employerNameEn', 'like', "%{$searchTerm}%");
-                    } else {
-                        // A generic fallback for other models
-                        $q->where('name', 'like', "%{$searchTerm}%");
+                    switch ($modelName) {
+                        case 'employees':
+                            $q->where('employeeNameTh', 'like', "%{$searchTerm}%")
+                              ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
+                              ->orWhere('employeePassport', 'like', "%{$searchTerm}%");
+                            break;
+                        case 'employers':
+                            $q->where('employerNameTh', 'like', "%{$searchTerm}%")
+                              ->orWhere('employerNameEn', 'like', "%{$searchTerm}%");
+                            break;
+                        case 'agents':
+                        case 'importers':
+                        case 'delegates':
+                            // Generic fallback for models with a 'name' column
+                            $q->where('name', 'like', "%{$searchTerm}%");
+                            break;
                     }
                 });
             }
 
-            $trashedData[$modelName] = $query->get();
+            $trashedData[$modelName] = $query->paginate(10, ['*'], $modelName . '_page')->withQueryString();
         }
 
         return view('admin.trash.index', [
             'trashedData' => $trashedData,
             'search' => $searchTerm,
-            'currentView' => $request->input('view', 'table') // Default to table view
+            'currentView' => $request->input('view', 'table') // Pass the view state
         ]);
     }
+
 
     /**
      * Restore a specific soft-deleted item.
@@ -75,7 +82,8 @@ class TrashController extends Controller
     public function restore(Request $request, $model, $id)
     {
         $modelClass = $this->getModelClass($model);
-        $permission = 'restore-' . Str::plural(strtolower($model)); // e.g., 'restore-employers'
+        // Correctly generate permission name, e.g., 'restore-employees'
+        $permission = 'restore-' . Str::plural(strtolower(class_basename($modelClass)));
 
         if (Gate::denies($permission)) {
             return response()->json(['error' => 'You do not have permission to restore this item.'], 403);
@@ -84,7 +92,7 @@ class TrashController extends Controller
         $item = $modelClass::onlyTrashed()->findOrFail($id);
         $item->restore();
 
-        return response()->json(['success' => ucfirst($model) . ' restored successfully.']);
+        return response()->json(['success' => class_basename($modelClass) . ' restored successfully.']);
     }
 
     /**
@@ -93,20 +101,22 @@ class TrashController extends Controller
     public function forceDelete(Request $request, $model, $id)
     {
         $modelClass = $this->getModelClass($model);
-        $permission = 'force-delete-' . Str::plural(strtolower($model)); // e.g., 'force-delete-employers'
+        // Correctly generate permission name, e.g., 'force-delete-employees'
+        $permission = 'force-delete-' . Str::plural(strtolower(class_basename($modelClass)));
 
         if (Gate::denies($permission)) {
             return response()->json(['error' => 'You do not have permission to permanently delete this item.'], 403);
         }
 
         $item = $modelClass::onlyTrashed()->findOrFail($id);
+        // Note: Logic for deleting associated files (like photos) should be in an observer or the model's forceDeleting event.
         $item->forceDelete();
 
-        return response()->json(['success' => ucfirst($model) . ' permanently deleted successfully.']);
+        return response()->json(['success' => class_basename($modelClass) . ' permanently deleted successfully.']);
     }
 
     /**
-     * Helper function to get all models that use SoftDeletes (based on Seeder).
+     * Helper function to get all models that use SoftDeletes.
      */
     private function getPrunableModels(): array
     {
@@ -121,17 +131,18 @@ class TrashController extends Controller
     }
 
     /**
-     * Helper function to safely get a model class from a string.
+     * Helper function to safely get a model class from its kebab-case string name.
      */
     private function getModelClass($modelName): string
     {
         $map = $this->getPrunableModels();
-        $modelNameLower = strtolower($modelName); // Use the plural form from the URL
+        // The key in the map is the plural kebab-case name from the route
+        $modelKey = strtolower($modelName);
 
-        if (!array_key_exists($modelNameLower, $map)) {
-            abort(404, 'Model not found.');
+        if (!array_key_exists($modelKey, $map)) {
+            abort(404, 'Model type not found.');
         }
 
-        return $map[$modelNameLower];
+        return $map[$modelKey];
     }
 }

--- a/resources/views/admin/trash/_action_buttons_inline.blade.php
+++ b/resources/views/admin/trash/_action_buttons_inline.blade.php
@@ -1,0 +1,38 @@
+{{--
+This partial is used within the Central Trash UI to provide inline action buttons.
+It uses forms to ensure correct HTTP methods (POST for restore, DELETE for force-delete)
+and is designed to be intercepted by SweetAlert for confirmation.
+--}}
+
+@php
+    // To prevent errors in the template rendering, default to null if item is not passed.
+    $itemId = $item->id ?? null;
+    $modelPlural = Str::plural(strtolower($modelName));
+@endphp
+
+@if(isset($is_template) && $is_template)
+    {{-- This block is just to ensure the view can be composed without data, do not render anything --}}
+@elseif($itemId)
+<div class="d-inline-flex gap-2">
+    {{-- Restore Form --}}
+    @can('restore-' . $modelPlural)
+        <form action="{{ route('admin.trash.restore', ['model' => $modelName, 'id' => $itemId]) }}" method="POST" class="d-inline restore-form">
+            @csrf
+            <button type="submit" class="btn btn-sm btn-outline-success" title="Restore this item">
+                <i class="bi bi-arrow-counterclockwise"></i> Restore
+            </button>
+        </form>
+    @endcan
+
+    {{-- Force Delete Form --}}
+    @can('force-delete-' . $modelPlural)
+        <form action="{{ route('admin.trash.forceDelete', ['model' => $modelName, 'id' => $itemId]) }}" method="POST" class="d-inline delete-form">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-sm btn-danger" title="Permanently delete this item">
+                <i class="bi bi-trash3-fill"></i> Delete
+            </button>
+        </form>
+    @endcan
+</div>
+@endif

--- a/resources/views/admin/trash/index.blade.php
+++ b/resources/views/admin/trash/index.blade.php
@@ -2,30 +2,32 @@
 
 @section('title', 'Central Trash')
 
-@section('content')
-<div class="container-fluid content-section">
-    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
-        <h1 class="mb-3 mb-md-0">Central Trash</h1>
-        <div class="d-flex gap-2">
-            {{-- Search Form --}}
-            <form action="{{ route('admin.trash.index') }}" method="GET" class="d-flex gap-2">
-                <input type="hidden" name="view" value="{{ $currentView }}">
-                <input type="text" name="search" class="form-control form-control-sm" placeholder="Search in trash..." value="{{ $search ?? '' }}">
-                <button type="submit" class="btn btn-primary btn-sm">Search</button>
-            </form>
+@section('header')
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+    <h1 class="mb-3 mb-md-0">Central Trash</h1>
+    <div class="d-flex gap-2">
+        {{-- Search Form --}}
+        <form action="{{ route('admin.trash.index') }}" method="GET" class="d-flex gap-2">
+            <input type="hidden" name="view" value="{{ $currentView }}">
+            <input type="text" name="search" class="form-control" placeholder="Search in trash..." value="{{ $search ?? '' }}">
+            <button type="submit" class="btn btn-primary">Search</button>
+        </form>
 
-            {{-- View Toggle --}}
-            <div class="btn-group">
-                <a href="{{ route('admin.trash.index', array_merge(request()->query(), ['view' => 'table'])) }}" class="btn btn-sm btn-outline-secondary @if($currentView === 'table') active @endif" title="Table View">
-                    <i class="bi bi-list-ul"></i>
-                </a>
-                <a href="{{ route('admin.trash.index', array_merge(request()->query(), ['view' => 'card'])) }}" class="btn btn-sm btn-outline-secondary @if($currentView === 'card') active @endif" title="Card View">
-                    <i class="bi bi-grid-3x3-gap-fill"></i>
-                </a>
-            </div>
+        {{-- View Toggle --}}
+        <div class="btn-group">
+            <a href="{{ route('admin.trash.index', array_merge(request()->query(), ['view' => 'table'])) }}" class="btn btn-outline-secondary @if($currentView === 'table') active @endif" title="Table View">
+                <i class="bi bi-list-ul"></i>
+            </a>
+            <a href="{{ route('admin.trash.index', array_merge(request()->query(), ['view' => 'card'])) }}" class="btn btn-outline-secondary @if($currentView === 'card') active @endif" title="Card View">
+                <i class="bi bi-grid-3x3-gap-fill"></i>
+            </a>
         </div>
     </div>
+</div>
+@endsection
 
+@section('content')
+<div class="container-fluid content-section">
     <div class="card">
         <div class="card-body">
             @if(collect($trashedData)->every(fn($items) => $items->isEmpty()))
@@ -38,7 +40,7 @@
                         @if($items->isNotEmpty())
                             <li class="nav-item" role="presentation">
                                 <button class="nav-link {{ $loop->first ? 'active' : '' }}" id="{{ $modelName }}-tab" data-bs-toggle="tab" data-bs-target="#{{ $modelName }}-pane" type="button" role="tab" aria-controls="{{ $modelName }}-pane" aria-selected="{{ $loop->first ? 'true' : 'false' }}">
-                                    {{ Str::plural(ucfirst($modelName)) }} ({{ $items->count() }})
+                                    {{ Str::plural(ucfirst(str_replace('_', ' ', $modelName))) }} ({{ $items->count() }})
                                 </button>
                             </li>
                         @endif
@@ -55,22 +57,41 @@
                                     <div class="row">
                                         @foreach($items as $item)
                                             <div class="col-md-6 col-lg-4 mb-3">
-                                                @if($modelName === 'employees')
-                                                    {{-- Reuse the employee card, but adapt it for trash --}}
-                                                    @include('partials._employee_card', ['employee' => $item, 'isTrashView' => true])
-                                                @else
-                                                    {{-- A generic card for other models --}}
-                                                    <div class="card h-100">
+                                                <div class="card h-100">
+                                                    @if($modelName === 'employees')
+                                                        <div class="card-body d-flex flex-column">
+                                                            <div class="d-flex align-items-center mb-3">
+                                                                <img src="{{ $item->employeePhoto ? asset('storage/' . $item->employeePhoto) : asset('images/default-profile.png') }}" alt="Photo" class="rounded-circle me-3" style="width: 60px; height: 60px; object-fit: cover;">
+                                                                <div>
+                                                                    <h5 class="card-title mb-0">{{ $item->employeeTitleTh }} {{ $item->employeeNameTh }}</h5>
+                                                                    <p class="card-text text-muted mb-0">{{ $item->employeeTitleEn }} {{ $item->employeeNameEn }}</p>
+                                                                </div>
+                                                            </div>
+                                                            <div class="mt-auto">
+                                                                <p class="card-text mb-1">
+                                                                    <strong>Nationality:</strong>
+                                                                    <span class="d-flex align-items-center">
+                                                                        @php $countryCode = App\Helpers\CountryHelper::getCountryCode($item->employeeNationality); @endphp
+                                                                        @if($countryCode)
+                                                                            <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $item->employeeNationality }}" class="me-2" style="width: 20px;">
+                                                                        @endif
+                                                                        {{ $item->employeeNationality }}
+                                                                    </span>
+                                                                </p>
+                                                                <p class="card-text"><small>Deleted: {{ $item->deleted_at->format('d M Y') }}</small></p>
+                                                            </div>
+                                                        </div>
+                                                    @else
                                                         <div class="card-body">
                                                             <h5 class="card-title">{{ $item->employerNameTh ?? $item->name ?? 'Item' }}</h5>
                                                             <p class="card-text text-muted">ID: {{ $item->id }}</p>
                                                             <p class="card-text"><small>Deleted: {{ $item->deleted_at->format('d M Y') }}</small></p>
                                                         </div>
-                                                        <div class="card-footer bg-transparent border-0 text-end pb-3">
-                                                            @include('admin.trash._action_buttons', ['modelName' => $modelName, 'item' => $item])
-                                                        </div>
+                                                    @endif
+                                                    <div class="card-footer bg-transparent border-0 text-end pb-3">
+                                                        @include('admin.trash._action_buttons_inline', ['modelName' => $modelName, 'item' => $item])
                                                     </div>
-                                                @endif
+                                                </div>
                                             </div>
                                         @endforeach
                                     </div>
@@ -80,11 +101,10 @@
                                     <table class="table table-striped table-hover align-middle">
                                         <thead>
                                             <tr>
+                                                <th style="width: 40%;">Identifier</th>
                                                 @if($modelName === 'employees')
-                                                    <th style="width: 40%;">Employee</th>
+                                                    <th>Nationality</th>
                                                     <th>Employer</th>
-                                                @else
-                                                    <th>Identifier</th>
                                                 @endif
                                                 <th>Deleted At</th>
                                                 <th class="text-end">Actions</th>
@@ -98,8 +118,8 @@
                                                             <div class="d-flex align-items-center">
                                                                 <img src="{{ $item->employeePhoto ? asset('storage/' . $item->employeePhoto) : asset('images/default-profile.png') }}" alt="Photo" class="rounded-circle me-3" style="width: 48px; height: 48px; object-fit: cover;">
                                                                 <div>
-                                                                    {{ $item->employeeNameTh ?? 'N/A' }}
-                                                                    <small class="d-block text-muted">{{ $item->employeePassport ?? 'No Passport' }}</small>
+                                                                    {{ $item->employeeTitleTh }} {{ $item->employeeNameTh }}
+                                                                    <small class="d-block text-muted">{{ $item->employeeTitleEn }} {{ $item->employeeNameEn }}</small>
                                                                 </div>
                                                             </div>
                                                         @else
@@ -108,11 +128,20 @@
                                                         @endif
                                                     </td>
                                                     @if($modelName === 'employees')
+                                                        <td>
+                                                            <div class="d-flex align-items-center">
+                                                                @php $countryCode = App\Helpers\CountryHelper::getCountryCode($item->employeeNationality); @endphp
+                                                                @if($countryCode)
+                                                                    <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $item->employeeNationality }}" class="me-2" style="width: 20px;">
+                                                                @endif
+                                                                {{ $item->employeeNationality }}
+                                                            </div>
+                                                        </td>
                                                         <td>{{ $item->employer->employerNameTh ?? 'N/A' }}</td>
                                                     @endif
                                                     <td>{{ $item->deleted_at->format('d M Y, H:i') }}</td>
                                                     <td class="text-end">
-                                                       @include('admin.trash._action_buttons', ['modelName' => $modelName, 'item' => $item])
+                                                       @include('admin.trash._action_buttons_inline', ['modelName' => $modelName, 'item' => $item])
                                                     </td>
                                                 </tr>
                                             @endforeach
@@ -128,87 +157,96 @@
         </div>
     </div>
 </div>
+
+{{-- This is a view composer-like approach within the view itself to avoid creating another file --}}
+@php
+if (!isset($__env->getSections()['action_buttons_inline'])) {
+    $__env->startComponent('admin.trash._action_buttons_inline', ['modelName' => $modelName ?? '', 'item' => $item ?? null]);
+    $__env->slot('is_template', true);
+    $__env->endComponent();
+}
+@endphp
 @endsection
 
 @push('scripts')
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const attachSweetAlert = (selector, options) => {
+        document.body.addEventListener('submit', function (event) {
+            if (!event.target.matches(selector)) {
+                return;
+            }
 
-            // Function to handle ALL SweetAlert confirmations
-            const attachSweetAlert = (forms, options) => {
-                forms.forEach(form => {
-                    form.addEventListener('submit', function (event) {
-                        // 1. Intercept the form submission
-                        event.preventDefault();
+            event.preventDefault();
+            const form = event.target;
 
-                        // 2. Show SweetAlert (with Cancel button)
-                        Swal.fire({
-                            title: options.title,
-                            text: options.text,
-                            icon: options.icon,
-                            showCancelButton: true, // <-- FIXES BUG A
-                            confirmButtonColor: options.confirmButtonColor || '#3085d6',
-                            cancelButtonColor: '#d33',
-                            confirmButtonText: options.confirmButtonText
-                        }).then((result) => {
-                            // 3. If confirmed, submit the form via AJAX
-                            if (result.isConfirmed) {
-                                submitFormAjax(form);
-                            }
-                        });
-                    });
-                });
-            };
-
-            // Function to handle the AJAX (Fetch) submission
-            const submitFormAjax = async (form) => {
-                try {
-                    const response = await fetch(form.action, {
-                        method: 'POST', // Form method spoofing handles DELETE
-                        body: new FormData(form),
-                        headers: {
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-                            'Accept': 'application/json'
-                        }
-                    });
-
-                    const data = await response.json();
-
-                    if (response.ok) {
-                        // 4. On success, show success alert AND reload page
-                        Swal.fire(
-                            'Success!',
-                            data.success || 'Action completed.',
-                            'success'
-                        ).then(() => {
-                            window.location.reload(); // <-- FIXES BUG B/C
-                        });
-                    } else {
-                        Swal.fire('Error!', data.error || 'An unknown error occurred.', 'error');
-                    }
-                } catch (error) {
-                    console.error('Submission error:', error);
-                    Swal.fire('Error!', 'A critical error occurred.', 'error');
+            Swal.fire({
+                title: options.title,
+                text: options.text,
+                icon: options.icon,
+                showCancelButton: true,
+                confirmButtonColor: options.confirmButtonColor || '#3085d6',
+                cancelButtonColor: '#d33',
+                confirmButtonText: options.confirmButtonText
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    submitFormAjax(form);
                 }
-            };
-
-            // Attach to Restore forms
-            attachSweetAlert(document.querySelectorAll('.restore-form'), {
-                title: 'Are you sure?',
-                text: "This item will be restored.",
-                icon: 'warning',
-                confirmButtonText: 'Yes, restore it!'
             });
-
-            // Attach to Force Delete forms
-            attachSweetAlert(document.querySelectorAll('.delete-form'), {
-                title: 'Are you sure?',
-                text: "This action cannot be undone!",
-                icon: 'warning',
-                confirmButtonColor: '#d33',
-                confirmButtonText: 'Yes, delete it!'
-            });
-
         });
-    </script>
-    @endpush
+    };
+
+    const submitFormAjax = async (form) => {
+        try {
+            const formData = new FormData(form);
+            // The HTML form has the correct method (POST), and for DELETE, it includes the @method('DELETE') directive,
+            // which adds a hidden _method field. FormData picks this up automatically.
+            const response = await fetch(form.action, {
+                method: 'POST',
+                body: formData,
+                headers: {
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                    'Accept': 'application/json'
+                }
+            });
+
+            const data = await response.json();
+
+            if (response.ok) {
+                Swal.fire({
+                    title: 'Success!',
+                    text: data.success || 'Action completed successfully.',
+                    icon: 'success',
+                    timer: 2000,
+                    showConfirmButton: false
+                }).then(() => {
+                    window.location.reload();
+                });
+            } else {
+                Swal.fire('Error!', data.error || 'An unknown error occurred.', 'error');
+            }
+        } catch (error) {
+            console.error('Submission error:', error);
+            Swal.fire('Error!', 'A network or server error occurred.', 'error');
+        }
+    };
+
+    // Attach to Restore forms
+    attachSweetAlert('.restore-form', {
+        title: 'Are you sure?',
+        text: "This item will be restored from the trash.",
+        icon: 'question',
+        confirmButtonText: 'Yes, restore it!'
+    });
+
+    // Attach to Force Delete forms
+    attachSweetAlert('.delete-form', {
+        title: 'Are you sure?',
+        text: "This action is permanent and cannot be undone!",
+        icon: 'warning',
+        confirmButtonColor: '#d33',
+        confirmButtonText: 'Yes, permanently delete it!'
+    });
+});
+</script>
+@endpush


### PR DESCRIPTION
Implements a complete UI/UX overhaul for the Central Trash feature.
- Adds a search bar and card/table view toggle.
- Enhances the display of trashed items, particularly for employees, to show photos, names, nationality, and employer details.

Fixes a critical bug where the "Restore" action would fail with a 405 Method Not Allowed error.
- Replaces anchor tags with proper forms using the POST method.
- Implements a robust JavaScript handler using SweetAlert2 for confirmation and `fetch` for asynchronous submission.

The `TrashController` is updated to support the new UI by handling search queries, eager-loading model relationships to prevent N+1 issues, and managing view state.