### PR TITLE
feat: Implement floating sidebar menu on scroll

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -99,3 +99,62 @@ select:disabled, input:disabled, textarea:disabled, input:read-only, textarea:re
 }
 
 /* END: Custom Form Styles */
+
+/* START: Floating Sidebar Styles */
+@media (min-width: 992px) {
+    #sidebar.sidebar-scrolled {
+        position: fixed;
+        top: 1.5rem;
+        left: 1.5rem;
+        height: calc(100vh - 3rem);
+        width: 80px; /* Collapsed width */
+        overflow: hidden;
+        transition: width 0.3s ease-in-out;
+        z-index: 1030;
+        border-radius: 0.75rem;
+    }
+
+    #sidebar.sidebar-scrolled:hover {
+        width: 260px; /* Expanded width */
+    }
+
+    #sidebar.sidebar-scrolled .navbar-brand,
+    #sidebar.sidebar-scrolled .list-group-item span,
+    #sidebar.sidebar-scrolled .mt-auto .d-flex div,
+    #sidebar.sidebar-scrolled hr {
+        transition: opacity 0.3s ease-in-out;
+    }
+
+    #sidebar.sidebar-scrolled:not(:hover) .navbar-brand,
+    #sidebar.sidebar-scrolled:not(:hover) .list-group-item span,
+    #sidebar.sidebar-scrolled:not(:hover) .mt-auto .d-flex div,
+    #sidebar.sidebar-scrolled:not(:hover) hr {
+        opacity: 0;
+        pointer-events: none; /* Prevent clicking on hidden text */
+    }
+
+    #sidebar.sidebar-scrolled .list-group-item {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+     #sidebar.sidebar-scrolled .list-group-item i {
+        font-size: 1.5rem; /* Make icons bigger when collapsed */
+    }
+
+    #sidebar.sidebar-scrolled:hover .list-group-item {
+       justify-content: flex-start;
+    }
+    #sidebar.sidebar-scrolled:hover .list-group-item i {
+        font-size: 1rem; /* Return to normal size on hover */
+    }
+
+
+    #sidebar.sidebar-scrolled .mt-auto .d-flex {
+        justify-content: center;
+    }
+    #sidebar.sidebar-scrolled:hover .mt-auto .d-flex {
+        justify-content: flex-start;
+    }
+}
+/* END: Floating Sidebar Styles */

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -11,6 +11,29 @@ window.Alpine = Alpine;
 Alpine.start();
 
 document.addEventListener('DOMContentLoaded', function () {
+    // START: Floating Sidebar Logic
+    const sidebar = document.getElementById('sidebar');
+    const mainContent = document.getElementById('main-content');
+
+    if (sidebar && mainContent) {
+        window.addEventListener('scroll', function() {
+            if (window.innerWidth < 992) {
+                // Don't apply scrolling effect on smaller screens where sidebar is an offcanvas
+                return;
+            }
+
+            if (window.scrollY > 200) { // Adjust this value to change when the effect triggers
+                sidebar.classList.add('sidebar-scrolled');
+                // Add padding to the main content to prevent it from jumping underneath the fixed sidebar
+                mainContent.style.setProperty('padding-left', '100px', 'important');
+            } else {
+                sidebar.classList.remove('sidebar-scrolled');
+                 mainContent.style.paddingLeft = ''; // Revert to original padding
+            }
+        });
+    }
+    // END: Floating Sidebar Logic
+
     const universalPreviewModalEl = document.getElementById('universalPreviewModal');
     if (!universalPreviewModalEl) return;
 


### PR DESCRIPTION
This commit introduces a new feature to the main layout's sidebar.

- When the user scrolls down the page on larger screens (>= 992px), the sidebar transitions to a fixed position.
- In its fixed state, the sidebar is collapsed to a minimal width, showing only the icons.
- Hovering over the collapsed sidebar expands it to its full width, revealing the menu item text.
- This improves user experience on long pages by keeping navigation accessible without taking up significant screen real estate.

The implementation uses a combination of a JavaScript scroll listener to toggle a CSS class and CSS transitions for smooth animations.