### PR TITLE
Fix: Correct Central Trash search, display, and export

### DIFF
--- a/app/Http/Controllers/Admin/TrashController.php
+++ b/app/Http/Controllers/Admin/TrashController.php
@@ -56,8 +56,7 @@ class TrashController extends Controller
                                 ->orWhere('employerNameEn', 'like', "%{$searchTerm}%");
                             break;
                         case 'agents':
-                            $q->where('agentNameTh', 'like', "%{$searchTerm}%")
-                                ->orWhere('agentNameEn', 'like', "%{$searchTerm}%");
+                            $q->where('agentNameEn', 'like', "%{$searchTerm}%");
                             break;
                         case 'importers':
                             $q->where('importerNameTh', 'like', "%{$searchTerm}%")
@@ -89,48 +88,55 @@ class TrashController extends Controller
      */
     public function exportTrash(Request $request)
     {
-        $allTrashedData = [];
-        $models = $this->getPrunableModels();
-        $searchTerm = $request->input('search');
-
-        // 1. Fetch all data, applying the same filters as the index page
-        foreach ($models as $modelName => $modelClass) {
-            $query = $modelClass::onlyTrashed();
-
-            if ($searchTerm) {
-                $query->where(function ($q) use ($searchTerm, $modelName) {
-                    // This switch MUST be kept in sync with the index method's search logic
-                    switch ($modelName) {
-                        case 'employees':
-                            $q->where('employeeNameTh', 'like', "%{$searchTerm}%")
-                                ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
-                                ->orWhere('employeePassport', 'like', "%{$searchTerm}%");
-                            break;
-                        case 'employers':
-                            $q->where('employerNameTh', 'like', "%{$searchTerm}%")
-                                ->orWhere('employerNameEn', 'like', "%{$searchTerm}%");
-                            break;
-                        case 'agents':
-                            $q->where('agentNameTh', 'like', "%{$searchTerm}%")
-                                ->orWhere('agentNameEn', 'like', "%{$searchTerm}%");
-                            break;
-                        case 'importers':
-                            $q->where('importerNameTh', 'like', "%{$searchTerm}%")
-                                ->orWhere('importerNameEn', 'like', "%{$searchTerm}%");
-                            break;
-                        case 'delegates':
-                            $q->where('delegateNameTh', 'like', "%{$searchTerm}%")
-                                ->orWhere('delegateNameEn', 'like', "%{$searchTerm}%");
-                            break;
-                    }
-                });
-            }
-            // Fetch all matching records, not paginated
-            $allTrashedData[$modelName] = $query->get();
+        $modelName = $request->input('model');
+        if (!$modelName) {
+            abort(400, 'A model type must be specified for export.');
         }
 
+        $models = $this->getPrunableModels();
+        if (!isset($models[$modelName])) {
+            abort(404, 'The specified model type is not valid for export.');
+        }
+
+        $modelClass = $models[$modelName];
+        $searchTerm = $request->input('search');
+
+        // 1. Fetch the specific model's data, applying the same filters as the index page
+        $query = $modelClass::onlyTrashed();
+
+        if ($searchTerm) {
+            $query->where(function ($q) use ($searchTerm, $modelName) {
+                // This switch MUST be kept in sync with the index method's search logic
+                switch ($modelName) {
+                    case 'employees':
+                        $q->where('employeeNameTh', 'like', "%{$searchTerm}%")
+                            ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
+                            ->orWhere('employeePassport', 'like', "%{$searchTerm}%");
+                        break;
+                    case 'employers':
+                        $q->where('employerNameTh', 'like', "%{$searchTerm}%")
+                            ->orWhere('employerNameEn', 'like', "%{$searchTerm}%");
+                        break;
+                    case 'agents':
+                        // This is the corrected logic from the index method
+                        $q->where('agentNameEn', 'like', "%{$searchTerm}%");
+                        break;
+                    case 'importers':
+                        $q->where('importerNameTh', 'like', "%{$searchTerm}%")
+                            ->orWhere('importerNameEn', 'like', "%{$searchTerm}%");
+                        break;
+                    case 'delegates':
+                        $q->where('delegateNameTh', 'like', "%{$searchTerm}%")
+                            ->orWhere('delegateNameEn', 'like', "%{$searchTerm}%");
+                        break;
+                }
+            });
+        }
+
+        $recordsToExport = $query->get();
+
         // 2. Generate and stream a CSV file
-        return response()->streamDownload(function () use ($allTrashedData) {
+        return response()->streamDownload(function () use ($recordsToExport, $modelName) {
             $handle = fopen('php://output', 'w');
             // Add UTF-8 BOM to ensure Excel opens the file with correct encoding
             fprintf($handle, chr(0xEF).chr(0xBB).chr(0xBF));
@@ -138,50 +144,48 @@ class TrashController extends Controller
             // Add header row
             fputcsv($handle, ['Type', 'Identifier (TH)', 'Identifier (EN)', 'Date Deleted']);
 
-            foreach ($allTrashedData as $modelName => $collection) {
-                foreach ($collection as $item) {
-                    $identifierTh = '';
-                    $identifierEn = '';
+            foreach ($recordsToExport as $item) {
+                $identifierTh = '';
+                $identifierEn = '';
 
-                    // Determine the identifier based on model type
-                    switch ($modelName) {
-                        case 'employees':
-                            $identifierTh = $item->employeeNameTh;
-                            $identifierEn = $item->employeeNameEn;
-                            break;
-                        case 'employers':
-                            $identifierTh = $item->employerNameTh;
-                            $identifierEn = $item->employerNameEn;
-                            break;
-                        case 'agents':
-                            $identifierTh = $item->agentNameTh;
-                            $identifierEn = $item->agentNameEn;
-                            break;
-                        case 'importers':
-                            $identifierTh = $item->importerNameTh;
-                            $identifierEn = $item->importerNameEn;
-                            break;
-                        case 'delegates':
-                            $identifierTh = $item->delegateNameTh;
-                            $identifierEn = $item->delegateNameEn;
-                            break;
-                        case 'addresses':
-                            $identifierTh = "Address ID: " . $item->id;
-                            $identifierEn = $item->addressLine1;
-                            break;
-                    }
-
-                    fputcsv($handle, [
-                        Str::ucfirst($modelName),
-                        $identifierTh,
-                        $identifierEn,
-                        $item->deleted_at->toDateTimeString(),
-                    ]);
+                // Determine the identifier based on model type
+                switch ($modelName) {
+                    case 'employees':
+                        $identifierTh = $item->employeeNameTh;
+                        $identifierEn = $item->employeeNameEn;
+                        break;
+                    case 'employers':
+                        $identifierTh = $item->employerNameTh;
+                        $identifierEn = $item->employerNameEn;
+                        break;
+                    case 'agents':
+                        $identifierTh = 'N/A'; // agentNameTh does not exist
+                        $identifierEn = $item->agentNameEn;
+                        break;
+                    case 'importers':
+                        $identifierTh = $item->importerNameTh;
+                        $identifierEn = $item->importerNameEn;
+                        break;
+                    case 'delegates':
+                        $identifierTh = $item->delegateNameTh;
+                        $identifierEn = $item->delegateNameEn;
+                        break;
+                    case 'addresses':
+                        $identifierTh = "Address ID: " . $item->id;
+                        $identifierEn = $item->addressLine1;
+                        break;
                 }
+
+                fputcsv($handle, [
+                    Str::ucfirst($modelName),
+                    $identifierTh,
+                    $identifierEn,
+                    $item->deleted_at->toDateTimeString(),
+                ]);
             }
 
             fclose($handle);
-        }, 'trash_export_' . date('Y-m-d') . '.csv', [
+        }, 'trash_export_' . $modelName . '_' . date('Y-m-d') . '.csv', [
             'Content-Type' => 'text/csv; charset=UTF-8',
         ]);
     }

--- a/resources/views/admin/trash/index.blade.php
+++ b/resources/views/admin/trash/index.blade.php
@@ -106,8 +106,17 @@
                                                                     <small class="d-block text-muted">{{ $item->employeeTitleEn }} {{ $item->employeeNameEn }}</small>
                                                                 </div>
                                                             </div>
+                                                        @elseif($modelName === 'agents')
+                                                            {{ $item->agentNameEn }}
+                                                            <small class="d-block text-muted">ID: {{ $item->id }}</small>
+                                                        @elseif($modelName === 'importers')
+                                                            {{ $item->importerNameTh }}
+                                                            <small class="d-block text-muted">{{ $item->importerNameEn }}</small>
+                                                        @elseif($modelName === 'delegates')
+                                                            {{ $item->delegateNameTh }}
+                                                            <small class="d-block text-muted">{{ $item->delegateNameEn }}</small>
                                                         @else
-                                                            {{ $item->employerNameTh ?? $item->name ?? $item->address_line_1 ?? 'N/A' }}
+                                                            {{ $item->employerNameTh ?? $item->name ?? $item->address_line_1 ?? 'Item ID: ' . $item->id }}
                                                             <small class="d-block text-muted">ID: {{ $item->id }}</small>
                                                         @endif
                                                     </td>
@@ -165,6 +174,38 @@
 @push('scripts')
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+    const exportButton = document.querySelector('a.btn-info[href*="export"]');
+    const trashTabs = document.querySelectorAll('#trashTabs .nav-link');
+    const searchInput = document.querySelector('input[name="search"]');
+
+    const updateExportLink = () => {
+        const activeTab = document.querySelector('#trashTabs .nav-link.active');
+        if (!activeTab || !exportButton) {
+            return;
+        }
+
+        const modelName = activeTab.id.replace('-tab', '');
+        const currentSearch = searchInput ? searchInput.value : '';
+
+        // Build a fresh URL to avoid stacking query parameters
+        const url = new URL(exportButton.href.split('?')[0]);
+        url.searchParams.set('model', modelName);
+
+        // Only add the search parameter if it's not empty
+        if (currentSearch) {
+            url.searchParams.set('search', currentSearch);
+        }
+
+        exportButton.href = url.toString();
+    };
+
+    trashTabs.forEach(tab => {
+        tab.addEventListener('shown.bs.tab', updateExportLink);
+    });
+
+    // Initial setup on page load
+    updateExportLink();
+
     const attachSweetAlert = (selector, options) => {
         document.body.addEventListener('submit', function (event) {
             if (!event.target.matches(selector)) {


### PR DESCRIPTION
- Fixes SQL error when searching for agents in Central Trash by querying the correct `agentNameEn` column.
- Resolves the "N/A" display bug by adding logic to the view to show the correct identifier columns for each model type.
- Implements a "Smart Export" feature, allowing the export of filtered data from the active tab only.
- Updates the "Export" button to be dynamic, including the active model and search query in the export URL.