### PR TITLE
feat: Implement Change Assignment modal and logic

### DIFF
--- a/app/Http/Controllers/Admin/TicketController.php
+++ b/app/Http/Controllers/Admin/TicketController.php
@@ -6,6 +6,10 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\JobTicket;
 use Illuminate\View\View;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class TicketController extends Controller
 {
@@ -50,6 +54,40 @@ class TicketController extends Controller
         ]);
 
         // The categorized_attachments accessor will handle the rest.
-        return view('admin.tickets.show', compact('ticket'));
+        $isClosed = in_array($ticket->status, ['resolved', 'rejected']);
+        // (S11.4) ดึงรายชื่อ Admin และ Staff ทั้งหมดสำหรับ Dropdown
+        $staffAndAdmins = User::role(['admin', 'staff'])->orderBy('name')->get(['id', 'name']);
+        return view('admin.tickets.show', compact('ticket', 'isClosed', 'staffAndAdmins'));
+    }
+
+    /**
+     * (S11.4) Update the assigned user for a specific ticket.
+     */
+    public function updateAssignment(Request $request, JobTicket $ticket)
+    {
+        if (!Auth::user()->can('manage-tickets')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        // 1. ตรวจสอบข้อมูล
+        $validated = $request->validate([
+            'assigned_to_user_id' => 'required|exists:users,id',
+        ]);
+
+        $newUser = User::findOrFail($validated['assigned_to_user_id']);
+
+        // 2. อัปเดตตั๋ว
+        $ticket->update([
+            'assigned_to_user_id' => $newUser->id,
+        ]);
+
+        // 3. บันทึก System Message
+        $ticket->messages()->create([
+            'user_id' => Auth::id(),
+            'message_type' => 'system_activity',
+            'body' => 'Assignment changed to ' . $newUser->name . ' by ' . Auth::user()->name,
+        ]);
+
+        return redirect()->route('admin.tickets.show', $ticket)->with('success', 'Ticket assignment updated successfully.');
     }
 }

--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -397,7 +397,10 @@
                                 Forward to P-Workflow
                             </button>
                         </form>
-                         <button class="btn btn-outline-secondary" disabled>Change Assignment (V2.4-S11)</button>
+                        {{-- Change Assignment Button --}}
+                        <button type="button" class="btn btn-outline-secondary d-grid" data-bs-toggle="modal" data-bs-target="#changeAssignmentModal" {{ $isClosed ? 'disabled' : '' }}>
+                            <i class="bi bi-person-fill-gear me-2"></i> Change Assignment
+                        </button>
                     </div>
                 @endif
             </div>
@@ -408,6 +411,39 @@
     @include('tickets.partials._existing_employee_modal')
     @include('tickets.partials._new_employee_modal')
 </div> {{-- END of x-data scope (BUG 1 FIX) --}}
+
+{{-- (S11.4) Change Assignment Modal --}}
+<div class="modal fade" id="changeAssignmentModal" tabindex="-1" aria-labelledby="changeAssignmentModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form action="{{ route('admin.tickets.updateAssignment', $ticket) }}" method="POST">
+                @csrf
+                <div class="modal-header">
+                    <h5 class="modal-title" id="changeAssignmentModalLabel">Change Ticket Assignment</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Current Assignee: <strong>{{ $ticket->assignedTo->name ?? 'Unassigned' }}</strong></p>
+                    <div class="mb-3">
+                        <label for="assigned_to_user_id" class="form-label">Assign to New Staff:</label>
+                        <select class="form-select" id="assigned_to_user_id" name="assigned_to_user_id" required>
+                            <option value="">-- Select Staff --</option>
+                            @foreach($staffAndAdmins as $user)
+                                <option value="{{ $user->id }}" {{ $ticket->assigned_to_user_id == $user->id ? 'selected' : '' }}>
+                                    {{ $user->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save Changes</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 
 @endsection
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -106,7 +106,8 @@ Route::middleware(['auth', 'permission:manage-tickets'])->prefix('admin')->name(
     // (V2.4-S11) Ticket Status Actions
     Route::post('tickets/{ticket}/resolve', [TicketStatusController::class, 'resolve'])->name('tickets.resolve');
     Route::post('tickets/{ticket}/reject', [TicketStatusController::class, 'reject'])->name('tickets.reject');
-Route::post('tickets/{ticket}/forward', [TicketStatusController::class, 'forward'])->name('tickets.forward'); // <-- เพิ่มบรรทัดนี้
+    Route::post('tickets/{ticket}/forward', [TicketStatusController::class, 'forward'])->name('tickets.forward');
+    Route::post('tickets/{ticket}/update-assignment', [AdminTicketController::class, 'updateAssignment'])->name('tickets.updateAssignment'); // <-- เพิ่มบรรทัดนี้
     // Future routes (update/assign) will go here.
 });
 


### PR DESCRIPTION
Adds the functionality for admins and staff to change the assigned user on a job ticket.

- Modifies `Admin\TicketController` to pass a list of staff and admin users to the `show` view.
- Adds the `updateAssignment` method to `Admin\TicketController` to handle the assignment update logic, including validation and system message creation.
- Registers a new POST route for the `updateAssignment` action.
- Updates the `admin.tickets.show` view to include a "Change Assignment" button that triggers a new modal.
- The new modal contains a form with a dropdown populated with the staff/admin list, allowing for the reassignment of the ticket.