### PR TITLE
feat: Mitigate session locking and improve API robustness

### DIFF
--- a/app/Http/Controllers/ApiWeb/EmployerEmployeeApiController.php
+++ b/app/Http/Controllers/ApiWeb/EmployerEmployeeApiController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers\ApiWeb;
+
+use App\Http\Controllers\Controller;
+use App\Models\Employee;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\JsonResponse;
+// V2.4-S13-P2: Import Session facade
+use Illuminate\Support\Facades\Session;
+
+class EmployerEmployeeApiController extends Controller
+{
+    /**
+     * Display a listing of the resource (Employees).
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $user = Auth::user();
+
+        // V2.4-S13-P2: CRITICAL FIX - Session Lock Mitigation
+        // Since this is a read-only API request, we close the session for writing
+        // immediately after authentication (which is handled by middleware).
+        // This prevents session file locking issues, common with the 'file' driver.
+        Session::save();
+
+        $query = Employee::query();
+
+        // Define the fields required
+        $requiredFields = [
+            'id',
+            'employeeNameTh',
+            'employeeNameEn',
+            'employeePassport',
+            'employee_photo',
+            'employer_id'
+        ];
+
+        // 1. Authorization & Scoping Logic (V2.4-S13 Logic)
+        if ($user->can('manage-tickets')) {
+            // --- Admin/Staff Logic ---
+            $requestedEmployerId = $request->query('employer_id');
+            if ($requestedEmployerId) {
+                $query->where('employer_id', $requestedEmployerId);
+            } else {
+                if ($request->header('X-Context') === 'smart-ticket-create') {
+                    return response()->json([]);
+                }
+                // Otherwise (e.g. other admin views), return all (default admin behavior)
+            }
+        } elseif ($user->employer) {
+            // --- Employer Logic ---
+            $query->where('employer_id', $user->employer->id);
+        } else {
+            return response()->json(['error' => 'Unauthorized access.'], 403);
+        }
+
+        // 2. Data Retrieval and Formatting
+        $employees = $query->select($requiredFields)->latest()->get();
+
+        // 3. Append Accessors (This is where serialization happens)
+        $employees->each(function ($employee) {
+            $employee->append('photo_url');
+        });
+
+        return response()->json($employees);
+    }
+}

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -2,8 +2,6 @@
 
 namespace App\Models;
 
-// ... (Existing imports)
-// Add Attribute and Storage imports
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -11,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
 
 class Employee extends Model
 {
@@ -99,24 +98,48 @@ class Employee extends Model
         'terminated_at' => 'datetime',
     ];
 
-    // --- V2.4-S6: Accessor for Photo URL ---
     /**
-     * Get the full URL for the employee's photo, with a fallback avatar.
-     * Usage in Blade/API: $employee->photo_url
+     * Get the URL to the employee's photo.
+     * V2.4-S13-P2: CRITICAL FIX - Ensure robustness during API serialization.
+     * Handle nulls, missing attributes, and missing files defensively to prevent crashes.
      */
     protected function photoUrl(): Attribute
     {
         return Attribute::make(
-            get: function () {
-                // Robust check: Ensure property is set AND file exists on disk
-                if ($this->employeePhoto && Storage::disk('public')->exists($this->employeePhoto)) {
-                    return Storage::disk('public')->url($this->employeePhoto);
+            get: function ($value, $attributes) {
+                // Define default placeholder (Ensure 'public/images/default_avatar.png' exists in your project)
+                $defaultAvatar = asset('images/default_avatar.png');
+
+                // 1. Check if 'employee_photo' attribute exists in the attributes array
+                // (Crucial when using specific select() queries)
+                if (!isset($attributes['employee_photo'])) {
+                    return $defaultAvatar;
                 }
-                // Fallback using ui-avatars.com based on the name
-                $name = urlencode($this->employeeNameTh ?? $this->employeeNameEn ?? 'User');
-                // Use primary color defined in app.blade.php (F97316 - Orange)
-                return "https://ui-avatars.com/api/?name={$name}&color=FFFFFF&background=F97316&size=128";
-            }
+
+                $photoPath = $attributes['employee_photo'];
+
+                // 2. Check if the path is null or empty
+                if (!$photoPath) {
+                    return $defaultAvatar;
+                }
+
+                // 3. Determine the storage disk (assuming 'public')
+                $disk = 'public';
+
+                // 4. Check if the file actually exists on the disk before generating URL
+                try {
+                    if (Storage::disk($disk)->exists($photoPath)) {
+                        return Storage::disk($disk)->url($photoPath);
+                    }
+                } catch (\Exception $e) {
+                    // Log the error if storage access fails (e.g., permission issues), but do not crash the API
+                    $employeeId = $attributes['id'] ?? 'N/A';
+                    Log::warning("Storage access error for Employee photo (ID: {$employeeId}): " . $e->getMessage());
+                }
+
+                // 5. Fallback if file is missing or error occurred
+                return $defaultAvatar;
+            },
         );
     }
 


### PR DESCRIPTION
This patch addresses two key issues:

1.  **Session Locking:** In `EmployerEmployeeApiController`, `Session::save()` is now called immediately after authentication. This prevents the session file from being locked during read-only API requests, mitigating potential request timeouts and hangs.

2.  **Accessor Robustness:** The `photoUrl` accessor in the `Employee` model has been rewritten to be more defensive. It now handles cases where the `employee_photo` attribute is missing (due to `select` queries), the path is null, the file doesn't exist on the storage disk, or a storage access error occurs. This prevents the API from crashing during serialization.