### PR TITLE
feat: Implement Forward to P-Workflow button

### DIFF
--- a/app/Http/Controllers/Admin/TicketStatusController.php
+++ b/app/Http/Controllers/Admin/TicketStatusController.php
@@ -54,4 +54,26 @@ class TicketStatusController extends Controller
 
         return redirect()->route('admin.tickets.show', $ticket)->with('success', 'Ticket marked as Rejected.');
     }
+
+    /**
+     * Mark the specified ticket as In Progress (Forwarded to Workflow).
+     */
+    public function forward(JobTicket $ticket)
+    {
+        if (!Auth::user()->can('manage-tickets')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        // 1. อัปเดตสถานะเป็น in_progress
+        $ticket->update(['status' => 'in_progress']);
+
+        // 2. เพิ่มข้อความ System ลงในแชท
+        $ticket->messages()->create([
+            'user_id' => Auth::id(),
+            'message_type' => 'system_activity',
+            'body' => 'Ticket status changed to In Progress (Forwarded) by ' . Auth::user()->name,
+        ]);
+
+        return redirect()->route('admin.tickets.show', $ticket)->with('success', 'Ticket forwarded to workflow.');
+    }
 }

--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -374,7 +374,19 @@
                                 <i class="bi bi-x-octagon-fill me-2"></i> Reject Ticket
                             </button>
                         </form>
-                        <button class="btn btn-outline-primary" disabled>Forward to P-Workflow (V2.4-S11)</button>
+                        {{-- Forward to P-Workflow Button --}}
+                        <form id="forward-form" action="{{ route('admin.tickets.forward', $ticket) }}" method="POST" class="d-grid">
+                            @csrf
+                            <button type="button" class="btn btn-outline-primary btn-submit-swal"
+                                    data-swal-title="ยืนยันการส่งต่องาน"
+                                    data-swal-text="คุณต้องการส่งต่องานนี้เข้าสู่ P-Workflow (สถานะ In Progress) ใช่หรือไม่?"
+                                    data-swal-icon="info"
+                                    data-swal-confirm-text="ใช่, ส่งต่อเลย"
+                                    {{ $isClosed ? 'disabled' : '' }}>
+                                <i class="bi bi-arrow-right-circle-fill me-2"></i>
+                                Forward to P-Workflow
+                            </button>
+                        </form>
                          <button class="btn btn-outline-secondary" disabled>Change Assignment (V2.4-S11)</button>
                     </div>
                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -106,6 +106,7 @@ Route::middleware(['auth', 'permission:manage-tickets'])->prefix('admin')->name(
     // (V2.4-S11) Ticket Status Actions
     Route::post('tickets/{ticket}/resolve', [TicketStatusController::class, 'resolve'])->name('tickets.resolve');
     Route::post('tickets/{ticket}/reject', [TicketStatusController::class, 'reject'])->name('tickets.reject');
+Route::post('tickets/{ticket}/forward', [TicketStatusController::class, 'forward'])->name('tickets.forward'); // <-- เพิ่มบรรทัดนี้
     // Future routes (update/assign) will go here.
 });
 


### PR DESCRIPTION
This commit introduces the functionality for the "Forward to P-Workflow" button on the admin ticket view.

- Adds a new POST route `admin/tickets/{ticket}/forward` to handle the action.
- Implements the `forward` method in `TicketStatusController` to:
  - Change the ticket status to `in_progress`.
  - Add a system activity message to the ticket's conversation history.
  - Redirect back to the ticket page with a success message.
- Replaces the disabled placeholder button in the `admin/tickets/show.blade.php` view with a functional form.
- The new button is integrated with the existing SweetAlert confirmation script (`btn-submit-swal`) to provide a user-friendly confirmation dialog before submitting the action.