### PR TITLE
feat: Add nationality to employee search results in ticket modal

### DIFF
--- a/resources/views/tickets/partials/_existing_employee_modal.blade.php
+++ b/resources/views/tickets/partials/_existing_employee_modal.blade.php
@@ -40,6 +40,7 @@
                                     <strong x-text="employee.employeeNameTh"></strong>
                                     <span class="text-muted" x-text="employee.employeeNameEn ? '(' + employee.employeeNameEn + ')' : ''"></span>
                                     <small class="text-muted d-block" x-text="'Passport: ' + (employee.employeePassport || 'N/A')"></small>
+                                    <p class="mb-0 text-muted" style="font-size: 0.85rem;">Nationality: <strong x-text="employee.nationality"></strong></p>
                                 </span>
                             </label>
                         </template>


### PR DESCRIPTION
Adds the employee's nationality to the search results in the "Existing Employee" modal of the Smart Ticket System. This provides more context for the user when selecting an employee.