### PR TITLE
Fix(Notifications): Correct table headers to fix column-shift bug

### DIFF
--- a/resources/views/notifications/_work_permit_mou_table.blade.php
+++ b/resources/views/notifications/_work_permit_mou_table.blade.php
@@ -7,27 +7,49 @@
     <table class="table table-hover table-sm">
         {{-- Section 1: For Renewal --}}
         <thead class="table-light">
-            <tr><th colspan="6">ขอต่อ ({{ $forRenewal->count() }} รายการ)</th></tr>
-            <tr><th>#</th><th>ชื่อลูกจ้าง</th><th>นายจ้าง</th><th>วันที่ครบกำหนด</th><th>สถานะ</th><th class="text-center">จัดการ</th></tr>
+            <tr><th colspan="10">ขอต่อ ({{ $forRenewal->count() }} รายการ)</th></tr>
+            <tr>
+                <th style="width: 1%;"><input class="form-check-input" type="checkbox" id="select-all-checkbox-notifications-mou1"></th>
+                <th style="width: 1%;">#</th>
+                <th>ชื่อลูกจ้าง</th>
+                <th>นายจ้าง</th>
+                <th>ประเภท</th>
+                <th>สัญชาติ</th>
+                <th>วันที่ครบกำหนด</th>
+                <th>สถานะ</th>
+                <th>วันคงเหลือ</th>
+                <th class="text-center">จัดการ</th>
+            </tr>
         </thead>
         <tbody>
             @forelse($forRenewal as $notification)
                 @include('notifications._notification_table_row', ['notification' => $notification, 'itemNumber' => $loop->iteration])
             @empty
-                <tr><td colspan="6" class="text-center text-muted">ไม่มีรายการที่ต้องดำเนินการ</td></tr>
+                <tr><td colspan="10" class="text-center text-muted">ไม่มีรายการที่ต้องดำเนินการ</td></tr>
             @endforelse
         </tbody>
 
         {{-- Section 2: For New Application --}}
         <thead class="table-light mt-4">
-            <tr><th colspan="6">ขอรับใหม่ ({{ $forNewApplication->count() }} รายการ)</th></tr>
-             <tr><th>#</th><th>ชื่อลูกจ้าง</th><th>นายจ้าง</th><th>วันที่ครบกำหนด</th><th>สถานะ</th><th class="text-center">จัดการ</th></tr>
+            <tr><th colspan="10">ขอรับใหม่ ({{ $forNewApplication->count() }} รายการ)</th></tr>
+             <tr>
+                <th style="width: 1%;"><input class="form-check-input" type="checkbox" id="select-all-checkbox-notifications-mou2"></th>
+                <th style="width: 1%;">#</th>
+                <th>ชื่อลูกจ้าง</th>
+                <th>นายจ้าง</th>
+                <th>ประเภท</th>
+                <th>สัญชาติ</th>
+                <th>วันที่ครบกำหนด</th>
+                <th>สถานะ</th>
+                <th>วันคงเหลือ</th>
+                <th class="text-center">จัดการ</th>
+            </tr>
         </thead>
         <tbody>
             @forelse($forNewApplication as $notification)
                 @include('notifications._notification_table_row', ['notification' => $notification, 'itemNumber' => $loop->iteration])
             @empty
-                <tr><td colspan="6" class="text-center text-muted">ไม่มีรายการที่หมดอายุ</td></tr>
+                <tr><td colspan="10" class="text-center text-muted">ไม่มีรายการที่หมดอายุ</td></tr>
             @endforelse
         </tbody>
     </table>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -100,11 +100,15 @@
                             <table class="table table-hover table-sm">
                                 <thead>
                                     <tr>
-                                        <th>#</th>
+                                        <th style="width: 1%;"><input class="form-check-input" type="checkbox" id="select-all-checkbox-notifications-std"></th>
+                                        <th style="width: 1%;">#</th>
                                         <th>ชื่อลูกจ้าง</th>
                                         <th>นายจ้าง</th>
+                                        <th>ประเภท</th>
+                                        <th>สัญชาติ</th>
                                         <th>วันที่ครบกำหนด</th>
                                         <th>สถานะ</th>
+                                        <th>วันคงเหลือ</th>
                                         <th class="text-center">จัดการ</th>
                                     </tr>
                                 </thead>
@@ -115,7 +119,7 @@
                                         @endphp
                                         @include('notifications._notification_table_row', ['notification' => $notification, 'itemNumber' => $itemNumber])
                                     @empty
-                                        <tr><td colspan="6" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
+                                        <tr><td colspan="10" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
                                     @endforelse
                                 </tbody>
                             </table>


### PR DESCRIPTION
Fixes the "Column-Shift Bug" by updating the table headers in the notification views. The incorrect 6-column headers in 'resources/views/notifications/index.blade.php' and 'resources/views/notifications/_work_permit_mou_table.blade.php' have been replaced with the correct 10-column headers. The 'colspan' attributes in the tables have also been updated to match the new column count.