### PR TITLE
Fix: Correct stats and date handling in employer preview

### DIFF
--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -1,3 +1,4 @@
+@use \Carbon\Carbon;
 {{--
     This view is intentionally simplified to display data.
     It does not include @extends, @section, or any form elements.
@@ -61,7 +62,7 @@
         </div>
         <div class="col-md-6">
             <label class="form-label fw-bold">จดทะเบียนวันที่</label>
-            <p class="form-control-plaintext">{{ $employer->regDate?->format('d/m/Y') ?? 'N/A' }}</p>
+            {{-- This handles the 'regDate' as a STRING (because it's not casted in the Model) It checks if the string is not empty, then parses it, then formats it. --}} <p class="form-control-plaintext">{{ $employer->regDate ? Carbon::parse($employer->regDate)->format('d/m/Y') : 'N/A' }}</p>
         </div>
     </div>
 
@@ -155,19 +156,19 @@
         <div class="col-md-3">
             <div class="stat-card p-3 border rounded bg-light">
                 <h6 class="text-muted">ลูกจ้างทั้งหมด</h6>
-                <p class="fs-4 fw-bold mb-0">{{ $stats->total_employees ?? 0 }}</p>
+                <p class="fs-4 fw-bold mb-0">{{ $stats->total ?? 0 }}</p>
             </div>
         </div>
         <div class="col-md-3">
             <div class="stat-card p-3 border rounded bg-light">
                 <h6 class="text-muted">เพศชาย</h6>
-                <p class="fs-4 fw-bold mb-0">{{ $stats->male_employees ?? 0 }}</p>
+                <p class="fs-4 fw-bold mb-0">{{ $stats->male ?? 0 }}</p>
             </div>
         </div>
         <div class="col-md-3">
             <div class="stat-card p-3 border rounded bg-light">
                 <h6 class="text-muted">เพศหญิง</h6>
-                <p class="fs-4 fw-bold mb-0">{{ $stats->female_employees ?? 0 }}</p>
+                <p class="fs-4 fw-bold mb-0">{{ $stats->female ?? 0 }}</p>
             </div>
         </div>
         <div class="col-md-3">


### PR DESCRIPTION
This commit addresses two bugs in the employer preview modal:

1.  **Stats Mismatch:** The Blade view `_employer_data.blade.php` used incorrect variable names to display employee statistics (`$stats->total_employees`, `$stats->male_employees`, `$stats->female_employees`). These have been corrected to match the controller's output (`$stats->total`, `$stats->male`, `$stats->female`).

2.  **Date String Crash:** The `regDate` attribute on the `Employer` model is a string, not a casted date object. The view attempted to call the `format()` method directly on this string, causing a fatal error. The code has been updated to use `Carbon::parse()` to safely parse the date string before formatting it, preventing the crash. A `@use \Carbon\Carbon;` directive was also added to the view.