### PR TITLE
feat: Add job_title and job_description to employees

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -108,6 +108,8 @@ class Employee extends Model
         'other_doc_3_desc',
         'other_doc_4_desc',
         'insurance_document_path',
+        'job_title',
+        'job_description',
     ];
 
     /**

--- a/database/migrations/2025_11_16_135700_add_job_fields_to_employees_table.php
+++ b/database/migrations/2025_11_16_135700_add_job_fields_to_employees_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->string('job_title')->nullable()->after('startDate');
+            $table->text('job_description')->nullable()->after('job_title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn(['job_title', 'job_description']);
+        });
+    }
+};


### PR DESCRIPTION
Adds the `job_title` and `job_description` columns to the `employees` table through a new migration.

Also, updates the `Employee` model to include these new fields in the `$fillable` array.