### PR TITLE
fix(employers): Correct permission for employer search API

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -469,7 +469,7 @@ public function edit(Request $request, Employer $employer)
         // This endpoint is used in contexts where a user needs to select an employer.
         // We can reuse the 'manage-tickets' permission as it's a good proxy
         // for "is an admin or staff member".
-        $this->authorize('permission:manage-tickets');
+        $this->authorize('view-employers');
 
         $query = Employer::query();
 


### PR DESCRIPTION
The API endpoint for searching employers in the transfer employee modal was incorrectly protected by the 'manage-tickets' permission, causing it to fail for non-admin users.

This change replaces the incorrect permission with 'view-employers', which is the appropriate permission for listing employer data, resolving the bug while maintaining security.