### PR TITLE
Fix(Admin): Resolve 500 error on admin ticket view

### DIFF
--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -33,7 +33,7 @@
 
 @section('content')
 {{-- V2.4-S11: Initialize the unified Alpine.js component --}}
-<div class="content-section" x-data="hybridAttachmentManager({ ticketEmployerId: {{ $ticket->employer_user_id ?? 'null' }} })">
+<div class="content-section" x-data="hybridAttachmentManager()">
 
     {{-- V2.4-S10: Global Error/Success Display (Crucial for feedback after reply) --}}
     @if (session('error'))
@@ -288,7 +288,7 @@
                             {{-- Action Buttons --}}
                             <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                                 <div class="btn-group" role="group" aria-label="Attachment options">
-                                    <button type="button" class="btn btn-outline-primary" @click="openExistingEmployeeModal" :disabled="isUploading">
+                                    <button type="button" class="btn btn-outline-primary" @click="openExistingEmployeeModal({{ $ticket->employer_user_id ?? 'null' }})" :disabled="isUploading">
                                         <i class="bi bi-person-check"></i> แนบลูกจ้าง
                                     </button>
                                     <button type="button" class="btn btn-outline-success" @click="openNewEmployeeModal" :disabled="isUploading">

--- a/resources/views/components/hybrid-attachment-scripts.blade.php
+++ b/resources/views/components/hybrid-attachment-scripts.blade.php
@@ -1,8 +1,7 @@
 {{-- resources/views/components/hybrid-attachment-scripts.blade.php --}}
 {{-- V2.4-S11: Unified Reusable Alpine.js Component for Hybrid Attachments --}}
 <script>
-    function hybridAttachmentManager(options = {}) { // V2.4-S11.3: Add options
-        const ticketEmployerId = options.ticketEmployerId || null; // V2.4-S11.3: Store the ID
+    function hybridAttachmentManager() {
         return {
             // --- Core Basket State (Persistent) ---
             basket: {
@@ -156,11 +155,12 @@
                 }
             },
 
-            async openExistingEmployeeModal() {
-                // V2.4-S11.3: Pass the stored ID (null for employer, ID for admin)
+            // V2.4-S11.4: Refactored to accept ID from @click
+            async openExistingEmployeeModal(ticketEmployerId = null) {
+                // Pass the ID (null for employer, ID for admin)
                 await this.fetchEmployees(ticketEmployerId);
 
-                // V2.4-S11.3 (Bug 2 Fix): Reset selections, don't pre-load
+                // V2.4-S11.3 (Bug 2 Fix): Reset selections
                 this.selectedEmployeeIds = [];
                 if (this.modalInstances.existing) this.modalInstances.existing.show();
             },


### PR DESCRIPTION
Reverts a portion of the V2.4-S11.3 implementation that caused a 500 error for administrators viewing a ticket.

The issue stemmed from passing the `ticketEmployerId` into the main `x-data` Alpine.js component initialization, which was incorrect for the admin context.

This patch refactors the approach:
1.  **Reverts** `show.blade.php` to initialize `hybridAttachmentManager()` without parameters.
2.  **Refactors** the "Attach Employee" button's `@click` directive to pass the `employer_user_id` directly to the `openExistingEmployeeModal()` function.
3.  **Reverts** `hybrid-attachment-scripts.blade.php` to remove the `options` parameter from the main `hybridAttachmentManager()` function.
4.  **Refactors** the `openExistingEmployeeModal()` function to accept the `ticketEmployerId` as a direct parameter from the `@click` event, ensuring the correct context is passed to the `fetchEmployees` API call.

This resolves the server-side error while maintaining the required functionality for fetching the correct set of employees in both admin and employer views.