### PR TITLE
feat: Implement User-Employer relationship

### DIFF
--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -27,6 +27,7 @@ class Employer extends Model
         'document_vat_registration',
         'document_map',
         'job_owner_id',
+        'user_id',
     ];
 
     public function employees()
@@ -42,5 +43,10 @@ class Employer extends Model
     public function jobOwner()
     {
         return $this->belongsTo(JobOwner::class, 'job_owner_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,4 +46,9 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function employer()
+    {
+        return $this->hasOne(Employer::class);
+    }
 }

--- a/database/migrations/2025_10_22_091400_add_user_id_to_employers_table.php
+++ b/database/migrations/2025_10_22_091400_add_user_id_to_employers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->foreignId('user_id')
+                ->nullable()
+                ->unique()
+                ->constrained('users')
+                ->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};


### PR DESCRIPTION
Adds the one-to-one relationship between the User and Employer models.

- Creates a new migration to add a `user_id` foreign key to the `employers` table.
- Adds the `hasOne` relationship to the `User` model.
- Adds the `belongsTo` relationship to the `Employer` model.
- Adds `user_id` to the `$fillable` array in the `Employer` model.