### PR TITLE
feat: Implement adaptive permissions UI for user management

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rule;
+use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
 class UserController extends Controller
@@ -79,7 +80,10 @@ class UserController extends Controller
      */
     public function edit(User $user)
     {
-        //
+        $roles = Role::all();
+        $allPermissions = Permission::all(); // Get the Master List (Source 211)
+        $userPermissions = $user->permissions->pluck('name')->toArray(); // Get only direct permissions
+        return view('admin.users.edit', compact('user', 'roles', 'allPermissions', 'userPermissions'));
     }
 
     /**
@@ -87,11 +91,35 @@ class UserController extends Controller
      */
     public function update(Request $request, User $user)
     {
-        // Logic for status toggle
-        $newStatus = $user->status === 'active' ? 'inactive' : 'active';
-        $user->update(['status' => $newStatus]); // Uses 'status' from $fillable (Source 83)
+        // Check if this is a request from the full "Edit Form" (Feature D)
+        if ($request->has('name')) {
+            $request->validate([
+                'name' => ['required', 'string', 'max:255'],
+                'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
+                'role_name' => ['required', 'string', Rule::exists('roles', 'name')],
+                'permissions' => ['nullable', 'array'] // 'permissions' is the name of our checkbox array
+            ]);
 
-        return redirect()->route('admin.users.index')->with('success', 'User status updated successfully.');
+            // Update User Details
+            $user->update([
+                'name' => $request->name,
+                'email' => $request->email,
+            ]);
+
+            // Sync Role (Note: We only sync the *first* role for simplicity)
+            $user->syncRoles([$request->role_name]);
+
+            // Sync Permissions (The core of Feature D) (Source 79)
+            // This uses the HasRoles trait (Source 102, 103)
+            $user->syncPermissions($request->input('permissions', []));
+
+            return redirect()->route('admin.users.index')->with('success', 'User permissions and details updated.');
+        } else {
+            // This is a request from the "Status Toggle" (Feature C)
+            $newStatus = $user->status === 'active' ? 'inactive' : 'active';
+            $user->update(['status' => $newStatus]); // Uses 'status' from $fillable (Source 105)
+            return redirect()->route('admin.users.index')->with('success', 'User status updated successfully.');
+        }
     }
 
     /**

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -1,0 +1,75 @@
+@extends('layouts.app')
+
+@section('header')
+    <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        {{ __('Edit User') }}: {{ $user->name }}
+    </h2>
+@endsection
+
+@section('title', 'Edit User')
+
+@section('content')
+<div class="container-fluid content-section">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+            <div class="p-6 bg-white border-b border-gray-200">
+
+                @if ($errors->any())
+                    <div class="alert alert-danger">
+                        <ul>
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                <form method="POST" action="{{ route('admin.users.update', $user->id) }}">
+                    @csrf
+                    @method('PUT')
+
+                    <div>
+                        <label for="name" class="form-label">Name</label>
+                        <input id="name" type="text" name="name" value="{{ old('name', $user->name) }}" required class="form-control" />
+                    </div>
+
+                    <div class="mt-4">
+                        <label for="email" class="form-label">Email</label>
+                        <input id="email" type="email" name="email" value="{{ old('email', $user->email) }}" required class="form-control" />
+                    </div>
+
+                    <div class="mt-4">
+                        <label for="role_name" class="form-label">Role</label>
+                        <select id="role_name" name="role_name" class="form-select">
+                            @foreach ($roles as $role)
+                                <option value="{{ $role->name }}" {{ $user->roles->contains($role) ? 'selected' : '' }}>
+                                    {{ ucfirst($role->name) }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+
+                    <div class="mt-6">
+                        <h3 class="text-lg font-medium">Delegate Permissions (Feature D)</h3>
+                        <div class="mt-4 row">
+                            @foreach ($allPermissions as $permission)
+                                <div class="col-md-4">
+                                    <div class="form-check">
+                                        <input id="perm-{{ $permission->id }}" type="checkbox" name="permissions[]" value="{{ $permission->name }}" {{ in_array($permission->name, $userPermissions) ? 'checked' : '' }} class="form-check-input" >
+                                        <label for="perm-{{ $permission->id }}" class="form-check-label">{{ $permission->name }}</label>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+
+                    <div class="flex items-center justify-end mt-4">
+                        <a href="{{ route('admin.users.index') }}" class="btn btn-secondary me-2">Cancel</a>
+                        <button type="submit" class="btn btn-primary">Update User</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
Adds an edit page for users where administrators can update user details (name, email, role). Implements a checkbox-based UI to dynamically assign or revoke individual permissions for staff users. Updates the `UserController@update` method to handle both status toggles and full user detail/permission updates.