### PR TITLE
feat: Enhance employee preview modal with comprehensive data

### DIFF
--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -1,184 +1,188 @@
-<div class="content-section">
- {{-- 1. Personal Information --}}
- <h5 class="text-primary"><i class="bi bi-person-badge"></i> ข้อมูลส่วนตัว</h5>
- <hr>
- <div class="row g-3 mb-4">
- <div class="col-md-3">
- <label class="fw-bold text-muted">ชื่อ-นามสกุล (ไทย)</label>
- <p>{{ $employee->english_prefix ?? '' }} {{ $employee->employeeNameTh ?? '-' }}</p>
+<div class="container-fluid">
+ {{-- Header: Photo & Name --}}
+ <div class="row mb-4 align-items-center">
+ <div class="col-md-3 text-center">
+ <div class="mb-2">
+ @if($employee->employeePhoto && Storage::disk('public')->exists($employee->employeePhoto))
+ <img src="{{ Storage::url($employee->employeePhoto) }}" alt="Profile" class="img-thumbnail rounded-circle" style="width: 150px; height: 150px; object-fit: cover;">
+ @else
+ <div class="bg-secondary text-white rounded-circle d-flex align-items-center justify-content-center mx-auto" style="width: 150px; height: 150px; font-size: 3rem;">
+ {{ mb_substr($employee->employeeNameTh ?? 'U', 0, 1) }}
  </div>
- <div class="col-md-3">
- <label class="fw-bold text-muted">Name (English)</label>
- <p>{{ $employee->employeeNameEn ?? '-' }}</p>
+ @endif
  </div>
- <div class="col-md-3">
- <label class="fw-bold text-muted">ชื่อเล่น</label>
- <p>{{ $employee->employeeNickname ?? '-' }}</p>
- </div>
- <div class="col-md-3">
- <label class="fw-bold text-muted">สัญชาติ</label>
- <p>{{ $employee->employeeNationality ?? '-' }}</p>
- </div>
- <div class="col-md-3">
- <label class="fw-bold text-muted">เบอร์โทรศัพท์</label>
- <p>{{ $employee->employeePhone ?? '-' }}</p>
- </div>
- <div class="col-md-3">
- <label class="fw-bold text-muted">Email (Login)</label>
- <p>{{ $employee->email ?? '-' }}</p>
- </div>
- <div class="col-md-3">
- <label class="fw-bold text-muted">Password</label>
- <p class="text-danger">{{ $employee->password ?? '-' }}</p>
- </div>
- <div class="col-md-3">
- <label class="fw-bold text-muted">สถานะ</label>
+ <h5 class="fw-bold text-primary mb-0">{{ $employee->english_prefix ?? '' }} {{ $employee->employeeNameTh ?? '-' }}</h5>
+ <small class="text-muted">{{ $employee->employeeNameEn ?? '-' }}</small>
+ <div class="mt-2">
  <span class="badge bg-{{ $employee->status == 1 ? 'success' : 'secondary' }}">
  {{ $employee->status == 1 ? 'Active' : 'Inactive' }}
  </span>
  </div>
  </div>
- {{-- 2. Documents & Files --}}
- <h5 class="text-success"><i class="bi bi-folder2-open"></i> เอกสารและไฟล์แนบ</h5>
- <hr>
- {{-- Passport --}}
- <div class="card mb-3 border-light bg-light">
- <div class="card-body">
- <h6 class="card-title fw-bold text-dark">1. ข้อมูลพาสปอร์ต (Passport)</h6>
- <div class="row">
- <div class="col-md-3"><small class="text-muted">เลขที่:</small> {{ $employee->employeePassport ?? '-' }}</div>
- <div class="col-md-3"><small class="text-muted">วันออก:</small> {{ $employee->passport_issue_date ? \Carbon\Carbon::parse($employee->passport_issue_date)->format('d/m/Y') : '-' }}</div>
- <div class="col-md-3"><small class="text-muted">วันหมดอายุ:</small> {{ $employee->passportExpiryDate ? \Carbon\Carbon::parse($employee->passportExpiryDate)->format('d/m/Y') : '-' }}</div>
- <div class="col-md-3">
- @if($employee->passport_file)
- <a href="{{ Storage::url($employee->passport_file) }}" target="_blank" class="btn btn-sm btn-outline-primary"><i class="bi bi-eye"></i> ดูไฟล์</a>
- @else
- <span class="text-muted">-</span>
- @endif
- </div>
- </div>
- </div>
- </div>
- {{-- Visa --}}
- <div class="card mb-3 border-light bg-light">
- <div class="card-body">
- <h6 class="card-title fw-bold text-dark">2. ข้อมูลวีซ่า (Visa)</h6>
- <div class="row">
- <div class="col-md-3"><small class="text-muted">ประเภท:</small> {{ $employee->visa_type ?? '-' }}</div>
- <div class="col-md-3"><small class="text-muted">วันหมดอายุ:</small> {{ $employee->visaExpiryDate ? \Carbon\Carbon::parse($employee->visaExpiryDate)->format('d/m/Y') : '-' }}</div>
- <div class="col-md-6 text-end">
- @if($employee->visa_file)
- <a href="{{ Storage::url($employee->visa_file) }}" target="_blank" class="btn btn-sm btn-outline-primary"><i class="bi bi-eye"></i> ดูไฟล์</a>
- @else
- <span class="text-muted">-</span>
- @endif
- </div>
- </div>
- </div>
- </div>
- {{-- Work Permit --}}
- <div class="card mb-3 border-light bg-light">
- <div class="card-body">
- <h6 class="card-title fw-bold text-dark">3. ใบอนุญาตทำงาน (Work Permit)</h6>
- <div class="row">
- <div class="col-md-3"><small class="text-muted">เลขที่:</small> {{ $employee->employeeWorkPermit ?? '-' }}</div>
- <div class="col-md-3"><small class="text-muted">วันหมดอายุ:</small> {{ $employee->workPermitExpiryDate ? \Carbon\Carbon::parse($employee->workPermitExpiryDate)->format('d/m/Y') : '-' }}</div>
- <div class="col-md-6 text-end">
- @if($employee->work_permit_file)
- <a href="{{ Storage::url($employee->work_permit_file) }}" target="_blank" class="btn btn-sm btn-outline-primary"><i class="bi bi-eye"></i> ดูไฟล์</a>
- @else
- <span class="text-muted">-</span>
- @endif
- </div>
- </div>
- </div>
- </div>
- {{-- Pink Card & 90 Day --}}
- <div class="row mb-3">
- <div class="col-md-6">
- <div class="card border-light bg-light h-100">
- <div class="card-body">
- <h6 class="card-title fw-bold">4. บัตรชมพู</h6>
- <p class="mb-1">เลขที่: {{ $employee->pinkCardNo ?? '-' }}</p>
- @if($employee->pink_card_file)
- <a href="{{ Storage::url($employee->pink_card_file) }}" target="_blank" class="btn btn-sm btn-outline-primary"><i class="bi bi-eye"></i> ดูไฟล์</a>
- @endif
- </div>
- </div>
- </div>
- <div class="col-md-6">
- <div class="card border-light bg-light h-100">
- <div class="card-body">
- <h6 class="card-title fw-bold">รายงานตัว 90 วัน</h6>
- <p class="mb-0">วันครบกำหนด: {{ $employee->ninetyDayReportDate ? \Carbon\Carbon::parse($employee->ninetyDayReportDate)->format('d/m/Y') : '-' }}</p>
- </div>
- </div>
- </div>
- </div>
- {{-- Insurance --}}
- <h5 class="text-info mt-4"><i class="bi bi-shield-check"></i> ข้อมูลประกัน</h5>
- <hr>
+ <div class="col-md-9">
  <div class="row g-3">
  <div class="col-md-4">
- <label class="fw-bold text-muted">ประเภทประกัน</label>
- <p>{{ $employee->insurance_type ?? '-' }}</p>
- </div>
- @if($employee->insurance_type == 'ประกันสังคม')
- <div class="col-md-4">
- <label class="fw-bold text-muted">โรงพยาบาล</label>
- <p>{{ $employee->hospital_name ?? '-' }}</p>
+ <label class="fw-bold text-muted small">ชื่อเล่น</label>
+ <div class="border-bottom pb-1">{{ $employee->employeeNickname ?? '-' }}</div>
  </div>
  <div class="col-md-4">
- <label class="fw-bold text-muted">ไฟล์ประกันสังคม</label>
- @if($employee->social_security_file)
- <br><a href="{{ Storage::url($employee->social_security_file) }}" target="_blank" class="btn btn-sm btn-outline-info">ดูไฟล์</a>
- @else
- <p>-</p>
- @endif
- </div>
- @elseif($employee->insurance_type == 'ประกันโรงพยาบาล' || $employee->insurance_type == 'ประกันเอกชน')
- <div class="col-md-4">
- <label class="fw-bold text-muted">บริษัท/รพ.</label>
- <p>{{ $employee->insurance_company ?? $employee->hospital_name ?? '-' }}</p>
+ <label class="fw-bold text-muted small">เพศ</label>
+ <div class="border-bottom pb-1">{{ $employee->employeeGender ?? '-' }}</div>
  </div>
  <div class="col-md-4">
- <label class="fw-bold text-muted">วันหมดอายุ</label>
- <p>{{ $employee->insurance_expiry_date ? \Carbon\Carbon::parse($employee->insurance_expiry_date)->format('d/m/Y') : '-' }}</p>
+ <label class="fw-bold text-muted small">สัญชาติ</label>
+ <div class="border-bottom pb-1">{{ $employee->employeeNationality ?? '-' }}</div>
+ </div>
+ <div class="col-md-4">
+ <label class="fw-bold text-muted small">วันเกิด (อายุ)</label>
+ <div class="border-bottom pb-1">
+ {{ $employee->employeeDob ? \Carbon\Carbon::parse($employee->employeeDob)->format('d/m/Y') : '-' }} ({{ $employee->employeeAge ?? 0 }} ปี)
+ </div>
+ </div>
+ <div class="col-md-4">
+ <label class="fw-bold text-muted small">เบอร์โทรศัพท์</label>
+ <div class="border-bottom pb-1">{{ $employee->employeePhone ?? '-' }}</div>
  </div>
  <div class="col-md-12">
- <label class="fw-bold text-muted">ไฟล์กรมธรรม์</label>
+ <div class="alert alert-light border mt-2 mb-0 p-2">
+ <div class="row">
+ <div class="col-md-6">
+ <strong><i class="bi bi-envelope"></i> Email:</strong> {{ $employee->email ?? '-' }}
+ </div>
+ <div class="col-md-6">
+ <strong><i class="bi bi-key"></i> Password:</strong> <span class="text-danger">{{ $employee->password ?? '-' }}</span>
+ </div>
+ </div>
+ </div>
+ </div>
+ </div>
+ </div>
+ </div>
+
+ <hr>
+
+ {{-- Section 2: Work & Documents --}}
+ <h6 class="text-secondary fw-bold"><i class="bi bi-briefcase"></i> ข้อมูลงานและเอกสารประจำตัว</h6>
+ <div class="row g-3 mb-4">
+ <div class="col-md-6">
+ <div class="card h-100 border-light bg-light">
+ <div class="card-body p-3">
+ <strong>ตำแหน่งงาน:</strong> {{ $employee->job_position ?? '-' }}<br>
+ <strong>ลักษณะงาน:</strong> {{ $employee->job_description ?? '-' }}
+ </div>
+ </div>
+ </div>
+
+ {{-- Passport --}}
+ <div class="col-md-6">
+ <div class="card h-100">
+ <div class="card-header py-1 small fw-bold bg-white">1. พาสปอร์ต (Passport)</div>
+ <div class="card-body p-2 small">
+ <div class="d-flex justify-content-between"><span>เลขที่:</span> <strong>{{ $employee->employeePassport ?? '-' }}</strong></div>
+ <div class="d-flex justify-content-between"><span>วันออก:</span> <span>{{ $employee->passport_issue_date ? \Carbon\Carbon::parse($employee->passport_issue_date)->format('d/m/Y') : '-' }}</span></div>
+ <div class="d-flex justify-content-between"><span>หมดอายุ:</span> <span class="text-danger">{{ $employee->passportExpiryDate ? \Carbon\Carbon::parse($employee->passportExpiryDate)->format('d/m/Y') : '-' }}</span></div>
+ @if($employee->passport_file)
+ <a href="{{ Storage::url($employee->passport_file) }}" target="_blank" class="btn btn-sm btn-outline-primary w-100 mt-2"><i class="bi bi-eye"></i> ดูไฟล์แนบ</a>
+ @endif
+ </div>
+ </div>
+ </div>
+
+ {{-- Visa --}}
+ <div class="col-md-4">
+ <div class="card h-100">
+ <div class="card-header py-1 small fw-bold bg-white">2. วีซ่า (Visa)</div>
+ <div class="card-body p-2 small">
+ <div>ประเภท: <strong>{{ $employee->visa_type ?? '-' }}</strong></div>
+ <div>หมดอายุ: {{ $employee->visaExpiryDate ? \Carbon\Carbon::parse($employee->visaExpiryDate)->format('d/m/Y') : '-' }}</div>
+ @if($employee->visa_file)
+ <a href="{{ Storage::url($employee->visa_file) }}" target="_blank" class="btn btn-sm btn-outline-primary w-100 mt-2"><i class="bi bi-eye"></i> ดูไฟล์</a>
+ @endif
+ </div>
+ </div>
+ </div>
+
+ {{-- Work Permit --}}
+ <div class="col-md-4">
+ <div class="card h-100">
+ <div class="card-header py-1 small fw-bold bg-white">3. ใบอนุญาตทำงาน (Work Permit)</div>
+ <div class="card-body p-2 small">
+ <div>เลขที่: <strong>{{ $employee->employeeWorkPermit ?? '-' }}</strong></div>
+ <div>หมดอายุ: {{ $employee->workPermitExpiryDate ? \Carbon\Carbon::parse($employee->workPermitExpiryDate)->format('d/m/Y') : '-' }}</div>
+ @if($employee->work_permit_file)
+ <a href="{{ Storage::url($employee->work_permit_file) }}" target="_blank" class="btn btn-sm btn-outline-primary w-100 mt-2"><i class="bi bi-eye"></i> ดูไฟล์</a>
+ @endif
+ </div>
+ </div>
+ </div>
+
+ {{-- Pink Card --}}
+ <div class="col-md-4">
+ <div class="card h-100">
+ <div class="card-header py-1 small fw-bold bg-white">4. บัตรชมพู & 90 วัน</div>
+ <div class="card-body p-2 small">
+ <div>เลขที่: <strong>{{ $employee->pinkCardNo ?? '-' }}</strong></div>
+ <div>90วัน ครบ: {{ $employee->ninetyDayReportDate ? \Carbon\Carbon::parse($employee->ninetyDayReportDate)->format('d/m/Y') : '-' }}</div>
+ @if($employee->pink_card_file)
+ <a href="{{ Storage::url($employee->pink_card_file) }}" target="_blank" class="btn btn-sm btn-outline-primary w-100 mt-2"><i class="bi bi-eye"></i> ดูไฟล์</a>
+ @endif
+ </div>
+ </div>
+ </div>
+ </div>
+
+ <hr>
+
+ {{-- Section 3: Insurance --}}
+ <h6 class="text-info fw-bold"><i class="bi bi-shield-check"></i> ข้อมูลประกัน ({{ $employee->insurance_type ?? 'ไม่มีข้อมูล' }})</h6>
+ <div class="card mb-4 border-info">
+ <div class="card-body">
+ <div class="row">
+ @if($employee->insurance_type == 'ประกันสังคม')
+ <div class="col-md-6"><strong>โรงพยาบาล:</strong> {{ $employee->hospital_name ?? '-' }}</div>
+ <div class="col-md-6 text-end">
+ @if($employee->social_security_file)
+ <a href="{{ Storage::url($employee->social_security_file) }}" target="_blank" class="btn btn-sm btn-info text-white"><i class="bi bi-file-earmark-medical"></i> ไฟล์ประกันสังคม</a>
+ @endif
+ </div>
+ @elseif(in_array($employee->insurance_type, ['ประกันโรงพยาบาล', 'ประกันเอกชน']))
+ <div class="col-md-4"><strong>บริษัท/รพ.:</strong> {{ $employee->insurance_company ?? $employee->hospital_name ?? '-' }}</div>
+ <div class="col-md-4"><strong>วันหมดอายุ:</strong> {{ $employee->insurance_expiry_date ? \Carbon\Carbon::parse($employee->insurance_expiry_date)->format('d/m/Y') : '-' }}</div>
+ <div class="col-md-4 text-end">
  @if($employee->insurance_file)
- <br><a href="{{ Storage::url($employee->insurance_file) }}" target="_blank" class="btn btn-sm btn-outline-info">ดูไฟล์</a>
+ <a href="{{ Storage::url($employee->insurance_file) }}" target="_blank" class="btn btn-sm btn-info text-white"><i class="bi bi-file-earmark-medical"></i> ไฟล์กรมธรรม์</a>
+ @endif
+ </div>
  @else
- <p>-</p>
+ <div class="col-12 text-muted">- ไม่ระบุรายละเอียด -</div>
  @endif
  </div>
- @endif
  </div>
- {{-- Other Files Loop --}}
+ </div>
+
+ {{-- Section 4: Other Attachments Loop --}}
+ <h6 class="text-secondary fw-bold"><i class="bi bi-paperclip"></i> เอกสารอื่นๆ (ไฟล์ที่ 5-12)</h6>
+ <ul class="list-group mb-3">
  @php
  $hasOtherFiles = false;
- for($i=5; $i<=12; $i++) {
- if($employee->{'file_'.$i}) {
- $hasOtherFiles = true;
- break;
- }
- }
  @endphp
- @if($hasOtherFiles)
- <h5 class="text-warning mt-4"><i class="bi bi-paperclip"></i> เอกสารอื่นๆ</h5>
- <hr>
- <ul class="list-group">
  @for ($i = 5; $i <= 12; $i++)
- @if($employee->{'file_'.$i})
- <li class="list-group-item d-flex justify-content-between align-items-center">
- <span>เอกสารแนบที่ {{ $i }}</span>
- <a href="{{ Storage::url($employee->{'file_'.$i}) }}" target="_blank" class="btn btn-sm btn-outline-secondary">
- <i class="bi bi-download"></i> ดาวน์โหลด
- </a>
+ @php
+ $fileField = 'file_' . $i;
+ @endphp
+ @if($employee->$fileField)
+ @php
+ $hasOtherFiles = true;
+ @endphp
+ <li class="list-group-item d-flex justify-content-between align-items-center p-2">
+ <span><i class="bi bi-file-earmark"></i> เอกสารแนบตำแหน่งที่ {{ $i }}</span>
+ <a href="{{ Storage::url($employee->$fileField) }}" target="_blank" class="btn btn-sm btn-outline-secondary">Download</a>
  </li>
  @endif
  @endfor
- </ul>
+
+ @if(!$hasOtherFiles)
+ <li class="list-group-item text-center text-muted p-2"><small>ไม่มีเอกสารเพิ่มเติม</small></li>
  @endif
+ </ul>
 </div>


### PR DESCRIPTION
Completely replaces the content of the employee preview modal to ensure all data fields, photos, and file attachments visible on the edit page are now displayed.

- Displays employee photo or a fallback initial.
- Shows authentication details (email and plain text password).
- Explicitly lists Passport, Visa, Work Permit, and Pink Card files.
- Adds conditional logic to correctly display different insurance types and their associated files.
- Includes a loop to show all other attachments from file slots 5 through 12.
- Formats all dates to d/m/Y for consistency.