### PR TITLE
fix(preview): แก้ไขข้อมูลประกันในหน้าพรีวิวลูกจ้าง

### DIFF
--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -135,54 +135,37 @@
     {{-- Insurance Information --}}
     <h5>ข้อมูลประกัน</h5>
     <div class="row g-3">
-        @php
-            $insuranceType = $employee->insuranceType;
-            // Infer type if it's not explicitly set, based on which data fields are available.
-            if (!$insuranceType) {
-                if (!empty($employee->socialSecurityNumber)) {
-                    $insuranceType = 'ประกันสังคม';
-                } elseif (!empty($employee->insuranceCompany)) {
-                    $insuranceType = 'ประกันเอกชน';
-                } elseif (!empty($employee->hospitalName)) {
-                    // This could be Social Security or Hospital Insurance.
-                    // We assume if socialSecurityNumber is empty, it's Hospital Insurance.
-                    $insuranceType = 'ประกันโรงพยาบาล';
-                }
-            }
-        @endphp
-
         <div class="col-md-4">
             <label class="form-label fw-bold">ประเภทประกัน</label>
-            <p class="form-control-plaintext">{{ $insuranceType ?? 'N/A' }}</p>
+            <p class="form-control-plaintext">{{ $employee->insurance_type ?? 'N/A' }}</p>
         </div>
 
-        @if($insuranceType === 'ประกันสังคม')
+        @if($employee->insurance_type === 'ประกันสังคม')
             <div class="col-md-4">
                 <label class="form-label fw-bold">เลขประกันสังคม</label>
-                <p class="form-control-plaintext">{{ $employee->socialSecurityNumber ?? 'N/A' }}</p>
+                <p class="form-control-plaintext">{{ $employee->social_security_number ?? 'N/A' }}</p>
             </div>
             <div class="col-md-4">
                 <label class="form-label fw-bold">โรงพยาบาลตามสิทธิ</label>
-                {{-- Data inconsistency fix: hospital name could be in either field --}}
-                <p class="form-control-plaintext">{{ $employee->hospitalName ?? $employee->insuranceCompany ?? 'N/A' }}</p>
+                <p class="form-control-plaintext">{{ $employee->insurance_detail ?? 'N/A' }}</p>
             </div>
-        @elseif($insuranceType === 'ประกันเอกชน')
+        @elseif($employee->insurance_type === 'ประกันโรงพยาบาล')
+            <div class="col-md-4">
+                <label class="form-label fw-bold">โรงพยาบาล</label>
+                <p class="form-control-plaintext">{{ $employee->insurance_detail_hospital ?? 'N/A' }}</p>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label fw-bold">วันหมดอายุ</label>
+                <p class="form-control-plaintext">{{ $employee->insurance_expiry_date_hospital ? $employee->insurance_expiry_date_hospital->format('d/m/Y') : 'N/A' }}</p>
+            </div>
+        @elseif($employee->insurance_type === 'ประกันเอกชน')
             <div class="col-md-4">
                 <label class="form-label fw-bold">บริษัทประกัน</label>
-                <p class="form-control-plaintext">{{ $employee->insuranceCompany ?? 'N/A' }}</p>
+                <p class="form-control-plaintext">{{ $employee->insurance_detail_private ?? 'N/A' }}</p>
             </div>
-             <div class="col-md-4">
+            <div class="col-md-4">
                 <label class="form-label fw-bold">วันหมดอายุ</label>
-                <p class="form-control-plaintext">{{ $employee->insuranceExpiryDate ? $employee->insuranceExpiryDate->format('d/m/Y') : 'N/A' }}</p>
-            </div>
-        @elseif($insuranceType === 'ประกันโรงพยาบาล')
-             <div class="col-md-4">
-                <label class="form-label fw-bold">โรงพยาบาล</label>
-                <p class="form-control-plaintext">{{ $employee->hospitalName ?? 'N/A' }}</p>
-            </div>
-             <div class="col-md-4">
-                <label class="form-label fw-bold">วันหมดอายุ</label>
-                <p class="form-control-plaintext">{{ $employee->insuranceExpiryDate ? $employee->insuranceExpiryDate->format('d/m/Y') : 'N/A' }}</p>
+                <p class="form-control-plaintext">{{ $employee->insurance_expiry_date_private ? $employee->insurance_expiry_date_private->format('d/m/Y') : 'N/A' }}</p>
             </div>
         @else
             {{-- Fallback for cases with no clear type or data --}}


### PR DESCRIPTION
แก้ไขการแสดงผลข้อมูลในส่วน "ข้อมูลประกัน" ของหน้าพรีวิวลูกจ้างให้ดึงข้อมูลจากคอลัมน์ที่ถูกต้องตามประเภทของประกัน

- ใช้ `insurance_type` เป็นเงื่อนไขหลักในการแสดงผล
- อัปเดตการดึงข้อมูลสำหรับ 'ประกันสังคม', 'ประกันโรงพยาบาล', และ 'ประกันเอกชน' ให้ตรงกับชื่อคอลัมน์ในฐานข้อมูลที่ผู้ใช้ระบุ
- ลบตรรกะเดิมที่พยายามคาดเดาประเภทของประกันออกไป เพื่อให้การแสดงผลมีความแม่นยำและบำรุงรักษาง่ายขึ้น