### PR TITLE
feat: Separate passport type filters for Myanmar and Cambodia

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -125,12 +125,12 @@ public function reinstate(Employee $employee)
         }
     }
 
-    if ($request->filled('passport_type')) {
-        $passportType = $request->input('passport_type');
-        $query->where(function ($q) use ($passportType) {
-            $q->where('passportType', $passportType)
-                ->orWhere('passport_type_cambodia', $passportType);
-        });
+    if ($request->filled('passport_type_myanmar')) {
+        $query->where('passportType', $request->input('passport_type_myanmar'));
+    }
+
+    if ($request->filled('passport_type_cambodia')) {
+        $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'));
     }
     // --- END: ADDED FILTERING LOGIC ---
 
@@ -551,12 +551,12 @@ public function create(Request $request) // เพิ่ม Request $request เ
             }
         }
 
-        if ($request->filled('passport_type')) {
-            $passportType = $request->input('passport_type');
-            $query->where(function ($q) use ($passportType) {
-                $q->where('passportType', $passportType)
-                    ->orWhere('passport_type_cambodia', $passportType);
-            });
+        if ($request->filled('passport_type_myanmar')) {
+            $query->where('passportType', $request->input('passport_type_myanmar'));
+        }
+
+        if ($request->filled('passport_type_cambodia')) {
+            $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'));
         }
 
         $employees = $query->with('employer')->get();
@@ -648,12 +648,12 @@ public function create(Request $request) // เพิ่ม Request $request เ
             }
         }
 
-        if ($request->filled('passport_type')) {
-            $passportType = $request->input('passport_type');
-            $query->where(function ($q) use ($passportType) {
-                $q->where('passportType', $passportType)
-                    ->orWhere('passport_type_cambodia', $passportType);
-            });
+        if ($request->filled('passport_type_myanmar')) {
+            $query->where('passportType', $request->input('passport_type_myanmar'));
+        }
+
+        if ($request->filled('passport_type_cambodia')) {
+            $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'));
         }
 
         $totalEmployees = (clone $query)->count();

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -149,12 +149,12 @@ public function edit(Request $request, Employer $employer)
         $employeeQuery->whereDate('workPermitExpiryDate', $request->input('work_permit_expiry_date'));
     }
 
-    if ($request->filled('passport_type')) {
-        $passportType = $request->input('passport_type');
-        $employeeQuery->where(function ($q) use ($passportType) {
-            $q->where('passportType', $passportType)
-              ->orWhere('passport_type_cambodia', $passportType);
-        });
+    if ($request->filled('passport_type_myanmar')) {
+        $employeeQuery->where('passportType', $request->input('passport_type_myanmar'));
+    }
+
+    if ($request->filled('passport_type_cambodia')) {
+        $employeeQuery->where('passport_type_cambodia', $request->input('passport_type_cambodia'));
     }
     // --- END: ADDED FILTERING LOGIC ---
 
@@ -328,12 +328,12 @@ public function edit(Request $request, Employer $employer)
                 }
             }
 
-            if ($request->filled('passport_type')) {
-                $passportType = $request->input('passport_type');
-                $query->where(function ($q) use ($passportType) {
-                    $q->where('passportType', $passportType)
-                        ->orWhere('passport_type_cambodia', $passportType);
-                });
+            if ($request->filled('passport_type_myanmar')) {
+                $query->where('passportType', $request->input('passport_type_myanmar'));
+            }
+
+            if ($request->filled('passport_type_cambodia')) {
+                $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'));
             }
         }
 

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -41,12 +41,15 @@
                 <option value="yes" {{ request('pink_card') == 'yes' ? 'selected' : '' }}>มีบัตรชมพู</option>
                 <option value="no" {{ request('pink_card') == 'no' ? 'selected' : '' }}>ไม่มีบัตรชมพู</option>
             </select>
-            <select name="passport_type" class="form-select form-select-sm" style="width: auto;">
-                <option value="">-- ประเภทพาสปอร์ต --</option>
-                <option value="CI" {{ request('passport_type') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>
-                <option value="PJ" {{ request('passport_type') == 'PJ' ? 'selected' : '' }}>เล่ม PJ</option>
-                <option value="TD" {{ request('passport_type') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
-                <option value="International" {{ request('passport_type') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
+            <select name="passport_type_myanmar" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- ประเภทพาสปอร์ต (เมียนมา) --</option>
+                <option value="CI" {{ request('passport_type_myanmar') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>
+                <option value="PJ" {{ request('passport_type_myanmar') == 'PJ' ? 'selected' : '' }}>เล่ม PJ</option>
+            </select>
+            <select name="passport_type_cambodia" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- ประเภทพาสปอร์ต (กัมพูชา) --</option>
+                <option value="TD" {{ request('passport_type_cambodia') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
+                <option value="International" {{ request('passport_type_cambodia') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
             </select>
             <input type="date" name="work_permit_expiry_date" class="form-control form-control-sm" value="{{ request('work_permit_expiry_date') }}" title="ค้นหาตามวันหมดอายุใบอนุญาตทำงาน">
             <button type="submit" class="btn btn-sm btn-primary">กรอง</button>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -362,12 +362,15 @@
                     <option value="yes" @if(request('pink_card') == 'yes') selected @endif>มีบัตรชมพู</option>
                     <option value="no" @if(request('pink_card') == 'no') selected @endif>ไม่มีบัตรชมพู</option>
                 </select>
-                <select name="passport_type" class="form-select form-select-sm" style="width: auto;">
-                    <option value="">-- ประเภทพาสปอร์ต --</option>
-                    <option value="CI" {{ request('passport_type') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>
-                    <option value="PJ" {{ request('passport_type') == 'PJ' ? 'selected' : '' }}>เล่ม PJ</option>
-                    <option value="TD" {{ request('passport_type') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
-                    <option value="International" {{ request('passport_type') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
+                <select name="passport_type_myanmar" class="form-select form-select-sm" style="width: auto;">
+                    <option value="">-- ประเภทพาสปอร์ต (เมียนมา) --</option>
+                    <option value="CI" {{ request('passport_type_myanmar') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>
+                    <option value="PJ" {{ request('passport_type_myanmar') == 'PJ' ? 'selected' : '' }}>เล่ม PJ</option>
+                </select>
+                <select name="passport_type_cambodia" class="form-select form-select-sm" style="width: auto;">
+                    <option value="">-- ประเภทพาสปอร์ต (กัมพูชา) --</option>
+                    <option value="TD" {{ request('passport_type_cambodia') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
+                    <option value="International" {{ request('passport_type_cambodia') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
                 </select>
                 <input type="date" name="work_permit_expiry_date" class="form-control form-control-sm" value="{{ request('work_permit_expiry_date') }}" title="ค้นหาตามวันหมดอายุใบอนุญาตทำงาน">
                 <button type="submit" class="btn btn-sm btn-primary">กรอง</button>


### PR DESCRIPTION
Refactors the employee filtering UI on the main employee list and the employer edit page.

Replaces the single, generic "Passport Type" dropdown with two distinct, clearly labeled dropdowns:
- "Passport Type (Myanmar)"
- "Passport Type (Cambodia)"

The backend filtering logic in both EmployeeController and EmployerController has been updated to handle the new, separate request parameters (`passport_type_myanmar` and `passport_type_cambodia`), ensuring the filters query the correct database columns (`passportType` and `passport_type_cambodia` respectively).