### PR TITLE
feat(tenancy): Implement global scopes for employer tenancy

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -5,10 +5,31 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Builder;
 
 class Employee extends Model
 {
     use HasFactory, SoftDeletes;
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope('employerTenancy', function (Builder $builder) {
+            if (Auth::check() && Auth::user()->hasRole('employer')) {
+                // Find the employer record linked to this user
+                $employer = Auth::user()->employer;
+                if ($employer) {
+                    // This user is an 'employer'. Filter their view to *only*
+                    // Employees who belong to their linked Employer ID.
+                    $builder->where('employer_id', $employer->id);
+                } else {
+                    // This employer user is not linked to any employer record.
+                    // Show them nothing.
+                    $builder->whereRaw('1 = 0'); // Forces query to return empty
+                }
+            }
+        });
+    }
 
     // The $fillable array is correct as it matches the camelCase schema.
     protected $fillable = [

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -6,10 +6,23 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\JobOwner;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Builder;
 
 class Employer extends Model
 {
     use HasFactory, SoftDeletes;
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope('employerTenancy', function (Builder $builder) {
+            if (Auth::check() && Auth::user()->hasRole('employer')) {
+                // This user is an 'employer'. Filter their view to *only*
+                // the Employer record linked to their user_id.
+                $builder->where('user_id', Auth::id());
+            }
+        });
+    }
 
     protected $fillable = [
         'employerNameTh',

--- a/app/Policies/EmployeePolicy.php
+++ b/app/Policies/EmployeePolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Employee;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class EmployeePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/app/Policies/EmployerPolicy.php
+++ b/app/Policies/EmployerPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Employer;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class EmployerPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+// use Illuminate\Support\Facades\Gate;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The model to policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        'App\Models\Employer' => 'App\Policies\EmployerPolicy',
+        'App\Models\Employee' => 'App\Policies\EmployeePolicy',
+    ];
+
+    /**
+     * Register any authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
- Adds an anonymous global scope to the Employer model to filter by the authenticated user's ID if they have the 'employer' role.
- Adds an anonymous global scope to the Employee model to filter by the authenticated user's linked employer's ID. Includes a null check to prevent errors.
- Creates empty policy files for Employer and Employee.
- Registers the policies in AuthServiceProvider, creating the provider as it was missing.