### PR TITLE
feat(employees): Add passport type filter

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -115,6 +115,14 @@ public function reinstate(Employee $employee)
             });
         }
     }
+
+    if ($request->filled('passport_type')) {
+        $passportType = $request->input('passport_type');
+        $query->where(function ($q) use ($passportType) {
+            $q->where('passportType', $passportType)
+                ->orWhere('passport_type_cambodia', $passportType);
+        });
+    }
     // --- END: ADDED FILTERING LOGIC ---
 
     $totalEmployees = (clone $query)->count();
@@ -535,6 +543,14 @@ public function create(Request $request) // เพิ่ม Request $request เ
             } elseif ($request->input('pink_card') === 'no') {
                 $query->where(fn($q) => $q->whereNull('pinkCardNo')->orWhere('pinkCardNo', '=', ''));
             }
+        }
+
+        if ($request->filled('passport_type')) {
+            $passportType = $request->input('passport_type');
+            $query->where(function ($q) use ($passportType) {
+                $q->where('passportType', $passportType)
+                    ->orWhere('passport_type_cambodia', $passportType);
+            });
         }
 
         $employees = $query->with('employer')->get();

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -144,6 +144,14 @@ public function edit(Request $request, Employer $employer)
             });
         }
     }
+
+    if ($request->filled('passport_type')) {
+        $passportType = $request->input('passport_type');
+        $employeeQuery->where(function ($q) use ($passportType) {
+            $q->where('passportType', $passportType)
+              ->orWhere('passport_type_cambodia', $passportType);
+        });
+    }
     // --- END: ADDED FILTERING LOGIC ---
 
     $perPageOptions = [10, 25, 50];
@@ -310,6 +318,14 @@ public function edit(Request $request, Employer $employer)
                 } elseif ($request->input('pink_card') === 'no') {
                     $query->where(fn($q) => $q->whereNull('pinkCardNo')->orWhere('pinkCardNo', '=', ''));
                 }
+            }
+
+            if ($request->filled('passport_type')) {
+                $passportType = $request->input('passport_type');
+                $query->where(function ($q) use ($passportType) {
+                    $q->where('passportType', $passportType)
+                        ->orWhere('passport_type_cambodia', $passportType);
+                });
             }
         }
 

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -41,6 +41,13 @@
                 <option value="yes" {{ request('pink_card') == 'yes' ? 'selected' : '' }}>มีบัตรชมพู</option>
                 <option value="no" {{ request('pink_card') == 'no' ? 'selected' : '' }}>ไม่มีบัตรชมพู</option>
             </select>
+            <select name="passport_type" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- ประเภทพาสปอร์ต --</option>
+                <option value="CI" {{ request('passport_type') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>
+                <option value="PJ" {{ request('passport_type') == 'PJ' ? 'selected' : '' }}>เล่ม PJ</option>
+                <option value="TD" {{ request('passport_type') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
+                <option value="International" {{ request('passport_type') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
+            </select>
             <input type="date" name="work_permit_expiry_date" class="form-control form-control-sm" value="{{ request('work_permit_expiry_date') }}" title="ค้นหาตามวันหมดอายุใบอนุญาตทำงาน">
             <button type="submit" class="btn btn-sm btn-primary">กรอง</button>
             <a href="{{ route('employees.index') }}" class="btn btn-sm btn-secondary">ล้างค่า</a>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -362,6 +362,13 @@
                     <option value="yes" @if(request('pink_card') == 'yes') selected @endif>มีบัตรชมพู</option>
                     <option value="no" @if(request('pink_card') == 'no') selected @endif>ไม่มีบัตรชมพู</option>
                 </select>
+                <select name="passport_type" class="form-select form-select-sm" style="width: auto;">
+                    <option value="">-- ประเภทพาสปอร์ต --</option>
+                    <option value="CI" {{ request('passport_type') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>
+                    <option value="PJ" {{ request('passport_type') == 'PJ' ? 'selected' : '' }}>เล่ม PJ</option>
+                    <option value="TD" {{ request('passport_type') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
+                    <option value="International" {{ request('passport_type') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
+                </select>
                 <button type="submit" class="btn btn-sm btn-primary">กรอง</button>
                 <a href="{{ route('employers.edit', $employer->id) }}" class="btn btn-sm btn-secondary">ล้างค่า</a>
             </form>


### PR DESCRIPTION
Adds a new dropdown filter for passport type (CI, PJ, TD, International) to the employee list page and the employer's employee list page.

- The filter queries both `passportType` and `passport_type_cambodia` columns to ensure all relevant employees are included.
- The filtering logic is applied to both the display and export functions for both pages.
- The UI for both pages has been updated to include the new dropdown.