### PR TITLE
Fix: Hide delete buttons from unauthorized users

### DIFF
--- a/resources/views/agents/index.blade.php
+++ b/resources/views/agents/index.blade.php
@@ -31,11 +31,13 @@
                         <td>{{ $agent->agentPhone }}</td>
                         <td class="text-center">
                             <a href="{{ route('agents.edit', $agent) }}" class="btn btn-sm btn-outline-primary">แก้ไข</a>
+                            @can('delete-agents')
                             <form action="{{ route('agents.destroy', $agent) }}" method="POST" class="d-inline delete-form">
                                 @csrf
                                 @method('DELETE')
                                 <button type="submit" class="btn btn-sm btn-outline-danger">ลบ</button>
                             </form>
+                            @endcan
                         </td>
                     </tr>
                 @empty

--- a/resources/views/delegates/index.blade.php
+++ b/resources/views/delegates/index.blade.php
@@ -40,11 +40,13 @@
                         <td>{{ $delegate->delegateId }}</td>
                         <td>
                             <a href="{{ route('delegates.edit', $delegate->id) }}" class="btn btn-sm btn-primary">Edit</a>
+                            @can('delete-delegates')
                             <form action="{{ route('delegates.destroy', $delegate->id) }}" method="POST" style="display:inline-block;" class="delete-form">
                                 @csrf
                                 @method('DELETE')
                                 <button type="submit" class="btn btn-sm btn-danger">Delete</button>
                             </form>
+                            @endcan
                         </td>
                     </tr>
                     @endforeach

--- a/resources/views/importers/index.blade.php
+++ b/resources/views/importers/index.blade.php
@@ -36,11 +36,13 @@
                         <td>{{ $importer->importerLicenseNo }}</td>
                         <td class="text-center">
                             <a href="{{ route('importers.edit', $importer->id) }}" class="btn btn-sm btn-outline-primary">แก้ไข</a>
+                            @can('delete-importers')
                             <form action="{{ route('importers.destroy', $importer->id) }}" method="POST" class="d-inline delete-form">
                                 @csrf
                                 @method('DELETE')
                                 <button type="submit" class="btn btn-sm btn-outline-danger">ลบ</button>
                             </form>
+                            @endcan
                         </td>
                     </tr>
                 @empty


### PR DESCRIPTION
Wrapped the delete forms in `agents/index.blade.php`, `importers/index.blade.php`, and `delegates/index.blade.php` with the appropriate `@can` directives to ensure that only users with the correct permissions can see and use the delete functionality.