### PR TITLE
Fix: Correct variable names in preview modals

### DIFF
--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -17,11 +17,11 @@
             <div class="row mb-3">
                 <div class="col-md-6">
                     <label class="form-label fw-bold">ชื่อพนักงาน (ไทย)</label>
-                    <p class="form-control-plaintext">{{ $employee->full_name_th ?? 'N/A' }}</p>
+                    <p class="form-control-plaintext">{{ trim(($employee->employeeTitleTh ?? '') . ' ' . ($employee->employeeNameTh ?? '')) ?: 'N/A' }}</p>
                 </div>
                 <div class="col-md-6">
                     <label class="form-label fw-bold">ชื่อพนักงาน (อังกฤษ)</label>
-                    <p class="form-control-plaintext">{{ $employee->full_name_en ?? 'N/A' }}</p>
+                    <p class="form-control-plaintext">{{ trim(($employee->employeeTitleEn ?? '') . ' ' . ($employee->employeeNameEn ?? '')) ?: 'N/A' }}</p>
                 </div>
             </div>
             <div class="row mb-3">


### PR DESCRIPTION
Corrects a data mismatch in the employee preview modal by replacing non-existent `full_name_th` and `full_name_en` variables with the correct database column names: `employeeTitleTh`, `employeeNameTh`, `employeeTitleEn`, and `employeeNameEn`.

Verified that the employer preview modal already used the correct variable names.