### PR TITLE
Fix(employee): Correct data and file saving on edit form

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -316,17 +316,61 @@ public function create(Request $request) // เพิ่ม Request $request เ
             'employee_doc_10' => 'nullable|file|mimes:pdf,jpg,jpeg,png',
             'employee_doc_11' => 'nullable|file|mimes:pdf,jpg,jpeg,png',
             'employee_doc_12' => 'nullable|file|mimes:pdf,jpg,jpeg,png',
+            'passport_file' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:2048',
+            'visa_file' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:2048',
+            'work_permit_file' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:2048',
+            'pink_card_file' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:2048',
+            'insurance_attachment' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:2048',
         ]);
 
         // --- V6: Step 2: Handle email and password mapping & hashing ---
-        $validated['email'] = $validated['employeeEmail'] ?? null;
-        unset($validated['employeeEmail']);
+        $data = $validated;
+        $data['email'] = $validated['employeeEmail'] ?? null;
+        unset($data['employeeEmail']);
 
-        if (!empty($validated['employeePassword'])) {
-            $validated['password'] = Hash::make($validated['employeePassword']);
+        if (!empty($request->input('employeePassword'))) {
+            $data['password'] = Hash::make($request->input('employeePassword'));
         } else {
-            unset($validated['employeePassword']);
+            unset($data['password']);
         }
+        unset($data['employeePassword']);
+
+        if ($request->hasFile('passport_file')) {
+            if ($employee->passport_file_path) {
+                Storage::disk('private')->delete($employee->passport_file_path);
+            }
+            $path = $request->file('passport_file')->store('employee_documents', 'private');
+            $data['passport_file_path'] = $path;
+        }
+        if ($request->hasFile('visa_file')) {
+            if ($employee->visa_file_path) {
+                Storage::disk('private')->delete($employee->visa_file_path);
+            }
+            $path = $request->file('visa_file')->store('employee_documents', 'private');
+            $data['visa_file_path'] = $path;
+        }
+        if ($request->hasFile('work_permit_file')) {
+            if ($employee->work_permit_file_path) {
+                Storage::disk('private')->delete($employee->work_permit_file_path);
+            }
+            $path = $request->file('work_permit_file')->store('employee_documents', 'private');
+            $data['work_permit_file_path'] = $path;
+        }
+        if ($request->hasFile('pink_card_file')) {
+            if ($employee->pink_card_file_path) {
+                Storage::disk('private')->delete($employee->pink_card_file_path);
+            }
+            $path = $request->file('pink_card_file')->store('employee_documents', 'private');
+            $data['pink_card_file_path'] = $path;
+        }
+        if ($request->hasFile('insurance_attachment')) {
+            if ($employee->insurance_attachment_path) {
+                Storage::disk('private')->delete($employee->insurance_attachment_path);
+            }
+            $path = $request->file('insurance_attachment')->store('employee_documents', 'private');
+            $data['insurance_attachment_path'] = $path;
+        }
+        $validated = $data;
 
         // --- V-6: Step 3: Define ALL 18 File Fields ---
         $fileFields = [

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -110,6 +110,14 @@ class Employee extends Model
         'insurance_document_path',
         'job_title',
         'job_description',
+        'visa_type',
+        'insurance_company',
+        'hospital_name',
+        'passport_file_path',
+        'visa_file_path',
+        'work_permit_file_path',
+        'pink_card_file_path',
+        'insurance_attachment_path',
     ];
 
     /**

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -249,7 +249,6 @@
                     <label for="insurance_document_path_social" class="form-label">แนบไฟล์เอกสารประกัน</label>
                      @if($employee->insurance_document_path && $employee->insurance_type == 'ประกันสังคม') <div class="small mb-1"><a href="{{ asset('storage/' . $employee->insurance_document_path) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูไฟล์ปัจจุบัน</a></div> @endif
                     <input type="file" class="form-control form-control-sm" name="insurance_document_path_social">
-                     @if($employee->insurance_document_path && $employee->insurance_type == 'ประกันสังคม') <div class="form-check mt-1"><input class="form-check-input" type="checkbox" value="1" name="remove_insurance_document_path"><label class="form-check-label small text-danger">ลบไฟล์นี้</label></div> @endif
                 </div>
              </div>
         </div>
@@ -268,7 +267,6 @@
                     <label for="insurance_document_path_hospital" class="form-label">แนบไฟล์เอกสารประกัน</label>
                      @if($employee->insurance_document_path && $employee->insurance_type == 'ประกันโรงพยาบาล') <div class="small mb-1"><a href="{{ asset('storage/' . $employee->insurance_document_path) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูไฟล์ปัจจุบัน</a></div> @endif
                     <input type="file" class="form-control form-control-sm" name="insurance_document_path_hospital">
-                     @if($employee->insurance_document_path && $employee->insurance_type == 'ประกันโรงพยาบาล') <div class="form-check mt-1"><input class="form-check-input" type="checkbox" value="1" name="remove_insurance_document_path"><label class="form-check-label small text-danger">ลบไฟล์นี้</label></div> @endif
                 </div>
             </div>
         </div>
@@ -287,7 +285,6 @@
                     <label for="insurance_document_path_private" class="form-label">แนบไฟล์เอกสารประกัน</label>
                     @if($employee->insurance_document_path && $employee->insurance_type == 'ประกันเอกชน') <div class="small mb-1"><a href="{{ asset('storage/' . $employee->insurance_document_path) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูไฟล์ปัจจุบัน</a></div> @endif
                     <input type="file" class="form-control form-control-sm" name="insurance_document_path_private">
-                    @if($employee->insurance_document_path && $employee->insurance_type == 'ประกันเอกชน') <div class="form-check mt-1"><input class="form-check-input" type="checkbox" value="1" name="remove_insurance_document_path"><label class="form-check-label small text-danger">ลบไฟล์นี้</label></div> @endif
                 </div>
             </div>
         </div>
@@ -334,12 +331,6 @@
                     <input type="file" class="form-control form-control-sm" id="{{ $docField }}" name="{{ $docField }}">
                      @if(in_array($i, $descSlots))
                         <input type="text" class="form-control form-control-sm mt-2" name="{{ $descField }}" placeholder="คำอธิบาย..." value="{{ old($descField, $employee->{$descField}) }}">
-                    @endif
-                    @if($employee->{$docField})
-                        <div class="form-check mt-1">
-                            <input class="form-check-input" type="checkbox" value="1" name="remove_{{ $docField }}" id="remove_{{ $docField }}">
-                            <label class="form-check-label small text-danger" for="remove_{{ $docField }}">ลบไฟล์นี้</label>
-                        </div>
                     @endif
                 </div>
             @endforeach


### PR DESCRIPTION
This commit addresses several bugs on the employee edit page:

- Updates the `Employee` model's `$fillable` array to include all missing fields, allowing them to be mass-assigned.
- Adds file handling logic to the `EmployeeController@update` method for passport, visa, work permit, pink card, and insurance documents. The logic now correctly stores new files and deletes old ones.
- Ensures passwords are only hashed and updated when a new value is provided.
- Removes all non-functional "Delete file" checkboxes from the `employees/edit.blade.php` view to improve user experience.