### PR TITLE
feat: Implement Universal Preview Modal System

### DIFF
--- a/app/Http/Controllers/PreviewController.php
+++ b/app/Http/Controllers/PreviewController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Employee;
+use App\Models\Employer;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Exception;
+
+class PreviewController extends Controller
+{
+    /**
+     * Display the specified resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Request $request)
+    {
+        $type = $request->input('type');
+        $id = $request->input('id');
+
+        try {
+            switch ($type) {
+                case 'employee':
+                    $employee = Employee::with(['employer'])->withTrashed()->findOrFail($id);
+                    return view('previews._employee_data', ['employee' => $employee]);
+
+                case 'employer':
+                    $employer = Employer::withTrashed()->findOrFail($id);
+                    $stats = $this->getEmployeeStats($id);
+                    return view('previews._employer_data', ['employer' => $employer, 'stats' => $stats]);
+
+                default:
+                    return response()->json(['error' => 'Invalid preview type specified.'], 400);
+            }
+        } catch (ModelNotFoundException $e) {
+            return response()->json(['error' => 'The requested resource was not found.'], 404);
+        } catch (Exception $e) {
+            return response()->json(['error' => 'An unexpected error occurred.'], 500);
+        }
+    }
+
+    /**
+     * Get employee statistics for a given employer.
+     *
+     * @param  int  $employer_id
+     * @return object
+     */
+    private function getEmployeeStats($employer_id)
+    {
+        $employees = Employee::where('employer_id', $employer_id)->whereNull('terminated_at')->get();
+
+        $total = $employees->count();
+        $male = $employees->where('employeeTitleTh', 'นาย')->count();
+        $female = $employees->whereIn('employeeTitleTh', ['นางสาว', 'นาง'])->count();
+
+        $breakdown = $employees->groupBy('employeeNationality')->map(function ($group) {
+            return (object) [
+                'male_count' => $group->where('employeeTitleTh', 'นาย')->count(),
+                'female_count' => $group->whereIn('employeeTitleTh', ['นางสาว', 'นาง'])->count(),
+                'total_count' => $group->count(),
+            ];
+        });
+
+        return (object) [
+            'total' => $total,
+            'male' => $male,
+            'female' => $female,
+            'breakdown' => $breakdown,
+        ];
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,3 +8,60 @@ import Alpine from 'alpinejs';
 window.Alpine = Alpine;
 
 Alpine.start();
+
+document.addEventListener('DOMContentLoaded', function () {
+    const universalPreviewModalEl = document.getElementById('universalPreviewModal');
+    if (!universalPreviewModalEl) return;
+
+    const universalPreviewModal = new bootstrap.Modal(universalPreviewModalEl);
+    const modalBody = universalPreviewModalEl.querySelector('.modal-body');
+    const modalTitle = universalPreviewModalEl.querySelector('.modal-title');
+
+    const loadingSpinnerHtml = `
+        <div class="d-flex justify-content-center align-items-center" style="min-height: 200px;">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+        </div>`;
+
+    document.addEventListener('click', function (event) {
+        const previewButton = event.target.closest('.btn-preview');
+        if (!previewButton) return;
+
+        event.preventDefault();
+
+        const modelType = previewButton.dataset.modelType;
+        const modelId = previewButton.dataset.modelId;
+
+        if (!modelType || !modelId) {
+            console.error('Preview button is missing data-model-type or data-model-id');
+            return;
+        }
+
+        // 1. Reset modal and show spinner
+        modalTitle.textContent = 'พรีวิวข้อมูล';
+        modalBody.innerHTML = loadingSpinnerHtml;
+        universalPreviewModal.show();
+
+        // 2. Fetch data
+        fetch(`/preview?type=${modelType}&id=${modelId}`)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                return response.text();
+            })
+            .then(html => {
+                // 3. On Success: Inject the returned HTML
+                modalBody.innerHTML = html;
+            })
+            .catch(error => {
+                // 4. On Failure: Inject an error message
+                console.error('Error fetching preview data:', error);
+                modalBody.innerHTML = `
+                    <div class="alert alert-danger" role="alert">
+                        เกิดข้อผิดพลาดในการโหลดข้อมูล: ${error.message}
+                    </div>`;
+            });
+    });
+});

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -543,6 +543,25 @@
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     @stack('scripts')
 
+<!-- Universal Preview Modal -->
+<div class="modal fade" id="universalPreviewModal" tabindex="-1" aria-labelledby="universalPreviewModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="universalPreviewModalLabel">พรีวิวข้อมูล</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="d-flex justify-content-center align-items-center" style="min-height: 200px;">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script>
 // Full-Featured Address Management Script
 document.addEventListener('DOMContentLoaded', function () {

--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -1,0 +1,104 @@
+{{-- resources/views/previews/_employee_data.blade.php --}}
+
+<div class="container-fluid">
+    {{-- Personal Information --}}
+    <h5>ข้อมูลส่วนตัว</h5>
+    <hr>
+    <div class="row">
+        <div class="col-md-8">
+            <div class="row mb-2">
+                <div class="col-md-6">
+                    <strong class="form-label">ชื่อพนักงาน (ไทย):</strong>
+                    <p class="form-control-plaintext">{{ $employee->employeeTitleTh }} {{ $employee->employeeNameTh }}</p>
+                </div>
+                <div class="col-md-6">
+                    <strong class="form-label">ชื่อพนักงาน (อังกฤษ):</strong>
+                    <p class="form-control-plaintext">{{ $employee->employeeTitleEn }} {{ $employee->employeeNameEn }}</p>
+                </div>
+            </div>
+            <div class="row mb-2">
+                <div class="col-md-6">
+                    <strong class="form-label">สังกัดนายจ้าง:</strong>
+                    <p class="form-control-plaintext">{{ $employee->employer->employer_name ?? 'N/A' }}</p>
+                </div>
+                <div class="col-md-6">
+                    <strong class="form-label">วันเดือนปีเกิด:</strong>
+                    <p class="form-control-plaintext">{{ formatDate($employee->employeeDob) }}</p>
+                </div>
+            </div>
+            <div class="row mb-2">
+                <div class="col-md-6">
+                    <strong class="form-label">สัญชาติ:</strong>
+                    <p class="form-control-plaintext">{{ displayValue($employee->employeeNationality) }}</p>
+                </div>
+                <div class="col-md-6">
+                    <strong class="form-label">เลขหนังสือเดินทาง (Passport No.):</strong>
+                    <p class="form-control-plaintext">{{ displayValue($employee->employeePassport) }}
+                        @if($employee->passportType)
+                            <span class="badge bg-secondary">{{ $employee->passportType }}</span>
+                        @endif
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 text-center">
+            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/120x120/f8fafc/6c757d?text=Photo' }}"
+                 class="img-thumbnail" style="width: 120px; height: 120px; object-fit: cover;">
+        </div>
+    </div>
+
+    <hr class="my-4">
+    <h5>ข้อมูลการจ้างงานและเอกสารราชการ</h5>
+    <div class="row g-3">
+        <div class="col-md-4"><strong>เลขที่ Namelist:</strong><p class="form-control-plaintext">{{ displayValue($employee->namelistNo) }}</p></div>
+        <div class="col-md-4"><strong>เลขที่คำขอ:</strong><p class="form-control-plaintext">{{ displayValue($employee->requestNo) }}</p></div>
+        <div class="col-md-4"><strong>เลขอ้างอิงคนงาน:</strong><p class="form-control-plaintext">{{ displayValue($employee->workerRefNo) }}</p></div>
+        <div class="col-md-4"><strong>เลขประจำตัว:</strong><p class="form-control-plaintext">{{ displayValue($employee->personalId) }}</p></div>
+        <div class="col-md-4"><strong>รหัสคนงาน (บริษัท):</strong><p class="form-control-plaintext">{{ displayValue($employee->companyWorkerId) }}</p></div>
+        <div class="col-md-4"><strong>เลขบัตรชมพู:</strong><p class="form-control-plaintext">{{ displayValue($employee->pinkCardNo) }}</p></div>
+        <div class="col-md-4"><strong>เลขประกันสังคม:</strong><p class="form-control-plaintext">{{ displayValue($employee->socialSecurityNo) }}</p></div>
+        <div class="col-md-4"><strong>เลขประจำตัวผู้เสียภาษี:</strong><p class="form-control-plaintext">{{ displayValue($employee->taxIdNo) }}</p></div>
+        <div class="col-md-4"><strong>โรงพยาบาลตามสิทธิ:</strong><p class="form-control-plaintext">{{ displayValue($employee->designatedHospital) }}</p></div>
+        <div class="col-md-4"><strong>วันหมดอายุหนังสือเดินทาง:</strong><p class="form-control-plaintext">{{ formatDate($employee->passportExpiryDate) }}</p></div>
+        <div class="col-md-4"><strong>วันหมดอายุใบอนุญาตทำงาน:</strong><p class="form-control-plaintext">{{ formatDate($employee->workPermitExpiryDate) }}</p></div>
+        <div class="col-md-4"><strong>ประเภทใบอนุญาตทำงาน:</strong><p class="form-control-plaintext">{{ $employee->workPermitMOUGroup === 'อื่นๆ' ? displayValue($employee->workPermitMOUGroupOther) : displayValue($employee->workPermitMOUGroup) }}</p></div>
+        <div class="col-md-4"><strong>วันหมดอายุวีซ่า:</strong><p class="form-control-plaintext">{{ formatDate($employee->visaExpiryDate) }}</p></div>
+        <div class="col-md-4"><strong>ใบอนุญาตทำงาน (Work Permit No.):</strong><p class="form-control-plaintext">{{ displayValue($employee->employeeWorkPermit) }}</p></div>
+        <div class="col-md-4"><strong>วันหมดอายุรายงานตัว 90 วัน:</strong><p class="form-control-plaintext">{{ formatDate($employee->ninetyDayReportDate) }}</p></div>
+        <div class="col-md-4"><strong>วันเริ่มงาน:</strong><p class="form-control-plaintext">{{ formatDate($employee->startDate) }}</p></div>
+        <div class="col-md-4"><strong>เบอร์โทรศัพท์:</strong><p class="form-control-plaintext">{{ displayValue($employee->employeePhone) }}</p></div>
+        <div class="col-md-4"><strong>อีเมล:</strong><p class="form-control-plaintext">{{ displayValue($employee->email) }}</p></div>
+        <div class="col-md-4"><strong>ตำแหน่ง:</strong><p class="form-control-plaintext">{{ displayValue($employee->employeePosition) }}</p></div>
+        <div class="col-md-4"><strong>ลักษณะงาน:</strong><p class="form-control-plaintext">{{ displayValue($employee->nature_of_work) }}</p></div>
+    </div>
+
+    <hr class="my-4">
+    <h5>เอกสารแนบ</h5>
+    <div class="row g-3">
+        @php
+        $labels = [
+            1 => '1. passport/visa/workpermit', 2 => '2. บัตรชมพู', 3 => '3. สัญญาจ้างงาน',
+            4 => '4. บัตรประชาชนเมียนมา/ทะเบียนบ้าน', 5 => 'เอกสารอื่นๆ 1', 6 => 'เอกสารอื่นๆ 2',
+            7 => 'เอกสารอื่นๆ 3', 8 => 'เอกสารอื่นๆ 4',
+        ];
+        @endphp
+        @foreach ($labels as $i => $label)
+            @php
+                $doc_field = 'document_' . $i;
+                $document_path = $employee->{$doc_field};
+            @endphp
+            <div class="col-md-4">
+                <strong>{{ $label }}:</strong>
+                @if($document_path)
+                    <p class="form-control-plaintext">
+                        <a href="{{ asset('storage/' . $document_path) }}" target="_blank">
+                            <i class="bi bi-file-earmark-text"></i> ดูเอกสาร
+                        </a>
+                    </p>
+                @else
+                    <p class="form-control-plaintext text-muted">N/A</p>
+                @endif
+            </div>
+        @endforeach
+    </div>
+</div>

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -1,0 +1,114 @@
+{{-- resources/views/previews/_employer_data.blade.php --}}
+
+<div class="container-fluid">
+    {{-- Employer Information --}}
+    <h5>ข้อมูลนายจ้าง</h5>
+    <hr>
+    <div class="row mb-2">
+        <div class="col-md-6">
+            <strong>ชื่อนายจ้าง (ไทย):</strong>
+            <p class="form-control-plaintext">{{ displayValue($employer->employerNameTh) }}</p>
+        </div>
+        <div class="col-md-6">
+            <strong>ชื่อนายจ้าง (อังกฤษ):</strong>
+            <p class="form-control-plaintext">{{ displayValue($employer->employerNameEn) }}</p>
+        </div>
+    </div>
+    <div class="row mb-2">
+        <div class="col-md-6">
+            <strong>รหัสนายจ้าง:</strong>
+            <p class="form-control-plaintext">{{ displayValue($employer->employerId) }}</p>
+        </div>
+        <div class="col-md-6">
+            <strong>เลขประจำตัวนายจ้าง:</strong>
+            <p class="form-control-plaintext">{{ displayValue($employer->employerTaxId) }}</p>
+        </div>
+    </div>
+    <div class="row mb-2">
+        <div class="col-md-6">
+            <strong>ผู้มีอำนาจลงนาม (ไทย):</strong>
+            <p class="form-control-plaintext">{{ displayValue($employer->signerNameTh) }}</p>
+        </div>
+        <div class="col-md-6">
+            <strong>ผู้มีอำนาจลงนาม (อังกฤษ):</strong>
+            <p class="form-control-plaintext">{{ displayValue($employer->signerNameEn) }}</p>
+        </div>
+    </div>
+    <div class="row mb-2">
+        <div class="col-md-6">
+            <strong>ประเภทกิจการ:</strong>
+            <p class="form-control-plaintext">{{ displayValue($employer->businessType) }} / {{ displayValue($employer->businessTypeEn) }}</p>
+        </div>
+        <div class="col-md-3">
+            <strong>ทุนจดทะเบียน:</strong>
+            <p class="form-control-plaintext">{{ displayValue($employer->regCapital) }}</p>
+        </div>
+        <div class="col-md-3">
+            <strong>จดทะเบียนวันที่:</strong>
+            <p class="form-control-plaintext">{{ formatDate($employer->regDate) }}</p>
+        </div>
+    </div>
+
+    <hr>
+    <h5>เอกสารแนบของนายจ้าง</h5>
+    <div class="row mb-3">
+        @php
+            $documents = [
+                'document_company_registration' => 'หนังสือรับรองบริษัท',
+                'document_vat_registration' => 'ภ.พ.20',
+                'document_map' => 'แผนที่',
+            ];
+        @endphp
+        @foreach($documents as $field => $label)
+            <div class="col-md-4">
+                <strong>{{ $label }}:</strong>
+                @if($employer->{$field})
+                    <p class="form-control-plaintext">
+                        <a href="{{ asset('storage/' . $employer->{$field}) }}" target="_blank">
+                            <i class="bi bi-file-earmark-text"></i> ดูเอกสาร
+                        </a>
+                    </p>
+                @else
+                    <p class="form-control-plaintext text-muted">N/A</p>
+                @endif
+            </div>
+        @endforeach
+    </div>
+
+    {{-- New Employee Stats Summary Section --}}
+    <hr class="my-4">
+    <h5>สรุปข้อมูลลูกจ้าง (ที่ยังไม่สิ้นสุดสัญญา)</h5>
+    <div class="card">
+        <div class="card-body">
+            <div class="row text-center">
+                <div class="col-4">
+                    <h5 class="mb-0">{{ $stats->total }}</h5>
+                    <small class="text-muted">ทั้งหมด</small>
+                </div>
+                <div class="col-4">
+                    <h5 class="mb-0">{{ $stats->male }}</h5>
+                    <small class="text-muted">ชาย</small>
+                </div>
+                <div class="col-4">
+                    <h5 class="mb-0">{{ $stats->female }}</h5>
+                    <small class="text-muted">หญิง</small>
+                </div>
+            </div>
+
+            @if($stats->breakdown->isNotEmpty())
+                <hr>
+                <h6>แยกตามสัญชาติ:</h6>
+                <ul class="list-group list-group-flush">
+                    @foreach($stats->breakdown as $nationality => $data)
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            {{ $nationality }}
+                            <span class="badge bg-primary rounded-pill">
+                                รวม: {{ $data->total_count }} (ช: {{ $data->male_count }}, ญ: {{ $data->female_count }})
+                            </span>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\Api\TemporaryUploadController;
 use App\Http\Controllers\TicketReplyController;
 // Add this new import for V2.4-S11:
 use App\Http\Controllers\Admin\TicketStatusController;
+use App\Http\Controllers\PreviewController;
 
 Route::get('/thai-addresses', [AddressController::class, 'getThaiAddressData'])->name('addresses.thai_data');
 Route::get('/', function () {
@@ -32,6 +33,7 @@ Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 Route::middleware('auth')->group(function () {
+    Route::get('/preview', [PreviewController::class, 'show'])->name('global.preview');
     // Profile routes from Breeze
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
This commit introduces a new "Universal Preview Modal" feature.

It includes:
- A `PreviewController` to handle fetching data for different models.
- A new `/preview` route for the controller.
- Blade partials in `resources/views/previews` for `_employee_data` and `_employer_data`.
- The HTML structure for the modal in the main `app.blade.php` layout.
- A JavaScript handler in `app.js` to manage the modal's state and content via AJAX.

This system allows for a consistent and reusable way to display read-only previews of various models throughout the application.