### PR TITLE
Fix: Cast regDate in Employer model and update view

### DIFF
--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -43,6 +43,17 @@ class Employer extends Model
         'user_id',
     ];
 
+    /**
+     * The attributes that should be cast.
+     * (Fix for Task 013, as per Commander's analysis)
+     *
+     * @var array
+     */
+    protected $casts = [
+        'regDate' => 'date:Y-m-d', // Add other date fields here if they exist, e.g.
+        // 'another_date_field' => 'date:Y-m-d',
+    ];
+
     public function employees()
     {
         return $this->hasMany(Employee::class);

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -62,7 +62,7 @@
         </div>
         <div class="col-md-6">
             <label class="form-label fw-bold">จดทะเบียนวันที่</label>
-            {{-- This handles the 'regDate' as a STRING (because it's not casted in the Model) It checks if the string is not empty, then parses it, then formats it. --}} <p class="form-control-plaintext">{{ $employer->regDate ? Carbon::parse($employer->regDate)->format('d/m/Y') : 'N/A' }}</p>
+            {{-- This will now work correctly because regDate is cast in the Model --}} <p class="form-control-plaintext">{{ $employer->regDate?->format('d/m/Y') ?? 'N/A' }}</p>
         </div>
     </div>
 


### PR DESCRIPTION
Casts the `regDate` attribute to a Carbon date object in the `Employer` model to prevent potential crashes when handling null or invalid date formats.

Updates the `_employer_data.blade.php` preview to use the nullsafe operator, ensuring that the date is formatted safely and gracefully handles null values.

This resolves the date-related crash and improves the robustness of the employer data preview. The statistics display was already correct and required no changes.