### PR TITLE
feat: Store employee passwords as plain text

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -215,10 +215,10 @@ public function create(Request $request) // เพิ่ม Request $request เ
         $validated['email'] = $validated['employeeEmail'] ?? null;
         unset($validated['employeeEmail']);
 
-        // if (!empty($validated['employeePassword'])) {
-        //     $validated['password'] = Hash::make($validated['employeePassword']);
-        // }
-        // unset($validated['employeePassword']);
+        if (!empty($validated['employeePassword'])) {
+            $validated['password'] = $validated['employeePassword']; // Save as plain text per user request
+        }
+        unset($validated['employeePassword']);
 
         // --- V6: Step 3: Unified File Upload Loop ---
         $fileFields = [
@@ -307,7 +307,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
             'insurance_detail_private' => 'nullable|string|max:255',
             'insurance_detail_social' => 'nullable|string|max:255',
             'employeeEmail' => 'nullable|email|max:255|unique:employees,email,' . $employee->id,
-            'employeePassword' => 'nullable|string|min:8',
+            'password' => 'nullable|string|min:8',
             'other_doc_1_desc' => 'nullable|string|max:255',
             'other_doc_2_desc' => 'nullable|string|max:255',
             'other_doc_3_desc' => 'nullable|string|max:255',
@@ -374,17 +374,13 @@ public function create(Request $request) // เพิ่ม Request $request เ
             $data['insurance_attachment_path'] = $path;
         }
 
-        // if (!empty($data['password'])) {
-        //     $data['password'] = Hash::make($data['password']);
-        // } else {
-        //     unset($data['password']);
-        // }
-        $validated = $data;
-        if(empty($validated['employeePassword'])) {
-            unset($validated['employeePassword']);
-        } else {
-            $validated['employeePassword'];
+        // If 'password' field is filled, it's already in $data from validation.
+        // If it's empty, we should not update the password.
+        if (empty($data['password'])) {
+            unset($data['password']); // Prevent updating with an empty value
         }
+
+        $validated = $data;
         // --- V-6: Step 3: Define ALL 18 File Fields ---
         $fileFields = [
             'employeePhoto', 'insurance_document_path','insurance_document_path_private',

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -300,8 +300,10 @@
                 <input type="email" class="form-control" id="employeeEmail" name="employeeEmail" value="{{ old('employeeEmail', $employee->email) }}">
             </div>
             <div class="col-md-6 mb-3">
-                <label for="employeePassword" class="form-label">รหัสผ่าน (กรอกเพื่อเปลี่ยน)</label>
-                <input type="text" class="form-control" id="employeePassword" name="employeePassword" value="{{ old('employeePassword', $employee->password) }}">
+                <label for="password" class="form-label">รหัสผ่าน (Password) </label>
+                <input type="text" class="form-control" id="password" name="password"
+                       value="{{ $employee->password }}" placeholder="กรอกรหัสผ่าน">
+                {{-- Note: type="text" creates a plain text box as requested --}}
             </div>
         </div>
 


### PR DESCRIPTION
Removes password hashing for the Employee model to store passwords in plain text as per user requirements.

- The `EmployeeController`'s `store` and `update` methods now save the password directly without hashing.
- The `employees.edit` view has been updated to show the current plain-text password in a text input field.
- Controller logic has been adjusted to handle the different input names for the password field between the create and edit forms.