### PR TITLE
Fix: Correct @click handlers for modal close buttons

### DIFF
--- a/resources/views/tickets/partials/_new_employee_modal.blade.php
+++ b/resources/views/tickets/partials/_new_employee_modal.blade.php
@@ -5,7 +5,7 @@
         <form @submit.prevent="submitNewEmployeeForm" id="newEmployeeActualForm" class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="newEmployeeModalLabel">กรอกข้อมูลลูกจ้างใหม่ (แจ้งเข้า)</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" @click="showNewEmployeeModal = false"></button>
             </div>
             <div class="modal-body">
                 {{-- Form Content (Simplified and adapted from employees/create.blade.php) --}}
@@ -97,7 +97,7 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" @click="showNewEmployeeModal = false">ยกเลิก</button>
                 {{-- Submit Button (Triggers the @submit.prevent on the form tag) --}}
                 <button type="submit" class="btn btn-success">
                     <i class="bi bi-person-plus me-1"></i> เพิ่มเข้าตะกร้า


### PR DESCRIPTION
This critical bug fix addresses an issue where the close ('X') and 'Cancel' buttons on the 'Existing Employee' and 'New Employee' modals were not functioning.

The `@click` directives were added to the respective buttons in the following files, linking them to the correct Alpine.js boolean flags:
- `resources/views/tickets/partials/_existing_employee_modal.blade.php` -> `showExistingEmployeeModal = false`
- `resources/views/tickets/partials/_new_employee_modal.blade.php` -> `showNewEmployeeModal = false`

This ensures the modals can be reliably closed by the user as intended.