### PR TITLE
Fix: Correct Blade to Alpine.js data passing syntax

### DIFF
--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -33,7 +33,9 @@
 
 @section('content')
 {{-- V2.4-S13: Initialize component, PASSING employerId for context --}}
-<div class="content-section" x-data="hybridAttachmentManager({ employerId: {{ $ticket->employer_user_id }} })">
+{{-- V2.4-S13-P1: CRITICAL FIX - Use @json directive for safe and correct data passing to Alpine.js --}}
+{{-- This ensures that the PHP value (integer or null) is correctly encoded as a JavaScript literal. --}}
+<div class="content-section" x-data="hybridAttachmentManager({ employerId: @json($ticket->employer_id ?? null) })">
 
     {{-- V2.4-S10: Global Error/Success Display (Crucial for feedback after reply) --}}
     @if (session('error'))

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -33,7 +33,9 @@
 
 @section('content')
 {{-- V-S13: Initialize component, PASSING employerId for context --}}
-<div class="content-section" x-data="hybridAttachmentManager({ employerId: {{ $ticket->employer_user_id }} })">
+{{-- V2.4-S13-P1: CRITICAL FIX - Use @json directive for safe and correct data passing to Alpine.js --}}
+{{-- This ensures that the PHP value (integer or null) is correctly encoded as a JavaScript literal. --}}
+<div class="content-section" x-data="hybridAttachmentManager({ employerId: @json($ticket->employer_id ?? null) })">
 
     {{-- V2.4-S10: Global Error/Success Display (Crucial for feedback after reply) --}}
     @if (session('error'))


### PR DESCRIPTION
Resolves a critical JavaScript error in the ticket reply views by using the `@json` Blade directive to safely pass data from PHP to the Alpine.js component. This ensures that both integer and null values are correctly encoded, preventing syntax errors that broke the component's initialization.