### PR TITLE
feat: Add Work Permit expiry filter to employer edit page

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -145,6 +145,10 @@ public function edit(Request $request, Employer $employer)
         }
     }
 
+    if ($request->filled('work_permit_expiry_date')) {
+        $employeeQuery->whereDate('workPermitExpiryDate', $request->input('work_permit_expiry_date'));
+    }
+
     if ($request->filled('passport_type')) {
         $passportType = $request->input('passport_type');
         $employeeQuery->where(function ($q) use ($passportType) {

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -369,6 +369,7 @@
                     <option value="TD" {{ request('passport_type') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
                     <option value="International" {{ request('passport_type') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
                 </select>
+                <input type="date" name="work_permit_expiry_date" class="form-control form-control-sm" value="{{ request('work_permit_expiry_date') }}" title="ค้นหาตามวันหมดอายุใบอนุญาตทำงาน">
                 <button type="submit" class="btn btn-sm btn-primary">กรอง</button>
                 <a href="{{ route('employers.edit', $employer->id) }}" class="btn btn-sm btn-secondary">ล้างค่า</a>
             </form>


### PR DESCRIPTION
Adds the Work Permit expiry date filter to the employee list on the employer edit page.

This change brings the filtering functionality in line with the main employee index page, allowing users to filter employees by their Work Permit expiry date when managing a specific employer.

- Added the `work_permit_expiry_date` query condition to the `edit` method in `EmployerController.php`.
- Added the corresponding date input field to the filter form in the `employers/edit.blade.php` view.