### PR TITLE
feat: Implement user index page with status toggle

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -13,7 +13,8 @@ class UserController extends Controller
      */
     public function index()
     {
-        return view('admin.users.index');
+        $users = User::with('roles')->latest()->get(); // Eager load roles (Source 84)
+        return view('admin.users.index', compact('users'));
     }
 
     /**
@@ -53,7 +54,11 @@ class UserController extends Controller
      */
     public function update(Request $request, User $user)
     {
-        //
+        // Logic for status toggle
+        $newStatus = $user->status === 'active' ? 'inactive' : 'active';
+        $user->update(['status' => $newStatus]); // Uses 'status' from $fillable (Source 83)
+
+        return redirect()->route('admin.users.index')->with('success', 'User status updated successfully.');
     }
 
     /**

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -9,7 +9,58 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
-                    <h2>User Management</h2>
+                    <div class="flex justify-end mb-4">
+                        <a href="{{ route('admin.users.create') }}" class="btn btn-primary">Create New User</a>
+                    </div>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Name
+                                </th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Email
+                                </th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Role
+                                </th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Status
+                                </th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Actions
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach ($users as $user)
+                                <tr>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                        {{ $user->name }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {{ $user->email }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {{ $user->roles->first()->name ?? 'N/A' }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {{ $user->status }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                        <form action="{{ route('admin.users.update', $user->id) }}" method="POST" style="display:inline;">
+                                            @csrf
+                                            @method('PUT')
+                                            <button type="submit" class="text-indigo-600 hover:text-indigo-900">
+                                                {{ $user->status === 'active' ? 'Deactivate' : 'Activate' }}
+                                            </button>
+                                        </form>
+                                        <a href="{{ route('admin.users.edit', $user->id) }}" class="text-indigo-600 hover:text-indigo-900 ml-4">Edit</a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit introduces the user management index page, allowing administrators to view a list of all users and manage their account status.

- The `UserController@index` method now fetches all users with their associated roles, ordered by the latest, and passes them to the `admin.users.index` view.
- The `UserController@update` method is implemented to handle toggling the `status` of a user between 'active' and 'inactive'.
- The `admin.users.index` Blade view is created to display a table of users with their name, email, role, and status.
- The view includes a form with a button to activate or deactivate each user, submitting a PUT request to the update method.
- A "Create New User" button has been added for future functionality.