### PR TITLE
Hotfix(V2.4-S20): Prevent error on employee API for null employer

### DIFF
--- a/app/Http/Controllers/Api/EmployerEmployeeController.php
+++ b/app/Http/Controllers/Api/EmployerEmployeeController.php
@@ -41,7 +41,7 @@ return [
 'id' => $employee->id,
 // --- V2.4-S19 (Plan B) Additions START ---
 'employer_id' => $employee->employer_id,
-'employer_name' => $employee->employer->employerNameTh ?? 'N/A', // Add Employer Name
+'employer_name' => $employee->employer?->employerNameTh ?? 'N/A', // Add Employer Name
 // --- V2.4-S19 (Plan B) Additions END ---
 'employeeNameTh' => $employee->employeeNameTh,
 'employeeNameEn' => $employee->employeeNameEn,


### PR DESCRIPTION
This commit applies a hotfix to `app/Http/Controllers/Api/EmployerEmployeeController.php` to prevent a 'Attempt to read property on null' error. This error occurred when an admin user tried to fetch employees that were not assigned to any employer (i.e., `employer_id` is NULL). The fix uses the nullsafe operator (`?->`) to safely access the employer's name, returning 'N/A' if the employer relationship is null.