### PR TITLE
feat: Handle employer-specific notifications

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -152,6 +152,7 @@ class CheckExpiries extends Command
                         'type' => $notificationType,
                     ],
                     [
+                        'employee_id' => null, // Explicitly set employee_id to null
                         'due_date' => $expiryDate,
                         'days_remaining' => $daysRemaining,
                         'status' => 'unread',

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -73,7 +73,7 @@ class NotificationController extends Controller
 
     private function getFilteredQuery(Request $request, string $type)
     {
-        $query = Notification::with('employee.employer', 'employer');
+        $query = Notification::with(['employee.employer', 'employer']);
 
         if ($type === 'cancelled') {
             $query->where('status', 'cancelled')->latest('updated_at');

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -16,11 +16,14 @@ class Notification extends Model
      */
     protected $fillable = [
         'employee_id',
+        'employer_id',
         'type',
         'message',
         'due_date',
         'status',
-        'days_remaining', // FIX: Added this field to allow mass assignment
+        'days_remaining',
+        'cancellation_reason',
+        'cancelled_at',
     ];
 
     /**
@@ -29,5 +32,13 @@ class Notification extends Model
     public function employee()
     {
         return $this->belongsTo(Employee::class);
+    }
+
+    /**
+     * Get the employer that the notification belongs to.
+     */
+    public function employer()
+    {
+        return $this->belongsTo(Employer::class);
     }
 }

--- a/database/migrations/2025_11_19_093800_update_notifications_table_for_employer_notifications.php
+++ b/database/migrations/2025_11_19_093800_update_notifications_table_for_employer_notifications.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            // Make employee_id nullable to accommodate employer-only notifications
+            $table->foreignId('employee_id')->nullable()->change();
+
+            // Add employer_id for employer-specific notifications
+            $table->foreignId('employer_id')->nullable()->after('employee_id')->constrained()->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            // Revert employee_id to non-nullable.
+            // NOTE: This might fail if there are records where employee_id is null.
+            // Manual data cleanup might be required before rollback.
+            $table->foreignId('employee_id')->nullable(false)->change();
+
+            // Drop the foreign key and the column
+            $table->dropForeign(['employer_id']);
+            $table->dropColumn('employer_id');
+        });
+    }
+};

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -1,6 +1,7 @@
 @php
     $employee = $notification->employee;
-    $employer = $notification->employee->employer ?? $notification->employer;
+    // Correctly determine the employer, whether the notification is linked to an employee or directly to an employer.
+    $employer = $employee->employer ?? $notification->employer;
     $days_remaining = $notification->days_remaining;
     $is_overdue = $days_remaining < 0;
 
@@ -20,12 +21,14 @@
 
 <div class="alert {{ $card_class }} notification-item">
     <div class="d-flex align-items-center gap-3">
+        {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
         @if($employee)
             <input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $employee->id }}" id="notification_checkbox_{{ $notification->id }}">
         @else
             <input class="form-check-input" type="checkbox" disabled>
         @endif
 
+        {{-- Use employee photo or a placeholder --}}
         <img src="{{ $employee->photo_url ?? 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
              alt="Photo"
              class="w-12 h-12 object-cover rounded-full bg-light flex-shrink-0"
@@ -35,6 +38,7 @@
             <div class="flex-grow-1">
                 <h5 class="alert-heading mb-1">
                     {{ $itemNumber }}.
+                    {{-- Display Employee Name or Employer Document Type --}}
                     @if($employee)
                         {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
                         <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
@@ -64,39 +68,36 @@
                 </p>
                 <p class="mb-0 small"><strong>วันครบกำหนด:</strong> {{ \Carbon\Carbon::parse($notification->due_date)->translatedFormat('d F Y') }}</p>
             </div>
-                <div class="text-end flex-shrink-0 ms-2">
-                    <span class="badge {{ $badge_class }} mb-2 d-block text-nowrap fs-6">
-                        @if($is_overdue)
-                            หมดอายุ {{ abs($days_remaining) }} วัน
-                        @else
-                            เหลือ {{ $days_remaining }} วัน
+            <div class="text-end flex-shrink-0 ms-2">
+                <span class="badge {{ $badge_class }} mb-2 d-block text-nowrap fs-6">
+                    @if($is_overdue)
+                        หมดอายุ {{ abs($days_remaining) }} วัน
+                    @else
+                        เหลือ {{ $days_remaining }} วัน
+                    @endif
+                </span>
+                <div class="d-flex flex-column flex-md-row gap-2" role="group">
+                    @if($notification->status === 'cancelled')
+                        <form action="{{ route('notifications.restore', $notification->id) }}" method="POST" class="d-grid d-md-inline">
+                            @csrf
+                            <button type="submit" class="btn btn-info" title="กู้คืน"><i class="bi bi-arrow-counterclockwise"></i> กู้คืน</button>
+                        </form>
+                        <form action="{{ route('notifications.forceDelete', $notification->id) }}" method="POST" class="d-grid d-md-inline" onsubmit="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้อย่างถาวร?');">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
+                        </form>
+                    @else
+                        <a href="#" class="btn btn-info" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
+                        <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
+                        {{-- Only show the 'Locate' button if there is an employee --}}
+                        @if($employee)
+                            <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ค้นหาตำแหน่ง"><i class="bi bi-geo-alt-fill"></i></a>
                         @endif
-                    </span>
-                    <div class="d-flex flex-column flex-md-row gap-2" role="group">
-        @if($notification->status === 'cancelled')
-            <form action="{{ route('notifications.restore', $notification->id) }}" method="POST" class="d-grid d-md-inline">
-                @csrf
-                <button type="submit" class="btn btn-info" title="กู้คืน"><i class="bi bi-arrow-counterclockwise"></i> กู้คืน</button>
-            </form>
-            <form action="{{ route('notifications.forceDelete', $notification->id) }}" method="POST" class="d-grid d-md-inline" onsubmit="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้อย่างถาวร?');">
-                @csrf
-                @method('DELETE')
-                <button type="submit" class="btn btn-danger" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
-            </form>
-        @else
-            <a href="#" class="btn btn-info" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
-            <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
-            <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ค้นหาตำแหน่ง"><i class="bi bi-geo-alt-fill"></i></a>
-            <a href="#" class="btn btn-warning" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
-        @endif
-    </div>
+                        <a href="#" class="btn btn-warning" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
+                    @endif
                 </div>
             </div>
         </div>
     </div>
-@else
-    {{-- Fallback for deleted employee --}}
-    <div class="alert alert-secondary notification-item-deleted" role="alert">
-        การแจ้งเตือนนี้เกี่ยวข้องกับข้อมูลลูกจ้างที่ถูกลบออกจากระบบไปแล้ว
-    </div>
-@endif
+</div>

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -1,4 +1,6 @@
 @php
+    $employee = $notification->employee;
+    $employer = $employee->employer ?? $notification->employer;
     $days_remaining = $notification->days_remaining;
     $is_overdue = $days_remaining < 0;
     $text_class = 'text-dark';
@@ -13,35 +15,39 @@
 
 <tr>
     <td>
-        @if($notification->employee)
-            <input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $notification->employee->id }}" id="notification_table_checkbox_{{ $notification->id }}">
+        {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
+        @if($employee)
+            <input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $employee->id }}" id="notification_table_checkbox_{{ $notification->id }}">
+        @else
+            <input class="form-check-input" type="checkbox" value="" disabled>
         @endif
     </td>
     <td>{{ $itemNumber }}</td>
-    <td class="d-flex align-items-center">
-        @if($notification->employee)
-            <img src="{{ $notification->employee->photo_url }}"
-                 alt="Photo" class="employee-photo-thumb" style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; margin-right: 1rem;">
-            <div>
+    <td>
+        @if($employee)
+            <div class="d-flex align-items-center">
+                <img src="{{ $employee->photo_url }}" alt="Photo" class="employee-photo-thumb" style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; margin-right: 1rem;">
                 <div>
-                    {{ $notification->employee->employeeTitleEn ?? '' }} {{ $notification->employee->employeeNameEn ?? 'N/A' }}
-                    <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employee" data-model-id="{{ $notification->employee->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
+                    <div>
+                        {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
+                        <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
+                    </div>
+                    <div class="small text-muted">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }}</div>
                 </div>
-                <div class="small text-muted">{{ $notification->employee->employeeTitleTh ?? '' }} {{ $notification->employee->employeeNameTh ?? 'N/A' }}</div>
             </div>
         @else
-            <div class="text-muted">N/A</div>
+            <div class="text-muted">เอกสารนายจ้าง</div>
         @endif
     </td>
     <td>
-        @if(optional($notification->employee)->employeeNationality)
+        @if($employee && $employee->employeeNationality)
             @php
-                $countryCode = \App\Helpers\CountryHelper::getCountryCode($notification->employee->employeeNationality);
+                $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
             @endphp
             @if($countryCode)
                 <span class="d-inline-flex align-items-center">
                     <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 20px; height: 15px; margin-right: 8px;">
-                    <span>{{ $notification->employee->employeeNationality }}</span>
+                    <span>{{ $employee->employeeNationality }}</span>
                 </span>
             @endif
         @else
@@ -49,9 +55,6 @@
         @endif
     </td>
     <td>
-        @php
-            $employer = $notification->employee->employer ?? $notification->employer;
-        @endphp
         {{ $employer->employerNameTh ?? 'N/A' }}
         @if($employer)
             <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employer" data-model-id="{{ $employer->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
@@ -66,24 +69,25 @@
         @endif
     </td>
     <td class="text-center">
-<div class="d-flex flex-column flex-md-row justify-content-center gap-2">
-    @if($notification->status === 'cancelled')
-        <form action="{{ route('notifications.restore', $notification->id) }}" method="POST" class="d-grid d-md-inline">
-            @csrf
-            <button type="submit" class="btn btn-info btn-sm" title="กู้คืน"><i class="bi bi-arrow-counterclockwise"></i> กู้คืน</button>
-        </form>
-         <form action="{{ route('notifications.forceDelete', $notification->id) }}" method="POST" class="d-grid d-md-inline" onsubmit="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้อย่างถาวร?');">
-            @csrf
-            @method('DELETE')
-            <button type="submit" class="btn btn-danger btn-sm" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
-        </form>
-    @else
-        <a href="#" class="btn btn-info" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
-        <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
-        <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ค้นหาตำแหน่ง"><i class="bi bi-geo-alt-fill"></i></a>
-        <a href="#" class="btn btn-warning" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
-    @endif
-</div>
-    </div>
-</td>
+        <div class="d-flex flex-column flex-md-row justify-content-center gap-2">
+            @if($notification->status === 'cancelled')
+                <form action="{{ route('notifications.restore', $notification->id) }}" method="POST" class="d-grid d-md-inline">
+                    @csrf
+                    <button type="submit" class="btn btn-info btn-sm" title="กู้คืน"><i class="bi bi-arrow-counterclockwise"></i> กู้คืน</button>
+                </form>
+                 <form action="{{ route('notifications.forceDelete', $notification->id) }}" method="POST" class="d-grid d-md-inline" onsubmit="return confirm('คุณแน่ใจหรือไม่ว่าต้องการลบรายการนี้อย่างถาวร?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger btn-sm" title="ลบถาวร"><i class="bi bi-trash3-fill"></i></button>
+                </form>
+            @else
+                <a href="#" class="btn btn-info" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
+                <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
+                @if($employee)
+                    <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ค้นหาตำแหน่ง"><i class="bi bi-geo-alt-fill"></i></a>
+                @endif
+                <a href="#" class="btn btn-warning" title="ยกเลิก" data-bs-toggle="modal" data-bs-target="#cancelNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-x-circle"></i></a>
+            @endif
+        </div>
+    </td>
 </tr>


### PR DESCRIPTION
This commit resolves a fatal error on the notifications page caused by the introduction of employer-specific notifications (e.g., 'employer_document_expiry').

The key changes include:
- A new migration to add a nullable `employer_id` to the `notifications` table and make `employee_id` nullable.
- Updated the `Notification` model with the new `employer()` relationship.
- Refactored the `NotificationController` to correctly eager-load both employee and employer relationships.
- Updated the `CheckExpiries` command to handle the creation of employer-only notifications correctly.
- Patched the notification view partials (`_notification_item.blade.php` and `_notification_table_row.blade.php`) to conditionally render data, preventing errors when a notification is not linked to an employee.