### PR TITLE
Fix: Align Cambodian passport filter values with database

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -48,8 +48,8 @@
             </select>
             <select name="passport_type_cambodia" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- ประเภทพาสปอร์ต (กัมพูชา) --</option>
-                <option value="TD" {{ request('passport_type_cambodia') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
-                <option value="International" {{ request('passport_type_cambodia') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
+                <option value="เล่ม TD" {{ request('passport_type_cambodia') == 'เล่ม TD' ? 'selected' : '' }}>เล่ม TD</option>
+                <option value="เล่มอินเตอร์" {{ request('passport_type_cambodia') == 'เล่มอินเตอร์' ? 'selected' : '' }}>เล่มอินเตอร์</option>
             </select>
             <input type="date" name="work_permit_expiry_date" class="form-control form-control-sm" value="{{ request('work_permit_expiry_date') }}" title="ค้นหาตามวันหมดอายุใบอนุญาตทำงาน">
             <button type="submit" class="btn btn-sm btn-primary">กรอง</button>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -369,8 +369,8 @@
                 </select>
                 <select name="passport_type_cambodia" class="form-select form-select-sm" style="width: auto;">
                     <option value="">-- ประเภทพาสปอร์ต (กัมพูชา) --</option>
-                    <option value="TD" {{ request('passport_type_cambodia') == 'TD' ? 'selected' : '' }}>เล่ม TD</option>
-                    <option value="International" {{ request('passport_type_cambodia') == 'International' ? 'selected' : '' }}>เล่มอินเตอร์</option>
+                    <option value="เล่ม TD" {{ request('passport_type_cambodia') == 'เล่ม TD' ? 'selected' : '' }}>เล่ม TD</option>
+                    <option value="เล่มอินเตอร์" {{ request('passport_type_cambodia') == 'เล่มอินเตอร์' ? 'selected' : '' }}>เล่มอินเตอร์</option>
                 </select>
                 <input type="date" name="work_permit_expiry_date" class="form-control form-control-sm" value="{{ request('work_permit_expiry_date') }}" title="ค้นหาตามวันหมดอายุใบอนุญาตทำงาน">
                 <button type="submit" class="btn btn-sm btn-primary">กรอง</button>


### PR DESCRIPTION
The dropdown filter for Cambodian passport types on the employee list pages was not working correctly because the `value` attributes in the HTML `<option>` tags (e.g., "TD", "International") did not match the actual strings stored in the database (e.g., "เล่ม TD", "เล่มอินเตอร์").

This commit updates the `value` attributes in the following files to use the correct Thai strings, ensuring the filter queries the database accurately:
- `resources/views/employees/index.blade.php`
- `resources/views/employers/edit.blade.php`

This change restores the filtering functionality on all relevant pages.