### PR TITLE
Fix: Correct Blade layout syntax on create user page

### DIFF
--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -1,82 +1,78 @@
-<x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Create New User') }}
-        </h2>
-    </x-slot>
+@extends('layouts.app')
+@section('header')
+<h2 class="font-semibold text-xl text-gray-800 leading-tight">
+    {{ __('Create New User') }}
+</h2>
+@endsection
+@section('title', 'Create New User')
+@section('content')
+<div class="ccontainer-fluid content-section">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+            <div class="p-6 bg-white border-b border-gray-200">
+                @if ($errors->any())
+                <div class="mb-4">
+                    <div class="font-medium text-red-600">{{ __('Whoops! Something went wrong.') }}</div>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 bg-white border-b border-gray-200">
-                    @if ($errors->any())
-                        <div class="mb-4">
-                            <div class="font-medium text-red-600">{{ __('Whoops! Something went wrong.') }}</div>
-                            <ul class="mt-3 list-disc list-inside text-sm text-red-600">
-                                @foreach ($errors->all() as $error)
-                                    <li>{{ $error }}</li>
-                                @endforeach
-                            </ul>
-                        </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('admin.users.store') }}" x-data="{ selectedRole: '{{ old('role_name', 'staff') }}' }">
-                        @csrf
-
-                        <!-- Name -->
-                        <div>
-                            <label for="name" class="block font-medium text-sm text-gray-700">{{ __('Name') }}</label>
-                            <input id="name" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="text" name="name" value="{{ old('name') }}" required autofocus />
-                        </div>
-
-                        <!-- Email Address -->
-                        <div class="mt-4">
-                            <label for="email" class="block font-medium text-sm text-gray-700">{{ __('Email') }}</label>
-                            <input id="email" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="email" name="email" value="{{ old('email') }}" required />
-                        </div>
-
-                        <!-- Password -->
-                        <div class="mt-4">
-                            <label for="password" class="block font-medium text-sm text-gray-700">{{ __('Password') }}</label>
-                            <input id="password" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="password" name="password" required autocomplete="new-password" />
-                        </div>
-
-                        <!-- Confirm Password -->
-                        <div class="mt-4">
-                            <label for="password_confirmation" class="block font-medium text-sm text-gray-700">{{ __('Confirm Password') }}</label>
-                            <input id="password_confirmation" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="password" name="password_confirmation" required />
-                        </div>
-
-                        <!-- Role -->
-                        <div class="mt-4">
-                            <label for="role_name" class="block font-medium text-sm text-gray-700">{{ __('Role') }}</label>
-                            <select id="role_name" name="role_name" x-model="selectedRole" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
-                                @foreach ($roles as $role)
-                                    <option value="{{ $role->name }}" {{ old('role_name') == $role->name ? 'selected' : '' }}>{{ ucfirst($role->name) }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-
-                        <!-- Employer (Conditional) -->
-                        <div class="mt-4" x-show="selectedRole === 'employer'" style="display: none;" x-transition>
-                            <label for="employer_id" class="block font-medium text-sm text-gray-700">{{ __('Link to Employer (Required)') }}</label>
-                            <select id="employer_id" name="employer_id" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
-                                <option value="">-- {{ __('Select Employer') }} --</option>
-                                @foreach ($employers as $employer)
-                                    <option value="{{ $employer->id }}" {{ old('employer_id') == $employer->id ? 'selected' : '' }}>{{ $employer->employerNameTh }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-
-                        <div class="flex items-center justify-end mt-4">
-                             <a href="{{ route('admin.users.index') }}" class="underline text-sm text-gray-600 hover:text-gray-900">{{ __('Cancel') }}</a>
-                            <button type="submit" class="ml-4 inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                                {{ __('Create User') }}
-                            </button>
-                        </div>
-                    </form>
+                    <ul class="mt-3 list-disc list-inside text-sm text-red-600">
+                        @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
                 </div>
+                @endif
+
+                <form method="POST" action="{{ route('admin.users.store') }}" x-data="{ selectedRole: '{{ old('role_name', 'staff') }}' }">
+                    @csrf
+
+                    <div>
+                        <label for="name" class="block font-medium text-sm text-gray-700">{{ __('Name') }}</label>
+                        <input id="name" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="text" name="name" value="{{ old('name') }}" required autofocus />
+                    </div>
+
+                    <div class="mt-4">
+                        <label for="email" class="block font-medium text-sm text-gray-700">{{ __('Email') }}</label>
+                        <input id="email" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="email" name="email" value="{{ old('email') }}" required />
+                    </div>
+
+                    <div class="mt-4">
+                        <label for="password" class="block font-medium text-sm text-gray-700">{{ __('Password') }}</label>
+                        <input id="password" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="password" name="password" required autocomplete="new-password" />
+                    </div>
+
+                    <div class="mt-4">
+                        <label for="password_confirmation" class="block font-medium text-sm text-gray-700">{{ __('Confirm Password') }}</label>
+                        <input id="password_confirmation" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="password" name="password_confirmation" required />
+                    </div>
+
+                    <div class="mt-4">
+                        <label for="role_name" class="block font-medium text-sm text-gray-700">{{ __('Role') }}</label>
+                        <select id="role_name" name="role_name" x-model="selectedRole" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                            @foreach ($roles as $role)
+                            <option value="{{ $role->name }}" {{ old('role_name') == $role->name ? 'selected' : '' }}>{{ ucfirst($role->name) }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+
+                    <div class="mt-4" x-show="selectedRole === 'employer'" style="display: none;" x-transition>
+                        <label for="employer_id" class="block font-medium text-sm text-gray-700">{{ __('Link to Employer (Required)') }}</label>
+                        <select id="employer_id" name="employer_id" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                            <option value="">-- {{ __('Select Employer') }} --</option>
+                            @foreach ($employers as $employer)
+                            <option value="{{ $employer->id }}" {{ old('employer_id') == $employer->id ? 'selected' : '' }}>{{ $employer->employerNameTh }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+
+                    <div class="flex items-center justify-end mt-4">
+                        <a href="{{ route('admin.users.index') }}" class="underline text-sm text-gray-600 hover:text-gray-900">{{ __('Cancel') }}</a>
+                        <button type="submit" class="ml-4 inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                            {{ __('Create User') }}
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>
-</x-app-layout>
+</div>
+@endsection


### PR DESCRIPTION
Resolves the "blank page" bug on the "Create User" page by converting the view from a component-based layout (`<x-app-layout>`) to the project's standard directive-based layout (`@extends('layouts.app')`).

This ensures consistency with the rest of the application's views and fixes the rendering issue.