### PR TITLE
feat: Add insurance_document_path to employees table

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -107,6 +107,7 @@ class Employee extends Model
         'other_doc_2_desc',
         'other_doc_3_desc',
         'other_doc_4_desc',
+        'insurance_document_path',
     ];
 
     /**

--- a/database/migrations/2025_11_16_121800_add_insurance_document_to_employees_table.php
+++ b/database/migrations/2025_11_16_121800_add_insurance_document_to_employees_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->string('insurance_document_path')->nullable()->after('social_security_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('insurance_document_path');
+        });
+    }
+};


### PR DESCRIPTION
Adds the `insurance_document_path` column to the `employees` table to store the path to the insurance document.

- Creates a new migration to add the nullable string column.
- Updates the `Employee` model to include the new column in the `$fillable` array.

**Important:** Please run `php artisan migrate` on your local machine to apply the database changes.