### PR TITLE
fix(employee-card): Display job_title instead of employeePosition

### DIFF
--- a/resources/views/employers/_employee_card.blade.php
+++ b/resources/views/employers/_employee_card.blade.php
@@ -21,7 +21,7 @@
                             @endif
                         @endif
                     </p>
-                    <p class="mb-1 text-muted small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }} ({{ $employee->employeePosition ?? 'ไม่ระบุตำแหน่ง' }})</p>
+                    <p class="mb-1 text-muted small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }} ({{ $employee->job_title ?? 'ไม่ระบุตำแหน่ง' }})</p>
                     <p class="mb-1 text-muted small">Passport: {{ $employee->employeePassport ?? '-' }} (หมดอายุ: {{ $employee->passportExpiryDate ? \Carbon\Carbon::parse($employee->passportExpiryDate)->format('d/m/Y') : '-' }})</p>
                     <p class="mb-1 text-muted small">Work Permit: {{ $employee->employeeWorkPermit ?? '-' }} (หมดอายุ: {{ $employee->workPermitExpiryDate ? \Carbon\Carbon::parse($employee->workPermitExpiryDate)->format('d/m/Y') : '-' }})</p>
                     <p class="mb-0 text-muted small">Visa ({{ $employee->workPermitMOUGroup ?? '-' }}) หมดอายุ: {{ $employee->visaExpiryDate ? \Carbon\Carbon::parse($employee->visaExpiryDate)->format('d/m/Y') : '-' }} | 90-Day: {{ $employee->ninetyDayReportDate ? \Carbon\Carbon::parse($employee->ninetyDayReportDate)->format('d/m/Y') : '-' }}</p>

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -34,7 +34,7 @@
             @endif
 
             <span class="employee-name-th d-block">
-                {{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }} ({{ $employee->employeePosition ?? 'N/A' }})
+                {{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }} ({{ $employee->job_title ?? 'N/A' }})
             </span>
 
             <span class="employer-name d-block text-muted">นายจ้าง: {{ $employerName }}</span>


### PR DESCRIPTION
The employee card partials were displaying the outdated `employeePosition` field for the job title, which resulted in 'N/A' being shown.

This commit updates the following files to use the correct `job_title` field:
- `resources/views/partials/_employee_card.blade.php`
- `resources/views/employers/_employee_card.blade.php`

This ensures the correct job title is displayed on employee cards across the application.