### PR TITLE
Fix: Critical bug fixes for Employer preview and Admin tickets

### DIFF
--- a/app/Http/Controllers/PreviewController.php
+++ b/app/Http/Controllers/PreviewController.php
@@ -50,7 +50,7 @@ class PreviewController extends Controller
      */
     private function getEmployeeStats($employer_id)
     {
-        $employees = Employee::where('employer_id', $employer_id)->get();
+        $employees = Employee::where('employer_id', $employer_id)->whereNull('terminated_at')->get();
 
         $total = $employees->count();
         $male = $employees->where('employeeTitleTh', 'นาย')->count();

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -43,6 +43,15 @@ class Employer extends Model
         'user_id',
     ];
 
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'regDate' => 'date:Y-m-d',
+    ];
+
     public function employees()
     {
         return $this->hasMany(Employee::class);


### PR DESCRIPTION
- Fixes a `regDate` formatting error in the Employer preview by adding a `date` cast to the `Employer` model.
- Corrects the employee statistics calculation in the `PreviewController` to exclude terminated employees.
- Confirmed that the reported typo in `StoreAdminJobTicketRequest` was already correct, so no change was needed.