### PR TITLE
Fix: Remove duplicate import in EmployerEmployeeController

### DIFF
--- a/app/Http/Controllers/Api/EmployerEmployeeController.php
+++ b/app/Http/Controllers/Api/EmployerEmployeeController.php
@@ -9,7 +9,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
-use Illuminate\Http\JsonResponse;
 
 class EmployerEmployeeController extends Controller
 {


### PR DESCRIPTION
Removed a duplicate 'use Illuminate\Http\JsonResponse;' statement from app/Http/Controllers/Api/EmployerEmployeeController.php to resolve a fatal error.