### PR TITLE
Fix: Improve employee photo alignment and remove checkbox

### DIFF
--- a/resources/views/employees/create.blade.php
+++ b/resources/views/employees/create.blade.php
@@ -108,10 +108,10 @@
                 </div>
             </div>
             {{-- Right Column --}}
-            <div class="col-md-4 text-center">
+            <div class="col-md-4 d-flex flex-column justify-content-center align-items-center">
                 <label for="employeePhoto" class="form-label">รูปภาพพนักงาน</label>
-                <img id="employeePhotoPreview" src="https://placehold.co/150x180/f8fafc/6c757d?text=Photo" class="img-thumbnail mb-2" style="max-width: 150px; height: 180px; object-fit: cover;">
-                <input type="file" class="form-control form-control-sm" id="employeePhoto" name="employeePhoto" accept="image/*" capture="environment">
+                <img id="employeePhotoPreview" src="https://placehold.co/150x180/f8fafc/6c757d?text=Photo" class="img-thumbnail mb-2" style="width: 150px; height: 180px; object-fit: cover;">
+                <input type="file" class="form-control form-control-sm w-75" id="employeePhoto" name="employeePhoto" accept="image/*" capture="environment">
             </div>
         </div>
 

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -87,16 +87,10 @@
                 </div>
             </div>
             {{-- Right Column --}}
-            <div class="col-md-4 text-center">
+            <div class="col-md-4 d-flex flex-column justify-content-center align-items-center">
                 <label for="employeePhoto" class="form-label">รูปภาพพนักงาน</label>
-                <img id="employeePhotoPreview" src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/150x180/f8fafc/6c757d?text=Photo' }}" class="img-thumbnail mb-2" style="max-width: 150px; height: 180px; object-fit: cover;">
-                <input type="file" class="form-control form-control-sm" id="employeePhoto" name="employeePhoto" accept="image/*" capture="environment">
-                @if($employee->employeePhoto)
-                    <div class="form-check mt-1 text-start">
-                        <input class="form-check-input" type="checkbox" name="remove_employeePhoto" id="remove_employeePhoto" value="1">
-                        <label class="form-check-label small text-danger" for="remove_employeePhoto">ลบรูปภาพนี้</label>
-                    </div>
-                @endif
+                <img id="employeePhotoPreview" src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/150x180/f8fafc/6c757d?text=Photo' }}" class="img-thumbnail mb-2" style="width: 150px; height: 180px; object-fit: cover;">
+                <input type="file" class="form-control form-control-sm w-75" id="employeePhoto" name="employeePhoto" accept="image/*" capture="environment">
             </div>
         </div>
 


### PR DESCRIPTION
Applied Bootstrap 5 flexbox utilities to vertically and horizontally center the employee photo section in `employees/create.blade.php` and `employees/edit.blade.php` for better visual alignment with adjacent form fields.

Removed the "Remove this image" checkbox from the `employees/edit.blade.php` view as it was deemed unnecessary and cluttered the user interface.