### PR TITLE
Fix: Adjust Employer Stats to Include All Employees

### DIFF
--- a/app/Http/Controllers/PreviewController.php
+++ b/app/Http/Controllers/PreviewController.php
@@ -50,7 +50,7 @@ class PreviewController extends Controller
      */
     private function getEmployeeStats($employer_id)
     {
-        $employees = Employee::where('employer_id', $employer_id)->whereNull('terminated_at')->get();
+        $employees = Employee::where('employer_id', $employer_id)->get();
 
         $total = $employees->count();
         $male = $employees->where('employeeTitleTh', 'นาย')->count();


### PR DESCRIPTION
Corrects the logic in the `getEmployeeStats` function in `PreviewController.php`.

The previous implementation only counted active employees (`whereNull('terminated_at')`), which resulted in an incorrect summary. The fix removes this condition to ensure the statistics include all employees associated with an employer, regardless of their termination status, as per the requirement.