### PR TITLE
Fix: Correct authorization for private document preview

### DIFF
--- a/app/Policies/EmployeePolicy.php
+++ b/app/Policies/EmployeePolicy.php
@@ -19,4 +19,23 @@ class EmployeePolicy
     {
         //
     }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Employee  $employee
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(User $user, Employee $employee)
+    {
+        // Users with 'manage-tickets' permission (Admins, Staff) can view any employee.
+        if ($user->can('manage-tickets')) {
+            return true;
+        }
+
+        // Employers can only view their own employees.
+        // Assumes the User model has a relationship to an Employer model.
+        return $user->id === $employee->employer->user_id;
+    }
 }


### PR DESCRIPTION
- Added a `view` method to the `EmployeePolicy`.
- This method correctly authorizes users (admins, staff, or the employee's own employer) to view employee records.
- This resolves the "403 Unauthorized" error when trying to access private documents like insurance files through the secure `employees.documents.serve` route in the employee preview modal.
- This approach fixes the bug at its source by addressing the authorization logic, rather than exposing private files via public URLs.