### PR TITLE
Feat: Polish Central Trash UI

### DIFF
--- a/jules-scratch/verification/verify_trash_ui.py
+++ b/jules-scratch/verification/verify_trash_ui.py
@@ -1,0 +1,32 @@
+
+import re
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Login
+    page.goto("http://localhost:8000/login")
+    page.get_by_label("Email").fill("admin@example.com")
+    page.get_by_label("Password").fill("admin_password_1234")
+    page.get_by_role("button", name="Log in").click()
+
+    # Wait for navigation to dashboard
+    expect(page).to_have_url(re.compile(".*dashboard"))
+
+    # Go to trash page
+    page.goto("http://localhost:8000/admin/trash")
+
+    # Expect the header to be correct
+    expect(page.get_by_role("heading", name="Central Trash")).to_be_visible()
+
+    # Take screenshot
+    page.screenshot(path="jules-scratch/verification/verification.png")
+
+    context.close()
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/resources/views/admin/trash/index.blade.php
+++ b/resources/views/admin/trash/index.blade.php
@@ -5,24 +5,6 @@
 @section('header')
 <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center">
     <h1 class="mb-3 mb-md-0">Central Trash</h1>
-    <div class="d-flex gap-2">
-        {{-- Search Form --}}
-        <form action="{{ route('admin.trash.index') }}" method="GET" class="d-flex gap-2">
-            <input type="hidden" name="view" value="{{ $currentView }}">
-            <input type="text" name="search" class="form-control" placeholder="Search in trash..." value="{{ $search ?? '' }}">
-            <button type="submit" class="btn btn-primary">Search</button>
-        </form>
-
-        {{-- View Toggle --}}
-        <div class="btn-group">
-            <a href="{{ route('admin.trash.index', array_merge(request()->query(), ['view' => 'table'])) }}" class="btn btn-outline-secondary @if($currentView === 'table') active @endif" title="Table View">
-                <i class="bi bi-list-ul"></i>
-            </a>
-            <a href="{{ route('admin.trash.index', array_merge(request()->query(), ['view' => 'card'])) }}" class="btn btn-outline-secondary @if($currentView === 'card') active @endif" title="Card View">
-                <i class="bi bi-grid-3x3-gap-fill"></i>
-            </a>
-        </div>
-    </div>
 </div>
 @endsection
 
@@ -30,6 +12,25 @@
 <div class="container-fluid content-section">
     <div class="card">
         <div class="card-body">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3">
+                {{-- Search Form --}}
+                <form action="{{ route('admin.trash.index') }}" method="GET" class="d-flex gap-2">
+                    <input type="hidden" name="view" value="{{ $currentView ?? 'table' }}">
+                    <input type="text" name="search" class="form-control" placeholder="Search in trash..." value="{{ $search ?? '' }}">
+                    <button type="submit" class="btn btn-primary">Search</button>
+                </form>
+
+                {{-- View Toggle --}}
+                <div class="btn-group">
+                    <a href="{{ route('admin.trash.index', array_merge(request()->query(), ['view' => 'table'])) }}" class="btn btn-outline-secondary @if(($currentView ?? 'table') === 'table') active @endif" title="Table View">
+                        <i class="bi bi-list-ul"></i>
+                    </a>
+                    <a href="{{ route('admin.trash.index', array_merge(request()->query(), ['view' => 'card'])) }}" class="btn btn-outline-secondary @if(($currentView ?? 'table') === 'card') active @endif" title="Card View">
+                        <i class="bi bi-grid-3x3-gap-fill"></i>
+                    </a>
+                </div>
+            </div>
+
             @if(collect($trashedData)->every(fn($items) => $items->isEmpty()))
                 <div class="alert alert-info text-center">
                     <i class="bi bi-trash3 me-2"></i> The trash is currently empty{{ $search ? ' for your search query' : '' }}.


### PR DESCRIPTION
Relocates the search bar and view toggle buttons to the main content area of the Central Trash page (`admin.trash.index`).

The UI now matches the intended design, with search and view controls located directly above the list of trashed items, improving usability and layout consistency.