### PR TITLE
feat: Implement standalone employment history page

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -606,6 +606,70 @@ public function create(Request $request) // เพิ่ม Request $request เ
         return response()->stream($callback, 200, $headers);
     }
 
+    public function historyIndex(Request $request)
+    {
+        $this->authorize('view-employees');
+
+        $query = Employee::query()->whereNotNull('terminated_at');
+
+        if ($request->filled('search')) {
+            $searchTerm = '%' . $request->input('search') . '%';
+            $query->where(function ($q) use ($searchTerm) {
+                $q->where('employeeNameTh', 'like', $searchTerm)
+                  ->orWhere('employeeNameEn', 'like', $searchTerm)
+                  ->orWhere('employeePassport', 'like', $searchTerm)
+                  ->orWhere('pinkCardNo', 'like', $searchTerm)
+                  ->orWhere('employeeWorkPermit', 'like', $searchTerm)
+                  ->orWhereHas('employer', function ($employerQuery) use ($searchTerm) {
+                      $employerQuery->where('employerNameTh', 'like', $searchTerm)
+                                    ->orWhere('employerNameEn', 'like', $searchTerm);
+                  });
+            });
+        }
+
+        if ($request->filled('nationality')) {
+            $query->where('employeeNationality', $request->input('nationality'));
+        }
+
+        if ($request->filled('mou_group')) {
+            $query->where('workPermitMOUGroup', $request->input('mou_group'));
+        }
+
+        if ($request->filled('pink_card')) {
+            if ($request->input('pink_card') === 'yes') {
+                $query->where(function ($q) {
+                    $q->whereNotNull('pinkCardNo')->where('pinkCardNo', '!=', '');
+                });
+            } elseif ($request->input('pink_card') === 'no') {
+                $query->where(function ($q) {
+                    $q->whereNull('pinkCardNo')->orWhere('pinkCardNo', '=', '');
+                });
+            }
+        }
+
+        if ($request->filled('passport_type')) {
+            $passportType = $request->input('passport_type');
+            $query->where(function ($q) use ($passportType) {
+                $q->where('passportType', $passportType)
+                    ->orWhere('passport_type_cambodia', $passportType);
+            });
+        }
+
+        $totalEmployees = (clone $query)->count();
+
+        $perPageOptions = [25, 50, 100];
+        $currentPerPage = $request->input('per_page', 25);
+
+        $employees = $query->with('employer')->latest('terminated_at')->paginate($currentPerPage)->withQueryString();
+
+        return view('employees.history', compact(
+            'employees',
+            'totalEmployees',
+            'perPageOptions',
+            'currentPerPage'
+        ))->with('currentView', $request->input('view', 'card'));
+    }
+
     /**
      * Serve a private document for a given employee.
      *

--- a/resources/views/employees/_history_card.blade.php
+++ b/resources/views/employees/_history_card.blade.php
@@ -1,0 +1,42 @@
+@php
+    $employerName = $employee->employer->employerNameTh ?? 'N/A';
+    $employeeFullName = $employee->employeeFullName;
+@endphp
+<div id="history-row-{{ $employee->id }}" class="list-group-item list-group-item-action">
+    <div class="d-flex align-items-center">
+        <div class="me-3">
+            <input class="form-check-input history-employee-checkbox" type="checkbox" data-employee-id="{{ $employee->id }}">
+        </div>
+
+        <img src="{{ $employee->photo_url }}" alt="Photo" class="employee-photo-thumb">
+
+        <div class="flex-grow-1">
+            <div class="d-flex w-100 justify-content-between">
+                <h5 class="mb-1">
+                    {{ $employee->employeeNameEn ?? 'N/A' }}
+                     @php
+                        $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
+                    @endphp
+                    @if($countryCode)
+                        <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" title="{{ $employee->employeeNationality }}" class="ms-2" style="width: 20px;">
+                    @endif
+                </h5>
+                <small class="text-muted" title="นายจ้าง">{{ $employerName }}</small>
+            </div>
+            <p class="mb-1">{{ $employeeFullName }}</p>
+            <small class="text-muted d-block">
+                Terminated: <strong>{{ $employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : '-' }}</strong>
+                <span class="badge bg-secondary">{{ $employee->days_since_termination }} วัน</span>
+            </small>
+            <small class="text-muted d-block">Reason: {{ $employee->termination_reason ?: '-' }}</small>
+        </div>
+
+        <div class="ms-auto ps-3">
+            <div class="btn-group-vertical btn-group-sm">
+                <button class="btn btn-outline-success btn-reinstate" title="Restore" data-employee-id="{{ $employee->id }}"><i class="bi bi-arrow-counterclockwise"></i></button>
+                <button class="btn btn-outline-danger btn-move-to-trash" title="Move to Trash" data-employee-id="{{ $employee->id }}"><i class="bi bi-trash3-fill"></i></button>
+                <button class="btn btn-outline-info btn-transfer-employee" title="Transfer Employer" data-employee-id="{{ $employee->id }}" data-employee-name="{{ $employeeFullName }}"><i class="bi bi-person-up"></i></button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/employees/history.blade.php
+++ b/resources/views/employees/history.blade.php
@@ -1,58 +1,367 @@
 @extends('layouts.app')
-
 @section('title', 'ประวัติการจ้างงาน')
 
 @section('content')
-<div class="content-section">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2 class="mb-0">ประวัติการจ้างงาน</h2>
-    </div>
+<div class="p-4 p-md-5 content-section">
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h4 class="mb-0">
+        ประวัติการจ้างงานทั้งหมด (รวม: {{ $totalEmployees }} คน)
+    </h4>
+</div>
 
-    <div class="table-responsive">
-        <table class="table table-hover">
-            <thead>
-                <tr>
-                    <th scope="col">#</th>
-                    <th scope="col">Photo</th>
-                    <th scope="col">Name (EN / TH)</th>
-                    <th scope="col">Passport</th>
-                    <th scope="col">Nationality</th>
-                    <th scope="col">Last Employer</th>
-                    <th scope="col">Termination Date</th>
-                </tr>
-            </thead>
-            <tbody>
-                @forelse($terminatedEmployees as $employee)
-                    <tr>
-                        <th scope="row">{{ $terminatedEmployees->firstItem() + $loop->index }}</th>
-                        <td class="align-middle text-center" style="width: 60px;">
-                            @if($employee->employeePhoto)
-                                <img src="{{ asset('storage/' . $employee->employeePhoto) }}" alt="Photo" class="img-fluid rounded-circle" style="width: 40px; height: 40px; object-fit: cover;">
-                            @else
-                                <div class="bg-secondary rounded-circle d-flex justify-content-center align-items-center text-white" style="width: 40px; height: 40px;">
-                                    <i class="bi bi-person-fill"></i>
-                                </div>
-                            @endif
-                        </td>
-                        <td class="align-middle">
-                            <div class="fw-bold">{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}</div>
-                            <div class="text-muted small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'ไม่มีชื่อภาษาไทย' }}</div>
-                        </td>
-                        <td class="align-middle">{{ $employee->employeePassport ?? '-' }}</td>
-                        <td class="align-middle">{{ $employee->employeeNationality ?? '-' }}</td>
-                        <td class="align-middle">{{ $employee->employer->employerNameTh ?? 'N/A' }}</td>
-                        <td class="align-middle">{{ $employee->termination_date ? \Carbon\Carbon::parse($employee->termination_date)->format('d/m/Y') : 'N/A' }}</td>
-                    </tr>
-                @empty
-                    <tr>
-                        <td colspan="7" class="text-center text-muted py-4">ไม่พบข้อมูลพนักงานที่ถูกเลิกจ้าง</td>
-                    </tr>
-                @endforelse
-            </tbody>
-        </table>
-    </div>
-     <div class="mt-4">
-        {{ $terminatedEmployees->links() }}
+<div class="card p-3 mb-3">
+    <div class="d-flex flex-column flex-md-row flex-wrap justify-content-md-between align-items-center gap-3">
+        <form method="GET" action="{{ route('employees.history') }}" class="d-flex flex-wrap align-items-center gap-2">
+            <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหา..." value="{{ request('search') }}" style="width: 200px;">
+            <select name="nationality" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- ทุกสัญชาติ --</option>
+                <option value="เมียนมา" {{ request('nationality') == 'เมียนมา' ? 'selected' : '' }}>เมียนมา</option>
+                <option value="ลาว" {{ request('nationality') == 'ลาว' ? 'selected' : '' }}>ลาว</option>
+                <option value="กัมพูชา" {{ request('nationality') == 'กัมพูชา' ? 'selected' : '' }}>กัมพูชา</option>
+                <option value="เวียดนาม" {{ request('nationality') == 'เวียดนาม' ? 'selected' : '' }}>เวียดนาม</option>
+            </select>
+            <select name="mou_group" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- ทุกประเภท มติ. --</option>
+                <option value="MOU" @if(request('mou_group') == 'MOU') selected @endif>MOU</option>
+                <option value="มติต่ออายุในประเทศ" @if(request('mou_group') == 'มติต่ออายุในประเทศ') selected @endif>มติต่ออายุในประเทศ</option>
+                <option value="มติขึ้นทะเบียน" @if(request('mou_group') == 'มติขึ้นทะเบียน') selected @endif>มติขึ้นทะเบียน</option>
+                <option value="อื่นๆ" @if(request('mou_group') == 'อื่นๆ') selected @endif>อื่นๆ</option>
+            </select>
+            <select name="pink_card" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- บัตรชมพู --</option>
+                <option value="yes" {{ request('pink_card') == 'yes' ? 'selected' : '' }}>มีบัตรชมพู</option>
+                <option value="no" {{ request('pink_card') == 'no' ? 'selected' : '' }}>ไม่มีบัตรชมพู</option>
+            </select>
+            <select name="passport_type" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- ประเภทพาสปอร์ต --</option>
+                <option value="CI" {{ request('passport_type') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>
+                <option value="PJ" {{ request('passport_type') == 'PJ' ? 'selected' : '' }}>เล่ม PJ</option>
+                <option value="TD" {{ request('passport_type') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
+                <option value="International" {{ request('passport_type') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
+            </select>
+            <button type="submit" class="btn btn-sm btn-primary">กรอง</button>
+            <a href="{{ route('employees.history') }}" class="btn btn-sm btn-secondary">ล้างค่า</a>
+        </form>
+        <div class="d-flex align-items-center gap-2">
+            <a href="{{ route('employees.export', array_merge(request()->query(), ['history' => 1])) }}" class="btn btn-sm btn-outline-success">
+                <i class="bi bi-file-earmark-excel me-1"></i> Export
+            </a>
+            <div class="btn-group btn-group-sm">
+                <a href="{{ route('employees.history', array_merge(request()->query(), ['view' => 'card'])) }}" class="btn {{ $currentView == 'card' ? 'btn-primary' : 'btn-outline-secondary' }}">การ์ด</a>
+                <a href="{{ route('employees.history', array_merge(request()->query(), ['view' => 'table'])) }}" class="btn {{ $currentView == 'table' ? 'btn-primary' : 'btn-outline-secondary' }}">ตาราง</a>
+            </div>
+            <div class="btn-group btn-group-sm">
+                @foreach($perPageOptions as $option)
+                    <a href="{{ route('employees.history', array_merge(request()->query(), ['per_page' => $option])) }}" class="btn {{ $currentPerPage == $option ? 'btn-primary' : 'btn-outline-secondary' }}">{{ $option }}</a>
+                @endforeach
+            </div>
+        </div>
     </div>
 </div>
+
+<div class="bulk-action-bar mb-3" id="history-bulk-action-bar" style="display: none;">
+    <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="history-select-all-checkbox-main">
+        <label class="form-check-label" for="history-select-all-checkbox-main">
+            เลือกทั้งหมด (<span id="history-selected-count">0</span>)
+        </label>
+    </div>
+    <button id="history-bulk-action-btn" class="btn btn-sm btn-info" disabled><i class="bi bi-person-up"></i> ย้ายนายจ้าง</button>
+</div>
+
+<div id="employeeListContainer">
+    @if($currentView === 'card')
+        <div class="list-group">
+            @forelse($employees as $employee)
+                @include('employees._history_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees])
+            @empty
+                <p class="text-center text-muted">ไม่พบประวัติการจ้างงาน</p>
+            @endforelse
+        </div>
+    @else
+        <div class="table-responsive">
+            <table class="table table-hover align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width: 1%;"><input class="form-check-input" type="checkbox" id="history-select-all-checkbox-table"></th>
+                        <th scope="col">Employee</th>
+                        <th scope="col">Employer</th>
+                        <th scope="col">Terminated Date</th>
+                        <th scope="col">Reason</th>
+                        <th scope="col">Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="historyTableBody">
+                    @forelse($employees as $employee)
+                    <tr id="history-row-{{ $employee->id }}">
+                        <td><input class="form-check-input history-employee-checkbox" type="checkbox" data-employee-id="{{ $employee->id }}"></td>
+                        <td>
+                            <div class="d-flex align-items-center">
+                                <img src="{{ $employee->photo_url }}" alt="Photo" class="employee-photo-thumb" style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; margin-right: 0.75rem;">
+                                <div>
+                                    <div class="fw-bold">{{ $employee->employeeNameEn ?? 'N/A' }}</div>
+                                    <div class="text-muted">{{ $employee->employeeFullName }}</div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="text-muted">{{ $employee->employer->employerNameTh ?? 'N/A' }}</td>
+                        <td>
+                            {{ $employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : '-' }}
+                            <span class="badge bg-secondary">{{ $employee->days_since_termination }} วัน</span>
+                        </td>
+                        <td>{{ $employee->termination_reason ?: '-' }}</td>
+                        <td class="text-nowrap">
+                            <button class="btn btn-sm btn-success btn-reinstate" title="Restore" data-employee-id="{{ $employee->id }}"><i class="bi bi-arrow-counterclockwise"></i></button>
+                            <button class="btn btn-sm btn-danger btn-move-to-trash" title="Move to Trash" data-employee-id="{{ $employee->id }}"><i class="bi bi-trash3-fill"></i></button>
+                            <button class="btn btn-sm btn-info btn-transfer-employee" title="Transfer Employer" data-employee-id="{{ $employee->id }}" data-employee-name="{{ $employee->employeeFullName }}"><i class="bi bi-person-up"></i></button>
+                        </td>
+                    </tr>
+                    @empty
+                    <tr>
+                        <td colspan="6" class="text-center text-muted">ไม่พบประวัติการจ้างงาน</td>
+                    </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    @endif
+    </div>
+
+    <div class="mt-4">
+        {{ $employees->links() }}
+    </div>
+</div>
+
+@include('partials._employee_action_modals')
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    let transferModalInstance = null;
+    let isBulkTransfer = false;
+
+    const tableBody = document.getElementById('historyTableBody');
+    const bulkActionBar = document.getElementById('history-bulk-action-bar');
+    const selectedCountSpan = document.getElementById('history-selected-count');
+    const mainSelectAllCheckbox = document.getElementById('history-select-all-checkbox-main');
+    const tableSelectAllCheckbox = document.getElementById('history-select-all-checkbox-table');
+    const bulkActionButton = document.getElementById('history-bulk-action-btn');
+    const transferModalEl = document.getElementById('transferEmployeeModal');
+    const employeeToTransferIdInput = document.getElementById('employee-to-transfer-id');
+    const employeeToTransferNameSpan = document.getElementById('employee-to-transfer-name');
+    const employerSearchInput = document.getElementById('employer-search-input');
+    const employerSearchResultsDiv = document.getElementById('employer-search-results');
+    const selectedEmployerDisplay = document.getElementById('selected-employer-display');
+    const selectedEmployerNameSpan = document.getElementById('selected-employer-name');
+    const confirmTransferBtn = document.getElementById('confirm-transfer-btn');
+
+    let selectedEmployer = null;
+
+    function updateBulkActionBar() {
+        const container = document.getElementById('employeeListContainer');
+        const selectedCheckboxes = container.querySelectorAll('.history-employee-checkbox:checked');
+        const count = selectedCheckboxes.length;
+        bulkActionBar.style.display = count > 0 ? 'flex' : 'none';
+        selectedCountSpan.textContent = count;
+        bulkActionButton.disabled = count === 0;
+        const allCheckboxes = container.querySelectorAll('.history-employee-checkbox');
+        if (allCheckboxes.length > 0) {
+            const isAllSelected = count === allCheckboxes.length;
+            if(mainSelectAllCheckbox) mainSelectAllCheckbox.checked = isAllSelected;
+            if(tableSelectAllCheckbox) tableSelectAllCheckbox.checked = isAllSelected;
+        }
+    }
+
+    function openTransferModal() {
+        employerSearchInput.value = '';
+        employerSearchResultsDiv.innerHTML = '';
+        employerSearchResultsDiv.style.display = 'block';
+        selectedEmployer = null;
+        selectedEmployerDisplay.style.display = 'none';
+        confirmTransferBtn.disabled = true;
+
+        if (!transferModalInstance) {
+            transferModalInstance = new bootstrap.Modal(transferModalEl);
+        }
+        transferModalInstance.show();
+    }
+
+    const performAction = (url, body = {}) => {
+        const method = body._method || 'POST';
+        if(body._method) delete body._method;
+
+        fetch(url, {
+            method: method,
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': csrfToken,
+                'Accept': 'application/json'
+            },
+            body: Object.keys(body).length ? JSON.stringify(body) : null
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                showToast(data.message || 'Action completed successfully.', 'success');
+                setTimeout(() => window.location.reload(), 1500);
+            } else {
+                showToast(data.message || 'An unknown error occurred.', 'danger');
+            }
+        })
+        .catch(error => {
+            console.error(`Error performing action to ${url}:`, error);
+            showToast('An error occurred while communicating with the server.', 'danger');
+        });
+    };
+
+    document.getElementById('employeeListContainer').addEventListener('click', (event) => {
+        const target = event.target.closest('button');
+        if (!target) return;
+        const employeeId = target.dataset.employeeId;
+
+        if (target.classList.contains('btn-reinstate')) {
+            Swal.fire({ title: 'ยืนยันการคืนสถานะ', text: "ลูกจ้างจะถูกย้ายกลับไปอยู่ในรายชื่อลูกจ้างปัจจุบัน", icon: 'question', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
+                .then(result => {
+                    if (result.isConfirmed) {
+                        performAction(`/employees/${employeeId}/reinstate`);
+                    }
+                });
+        } else if (target.classList.contains('btn-move-to-trash')) {
+            Swal.fire({ title: 'ยืนยันการย้ายไปถังขยะ', text: "ลูกจ้างจะถูกย้ายไปที่ถังขยะส่วนกลาง", icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก', confirmButtonColor: '#d33' })
+                .then(result => {
+                    if (result.isConfirmed) {
+                         performAction(`/employees/${employeeId}`, { _method: 'DELETE' });
+                    }
+                });
+        } else if (target.classList.contains('btn-transfer-employee')) {
+            isBulkTransfer = false;
+            employeeToTransferIdInput.value = employeeId;
+            employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้าง: ${target.dataset.employeeName}`;
+            openTransferModal();
+        }
+    });
+
+    document.getElementById('employeeListContainer').addEventListener('change', (event) => {
+        if (event.target.classList.contains('history-employee-checkbox')) {
+            updateBulkActionBar();
+        }
+    });
+
+    if(mainSelectAllCheckbox) {
+        mainSelectAllCheckbox.addEventListener('change', (event) => {
+            const isChecked = event.target.checked;
+            document.querySelectorAll('.history-employee-checkbox').forEach(cb => cb.checked = isChecked);
+            if(tableSelectAllCheckbox) tableSelectAllCheckbox.checked = isChecked;
+            updateBulkActionBar();
+        });
+    }
+
+    if(tableSelectAllCheckbox) {
+        tableSelectAllCheckbox.addEventListener('change', (event) => {
+            const isChecked = event.target.checked;
+            document.querySelectorAll('.history-employee-checkbox').forEach(cb => cb.checked = isChecked);
+            if(mainSelectAllCheckbox) mainSelectAllCheckbox.checked = isChecked;
+            updateBulkActionBar();
+        });
+    }
+
+    bulkActionButton.addEventListener('click', () => {
+        const selectedCheckboxes = document.querySelectorAll('.history-employee-checkbox:checked');
+        if (selectedCheckboxes.length === 0) return;
+        isBulkTransfer = true;
+        const employeeIds = Array.from(selectedCheckboxes).map(cb => cb.dataset.employeeId);
+        employeeToTransferIdInput.value = JSON.stringify(employeeIds);
+        employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้างที่เลือกจำนวน ${selectedCheckboxes.length} คน`;
+        openTransferModal();
+    });
+
+    const debounce = (func, delay) => {
+        let timeout;
+        return function(...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(() => func.apply(this, args), delay);
+        };
+    };
+
+    const handleEmployerSearch = debounce(() => {
+        const searchTerm = employerSearchInput.value.trim();
+        if (searchTerm.length < 2) {
+            employerSearchResultsDiv.innerHTML = '';
+            return;
+        }
+        employerSearchResultsDiv.innerHTML = '<p class="text-muted p-2">กำลังค้นหา...</p>';
+
+        fetch(`/api-web/employers/list?search=${encodeURIComponent(searchTerm)}`)
+            .then(response => response.ok ? response.json() : Promise.reject('Network response was not ok'))
+            .then(data => {
+                employerSearchResultsDiv.innerHTML = data.length === 0 ? '<p class="text-muted p-2">ไม่พบข้อมูลนายจ้าง</p>' : '';
+                data.forEach(employer => {
+                    const item = document.createElement('button');
+                    item.type = 'button';
+                    item.className = 'list-group-item list-group-item-action';
+                    item.innerHTML = `<strong>${employer.employerNameTh}</strong> <small class="text-muted">(${employer.employerId})</small>`;
+                    item.dataset.employerId = employer.id;
+                    item.dataset.employerName = employer.employerNameTh;
+                    employerSearchResultsDiv.appendChild(item);
+                });
+            })
+            .catch(error => {
+                console.error('Error fetching employers:', error);
+                employerSearchResultsDiv.innerHTML = '<p class="text-danger p-2">เกิดข้อผิดพลาดในการค้นหา</p>';
+            });
+    }, 300);
+
+    employerSearchInput.addEventListener('keyup', handleEmployerSearch);
+
+    employerSearchResultsDiv.addEventListener('click', (event) => {
+        const target = event.target.closest('button');
+        if (!target) return;
+        selectedEmployer = { id: target.dataset.employerId, name: target.dataset.employerName };
+        selectedEmployerNameSpan.textContent = selectedEmployer.name;
+        selectedEmployerDisplay.style.display = 'block';
+        confirmTransferBtn.disabled = false;
+        employerSearchResultsDiv.style.display = 'none';
+        employerSearchInput.value = '';
+    });
+
+    confirmTransferBtn.addEventListener('click', () => {
+        if (!selectedEmployer) return showToast('กรุณาเลือกนายจ้างใหม่ก่อน', 'danger');
+        const { id: newEmployerId, name: newEmployerName } = selectedEmployer;
+
+        const swalHtml = isBulkTransfer
+            ? `คุณต้องการย้ายลูกจ้างที่เลือกทั้งหมดไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`
+            : `คุณต้องการย้ายลูกจ้างไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`;
+
+        Swal.fire({ title: 'ยืนยันการย้ายนายจ้าง', html: swalHtml, icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
+            .then(result => {
+                if (result.isConfirmed) {
+                    if (isBulkTransfer) {
+                        const employeeIds = JSON.parse(employeeToTransferIdInput.value);
+                        performAction('/employees/bulk-transfer', { employee_ids: employeeIds, new_employer_id: newEmployerId });
+                    } else {
+                        const employeeId = employeeToTransferIdInput.value;
+                        performAction(`/employees/${employeeId}/transfer`, { new_employer_id: newEmployerId });
+                    }
+                }
+            });
+    });
+
+    if (transferModalEl) {
+        transferModalEl.addEventListener('show.bs.modal', () => document.body.classList.add('modal-stack-active'));
+        transferModalEl.addEventListener('hidden.bs.modal', () => document.body.classList.remove('modal-stack-active'));
+    }
+
+    updateBulkActionBar();
+});
+</script>
+<style>
+.modal-stack-active {
+    overflow: hidden;
+}
+.modal-stack-active .modal.fade.show:not(#transferEmployeeModal) {
+    opacity: 0.5;
+}
+</style>
+@endpush
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -179,6 +179,9 @@
                 <a href="{{ route('employees.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('employees.*') ? 'active' : '' }}">
                     <i class="bi bi-people-fill me-2"></i>ข้อมูลลูกจ้าง
                 </a>
+                <a href="{{ route('employees.history') }}" class="list-group-item list-group-item-action {{ request()->routeIs('employees.history') ? 'active' : '' }}" style="padding-left: 2.5rem;">
+                    <i class="bi bi-person-badge me-2"></i>ประวัติการจ้างงาน
+                </a>
                 @endcan
                 @can('view-importers')
                 <a href="{{ route('importers.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('importers.*') ? 'active' : '' }}"><i class="bi bi-box-arrow-in-down-left me-2"></i>ข้อมูลบริษัทนำเข้า</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,6 +52,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/employees/{employee}/locate', [EmployeeController::class, 'locate'])->name('employees.locate');
     Route::get('/employees/{employee}/create-job', [JobController::class, 'createFromEmployee'])->name('jobs.create_from_employee');
     Route::get('/employees/export', [EmployeeController::class, 'export'])->name('employees.export');
+    Route::get('/employees/history', [EmployeeController::class, 'historyIndex'])->name('employees.history');
     Route::get('/employees/{employee}/documents/{field}', [EmployeeController::class, 'serveDocument'])->name('employees.documents.serve');
     Route::resource('employees', EmployeeController::class);
     Route::resource('importers', ImporterController::class);


### PR DESCRIPTION
Adds a new "Employment History" page accessible from the main sidebar.

This page displays a global list of all terminated employees from all employers, reusing the same advanced search, filtering, and view-switching (card/table) functionalities as the main employee list.

The action buttons for each employee (Restore, Transfer to new employer, Move to Trash) are fully functional, replicating the logic from the existing employer-specific history modal.

- Adds `GET /employees/history` route and `EmployeeController@historyIndex` method.
- Creates `employees.history` view and `_history_card` partial.
- Implements frontend JavaScript for all actions, including bulk transfers.
- Adds a new link to the sidebar navigation.