### PR TITLE
feat: สร้าง Endpoint ที่ปลอดภัยสำหรับไฟล์ส่วนตัว

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -567,4 +567,38 @@ public function create(Request $request) // เพิ่ม Request $request เ
 
         return response()->stream($callback, 200, $headers);
     }
+
+    /**
+     * Serve a private document for a given employee.
+     *
+     * @param  \App\Models\Employee  $employee
+     * @param  string  $field
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse|\Illuminate\Http\RedirectResponse
+     */
+    public function serveDocument(Employee $employee, $field)
+    {
+        // Whitelist of allowed document fields to prevent security risks
+        $allowedFields = [
+            'employee_doc_1', 'employee_doc_2', 'employee_doc_3', 'employee_doc_4',
+            'insurance_document_path_private',
+            // Keep old fields for backward compatibility if needed
+            'passport_file_path', 'visa_file_path', 'work_permit_file_path',
+            'pink_card_file_path', 'insurance_attachment_path'
+        ];
+
+        if (!in_array($field, $allowedFields)) {
+            abort(404, 'Document type not found.');
+        }
+
+        // Use a policy to check if the user can view the employee
+        $this->authorize('view', $employee);
+
+        $filePath = $employee->{$field};
+
+        if (!$filePath || !Storage::disk('private')->exists($filePath)) {
+            abort(404, 'File not found.');
+        }
+
+        return Storage::disk('private')->response($filePath);
+    }
 }

--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -179,7 +179,7 @@
             <label class="form-label fw-bold">ไฟล์แนบประกัน</label>
             @if($employee->insurance_document_path_private)
                 <p class="form-control-plaintext">
-                    <a href="{{ Storage::disk('private')->url($employee->insurance_document_path_private) }}" target="_blank">
+                    <a href="{{ route('employees.documents.serve', ['employee' => $employee->id, 'field' => 'insurance_document_path_private']) }}" target="_blank">
                         <i class="bi bi-file-earmark-text"></i> ดูเอกสาร
                     </a>
                 </p>
@@ -217,14 +217,16 @@
                 $field = $file['field'];
                 $label = $file['label'];
                 $desc_field = $file['desc_field'] ?? null;
-                // Docs 1-4 are sensitive and stored on the private disk. Others are public.
-                $disk = in_array($field, ['employee_doc_1', 'employee_doc_2', 'employee_doc_3', 'employee_doc_4']) ? 'private' : 'public';
+                $isPrivate = in_array($field, ['employee_doc_1', 'employee_doc_2', 'employee_doc_3', 'employee_doc_4']);
+                $url = $isPrivate
+                    ? route('employees.documents.serve', ['employee' => $employee->id, 'field' => $field])
+                    : ($employee->{$field} ? Storage::disk('public')->url($employee->{$field}) : '#');
             @endphp
             <div class="col-md-4">
                 <label class="form-label fw-bold">{{ $label }}</label>
                 @if($employee->{$field})
                     <p class="form-control-plaintext">
-                        <a href="{{ Storage::disk($disk)->url($employee->{$field}) }}" target="_blank">
+                        <a href="{{ $url }}" target="_blank">
                             <i class="bi bi-file-earmark-text"></i> ดูเอกสาร
                         </a>
                          @if($desc_field && $employee->{$desc_field})

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,6 +52,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/employees/{employee}/locate', [EmployeeController::class, 'locate'])->name('employees.locate');
     Route::get('/employees/{employee}/create-job', [JobController::class, 'createFromEmployee'])->name('jobs.create_from_employee');
     Route::get('/employees/export', [EmployeeController::class, 'export'])->name('employees.export');
+    Route::get('/employees/{employee}/documents/{field}', [EmployeeController::class, 'serveDocument'])->name('employees.documents.serve');
     Route::resource('employees', EmployeeController::class);
     Route::resource('importers', ImporterController::class);
     Route::resource('agents', AgentController::class);


### PR DESCRIPTION
เพิ่ม Route และ Controller method ใหม่ (`serveDocument`) เพื่อจัดการการเข้าถึงไฟล์ส่วนตัวที่จัดเก็บไว้ใน `private` disk อย่างปลอดภัย การเปลี่ยนแปลงนี้จะช่วยป้องกันข้อผิดพลาด HTTP 500 ที่เกิดจากการพยายามสร้าง URL สาธารณะสำหรับไฟล์ที่ไม่สามารถเข้าถึงได้โดยตรง

- สร้าง Route ใหม่ `employees.documents.serve` เพื่อจัดการคำขอไฟล์
- เพิ่มเมธอด `EmployeeController@serveDocument` พร้อมการตรวจสอบสิทธิ์และรายการที่อนุญาตพิเศษสำหรับฟิลด์เอกสาร
- อัปเดต `_employee_data.blade.php` เพื่อใช้ Route ใหม่สำหรับลิงก์เอกสารส่วนตัวทั้งหมด