### PR TITLE
feat: Rebuild preview views from edit forms

### DIFF
--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -1,104 +1,125 @@
-{{-- resources/views/previews/_employee_data.blade.php --}}
-
-<div class="container-fluid">
+{{--
+    This view is intentionally simplified to display data.
+    It does not include @extends, @section, or any form elements.
+    It is loaded via AJAX into a modal.
+--}}
+<div class="content-section">
     {{-- Personal Information --}}
     <h5>ข้อมูลส่วนตัว</h5>
     <hr>
     <div class="row">
         <div class="col-md-8">
-            <div class="row mb-2">
+            {{-- Employer Name (as per blueprint) --}}
+            <div class="mb-3">
+                <label class="form-label fw-bold">สังกัดนายจ้าง:</label>
+                <p class="form-control-plaintext">{{ $employee->employer->employerNameTh ?? 'N/A' }}</p>
+            </div>
+            <div class="row mb-3">
                 <div class="col-md-6">
-                    <strong class="form-label">ชื่อพนักงาน (ไทย):</strong>
-                    <p class="form-control-plaintext">{{ $employee->employeeTitleTh }} {{ $employee->employeeNameTh }}</p>
+                    <label class="form-label fw-bold">ชื่อพนักงาน (ไทย)</label>
+                    <p class="form-control-plaintext">{{ $employee->full_name_th ?? 'N/A' }}</p>
                 </div>
                 <div class="col-md-6">
-                    <strong class="form-label">ชื่อพนักงาน (อังกฤษ):</strong>
-                    <p class="form-control-plaintext">{{ $employee->employeeTitleEn }} {{ $employee->employeeNameEn }}</p>
+                    <label class="form-label fw-bold">ชื่อพนักงาน (อังกฤษ)</label>
+                    <p class="form-control-plaintext">{{ $employee->full_name_en ?? 'N/A' }}</p>
                 </div>
             </div>
-            <div class="row mb-2">
+            <div class="row mb-3">
                 <div class="col-md-6">
-                    <strong class="form-label">สังกัดนายจ้าง:</strong>
-                    <p class="form-control-plaintext">{{ $employee->employer->employer_name ?? 'N/A' }}</p>
+                    <label class="form-label fw-bold">วันเดือนปีเกิด</label>
+                    <p class="form-control-plaintext">{{ $employee->employeeDob ? $employee->employeeDob->format('d/m/Y') : 'N/A' }}</p>
                 </div>
-                <div class="col-md-6">
-                    <strong class="form-label">วันเดือนปีเกิด:</strong>
-                    <p class="form-control-plaintext">{{ formatDate($employee->employeeDob) }}</p>
+                 <div class="col-md-6">
+                    <label class="form-label fw-bold">สัญชาติ</label>
+                    <p class="form-control-plaintext">{{ $employee->employeeNationality ?? 'N/A' }}</p>
                 </div>
             </div>
-            <div class="row mb-2">
+             <div class="row mb-3">
                 <div class="col-md-6">
-                    <strong class="form-label">สัญชาติ:</strong>
-                    <p class="form-control-plaintext">{{ displayValue($employee->employeeNationality) }}</p>
+                    <label class="form-label fw-bold">เลขหนังสือเดินทาง (Passport No.)</label>
+                    <p class="form-control-plaintext">{{ $employee->employeePassport ?? 'N/A' }}</p>
                 </div>
-                <div class="col-md-6">
-                    <strong class="form-label">เลขหนังสือเดินทาง (Passport No.):</strong>
-                    <p class="form-control-plaintext">{{ displayValue($employee->employeePassport) }}
-                        @if($employee->passportType)
-                            <span class="badge bg-secondary">{{ $employee->passportType }}</span>
-                        @endif
-                    </p>
+                 <div class="col-md-6">
+                    <label class="form-label fw-bold">ประเภทหนังสือเดินทาง</label>
+                    <p class="form-control-plaintext">{{ $employee->passportType ?? 'N/A' }}</p>
                 </div>
             </div>
         </div>
         <div class="col-md-4 text-center">
-            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/120x120/f8fafc/6c757d?text=Photo' }}"
-                 class="img-thumbnail" style="width: 120px; height: 120px; object-fit: cover;">
+            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/120x120/f8fafc/6c757d?text=Photo' }}" class="img-thumbnail mb-2" style="width: 120px; height: 120px; object-fit: cover;">
         </div>
     </div>
 
     <hr class="my-4">
     <h5>ข้อมูลการจ้างงานและเอกสารราชการ</h5>
     <div class="row g-3">
-        <div class="col-md-4"><strong>เลขที่ Namelist:</strong><p class="form-control-plaintext">{{ displayValue($employee->namelistNo) }}</p></div>
-        <div class="col-md-4"><strong>เลขที่คำขอ:</strong><p class="form-control-plaintext">{{ displayValue($employee->requestNo) }}</p></div>
-        <div class="col-md-4"><strong>เลขอ้างอิงคนงาน:</strong><p class="form-control-plaintext">{{ displayValue($employee->workerRefNo) }}</p></div>
-        <div class="col-md-4"><strong>เลขประจำตัว:</strong><p class="form-control-plaintext">{{ displayValue($employee->personalId) }}</p></div>
-        <div class="col-md-4"><strong>รหัสคนงาน (บริษัท):</strong><p class="form-control-plaintext">{{ displayValue($employee->companyWorkerId) }}</p></div>
-        <div class="col-md-4"><strong>เลขบัตรชมพู:</strong><p class="form-control-plaintext">{{ displayValue($employee->pinkCardNo) }}</p></div>
-        <div class="col-md-4"><strong>เลขประกันสังคม:</strong><p class="form-control-plaintext">{{ displayValue($employee->socialSecurityNo) }}</p></div>
-        <div class="col-md-4"><strong>เลขประจำตัวผู้เสียภาษี:</strong><p class="form-control-plaintext">{{ displayValue($employee->taxIdNo) }}</p></div>
-        <div class="col-md-4"><strong>โรงพยาบาลตามสิทธิ:</strong><p class="form-control-plaintext">{{ displayValue($employee->designatedHospital) }}</p></div>
-        <div class="col-md-4"><strong>วันหมดอายุหนังสือเดินทาง:</strong><p class="form-control-plaintext">{{ formatDate($employee->passportExpiryDate) }}</p></div>
-        <div class="col-md-4"><strong>วันหมดอายุใบอนุญาตทำงาน:</strong><p class="form-control-plaintext">{{ formatDate($employee->workPermitExpiryDate) }}</p></div>
-        <div class="col-md-4"><strong>ประเภทใบอนุญาตทำงาน:</strong><p class="form-control-plaintext">{{ $employee->workPermitMOUGroup === 'อื่นๆ' ? displayValue($employee->workPermitMOUGroupOther) : displayValue($employee->workPermitMOUGroup) }}</p></div>
-        <div class="col-md-4"><strong>วันหมดอายุวีซ่า:</strong><p class="form-control-plaintext">{{ formatDate($employee->visaExpiryDate) }}</p></div>
-        <div class="col-md-4"><strong>ใบอนุญาตทำงาน (Work Permit No.):</strong><p class="form-control-plaintext">{{ displayValue($employee->employeeWorkPermit) }}</p></div>
-        <div class="col-md-4"><strong>วันหมดอายุรายงานตัว 90 วัน:</strong><p class="form-control-plaintext">{{ formatDate($employee->ninetyDayReportDate) }}</p></div>
-        <div class="col-md-4"><strong>วันเริ่มงาน:</strong><p class="form-control-plaintext">{{ formatDate($employee->startDate) }}</p></div>
-        <div class="col-md-4"><strong>เบอร์โทรศัพท์:</strong><p class="form-control-plaintext">{{ displayValue($employee->employeePhone) }}</p></div>
-        <div class="col-md-4"><strong>อีเมล:</strong><p class="form-control-plaintext">{{ displayValue($employee->email) }}</p></div>
-        <div class="col-md-4"><strong>ตำแหน่ง:</strong><p class="form-control-plaintext">{{ displayValue($employee->employeePosition) }}</p></div>
-        <div class="col-md-4"><strong>ลักษณะงาน:</strong><p class="form-control-plaintext">{{ displayValue($employee->nature_of_work) }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">เลขที่ Namelist</label><p class="form-control-plaintext">{{ $employee->namelistNo ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">เลขที่คำขอ</label><p class="form-control-plaintext">{{ $employee->requestNo ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">เลขอ้างอิงคนงาน</label><p class="form-control-plaintext">{{ $employee->workerRefNo ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">เลขประจำตัว</label><p class="form-control-plaintext">{{ $employee->personalId ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">รหัสคนงาน (บริษัท)</label><p class="form-control-plaintext">{{ $employee->companyWorkerId ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">เลขบัตรชมพู</label><p class="form-control-plaintext">{{ $employee->pinkCardNo ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">เลขประกันสังคม</label><p class="form-control-plaintext">{{ $employee->socialSecurityNo ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">เลขประจำตัวผู้เสียภาษี</label><p class="form-control-plaintext">{{ $employee->taxIdNo ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">โรงพยาบาลตามสิทธิ</label><p class="form-control-plaintext">{{ $employee->designatedHospital ?? 'N/A' }}</p></div>
+
+        <div class="col-md-4"><label class="form-label fw-bold">วันหมดอายุหนังสือเดินทาง</label><p class="form-control-plaintext">{{ $employee->passportExpiryDate ? $employee->passportExpiryDate->format('d/m/Y') : 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">วันหมดอายุใบอนุญาตทำงาน</label><p class="form-control-plaintext">{{ $employee->workPermitExpiryDate ? $employee->workPermitExpiryDate->format('d/m/Y') : 'N/A' }}</p></div>
+        <div class="col-md-4">
+            <label class="form-label fw-bold">ประเภทใบอนุญาตทำงาน(กลุ่ม มติ.)</label>
+            <p class="form-control-plaintext">
+                {{ $employee->workPermitMOUGroup ?? 'N/A' }}
+                @if($employee->workPermitMOUGroup === 'อื่นๆ')
+                    ({{ $employee->workPermitMOUGroupOther ?? 'ไม่ระบุ' }})
+                @endif
+            </p>
+        </div>
+        <div class="col-md-4"><label class="form-label fw-bold">วันหมดอายุวีซ่า</label><p class="form-control-plaintext">{{ $employee->visaExpiryDate ? $employee->visaExpiryDate->format('d/m/Y') : 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">ใบอนุญาตทำงาน (Work Permit No.)</label><p class="form-control-plaintext">{{ $employee->employeeWorkPermit ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">วันหมดอายุรายงานตัว 90 วัน</label><p class="form-control-plaintext">{{ $employee->ninetyDayReportDate ? $employee->ninetyDayReportDate->format('d/m/Y') : 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">วันเริ่มงาน</label><p class="form-control-plaintext">{{ $employee->startDate ? $employee->startDate->format('d/m/Y') : 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">เบอร์โทรศัพท์</label><p class="form-control-plaintext">{{ $employee->employeePhone ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">อีเมล</label><p class="form-control-plaintext">{{ $employee->email ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">รหัสผ่าน / หมายเหตุ</label><p class="form-control-plaintext">{{ $employee->password ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">ตำแหน่ง</label><p class="form-control-plaintext">{{ $employee->employeePosition ?? 'N/A' }}</p></div>
+        <div class="col-md-4"><label class="form-label fw-bold">ลักษณะงาน (Nature of Work)</label><p class="form-control-plaintext">{{ $employee->nature_of_work ?? 'N/A' }}</p></div>
     </div>
 
-    <hr class="my-4">
-    <h5>เอกสารแนบ</h5>
-    <div class="row g-3">
+<hr class="my-4">
+<h5>เอกสารแนบ</h5>
+<div class="row g-3">
+    @for ($i = 1; $i <= 8; $i++)
         @php
-        $labels = [
-            1 => '1. passport/visa/workpermit', 2 => '2. บัตรชมพู', 3 => '3. สัญญาจ้างงาน',
-            4 => '4. บัตรประชาชนเมียนมา/ทะเบียนบ้าน', 5 => 'เอกสารอื่นๆ 1', 6 => 'เอกสารอื่นๆ 2',
-            7 => 'เอกสารอื่นๆ 3', 8 => 'เอกสารอื่นๆ 4',
-        ];
+            $doc_field = 'document_' . $i;
+            $desc_field = 'document_description_' . $i;
+            $labels = [
+                1 => '1. passport/visa/workpermit',
+                2 => '2. บัตรชมพู',
+                3 => '3. สัญญาจ้างงาน',
+                4 => '4. บัตรประชาชนเมียนมา/ทะเบียนบ้าน',
+                5 => 'เอกสารอื่นๆ 1',
+                6 => 'เอกสารอื่นๆ 2',
+                7 => 'เอกสารอื่นๆ 3',
+                8 => 'เอกสารอื่นๆ 4',
+            ];
+            $has_description_field = in_array($i, [3, 4, 5, 6, 7, 8]);
         @endphp
-        @foreach ($labels as $i => $label)
-            @php
-                $doc_field = 'document_' . $i;
-                $document_path = $employee->{$doc_field};
-            @endphp
-            <div class="col-md-4">
-                <strong>{{ $label }}:</strong>
-                @if($document_path)
-                    <p class="form-control-plaintext">
-                        <a href="{{ asset('storage/' . $document_path) }}" target="_blank">
-                            <i class="bi bi-file-earmark-text"></i> ดูเอกสาร
-                        </a>
-                    </p>
-                @else
-                    <p class="form-control-plaintext text-muted">N/A</p>
-                @endif
-            </div>
-        @endforeach
-    </div>
+        <div class="col-md-4">
+            <label class="form-label fw-bold">{{ $labels[$i] }}</label>
+            @if($employee->{$doc_field})
+                {{-- Blueprint: Render as a link --}}
+                <p class="form-control-plaintext">
+                    <a href="{{ Storage::url($employee->{$doc_field}) }}" target="_blank">
+                        <i class="bi bi-file-earmark-text"></i> ดูเอกสาร
+                    </a>
+                    @if($has_description_field && $employee->{$desc_field})
+                        <span class="text-muted"> ({{ $employee->{$desc_field} }})</span>
+                    @endif
+                </p>
+            @else
+                <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
+            @endif
+        </div>
+    @endfor
+</div>
 </div>

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -1,114 +1,190 @@
-{{-- resources/views/previews/_employer_data.blade.php --}}
+{{--
+    This view is intentionally simplified to display data.
+    It does not include @extends, @section, or any form elements.
+    It is loaded via AJAX into a modal.
+--}}
 
-<div class="container-fluid">
-    {{-- Employer Information --}}
+<div class="content-section">
     <h5>ข้อมูลนายจ้าง</h5>
     <hr>
-    <div class="row mb-2">
+    <div class="row mb-3">
         <div class="col-md-6">
-            <strong>ชื่อนายจ้าง (ไทย):</strong>
-            <p class="form-control-plaintext">{{ displayValue($employer->employerNameTh) }}</p>
+            <label class="form-label fw-bold">ชื่อนายจ้าง (ไทย)</label>
+            <p class="form-control-plaintext">{{ $employer->employerNameTh ?? 'N/A' }}</p>
         </div>
         <div class="col-md-6">
-            <strong>ชื่อนายจ้าง (อังกฤษ):</strong>
-            <p class="form-control-plaintext">{{ displayValue($employer->employerNameEn) }}</p>
+            <label class="form-label fw-bold">ชื่อนายจ้าง (อังกฤษ)</label>
+            <p class="form-control-plaintext">{{ $employer->employerNameEn ?? 'N/A' }}</p>
         </div>
     </div>
-    <div class="row mb-2">
+    <div class="row mb-3">
         <div class="col-md-6">
-            <strong>รหัสนายจ้าง:</strong>
-            <p class="form-control-plaintext">{{ displayValue($employer->employerId) }}</p>
+            <label class="form-label fw-bold">รหัสนายจ้าง</label>
+            <p class="form-control-plaintext">{{ $employer->employerId ?? 'N/A' }}</p>
         </div>
         <div class="col-md-6">
-            <strong>เลขประจำตัวนายจ้าง:</strong>
-            <p class="form-control-plaintext">{{ displayValue($employer->employerTaxId) }}</p>
+            <label class="form-label fw-bold">เจ้าของงาน</label>
+            {{-- Handle Relationship --}}
+            <p class="form-control-plaintext">{{ $employer->jobOwner?->name ?? 'N/A' }}</p>
         </div>
     </div>
-    <div class="row mb-2">
+    <div class="row mb-3">
         <div class="col-md-6">
-            <strong>ผู้มีอำนาจลงนาม (ไทย):</strong>
-            <p class="form-control-plaintext">{{ displayValue($employer->signerNameTh) }}</p>
-        </div>
-        <div class="col-md-6">
-            <strong>ผู้มีอำนาจลงนาม (อังกฤษ):</strong>
-            <p class="form-control-plaintext">{{ displayValue($employer->signerNameEn) }}</p>
+            <label class="form-label fw-bold">เลขประจำตัวนายจ้าง</label>
+            <p class="form-control-plaintext">{{ $employer->employerTaxId ?? 'N/A' }}</p>
         </div>
     </div>
-    <div class="row mb-2">
+    <div class="row mb-3">
         <div class="col-md-6">
-            <strong>ประเภทกิจการ:</strong>
-            <p class="form-control-plaintext">{{ displayValue($employer->businessType) }} / {{ displayValue($employer->businessTypeEn) }}</p>
+            <label class="form-label fw-bold">ผู้มีอำนาจลงนาม (ไทย)</label>
+            <p class="form-control-plaintext">{{ $employer->signerNameTh ?? 'N/A' }}</p>
         </div>
-        <div class="col-md-3">
-            <strong>ทุนจดทะเบียน:</strong>
-            <p class="form-control-plaintext">{{ displayValue($employer->regCapital) }}</p>
+        <div class="col-md-6">
+            <label class="form-label fw-bold">ผู้มีอำนาจลงนาม (อังกฤษ)</label>
+            <p class="form-control-plaintext">{{ $employer->signerNameEn ?? 'N/A' }}</p>
         </div>
-        <div class="col-md-3">
-            <strong>จดทะเบียนวันที่:</strong>
-            <p class="form-control-plaintext">{{ formatDate($employer->regDate) }}</p>
+    </div>
+    <div class="row mb-3">
+        <div class="col-md-6">
+            <label class="form-label fw-bold">ประเภทกิจการ</label>
+            <p class="form-control-plaintext">{{ $employer->businessType ?? 'N/A' }}</p>
+        </div>
+        <div class="col-md-6">
+            <label class="form-label fw-bold">Type of Business</label>
+            <p class="form-control-plaintext">{{ $employer->businessTypeEn ?? 'N/A' }}</p>
+        </div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-md-6">
+            <label class="form-label fw-bold">ทุนจดทะเบียน</label>
+            <p class="form-control-plaintext">{{ $employer->regCapital ?? 'N/A' }}</p>
+        </div>
+        <div class="col-md-6">
+            <label class="form-label fw-bold">จดทะเบียนวันที่</label>
+            <p class="form-control-plaintext">{{ $employer->regDate ? $employer->regDate->format('d/m/Y') : 'N/A' }}</p>
         </div>
     </div>
 
     <hr>
     <h5>เอกสารแนบของนายจ้าง</h5>
-    <div class="row mb-3">
-        @php
-            $documents = [
-                'document_company_registration' => 'หนังสือรับรองบริษัท',
-                'document_vat_registration' => 'ภ.พ.20',
-                'document_map' => 'แผนที่',
-            ];
-        @endphp
-        @foreach($documents as $field => $label)
-            <div class="col-md-4">
-                <strong>{{ $label }}:</strong>
-                @if($employer->{$field})
-                    <p class="form-control-plaintext">
-                        <a href="{{ asset('storage/' . $employer->{$field}) }}" target="_blank">
-                            <i class="bi bi-file-earmark-text"></i> ดูเอกสาร
-                        </a>
-                    </p>
-                @else
-                    <p class="form-control-plaintext text-muted">N/A</p>
-                @endif
-            </div>
-        @endforeach
-    </div>
-
-    {{-- New Employee Stats Summary Section --}}
-    <hr class="my-4">
-    <h5>สรุปข้อมูลลูกจ้าง (ที่ยังไม่สิ้นสุดสัญญา)</h5>
-    <div class="card">
-        <div class="card-body">
-            <div class="row text-center">
-                <div class="col-4">
-                    <h5 class="mb-0">{{ $stats->total }}</h5>
-                    <small class="text-muted">ทั้งหมด</small>
-                </div>
-                <div class="col-4">
-                    <h5 class="mb-0">{{ $stats->male }}</h5>
-                    <small class="text-muted">ชาย</small>
-                </div>
-                <div class="col-4">
-                    <h5 class="mb-0">{{ $stats->female }}</h5>
-                    <small class="text-muted">หญิง</small>
-                </div>
-            </div>
-
-            @if($stats->breakdown->isNotEmpty())
-                <hr>
-                <h6>แยกตามสัญชาติ:</h6>
-                <ul class="list-group list-group-flush">
-                    @foreach($stats->breakdown as $nationality => $data)
-                        <li class="list-group-item d-flex justify-content-between align-items-center">
-                            {{ $nationality }}
-                            <span class="badge bg-primary rounded-pill">
-                                รวม: {{ $data->total_count }} (ช: {{ $data->male_count }}, ญ: {{ $data->female_count }})
-                            </span>
-                        </li>
-                    @endforeach
-                </ul>
+    <div class="row">
+        <div class="col-md-4">
+            <label class="form-label fw-bold">หนังสือรับรองบริษัท</label>
+            @if($employer->document_company_registration)
+                <p class="form-control-plaintext">
+                    <a href="{{ Storage::url($employer->document_company_registration) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูเอกสาร</a>
+                </p>
+            @else
+                <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
             @endif
         </div>
+        <div class="col-md-4">
+            <label class="form-label fw-bold">ภ.พ.20</label>
+             @if($employer->document_vat_registration)
+                <p class="form-control-plaintext">
+                    <a href="{{ Storage::url($employer->document_vat_registration) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูเอกสาร</a>
+                </p>
+            @else
+                <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
+            @endif
+        </div>
+        <div class="col-md-4">
+            <label class="form-label fw-bold">แผนที่</label>
+            @if($employer->document_map)
+                <p class="form-control-plaintext">
+                    <a href="{{ Storage::url($employer->document_map) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูเอกสาร</a>
+                </p>
+            @else
+                <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
+            @endif
+        </div>
+    </div>
+</div>
+
+{{-- Registered Address Section --}}
+<div class="content-section mt-4">
+    <h5 class="mb-3">ที่อยู่ตามทะเบียน</h5>
+    <div class="vstack gap-3">
+        @forelse ($employer->addresses->where('type', 'registered') as $address)
+            <div class="address-card">
+                <p class="mb-0">
+                    เลขที่ {{ $address->addrNo ?? '' }} หมู่ {{ $address->addrMoo ?? '' }} ซอย{{ $address->addrSoi ?? '' }} ถนน{{ $address->addrRoad ?? '' }}
+                    แขวง/ตำบล {{ $address->addrSubDistrict ?? '' }} เขต/อำเภอ {{ $address->addrDistrict ?? '' }}
+                    {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
+                </p>
+                <p class="mb-0 text-muted small">
+                    Addr: {{ $address->addrNoEn ?? '' }}, Moo: {{ $address->addrMooEn ?? '' }}, Soi: {{ $address->addrSoiEn ?? '' }}, Road: {{ $address->addrRoadEn ?? '' }},
+                    {{ $address->addrSubDistrictEn ?? '' }}, {{ $address->addrDistrictEn ?? '' }},
+                    {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
+                </p>
+            </div>
+        @empty
+            <p class="text-muted">ยังไม่มีที่อยู่</p>
+        @endforelse
+    </div>
+</div>
+
+{{-- Workplace Address Section --}}
+<div class="content-section mt-4">
+    <h5 class="mb-3">ที่อยู่สถานที่ทำงาน</h5>
+    <div class="vstack gap-3">
+        @forelse ($employer->addresses->where('type', 'workplace') as $address)
+             <div class="address-card">
+                <p class="mb-0">
+                    เลขที่ {{ $address->addrNo ?? '' }} หมู่ {{ $address->addrMoo ?? '' }} ซอย{{ $address->addrSoi ?? '' }} ถนน{{ $address->addrRoad ?? '' }}
+                    แขวง/ตำบล {{ $address->addrSubDistrict ?? '' }} เขต/อำเภอ {{ $address->addrDistrict ?? '' }}
+                    {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
+                </p>
+                <p class="mb-0 text-muted small">
+                    Addr: {{ $address->addrNoEn ?? '' }}, Moo: {{ $address->addrMooEn ?? '' }}, Soi: {{ $address->addrSoiEn ?? '' }}, Road: {{ $address->addrRoadEn ?? '' }},
+                    {{ $address->addrSubDistrictEn ?? '' }}, {{ $address->addrDistrictEn ?? '' }},
+                    {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
+                </p>
+            </div>
+        @empty
+            <p class="text-muted">ยังไม่มีที่อยู่</p>
+        @endforelse
+    </div>
+</div>
+
+{{-- Blueprint: Add Stats Summary --}}
+<hr class="my-4">
+<div class="content-section">
+    <h5 class="mb-3">สรุปข้อมูลลูกจ้าง</h5>
+    <div class="row">
+        <div class="col-md-3">
+            <div class="stat-card p-3 border rounded bg-light">
+                <h6 class="text-muted">ลูกจ้างทั้งหมด</h6>
+                <p class="fs-4 fw-bold mb-0">{{ $stats->total_employees ?? 0 }}</p>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card p-3 border rounded bg-light">
+                <h6 class="text-muted">เพศชาย</h6>
+                <p class="fs-4 fw-bold mb-0">{{ $stats->male_employees ?? 0 }}</p>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card p-3 border rounded bg-light">
+                <h6 class="text-muted">เพศหญิง</h6>
+                <p class="fs-4 fw-bold mb-0">{{ $stats->female_employees ?? 0 }}</p>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card p-3 border rounded bg-light">
+                <h6 class="text-muted">มีบัตรชมพู</h6>
+                <p class="fs-4 fw-bold mb-0">{{ $stats->with_pink_card ?? 0 }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="mt-3">
+        <h6>สัญชาติ:</h6>
+        <ul class="list-unstyled">
+            @forelse($stats->by_nationality ?? [] as $nat)
+                 <li>{{ $nat->employeeNationality }}: {{ $nat->total }} คน</li>
+            @empty
+                <li>ไม่พบข้อมูล</li>
+            @endforelse
+        </ul>
     </div>
 </div>


### PR DESCRIPTION
Rebuilds the employee and employer preview partials using the corresponding `edit.blade.php` files as a template.

- Overwrites `_employee_data.blade.php` with the employee edit form and converts all fields to a read-only format using `form-control-plaintext`. Displays relationship names and adds the employer's name.
- Overwrites `_employer_data.blade.php` with the employer edit form and converts all fields to a read-only format. Removes the employee list and adds the employee statistics summary as per the blueprint.
- Corrects a fatal error by using the nullsafe operator (`?->`) for the `jobOwner` relationship to prevent errors on null relations.
- Corrects the data access for the `$stats` variable to use object notation (`$stats->...`).

Note: The `PreviewController` must be updated to provide the `$stats` object in the format expected by the new blueprint for the employer preview to render correctly.