### PR TITLE
feat: Add preview button to employee actions

### DIFF
--- a/resources/views/components/employee-action-buttons.blade.php
+++ b/resources/views/components/employee-action-buttons.blade.php
@@ -1,6 +1,11 @@
 @props(['employee', 'showLocateButton' => false])
 
 <div class="d-flex align-items-center justify-content-start">
+    {{-- Preview Button (Info Blue) --}}
+    <button type="button" class="btn btn-sm btn-outline-info btn-preview me-1" data-model-type="employee" data-model-id="{{ $employee->id }}" title="พรีวิวข้อมูล">
+        <i class="bi bi-search"></i>
+    </button>
+
     {{-- Create Job Button (Green) - Placeholder --}}
     <a href="#" class="btn btn-sm btn-outline-success me-1" title="Create Job (Coming Soon)">
         <i class="bi bi-briefcase-fill"></i>


### PR DESCRIPTION
Adds a new "Preview" button to the employee action buttons component.

This button is designed to trigger a universal preview modal, allowing users to view employee details without navigating to a new page. The button includes the necessary `data-model-type` and `data-model-id` attributes for the frontend JavaScript to correctly fetch and display the employee data.

By adding the button to the centralized `employee-action-buttons` Blade component, it now appears consistently in both the "card" and "table" views of the employee list.