### PR TITLE
Fix: Correct insurance document link in employee preview

### DIFF
--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -180,7 +180,7 @@
             <label class="form-label fw-bold">ไฟล์แนบประกัน</label>
             @if($employee->insurance_document_path_private)
                 <p class="form-control-plaintext">
-                    <a href="{{ route('employees.documents.serve', ['employee' => $employee->id, 'field' => 'insurance_document_path_private']) }}" target="_blank">
+                    <a href="{{ Storage::disk('public')->url($employee->insurance_document_path_private) }}" target="_blank">
                         <i class="bi bi-file-earmark-text"></i> ดูเอกสาร
                     </a>
                 </p>


### PR DESCRIPTION
The preview modal for employee data was generating an incorrect URL for the 'insurance_document_path_private' field. It was using a route that pointed to the `serveDocument` method, which is intended for files on the 'private' disk.

However, all employee documents, including this one, are stored on the 'public' disk. This mismatch caused an 'InvalidArgumentException' because the 'private' disk driver is not configured.

This commit fixes the issue by changing the URL generation logic in `_employee_data.blade.php` to use `Storage::disk('public')->url()` for the insurance document, aligning it with the method used for all other public attachments in the same view.