### PR TITLE
feat: Force implement V1.1 patch via full overwrite

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -18,7 +18,7 @@ class UserController extends Controller
      */
     public function index()
     {
-        $users = User::with('roles')->latest()->get(); // Eager load roles (Source 84)
+        $users = User::with('roles')->latest()->get();
         return view('admin.users.index', compact('users'));
     }
 
@@ -28,7 +28,7 @@ class UserController extends Controller
     public function create()
     {
         $roles = Role::all();
-        $employers = Employer::whereNull('user_id')->get(); // Only show unlinked employers (Source 18)
+        $employers = Employer::whereNull('user_id')->get();
         return view('admin.users.create', compact('roles', 'employers'));
     }
 
@@ -40,9 +40,9 @@ class UserController extends Controller
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
-            'role_name' => ['required', 'string', Rule::exists('roles', 'name')], // Use Spatie Role name (Source 9-15)
-            'employer_id' => ['nullable', 'required_if:role_name,employer', Rule::exists('employers', 'id')], // Required only for employer role (Source 1)
+            'password' => ['required', 'string', 'min:8', 'confirmed'], // <-- Password required on create
+            'role_name' => ['required', 'string', Rule::exists('roles', 'name')],
+            'employer_id' => ['nullable', 'required_if:role_name,employer', Rule::exists('employers', 'id')],
         ]);
 
         // Create User
@@ -50,17 +50,17 @@ class UserController extends Controller
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
-            'status' => 'active', // Default to active
+            'status' => 'active',
         ]);
 
         // Assign Role
         $user->assignRole($request->role_name);
 
-        // Link Employer (Feature A requirement) (Source 1)
+        // Link Employer
         if ($request->role_name === 'employer' && $request->employer_id) {
             $employer = Employer::find($request->employer_id);
             if ($employer) {
-                $employer->update(['user_id' => $user->id]); // Link user_id in employers table (Source 18)
+                $employer->update(['user_id' => $user->id]);
             }
         }
 
@@ -81,9 +81,16 @@ class UserController extends Controller
     public function edit(User $user)
     {
         $roles = Role::all();
-        $allPermissions = Permission::all(); // Get the Master List (Source 211)
-        $userPermissions = $user->permissions->pluck('name')->toArray(); // Get only direct permissions
-        return view('admin.users.edit', compact('user', 'roles', 'allPermissions', 'userPermissions'));
+        $allPermissions = Permission::all();
+        $userPermissions = $user->permissions->pluck('name')->toArray();
+
+        // V1.1 PATCH: Get available employers (unlinked OR this user's current linked one)
+        $currentEmployerId = $user->employer->id ?? null;
+        $employers = Employer::whereNull('user_id')
+            ->orWhere('id', $currentEmployerId)
+            ->get();
+
+        return view('admin.users.edit', compact('user', 'roles', 'allPermissions', 'userPermissions', 'employers'));
     }
 
     /**
@@ -96,28 +103,53 @@ class UserController extends Controller
             $request->validate([
                 'name' => ['required', 'string', 'max:255'],
                 'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
+                'password' => ['nullable', 'string', 'min:8', 'confirmed'], // <-- MUST BE NULLABLE on edit
                 'role_name' => ['required', 'string', Rule::exists('roles', 'name')],
-                'permissions' => ['nullable', 'array'] // 'permissions' is the name of our checkbox array
+                'employer_id' => ['nullable', 'required_if:role_name,employer', Rule::exists('employers', 'id')], // <-- ADDED (Bug Fix)
+                'permissions' => ['nullable', 'array']
             ]);
 
             // Update User Details
-            $user->update([
+            $updateData = [
                 'name' => $request->name,
                 'email' => $request->email,
-            ]);
+            ];
 
-            // Sync Role (Note: We only sync the *first* role for simplicity)
+            // V1.1 PATCH: Conditionally update password
+            if ($request->filled('password')) {
+                $updateData['password'] = Hash::make($request->password);
+            }
+            $user->update($updateData);
+
+            // Sync Role
             $user->syncRoles([$request->role_name]);
 
-            // Sync Permissions (The core of Feature D) (Source 79)
-            // This uses the HasRoles trait (Source 102, 103)
+            // V1.1 PATCH: Handle Employer Linkage (Bug Fix)
+            $currentEmployer = Employer::where('user_id', $user->id)->first();
+
+            if ($request->role_name === 'employer' && $request->employer_id) {
+                // Link new employer
+                if ($currentEmployer && $currentEmployer->id != $request->employer_id) {
+                    $currentEmployer->update(['user_id' => null]); // Unlink old
+                }
+                $newEmployer = Employer::find($request->employer_id);
+                if ($newEmployer) {
+                    $newEmployer->update(['user_id' => $user->id]); // Link new
+                }
+            } elseif ($currentEmployer) {
+                // Role changed *away* from employer, unlink them
+                $currentEmployer->update(['user_id' => null]);
+            }
+
+
+            // Sync Permissions
             $user->syncPermissions($request->input('permissions', []));
 
             return redirect()->route('admin.users.index')->with('success', 'User permissions and details updated.');
         } else {
             // This is a request from the "Status Toggle" (Feature C)
             $newStatus = $user->status === 'active' ? 'inactive' : 'active';
-            $user->update(['status' => $newStatus]); // Uses 'status' from $fillable (Source 105)
+            $user->update(['status' => $newStatus]);
             return redirect()->route('admin.users.index')->with('success', 'User status updated successfully.');
         }
     }

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -1,28 +1,32 @@
 @extends('layouts.app')
+
 @section('header')
-<h2 class="font-semibold text-xl text-gray-800 leading-tight">
-    {{ __('Create New User') }}
-</h2>
+    <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        {{ __('Create New User') }}
+    </h2>
 @endsection
+
 @section('title', 'Create New User')
+
 @section('content')
 <div class="ccontainer-fluid content-section">
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
         <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-            <div class="p-6 bg-white border-b border-gray-200">
-                @if ($errors->any())
-                <div class="mb-4">
-                    <div class="font-medium text-red-600">{{ __('Whoops! Something went wrong.') }}</div>
+            <div class="p-6 bg-white border-b border-gray-200" x-data="{ selectedRole: '{{ old('role_name', 'staff') }}', showPassword: false, showConfirmPassword: false }">
 
-                    <ul class="mt-3 list-disc list-inside text-sm text-red-600">
-                        @foreach ($errors->all() as $error)
-                        <li>{{ $error }}</li>
-                        @endforeach
-                    </ul>
-                </div>
+                @if ($errors->any())
+                    <div class="mb-4">
+                        <div class="font-medium text-red-600">{{ __('Whoops! Something went wrong.') }}</div>
+
+                        <ul class="mt-3 list-disc list-inside text-sm text-red-600">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
                 @endif
 
-                <form method="POST" action="{{ route('admin.users.store') }}" x-data="{ selectedRole: '{{ old('role_name', 'staff') }}' }">
+                <form method="POST" action="{{ route('admin.users.store') }}">
                     @csrf
 
                     <div>
@@ -37,19 +41,30 @@
 
                     <div class="mt-4">
                         <label for="password" class="block font-medium text-sm text-gray-700">{{ __('Password') }}</label>
-                        <input id="password" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="password" name="password" required autocomplete="new-password" />
+                        <div class="relative">
+                            <input :type="showPassword ? 'text' : 'password'" id="password" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="password" required autocomplete="new-password" />
+                            <button type="button" @click="showPassword = !showPassword" class="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5">
+                                <span x-text="showPassword ? 'Hide' : 'Show'"></span>
+                            </button>
+                        </div>
                     </div>
 
                     <div class="mt-4">
                         <label for="password_confirmation" class="block font-medium text-sm text-gray-700">{{ __('Confirm Password') }}</label>
-                        <input id="password_confirmation" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="password" name="password_confirmation" required />
+                         <div class="relative">
+                            <input :type="showConfirmPassword ? 'text' : 'password'" id="password_confirmation" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="password_confirmation" required />
+                             <button type="button" @click="showConfirmPassword = !showConfirmPassword" class="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5">
+                                <span x-text="showConfirmPassword ? 'Hide' : 'Show'"></span>
+                            </button>
+                        </div>
                     </div>
+
 
                     <div class="mt-4">
                         <label for="role_name" class="block font-medium text-sm text-gray-700">{{ __('Role') }}</label>
                         <select id="role_name" name="role_name" x-model="selectedRole" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
                             @foreach ($roles as $role)
-                            <option value="{{ $role->name }}" {{ old('role_name') == $role->name ? 'selected' : '' }}>{{ ucfirst($role->name) }}</option>
+                                <option value="{{ $role->name }}" {{ old('role_name') == $role->name ? 'selected' : '' }}>{{ ucfirst($role->name) }}</option>
                             @endforeach
                         </select>
                     </div>
@@ -59,13 +74,15 @@
                         <select id="employer_id" name="employer_id" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
                             <option value="">-- {{ __('Select Employer') }} --</option>
                             @foreach ($employers as $employer)
-                            <option value="{{ $employer->id }}" {{ old('employer_id') == $employer->id ? 'selected' : '' }}>{{ $employer->employerNameTh }}</option>
+                                <option value="{{ $employer->id }}" {{ old('employer_id') == $employer->id ? 'selected' : '' }}>{{ $employer->employerNameTh }}</option>
                             @endforeach
                         </select>
                     </div>
 
+
                     <div class="flex items-center justify-end mt-4">
                         <a href="{{ route('admin.users.index') }}" class="underline text-sm text-gray-600 hover:text-gray-900">{{ __('Cancel') }}</a>
+
                         <button type="submit" class="ml-4 inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
                             {{ __('Create User') }}
                         </button>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -9,14 +9,16 @@
 @section('title', 'Edit User')
 
 @section('content')
-<div class="container-fluid content-section">
+<div class="ccontainer-fluid content-section">
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
         <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-            <div class="p-6 bg-white border-b border-gray-200">
+            <div class="p-6 bg-white border-b border-gray-200" x-data="{ selectedRole: '{{ old('role_name', $user->roles->first()->name ?? 'staff') }}', showPassword: false, showConfirmPassword: false }">
 
                 @if ($errors->any())
-                    <div class="alert alert-danger">
-                        <ul>
+                    <div class="mb-4">
+                        <div class="font-medium text-red-600">{{ __('Whoops! Something went wrong.') }}</div>
+
+                        <ul class="mt-3 list-disc list-inside text-sm text-red-600">
                             @foreach ($errors->all() as $error)
                                 <li>{{ $error }}</li>
                             @endforeach
@@ -29,18 +31,35 @@
                     @method('PUT')
 
                     <div>
-                        <label for="name" class="form-label">Name</label>
-                        <input id="name" type="text" name="name" value="{{ old('name', $user->name) }}" required class="form-control" />
+                        <label for="name" class="block font-medium text-sm text-gray-700">{{ __('Name') }}</label>
+                        <input id="name" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="text" name="name" value="{{ old('name', $user->name) }}" required autofocus />
                     </div>
 
                     <div class="mt-4">
-                        <label for="email" class="form-label">Email</label>
-                        <input id="email" type="email" name="email" value="{{ old('email', $user->email) }}" required class="form-control" />
+                        <label for="email" class="block font-medium text-sm text-gray-700">{{ __('Email') }}</label>
+                        <input id="email" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" type="email" name="email" value="{{ old('email', $user->email) }}" required />
                     </div>
 
                     <div class="mt-4">
-                        <label for="role_name" class="form-label">Role</label>
-                        <select id="role_name" name="role_name" class="form-select">
+                        <label for="password" class="block font-medium text-sm text-gray-700">{{ __('New Password (Leave blank to keep current)') }}</label>
+                        <div class="relative">
+                             <input :type="showPassword ? 'text' : 'password'" id="password" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="password" autocomplete="new-password" />
+                        </div>
+                    </div>
+
+                    <div class="mt-4">
+                        <label for="password_confirmation" class="block font-medium text-sm text-gray-700">{{ __('Confirm New Password') }}</label>
+                        <div class="relative">
+                            <input :type="showConfirmPassword ? 'text' : 'password'" id="password_confirmation" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="password_confirmation" />
+                            <button type="button" @click="showPassword = !showPassword; showConfirmPassword = !showConfirmPassword;" class="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5">
+                                <span x-text="showPassword ? 'Hide' : 'Show'"></span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="mt-4">
+                        <label for="role_name" class="block font-medium text-sm text-gray-700">{{ __('Role') }}</label>
+                        <select id="role_name" name="role_name" x-model="selectedRole" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
                             @foreach ($roles as $role)
                                 <option value="{{ $role->name }}" {{ $user->roles->contains($role) ? 'selected' : '' }}>
                                     {{ ucfirst($role->name) }}
@@ -49,23 +68,41 @@
                         </select>
                     </div>
 
+                    <div class="mt-4" x-show="selectedRole === 'employer'" style="display: none;" x-transition>
+                        <label for="employer_id" class="block font-medium text-sm text-gray-700">{{ __('Link to Employer (Required)') }}</label>
+                        <select id="employer_id" name="employer_id" class="block mt-1 w-full rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                            <option value="">-- {{ __('Select Employer') }} --</option>
+                            @foreach ($employers as $employer)
+                                <option value="{{ $employer->id }}" {{ old('employer_id', $user->employer->id ?? null) == $employer->id ? 'selected' : '' }}>
+                                    {{ $employer->employerNameTh }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+
                     <div class="mt-6">
                         <h3 class="text-lg font-medium">Delegate Permissions (Feature D)</h3>
-                        <div class="mt-4 row">
+                        <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
                             @foreach ($allPermissions as $permission)
-                                <div class="col-md-4">
-                                    <div class="form-check">
-                                        <input id="perm-{{ $permission->id }}" type="checkbox" name="permissions[]" value="{{ $permission->name }}" {{ in_array($permission->name, $userPermissions) ? 'checked' : '' }} class="form-check-input" >
-                                        <label for="perm-{{ $permission->id }}" class="form-check-label">{{ $permission->name }}</label>
-                                    </div>
+                                <div>
+                                    <label for="perm-{{ $permission->id }}" class="inline-flex items-center">
+                                        <input id="perm-{{ $permission->id }}" type="checkbox" name="permissions[]" value="{{ $permission->name }}"
+                                            {{ in_array($permission->name, $userPermissions) ? 'checked' : '' }}
+                                            class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+                                            >
+                                        <span class="ml-2 text-sm text-gray-600">{{ $permission->name }}</span>
+                                    </label>
                                 </div>
                             @endforeach
                         </div>
                     </div>
 
+
                     <div class="flex items-center justify-end mt-4">
-                        <a href="{{ route('admin.users.index') }}" class="btn btn-secondary me-2">Cancel</a>
-                        <button type="submit" class="btn btn-primary">Update User</button>
+                         <a href="{{ route('admin.users.index') }}" class="underline text-sm text-gray-600 hover:text-gray-900">{{ __('Cancel') }}</a>
+                        <button type="submit" class="ml-4 inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                            {{ __('Update User') }}
+                        </button>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
This patch implements the V1.1 changes for user management by fully overwriting the controller and the create/edit views.

-   Updates `UserController` to include password update logic and correctly handle employer linking/unlinking.
-   Updates the `create.blade.php` and `edit.blade.php` views to include password and confirmation fields with a toggle for visibility.
-   Fixes a bug in the `edit` view where the available employers list was not correctly populated.