### PR TITLE
feat(tickets): Enhance admin ticket creation page

### DIFF
--- a/app/Http/Controllers/Api/EmployerEmployeeController.php
+++ b/app/Http/Controllers/Api/EmployerEmployeeController.php
@@ -28,14 +28,21 @@ class EmployerEmployeeController extends Controller
         // V2.4-S13: API Scoping Logic for Admin/Staff
         if ($user->can('manage-tickets')) {
             $employerId = $request->input('employer_id');
-
+            $employerUserId = $request->input('employer_user_id'); // <-- ADDED
+            // V2.4-S14 FIX: If employer_user_id is provided (from admin create page), find its linked employer_id
+            if ($employerUserId && !$employerId) { // <-- MODIFIED
+                $employerUser = \App\Models\User::find($employerUserId);
+                if ($employerUser && $employerUser->employer) {
+                    $employerId = $employerUser->employer->id; // <-- Get the correct employer ID
+                }
+            } // <-- ADDED
             // Admin/Staff MUST provide an employer_id to get results.
             if ($employerId) {
                 // We remove the global tenancy scope to search across all employers,
                 // and then apply a specific filter for the requested employer.
                 $query->withoutGlobalScopes()->where('employer_id', $employerId);
             } else {
-                // If no employer_id is provided, return an empty list to prevent data leakage.
+                // If no employer_id is provided (or found), return an empty list.
                 return response()->json([]);
             }
         }

--- a/resources/views/components/hybrid-attachment-scripts.blade.php
+++ b/resources/views/components/hybrid-attachment-scripts.blade.php
@@ -197,9 +197,14 @@ function hybridAttachmentManager(config = {}) {
             // V2.4-S13: Dynamically build the API URL
             let apiUrl = new URL('{{ route('api-web.employer.employees.index') }}', document.baseURI);
             if (this.contextEmployerId) {
-                // If contextEmployerId is set (either in Admin Create or Admin/Employer Reply),
-                // send it to the backend API for scoping.
-                apiUrl.searchParams.append('employer_id', this.contextEmployerId);
+                // V2.4-S14 Fix: Check if we are in the Admin Create view
+                if (this.isContextAdminCreate) {
+                    // In this view, contextEmployerId is a employer_USER_id.
+                    apiUrl.searchParams.append('employer_user_id', this.contextEmployerId);
+                } else {
+                    // In all other views (reply/show), contextEmployerId is the correct employer_id.
+                    apiUrl.searchParams.append('employer_id', this.contextEmployerId);
+                }
             }
 
             try {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -137,8 +137,11 @@
                 {{-- V2.4: Admin/Staff Ticket Inbox --}}
                 {{-- Visible if the user has 'manage-tickets' permission. This takes precedence. --}}
                 @can('manage-tickets')
-                <a href="{{ route('admin.tickets.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('admin.tickets.*') ? 'active' : '' }}">
+                <a href="{{ route('admin.tickets.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('admin.tickets.index') ? 'active' : '' }}">
                 <i class="bi bi-inbox-fill me-2"></i>กล่องตั๋วงาน
+                </a>
+                <a href="{{ route('admin.tickets.create') }}" class="list-group-item list-group-item-action {{ request()->routeIs('admin.tickets.create') ? 'active' : '' }}" style="padding-left: 2.5rem;">
+                    <i class="bi bi-plus-circle me-2"></i>สร้างตั๋วใหม่ (Admin)
                 </a>
                 @else
                 {{-- V2.4: Employer Ticket Menu --}}


### PR DESCRIPTION
Implements V2.4-S14 brief.

- Adds a "Create New Ticket" button to the sidebar for users with 'manage-tickets' permission, providing a direct link to the admin ticket creation page.
- Modifies the active state check for the main "Job Tickets" link to only trigger on the index page.
- Updates the employee API to accept `employer_user_id` in addition to `employer_id`. This allows the frontend to find an employer's employees using the employer's user ID, which is necessary on the admin create ticket page where the employer is selected from a user list.
- Adjusts the frontend Alpine.js component to send the correct parameter (`employer_user_id` or `employer_id`) based on the view context.