### PR TITLE
feat: Implement final menu security and permissions

### DIFF
--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -22,6 +22,7 @@ class RoleAndPermissionSeeder extends Seeder
         // Create Permissions
         $permissions = [
             'view-dashboard',
+            'view-notifications',
             'manage-users', 'manage-roles', 'manage-settings',
             'view-trash', //
             'view-employers', 'create-employers', 'edit-employers', 'delete-employers',
@@ -61,7 +62,12 @@ class RoleAndPermissionSeeder extends Seeder
             'view-employers', 'create-employers', 'edit-employers',
             'view-employees', 'edit-employees', 'create-employees',
             'terminate-employees',
-            'restore-employees'
+            'restore-employees',
+            'view-dashboard',
+            'view-notifications',
+            'view-importers', 'edit-importers',
+            'view-agents', 'edit-agents',
+            'view-delegates', 'edit-delegates'
         ];
 
         $staffRole->syncPermissions($staffPermissions);
@@ -81,7 +87,6 @@ class RoleAndPermissionSeeder extends Seeder
         $employerRole = Role::firstOrCreate(['name' => 'employer']);
         // [PATCH 3.2] Force Ground Truth Permissions (IDs 1, 5, 9)
         $employerPermissions = [
-            'view-dashboard', // ID 1 (Confirmed)
             'view-employers', // ID 5 (Confirmed)
             'view-employees' // ID 9 (Confirmed)
         ];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -125,18 +125,32 @@
         <aside id="sidebar">
             <a class="navbar-brand fs-4" href="#"><i class="bi bi-building-fill-gear"></i> Company Records</a>
             <div class="list-group" id="main-nav">
+                @can('view-dashboard')
                 <a href="#" class="list-group-item list-group-item-action"><i class="bi bi-pie-chart-fill me-2"></i>ภาพรวม</a>
+                @endcan
+                @can('view-notifications')
                 <a href="{{ route('notifications.index') }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center {{ request()->routeIs('notifications.*') ? 'active' : '' }}">
                     <span><i class="bi bi-bell-fill me-2"></i>แจ้งเตือน</span>
                 </a>
+                @endcan
                 <hr>
+                @can('view-employers')
                 <a href="{{ route('employers.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('employers.*') ? 'active' : '' }}"><i class="bi bi-person-vcard-fill me-2"></i>ข้อมูลนายจ้าง</a>
+                @endcan
+                @can('view-employees')
                 <a href="{{ route('employees.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('employees.*') ? 'active' : '' }}">
                     <i class="bi bi-people-fill me-2"></i>ข้อมูลลูกจ้าง
                 </a>
+                @endcan
+                @can('view-importers')
                 <a href="{{ route('importers.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('importers.*') ? 'active' : '' }}"><i class="bi bi-box-arrow-in-down-left me-2"></i>ข้อมูลบริษัทนำเข้า</a>
+                @endcan
+                @can('view-agents')
                 <a href="{{ route('agents.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('agents.*') ? 'active' : '' }}"><i class="bi bi-person-square me-2"></i>ข้อมูลเอเจนซี่</a>
+                @endcan
+                @can('view-delegates')
                 <a href="{{ route('delegates.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('delegates.*') ? 'active' : '' }}"><i class="bi bi-people-fill me-2"></i>ข้อมูลพนักงาน</a>
+                @endcan
 
                 @can('manage-users')
                 <a href="{{ route('admin.users.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('admin.users.*') ? 'active' : '' }}"><i class="bi bi-person-fill-gear me-2"></i>จัดการผู้ใช้งาน</a>


### PR DESCRIPTION
This commit implements the V1.3 requirements by updating role permissions and securing UI menu links.

- Updated `RoleAndPermissionSeeder` to:
  - Add `view-notifications` permission.
  - Grant staff additional permissions for dashboard, notifications, importers, agents, and delegates.
  - Revoke employer permission for `view-dashboard`.
- Updated `app.blade.php` to wrap all main menu links with `@can` directives, ensuring that users only see the links they have permission to access.