### PR TITLE
Fix: Resolve Bootstrap ReferenceError in app.js

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,4 @@
+import { Modal } from 'bootstrap';
 import './bootstrap';
 import './employment-history.js';
 import './terminate-employee.js';
@@ -13,7 +14,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const universalPreviewModalEl = document.getElementById('universalPreviewModal');
     if (!universalPreviewModalEl) return;
 
-    const universalPreviewModal = new bootstrap.Modal(universalPreviewModalEl);
+    const modal = Modal.getOrCreateInstance(universalPreviewModalEl);
     const modalBody = universalPreviewModalEl.querySelector('.modal-body');
     const modalTitle = universalPreviewModalEl.querySelector('.modal-title');
 
@@ -41,7 +42,7 @@ document.addEventListener('DOMContentLoaded', function () {
         // 1. Reset modal and show spinner
         modalTitle.textContent = 'พรีวิวข้อมูล';
         modalBody.innerHTML = loadingSpinnerHtml;
-        universalPreviewModal.show();
+        modal.show();
 
         // 2. Fetch data
         fetch(`/preview?type=${modelType}&id=${modelId}`)


### PR DESCRIPTION
Corrected a `ReferenceError: bootstrap is not defined` in `resources/js/app.js`.

The error occurred because `new bootstrap.Modal()` was called without the Bootstrap library's Modal component being properly imported into the module's scope.

The fix involves:
1.  Importing the `Modal` component directly from the 'bootstrap' package at the top of the file.
2.  Replacing the direct instantiation with the static `Modal.getOrCreateInstance()` method to ensure the modal instance is handled correctly, preventing potential issues with multiple instantiations.