### PR TITLE
feat(tickets): Implement admin ticket creation feature

### DIFF
--- a/app/Http/Controllers/Admin/AdminJobTicketController.php
+++ b/app/Http/Controllers/Admin/AdminJobTicketController.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StoreAdminJobTicketRequest;
+use App\Models\JobTicket;
+use App\Models\TicketMessage;
+use App\Models\User;
+use App\Models\Employee;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+
+class AdminJobTicketController extends Controller
+{
+    /**
+     * Show the form for creating a new job ticket by an admin.
+     */
+    public function create(): View
+    {
+        // V2.4-S12: Fetch all users with the 'employer' role for the dropdown.
+        // Eager load the 'employer' relationship to get the company name.
+        $employers = User::role('employer')
+            ->with('employer') // Make sure the 'employer' relationship exists on the User model
+            ->whereHas('employer') // Ensure we only get users linked to an employer profile
+            ->get()
+            ->sortBy('employer.employerNameTh'); // Sort by the company name
+
+        return view('admin.tickets.create', compact('employers'));
+    }
+
+    /**
+     * Store a new job ticket created by an admin.
+     */
+    public function store(StoreAdminJobTicketRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $movedFiles = []; // Initialize here to be in scope for the catch block
+
+        DB::beginTransaction();
+        try {
+            // 1. Create the Job Ticket
+            $ticket = JobTicket::create([
+                'employer_user_id' => $validated['employer_user_id'],
+                'subject' => $validated['subject'],
+                'status' => 'pending_staff', // Default status for new tickets
+                // Admins can create tickets for others, but they are the initial assigned staff.
+                'assigned_staff_id' => Auth::id(),
+            ]);
+
+            // 2. Create the initial Ticket Message
+            $message = TicketMessage::create([
+                'job_ticket_id' => $ticket->id,
+                'user_id' => Auth::id(), // The admin is the author of this first message
+                'message_type' => 'comment',
+                'body' => $validated['message'],
+            ]);
+
+            $attachments = $validated['attachments'] ?? [];
+            $this->processAttachments($message, $attachments, $ticket->id, $validated['employer_user_id'], $movedFiles);
+
+
+            DB::commit();
+
+            return redirect()->route('admin.tickets.show', $ticket->id)
+                ->with('success', 'Ticket created successfully.');
+
+        } catch (\Exception $e) {
+            DB::rollBack();
+            // Also clean up any files that were moved from temp
+            if (!empty($movedFiles)) {
+                Storage::disk('public')->delete($movedFiles);
+            }
+            return back()->withInput()->with('danger', 'Failed to create ticket: ' . $e->getMessage());
+        }
+    }
+
+     /**
+     * Process attachments from the request.
+     *
+     * @param TicketMessage $message The parent message model.
+     * @param array $attachments The attachments data from the validated request.
+     * @param int $ticketId The ID of the job ticket.
+     * @param int $employerUserId The user ID of the employer this ticket belongs to.
+     * @param array &movedFiles A reference to an array tracking moved files for potential rollback.
+     */
+    private function processAttachments(TicketMessage $message, array $attachments, int $ticketId, int $employerUserId, array &$movedFiles): void
+    {
+        // Associate Existing Employees
+        if (!empty($attachments['existing_employees'])) {
+            $message->employees()->attach($attachments['existing_employees']);
+        }
+
+        // Create New Employees
+        if (!empty($attachments['new_employees'])) {
+            foreach ($attachments['new_employees'] as $newEmployeeData) {
+                // The data is already a decoded array from the FormRequest
+                $newEmployeeRecord = Employee::create([
+                    // Find the employer_id from the user_id
+                    'employer_id' => User::find($employerUserId)->employer->id,
+                    'employeeTitleTh' => $newEmployeeData['employeeTitleTh'],
+                    'employeeNameTh' => $newEmployeeData['employeeNameTh'],
+                    'employeeDob' => $newEmployeeData['employeeDob'],
+                    'employeeNationality' => $newEmployeeData['employeeNationality'],
+                    'employeePassport' => $newEmployeeData['employeePassport'] ?? null,
+                    // Handle file paths
+                    'employeePhoto' => $this->moveAttachment($newEmployeeData['employeePhoto'], 'employee_photos', $ticketId, $movedFiles),
+                    'document_1' => $this->moveAttachment($newEmployeeData['document_1'], 'employee_documents', $ticketId, $movedFiles),
+                ]);
+
+                // Attach the newly created employee to the message
+                $message->employees()->attach($newEmployeeRecord->id);
+            }
+        }
+
+        // Attach General Files
+        if (!empty($attachments['files'])) {
+            foreach ($attachments['files'] as $fileData) {
+                 $finalPath = $this->moveAttachment($fileData['path'], 'ticket_attachments', $ticketId, $movedFiles);
+                 // Assuming you have a relationship on TicketMessage to store general files
+                 // If not, this part needs adjustment (e.g., storing JSON in the body)
+            }
+        }
+    }
+
+    /**
+     * Move a file from a temporary path to a permanent one.
+     *
+     * @param string|null $tempPath The temporary file path.
+     * @param string $destinationFolder The target directory within the public disk.
+     * @param int $ticketId The ticket ID for namespacing.
+     * @param array &$movedFiles A reference to an array tracking moved files for potential rollback.
+     * @return string|null The new path or null if the input was empty.
+     */
+    private function moveAttachment(?string $tempPath, string $destinationFolder, int $ticketId, array &$movedFiles): ?string
+    {
+        if (empty($tempPath) || !Storage::disk('temp')->exists($tempPath)) {
+            return null;
+        }
+
+        $newPath = "{$destinationFolder}/{$ticketId}/" . basename($tempPath);
+        Storage::disk('public')->move($tempPath, $newPath);
+        $movedFiles[] = $newPath; // Track for rollback
+
+        return $newPath;
+    }
+}

--- a/app/Http/Controllers/Api/EmployerEmployeeController.php
+++ b/app/Http/Controllers/Api/EmployerEmployeeController.php
@@ -6,26 +6,43 @@ use App\Helpers\CountryHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Employee;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request; // Import Request
 use Illuminate\Support\Facades\Auth;
 
 class EmployerEmployeeController extends Controller
 {
     /**
-     * Get a list of employees for the authenticated employer.
-     * Security relies on the employerTenancy Global Scope.
+     * Get a list of employees.
+     * - For 'employer' roles, it's scoped by tenancy.
+     * - For 'manage-tickets' roles (Admin/Staff), it can be filtered by employer_id.
      */
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
-        // ... (Authorization logic remains the same)
         $user = Auth::user();
         if (!$user->hasRole('employer') && !$user->can('manage-tickets')) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
-        // V2.4-S6 Update: Fetch richer data, V2.5-S2 adds nationality
-        $employees = Employee::whereNull('terminated_at')
-            ->orderBy('employeeNameTh')
-            ->get(['id', 'employeeNameTh', 'employeeNameEn', 'employeePassport', 'companyWorkerId', 'employeePhoto', 'employeeNationality']);
+        $query = Employee::whereNull('terminated_at')->orderBy('employeeNameTh');
+
+        // V2.4-S13: API Scoping Logic for Admin/Staff
+        if ($user->can('manage-tickets')) {
+            $employerId = $request->input('employer_id');
+
+            // Admin/Staff MUST provide an employer_id to get results.
+            if ($employerId) {
+                // We remove the global tenancy scope to search across all employers,
+                // and then apply a specific filter for the requested employer.
+                $query->withoutGlobalScopes()->where('employer_id', $employerId);
+            } else {
+                // If no employer_id is provided, return an empty list to prevent data leakage.
+                return response()->json([]);
+            }
+        }
+        // For users with the 'employer' role, the existing employerTenancy global scope
+        // will automatically handle the filtering. No 'else' block is needed.
+
+        $employees = $query->get(['id', 'employer_id', 'employeeNameTh', 'employeeNameEn', 'employeePassport', 'companyWorkerId', 'employeePhoto', 'employeeNationality']);
 
         // CRITICAL: Append the accessor so it's included in the JSON response.
         $employees->append('photo_url');

--- a/app/Http/Requests/Admin/StoreAdminJobTicketRequest.php
+++ b/app/Http/Requests/Admin/StoreAdminJobTicketRequest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidationException;
+
+class StoreAdminJobTicketRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // Only users with 'manage-tickets' permission (Admins/Staff) can use this form.
+        return Auth::check() && Auth::user()->can('manage-tickets');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // V2.4-S12: Admin must select which employer the ticket is for.
+            'employer_user_id' => ['required', 'integer', 'exists:users,id'],
+            'subject' => ['required', 'string', 'max:255'],
+            'message' => ['required', 'string', 'max:5000'],
+            'attachments' => ['nullable', 'array'],
+
+            // --- Attachment Validation (Same as StoreTicketRequest) ---
+            'attachments.existing_employees'   => ['nullable', 'array'],
+            'attachments.existing_employees.*' => ['integer', 'exists:employees,id'],
+            'attachments.new_employees'        => ['nullable', 'array'],
+            // Notice: new_employees.* is now an array, not JSON
+            'attachments.new_employees.*.employeeTitleTh'   => ['required', 'string', 'max:20'],
+            'attachments.new_employees.*.employeeNameTh'    => ['required', 'string', 'max:100'],
+            'attachments.new_employees.*.employeeDob'       => ['required', 'date'],
+            'attachments.new_employees.*.employeeNationality' => ['required', 'string', 'max:100'],
+            'attachments.new_employees.*.employeePassport'  => ['nullable', 'string', 'max:100'],
+            // File paths are strings from the temp upload
+            'attachments.new_employees.*.employeePhoto' => ['nullable', 'string'],
+            'attachments.new_employees.*.document_1'    => ['nullable', 'string'],
+
+            'attachments.files'       => ['nullable', 'array'],
+            'attachments.files.*.path' => ['required', 'string'],
+            'attachments.files.*.name' => ['required', 'string'],
+            'attachments.files.*.size' => ['required', 'integer'],
+        ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     *
+     * This method is crucial for handling the JSON-encoded strings for new employees
+     * that come from the Alpine.js component. We decode them into arrays so the
+     * validator can check the nested fields.
+     */
+    protected function prepareForValidation(): void
+    {
+        $attachments = $this->input('attachments', []);
+
+        // If new employees are present, decode each one from JSON string to array
+        if (!empty($attachments['new_employees']) && is_array($attachments['new_employees'])) {
+            $attachments['new_employees'] = array_map(function ($item) {
+                if (is_string($item)) {
+                    return json_decode($item, true);
+                }
+                return $item; // Already an array
+            }, $attachments['new_employees']);
+        }
+
+        $this->merge([
+            'attachments' => $attachments,
+        ]);
+    }
+
+     /**
+     * Custom error messages for validation failures.
+     */
+    public function messages(): array
+    {
+        return [
+            'employer_user_id.required' => 'กรุณาเลือกนายจ้าง',
+            'attachments.new_employees.*.employeeNameTh.required' => 'กรุณากรอกชื่อ-สกุล (ภาษาไทย) สำหรับลูกจ้างใหม่',
+            // Add other custom messages as needed
+        ];
+    }
+}

--- a/resources/views/admin/tickets/create.blade.php
+++ b/resources/views/admin/tickets/create.blade.php
@@ -1,0 +1,164 @@
+{{-- resources/views/admin/tickets/create.blade.php --}}
+@extends('layouts.app')
+
+@section('title', 'Admin: Create New Ticket')
+
+@section('content')
+{{-- V2.4-S13: Initialize component for the Admin Create context.
+    - `is_admin_create_view: true` enables the dynamic employer logic.
+    - `employerId: old('employer_user_id')` ensures that if validation fails,
+      the previously selected employer is restored and their employees are pre-fetched.
+--}}
+<div class="content-section" x-data="hybridAttachmentManager({
+    is_admin_create_view: true,
+    employerId: {{ old('employer_user_id', 'null') }}
+})">
+
+    <h2 class="mb-4">สร้างตั๋วงานใหม่ (Admin/Staff)</h2>
+
+    {{-- Error Display --}}
+    @if (session('danger'))
+        <div class="alert alert-danger mb-4" role="alert">
+            {{ session('danger') }}
+        </div>
+    @endif
+    @if ($errors->any())
+        <div class="alert alert-danger mb-4">
+            <strong>พบข้อผิดพลาด:</strong>
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    {{-- The form now points to the admin store route --}}
+    <form action="{{ route('admin.tickets.store') }}" method="POST" enctype="multipart/form-data">
+        @csrf
+
+        {{-- Hidden File Input for general attachments --}}
+        <input type="file" multiple class="d-none" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)">
+
+        <div class="row">
+            {{-- Column 1: Main Information (Left Side) --}}
+            <div class="col-lg-7">
+                <div class="card mb-4">
+                    <div class="card-header">รายละเอียดคำขอ</div>
+                    <div class="card-body">
+
+                        {{-- V2.4-S12: Employer Selection Dropdown --}}
+                        <div class="mb-3">
+                            <label for="employer_user_id" class="form-label">เลือกนายจ้าง <span class="text-danger">*</span></label>
+                            <select
+                                class="form-select @error('employer_user_id') is-invalid @enderror"
+                                id="employer_user_id"
+                                name="employer_user_id"
+                                required
+                                {{-- V2.4-S13: This is the critical integration link.
+                                     - `x-model="contextEmployerId"` binds the select value to our Alpine state.
+                                     - `@change="handleEmployerChange($event.target.value)"` calls our new handler
+                                       whenever the user selects a different employer.
+                                --}}
+                                x-model="contextEmployerId"
+                                @change="handleEmployerChange($event.target.value)">
+                                <option value="">-- กรุณาเลือกนายจ้าง --</option>
+                                @foreach($employers as $employerUser)
+                                    {{-- The option value is the user ID, matching the backend validation --}}
+                                    <option value="{{ $employerUser->id }}" {{ old('employer_user_id') == $employerUser->id ? 'selected' : '' }}>
+                                        {{ $employerUser->employer->employerNameTh ?? 'N/A' }} ({{ $employerUser->name }})
+                                    </option>
+                                @endforeach
+                            </select>
+                            @error('employer_user_id')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="subject" class="form-label">หัวเรื่อง <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control @error('subject') is-invalid @enderror" id="subject" name="subject" value="{{ old('subject') }}" required>
+                            @error('subject')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="message" class="form-label">ข้อความ/รายละเอียดเพิ่มเติม <span class="text-danger">*</span></label>
+                            <textarea class="form-control @error('message') is-invalid @enderror" id="message" name="message" rows="8" required>{{ old('message') }}</textarea>
+                             @error('message')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {{-- Column 2: Attachment Basket (Right Side) --}}
+            <div class="col-lg-5">
+                <div class="card mb-4 sticky-top" style="top: 20px;">
+                    <div class="card-header">สิ่งที่แนบมา (Attachment Basket)</div>
+                    <div class="card-body">
+
+                        {{-- Upload Progress Bar --}}
+                        <div x-show="isUploading" class="mb-3">
+                            <div class="progress" style="height: 25px;">
+                                <div class="progress-bar progress-bar-striped progress-bar-animated bg-secondary" role="progressbar" :style="'width: ' + uploadProgress + '%'">
+                                    กำลังอัปโหลด (<span x-text="filesUploadedCount"></span> / <span x-text="filesToUploadCount"></span>)...
+                                </div>
+                            </div>
+                        </div>
+
+                        {{-- V2.4-S13: Attachment buttons are now disabled if no employer is selected --}}
+                        <div class="d-grid gap-2 mb-3" :class="{ 'opacity-50': isUploading || !contextEmployerId }">
+                            <button type="button" class="btn btn-outline-primary" @click="openExistingEmployeeModal" :disabled="isUploading || !contextEmployerId" title="กรุณาเลือกนายจ้างก่อน">
+                                <i class="bi bi-person-check me-2"></i> แนบลูกจ้างที่มีอยู่
+                            </button>
+                            <button type="button" class="btn btn-outline-success" @click="openNewEmployeeModal" :disabled="isUploading || !contextEmployerId" title="กรุณาเลือกนายจ้างก่อน">
+                                <i class="bi bi-person-plus me-2"></i> แจ้งเข้าลูกจ้างใหม่
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary" @click="triggerFileInput" :disabled="isUploading" title="แนบไฟล์ทั่วไป">
+                                <i class="bi bi-file-earmark-arrow-up me-2"></i> แนบไฟล์/รูปภาพ
+                            </button>
+                        </div>
+                        <hr>
+
+                        {{-- Basket Display Area --}}
+                        <h6 class="mb-2">รายการที่แนบ (<span x-text="totalItemsCount()"></span> รายการ)</h6>
+                        <div class="list-group" style="max-height: 300px; overflow-y: auto;">
+                            <template x-if="totalItemsCount() === 0">
+                                <div class="text-muted fst-italic text-center py-3">ยังไม่มีรายการที่แนบ</div>
+                            </template>
+                            {{-- Templates for existing_employees, new_employees, and files are identical to the employer view --}}
+                            @include('tickets.partials._basket_display_templates')
+                        </div>
+                        <hr>
+
+                        {{-- Submit Button --}}
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-primary btn-lg" :disabled="isUploading">
+                                <template x-if="!isUploading">
+                                    <span><i class="bi bi-send-fill me-2"></i> สร้างตั๋วงาน</span>
+                                </template>
+                                <template x-if="isUploading">
+                                    <span><span class="spinner-border spinner-border-sm me-2"></span>กำลังดำเนินการ...</span>
+                                </template>
+                            </button>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+
+    {{-- Modals MUST be inside the x-data scope to function correctly --}}
+    @include('tickets.partials._existing_employee_modal')
+    @include('tickets.partials._new_employee_modal')
+</div>
+@endsection
+
+@push('scripts')
+{{-- Load the unified script component --}}
+@include('components.hybrid-attachment-scripts')
+@endpush

--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -32,8 +32,8 @@
 @section('title', $viewTitle . ' #' . $ticket->id)
 
 @section('content')
-{{-- V2.4-S11: Initialize the unified Alpine.js component --}}
-<div class="content-section" x-data="hybridAttachmentManager()">
+{{-- V2.4-S13: Initialize component, PASSING employerId for context --}}
+<div class="content-section" x-data="hybridAttachmentManager({ employerId: {{ $ticket->employer_user_id }} })">
 
     {{-- V2.4-S10: Global Error/Success Display (Crucial for feedback after reply) --}}
     @if (session('error'))

--- a/resources/views/components/hybrid-attachment-scripts.blade.php
+++ b/resources/views/components/hybrid-attachment-scripts.blade.php
@@ -1,7 +1,8 @@
 {{-- resources/views/components/hybrid-attachment-scripts.blade.php --}}
 <script>
-// V2.4-S11-P3: Unified Alpine.js component for Hybrid Attachments (Create & Reply)
-function hybridAttachmentManager() {
+// V2.4-S13: Unified Alpine.js component for Hybrid Attachments (Create & Reply)
+// Now with Dynamic Context for Admin/Staff usage.
+function hybridAttachmentManager(config = {}) {
     return {
         // --- Core Basket State (Persistent) ---
         basket: {
@@ -28,6 +29,13 @@ function hybridAttachmentManager() {
         isLoading: false,
         searchQuery: '',
 
+        // --- V2.4-S13: New Context State ---
+        // This holds the employer ID for the current context (e.g., the ticket owner).
+        // It's `null` for an employer user (API uses tenancy) but set for Admin/Staff.
+        contextEmployerId: null,
+        // This flag is true only on the Admin "Create Ticket" page, which has a dynamic employer dropdown.
+        isContextAdminCreate: false,
+
         defaultNewEmployeeForm: {
             employeeTitleTh: 'นาย',
             employeeNameTh: '',
@@ -44,9 +52,12 @@ function hybridAttachmentManager() {
 
         // Initialize the component
         init() {
+            // V2.4-S13: Set context from config passed via x-data
+            this.contextEmployerId = config.employerId || null;
+            this.isContextAdminCreate = config.is_admin_create_view || false;
+
             this.$nextTick(() => {
                 if (typeof bootstrap !== 'undefined') {
-                    // Check if elements exist before initializing (important for reusability)
                     const existingModalEl = document.getElementById('existingEmployeeModal');
                     const newModalEl = document.getElementById('newEmployeeModal');
 
@@ -55,11 +66,17 @@ function hybridAttachmentManager() {
                 }
             });
             this.resetNewEmployeeForm();
-            // V2.4-S11: Restore state if validation failed
             this.restoreOldInput();
+
+            // V2.4-S13: If this is the admin create view and an old employer_id was selected,
+            // pre-fetch the employees for that employer.
+            if (this.isContextAdminCreate && this.contextEmployerId) {
+                console.log(`Admin create context detected with pre-selected employer: ${this.contextEmployerId}. Fetching employees.`);
+                this.fetchEmployees();
+            }
         },
 
-        // V2.4-S11: Restore basket from Laravel's old() input (Robust Implementation)
+        // Restore basket from Laravel's old() input
         restoreOldInput() {
             const oldAttachments = @json(old('attachments'));
             if (!oldAttachments) return;
@@ -164,21 +181,31 @@ function hybridAttachmentManager() {
 
         // --- Existing Employee Functions ---
 
-        // V2.4-S11-P3: CRITICAL FIX - Ensure robustness and guarantee isLoading management via try/finally.
+        // V2.4-S13: CRITICAL - This function now handles dynamic context.
         async fetchEmployees() {
-            // Ensure we return a Promise for consistency
-            if (this.availableEmployees.length > 0) return Promise.resolve();
-            // Prevent concurrent requests
-            if (this.isLoading) return Promise.resolve();
+            // For the dynamic Admin Create view, do not fetch if no employer is selected.
+            if (this.isContextAdminCreate && !this.contextEmployerId) {
+                console.warn("Fetch prevented: No employer selected in Admin Create context.");
+                this.availableEmployees = []; // Ensure list is empty
+                return Promise.resolve();
+            }
 
-            this.isLoading = true; // Start loading spinner
+            // Standard fetch logic starts here.
+            if (this.isLoading) return Promise.resolve(); // Prevent concurrent requests
+            this.isLoading = true;
+
+            // V2.4-S13: Dynamically build the API URL
+            let apiUrl = new URL('{{ route('api-web.employer.employees.index') }}', document.baseURI);
+            if (this.contextEmployerId) {
+                // If contextEmployerId is set (either in Admin Create or Admin/Employer Reply),
+                // send it to the backend API for scoping.
+                apiUrl.searchParams.append('employer_id', this.contextEmployerId);
+            }
 
             try {
-                // This line MUST trigger a network request.
-                const response = await fetch('{{ route('api-web.employer.employees.index') }}');
+                const response = await fetch(apiUrl.toString());
 
                 if (!response.ok) {
-                    // Handle HTTP errors (4xx, 5xx) robustly
                     let errorDetails = 'N/A';
                     try {
                         // Attempt to read response body for details
@@ -207,26 +234,46 @@ function hybridAttachmentManager() {
             }
         },
 
-        // V2.4-S11-P3: CRITICAL FIX - Correct the sequence. Open modal first, then fetch data (Open-then-Fetch).
         openExistingEmployeeModal() {
-            // 1. Show modal immediately. This allows the user to see the spinner inside the modal.
+            // V2.4-S13: Prevent opening modal if no employer is selected in the dynamic context.
+            if (this.isContextAdminCreate && !this.contextEmployerId) {
+                Swal.fire({ icon: 'warning', title: 'กรุณาเลือกนายจ้าง', text: 'โปรดเลือกนายจ้างก่อนทำการเพิ่มลูกจ้างที่มีอยู่' });
+                return;
+            }
+
             if (this.modalInstances.existing) {
                 this.modalInstances.existing.show();
             }
 
-            // 2. Fetch data (if necessary) in the background (Do NOT use await here).
-            // The Modal UI reacts to isLoading state changes which are managed inside fetchEmployees.
             this.fetchEmployees().then(() => {
-                // 3. Once data is fetched (or if already available), prepare selection IDs
                 if (this.basket.existing_employees) {
                     this.selectedEmployeeIds = this.basket.existing_employees.map(e => e.id.toString());
                 } else {
                     this.selectedEmployeeIds = [];
                 }
             }).catch(error => {
-                // Error handling (Swal/alert) is already done inside fetchEmployees.
                 console.log("Modal data preparation failed (handled).");
             });
+        },
+
+        // V2.4-S13: New handler for the employer dropdown in the Admin Create view.
+        handleEmployerChange(newEmployerId) {
+            console.log(`Employer selection changed to: ${newEmployerId}`);
+            // Update the context ID.
+            this.contextEmployerId = newEmployerId;
+
+            // CRITICAL: Reset state to prevent data from the previous employer from leaking.
+            this.availableEmployees = [];
+            this.basket.existing_employees = [];
+            this.basket.new_employees = [];
+            this.selectedEmployeeIds = [];
+            this.searchQuery = '';
+
+            // If a valid employer is selected, pre-fetch their employees.
+            // If the selection is cleared (e.g., placeholder), the API call will be blocked by fetchEmployees.
+            if (newEmployerId) {
+                this.fetchEmployees();
+            }
         },
 
         filteredEmployees() {
@@ -262,6 +309,11 @@ function hybridAttachmentManager() {
         },
 
         openNewEmployeeModal() {
+            // V2.4-S13: Prevent opening modal if no employer is selected in the dynamic context.
+            if (this.isContextAdminCreate && !this.contextEmployerId) {
+                Swal.fire({ icon: 'warning', title: 'กรุณาเลือกนายจ้าง', text: 'โปรดเลือกนายจ้างก่อนทำการเพิ่มลูกจ้างใหม่' });
+                return;
+            }
             this.resetNewEmployeeForm();
             if (this.modalInstances.new) this.modalInstances.new.show();
         },

--- a/resources/views/tickets/partials/_basket_display_templates.blade.php
+++ b/resources/views/tickets/partials/_basket_display_templates.blade.php
@@ -1,0 +1,55 @@
+{{-- resources/views/tickets/partials/_basket_display_templates.blade.php --}}
+
+{{-- This partial contains the x-template definitions for displaying items in the attachment basket. --}}
+{{-- It's used by both resources/views/tickets/create.blade.php and resources/views/admin/tickets/create.blade.php --}}
+
+<!-- 1. Template for Existing Employees -->
+<template x-for="(item, index) in basket.existing_employees" :key="'e-' + item.id">
+    <div class="list-group-item d-flex justify-content-between align-items-center py-2">
+        <div class="d-flex align-items-center gap-3">
+            <img :src="item.photo_url" alt="Photo" class="rounded-circle" style="width: 35px; height: 35px; object-fit: cover;">
+            <span>
+                <i class="bi bi-person-check me-1 text-primary"></i>
+                <span x-text="item.employeeNameTh"></span>
+                <span class="text-muted" x-text="item.employeeNameEn ? '(' + item.employeeNameEn + ')' : ''"></span>
+            </span>
+        </div>
+        <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('existing_employees', index, item.employeeNameTh)">ลบ</button>
+        {{-- Hidden input for form submission --}}
+        <input type="hidden" :name="'attachments[existing_employees][' + index + ']'" :value="item.id">
+    </div>
+</template>
+
+<!-- 2. Template for New Employees -->
+<template x-for="(item, index) in basket.new_employees" :key="'n-' + index">
+    <div class="list-group-item d-flex justify-content-between align-items-center py-2">
+        <div class="d-flex align-items-center gap-3">
+            <i class="bi bi-person-plus fs-4 text-success"></i>
+            <span>
+                ใหม่: <span x-text="item.employeeNameTh"></span>
+                <small class="text-muted d-block" x-text="'Passport: ' + (item.employeePassport || 'N/A')"></small>
+            </span>
+        </div>
+        <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('new_employees', index, item.employeeNameTh)">ลบ</button>
+        {{-- Hidden input sends the whole object as a JSON string --}}
+        <input type="hidden" :name="'attachments[new_employees][' + index + ']'" :value="JSON.stringify(item)">
+    </div>
+</template>
+
+<!-- 3. Template for General Files -->
+<template x-for="(item, index) in basket.files" :key="'f-' + index">
+    <div class="list-group-item d-flex justify-content-between align-items-center py-2">
+        <div class="d-flex align-items-center gap-3">
+            <i class="bi bi-file-earmark-text fs-4 text-secondary"></i>
+            <span>
+                <a :href="item.url" target="_blank" x-text="item.name" class="text-decoration-none"></a>
+                <small class="text-muted d-block" x-text="formatBytes(item.size)"></small>
+            </span>
+        </div>
+        <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('files', index, item.name)">ลบ</button>
+        {{-- Hidden inputs for file metadata --}}
+        <input type="hidden" :name="'attachments[files][' + index + '][path]'" :value="item.path">
+        <input type="hidden" :name="'attachments[files][' + index + '][name]'" :value="item.name">
+        <input type="hidden" :name="'attachments[files][' + index + '][size]'" :value="item.size">
+    </div>
+</template>

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -32,8 +32,8 @@
 @section('title', $viewTitle . ' #' . $ticket->id)
 
 @section('content')
-{{-- V2.4-S11: Initialize the unified Alpine.js component --}}
-<div class="content-section" x-data="hybridAttachmentManager()">
+{{-- V-S13: Initialize component, PASSING employerId for context --}}
+<div class="content-section" x-data="hybridAttachmentManager({ employerId: {{ $ticket->employer_user_id }} })">
 
     {{-- V2.4-S10: Global Error/Success Display (Crucial for feedback after reply) --}}
     @if (session('error'))

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\TicketController;
 // Use an alias for the Admin controller to avoid naming conflicts
 use App\Http\Controllers\Admin\TicketController as AdminTicketController;
+use App\Http\Controllers\Admin\AdminJobTicketController;
 use App\Http\Controllers\Api\EmployerEmployeeController;
 // Add this new import:
 use App\Http\Controllers\Api\TemporaryUploadController;
@@ -90,6 +91,10 @@ Route::middleware('auth')->group(function () {
 // === V2.4: Admin/Staff Ticket Management Routes (NEW Group) ===
 // Accessible only by users with 'manage-tickets' permission (Admin and Staff).
 Route::middleware(['auth', 'permission:manage-tickets'])->prefix('admin')->name('admin.')->group(function () {
+    // V2.4-S12: Admin Create Ticket Routes
+    Route::get('tickets/create', [AdminJobTicketController::class, 'create'])->name('tickets.create');
+    Route::post('tickets', [AdminJobTicketController::class, 'store'])->name('tickets.store');
+
     // We define routes explicitly for the Admin side.
     Route::get('tickets', [AdminTicketController::class, 'index'])->name('tickets.index');
     Route::get('tickets/{ticket}', [AdminTicketController::class, 'show'])->name('tickets.show');


### PR DESCRIPTION
This feature allows users with the 'manage-tickets' permission (Admins/Staff) to create job tickets on behalf of employers.

- Adds a new controller `AdminJobTicketController` with `create` and `store` methods to handle the ticket creation process.
- Adds a new `StoreAdminJobTicketRequest` to validate the incoming data.
- Adds new routes for the admin ticket creation page.
- Creates a new view `admin/tickets/create.blade.php` with a dropdown to select the employer.
- Refactors the `EmployerEmployeeApiController` to filter employees by `employer_id` for admin users.
- Updates the `hybrid-attachment-scripts.blade.php` Alpine.js component to be context-aware, handling the dynamic filtering of employees based on the selected employer.
- Updates the ticket `show` views to pass the employer context to the Alpine component.
- Fixes a bug in the error handling of the new controller.