### PR TITLE
feat(tickets): add resolved, rejected, and forward actions

### DIFF
--- a/app/Enums/TicketStatus.php
+++ b/app/Enums/TicketStatus.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums;
+
+enum TicketStatus: string
+{
+    case Pending = 'pending';
+    case InProgress = 'in-progress';
+    case Closed = 'closed';
+    case Resolved = 'resolved';
+    case Rejected = 'rejected';
+    case InWorkflow = 'in-workflow';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::InProgress => 'In Progress',
+            self::Closed => 'Closed',
+            self::Resolved => 'Resolved',
+            self::Rejected => 'Rejected',
+            self::InWorkflow => 'In-Workflow',
+        };
+    }
+}

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -16,6 +16,7 @@ use Illuminate\View\View;
 use Illuminate\Http\RedirectResponse;
 // Import Exception for robust error handling
 use Exception;
+use App\Enums\TicketStatus;
 // Ensure Illuminate\Http\Request is NOT imported if it conflicts or is unused.
 
 class TicketController extends Controller
@@ -232,5 +233,26 @@ class TicketController extends Controller
 
         // The categorized_attachments accessor will handle the rest of the data loading.
         return view('tickets.show', compact('ticket'));
+    }
+
+    public function resolveTicket(JobTicket $ticket): RedirectResponse
+    {
+        $ticket->update(['status' => TicketStatus::Resolved]);
+
+        return redirect()->route('tickets.show', $ticket)->with('success', 'Ticket marked as Resolved.');
+    }
+
+    public function rejectTicket(JobTicket $ticket): RedirectResponse
+    {
+        $ticket->update(['status' => TicketStatus::Rejected]);
+
+        return redirect()->route('tickets.show', $ticket)->with('success', 'Ticket marked as Rejected.');
+    }
+
+    public function forwardToWorkflow(JobTicket $ticket): RedirectResponse
+    {
+        $ticket->update(['status' => TicketStatus::InWorkflow]);
+
+        return redirect()->route('tickets.show', $ticket)->with('success', 'Ticket forwarded to P-Workflow.');
     }
 }

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -26,7 +26,7 @@
     // Access the pre-processed attachments via the accessor
     $attachments = $ticket->categorized_attachments;
     // V2.4-S10: Check if the ticket is closed
-    $isClosed = in_array($ticket->status, ['resolved', 'rejected']);
+    $isClosed = in_array($ticket->status, [\App\Enums\TicketStatus::Resolved->value, \App\Enums\TicketStatus::Rejected->value, \App\Enums\TicketStatus::Closed->value]);
 @endphp
 
 @section('title', $viewTitle . ' #' . $ticket->id)
@@ -319,6 +319,44 @@
             @endif
             {{-- End Section 3: Reply Box --}}
 
+            {{-- V2.4-S12: Staff/Admin Action Buttons --}}
+            @can('manage-tickets')
+                @if (!$isClosed)
+                    <div class="card mt-4">
+                        <div class="card-header"><h5 class="mb-0">Ticket Actions</h5></div>
+                        <div class="card-body">
+                            <div class="d-flex flex-wrap gap-3">
+                                {{-- 1. Mark as Resolved --}}
+                                <form action="{{ route('tickets.resolve', $ticket) }}" method="POST" onsubmit="return confirm('Are you sure you want to mark this ticket as Resolved?');">
+                                    @csrf
+                                    @method('PATCH')
+                                    <button type="submit" class="btn btn-success">
+                                        <i class="bi bi-check-circle me-2"></i>Mark as Resolved
+                                    </button>
+                                </form>
+
+                                {{-- 2. Mark as Rejected --}}
+                                <form action="{{ route('tickets.reject', $ticket) }}" method="POST" onsubmit="return confirm('Are you sure you want to REJECT this ticket?');">
+                                    @csrf
+                                    @method('PATCH')
+                                    <button type="submit" class="btn btn-danger">
+                                        <i class="bi bi-x-circle me-2"></i>Mark as Rejected
+                                    </button>
+                                </form>
+
+                                {{-- 3. Forward to P-Workflow --}}
+                                <form action="{{ route('tickets.forward', $ticket) }}" method="POST" onsubmit="return confirm('Are you sure you want to forward this to P-Workflow?');">
+                                    @csrf
+                                    @method('PATCH')
+                                    <button type="submit" class="btn btn-primary">
+                                        <i class="bi bi-arrow-right-circle me-2"></i>Forward to P-Workflow
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                @endif
+            @endcan
         </div>
 
         {{-- Column 2: Metadata Sidebar --}}
@@ -355,16 +393,7 @@
                         {{ $ticket->assignedStaff->name ?? ($isAdminView ? 'ยังไม่ได้มอบหมาย' : 'รอเจ้าหน้าที่รับเรื่อง') }}
                     </li>
                 </ul>
-                {{-- Admin Action Buttons (Placeholder for V2.4-S11) --}}
-                @if($isAdminView)
-                    <div class="card-body d-grid gap-2">
-                         <h5 class="mb-3">การจัดการ (Admin/Staff)</h5>
-                        <button class="btn btn-outline-success" disabled>Mark as Resolved (V2.4-S11)</button>
-                        <button class="btn btn-outline-danger" disabled>Reject Ticket (V2.4-S11)</button>
-                        <button class="btn btn-outline-primary" disabled>Forward to P-Workflow (V2.4-S11)</button>
-                         <button class="btn btn-outline-secondary" disabled>Change Assignment (V2.4-S11)</button>
-                    </div>
-                @endif
+                {{-- Admin actions are now in the main content area --}}
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,13 @@ Route::middleware('auth')->group(function () {
     // V2.4-S10: Employer Reply Route
     Route::post('tickets/{ticket}/replies', [TicketReplyController::class, 'store'])->name('tickets.replies.store');
 
+    // --- V2.4-S12: Staff/Admin Ticket Action Routes ---
+    Route::middleware('can:manage-tickets')->group(function () {
+        Route::patch('/tickets/{ticket}/resolve', [TicketController::class, 'resolveTicket'])->name('tickets.resolve');
+        Route::patch('/tickets/{ticket}/reject', [TicketController::class, 'rejectTicket'])->name('tickets.reject');
+        Route::patch('/tickets/{ticket}/forward', [TicketController::class, 'forwardToWorkflow'])->name('tickets.forward');
+    });
+
     // --- V2.4-S5/S6: Internal API Routes for Web Interface ---
     Route::prefix('api-web')->name('api-web.')->group(function () {
         Route::get('employer/employees', [EmployerEmployeeController::class, 'index'])->name('employer.employees.index');


### PR DESCRIPTION
Adds 'Resolved,' 'Rejected,' and 'Forward to P-Workflow' action buttons to the ticket details page for staff and admin users.

- Introduces `app/Enums/TicketStatus.php` to manage ticket statuses.
- Adds PATCH routes for `tickets.resolve`, `tickets.reject`, and `tickets.forward`.
- Implements `resolveTicket`, `rejectTicket`, and `forwardToWorkflow` methods in `TicketController`.
- Conditionally renders the action buttons in `tickets/show.blade.php`, appearing only for users with `manage-tickets` permission and on tickets not already in a terminal state.