### PR TITLE
fix: Add validation for Myanmar passport type in update

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -171,6 +171,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
         // --- V6: Step 1: Validate ALL text/date data (new and old) ---
         $validated = $request->validate([
             'employer_id' => 'required|exists:employers,id',
+            'passportType' => 'nullable|string|max:255',
             'employeeTitleTh' => 'required|string|max:255',
             'employeeNameTh' => 'required|string|max:255',
             'employeeTitleEn' => 'nullable|string|max:255',


### PR DESCRIPTION
This change adds the missing 'passportType' validation rule to the EmployeeController's update method. This resolves a bug where the passport type for Myanmar nationals was not being saved when editing an employee's record.