### PR TITLE
Fix: Resolve ticket creation and attachment issues

### DIFF
--- a/app/Http/Controllers/Api/EmployerEmployeeController.php
+++ b/app/Http/Controllers/Api/EmployerEmployeeController.php
@@ -46,8 +46,15 @@ class EmployerEmployeeController extends Controller
                 return response()->json([]);
             }
         }
-        // For users with the 'employer' role, the existing employerTenancy global scope
-        // will automatically handle the filtering. No 'else' block is needed.
+        // V2.5-S7 FIX: Explicitly apply tenancy for employers to prevent global scope issues.
+        } else if ($user->hasRole('employer')) {
+            if ($user->employer) {
+                $query->where('employer_id', $user->employer->id);
+            } else {
+                // If employer user is not linked to an employer record, return empty.
+                return response()->json([]);
+            }
+        }
 
         $employees = $query->get(['id', 'employer_id', 'employeeNameTh', 'employeeNameEn', 'employeePassport', 'companyWorkerId', 'employeePhoto', 'employeeNationality']);
 

--- a/app/Http/Requests/StoreTicketRequest.php
+++ b/app/Http/Requests/StoreTicketRequest.php
@@ -25,31 +25,69 @@ class StoreTicketRequest extends FormRequest
      */
     public function rules(): array
     {
+        // V2.5-S8: Loosen validation to match Admin side. Controller handles logic.
         return [
             'subject' => ['required', 'string', 'max:255'],
             'message' => ['nullable', 'string', 'max:5000'],
             'attachments' => ['nullable', 'array'],
-            // Existing/New Employees validation rules remain the same
-            'attachments.existing_employees' => ['nullable', 'array'],
-            'attachments.existing_employees.*' => ['integer', 'exists:employees,id'],
-            'attachments.new_employees' => ['nullable', 'array'],
-            'attachments.new_employees.*' => ['json'],
-            // V2.4-S7: Validate General File Attachments
+
+            // 1. Files
             'attachments.files' => ['nullable', 'array'],
             'attachments.files.*.name' => ['required', 'string', 'max:255'],
             'attachments.files.*.size' => ['required', 'integer', 'min:1'],
             'attachments.files.*.path' => [
                 'required',
                 'string',
-                // CRITICAL SECURITY: Custom rule to ensure the path exists in the temporary storage
                 function ($attribute, $value, $fail) {
-                    // Ensure it looks like a temp path AND the file exists on the 'public' disk
                     if (!str_starts_with($value, 'temp_uploads/') || !Storage::disk('public')->exists($value)) {
-                        // This prevents users from submitting arbitrary file paths or expired uploads
                         $fail("The file attachment path is invalid or the file has expired.");
                     }
                 },
             ],
+
+            // 2. Existing Employees
+            'attachments.existing_employees' => ['nullable', 'array'],
+            'attachments.existing_employees.*' => [
+                'required',
+                'integer',
+                'distinct',
+                // Ensure the employee belongs to the authenticated employer.
+                'exists:employees,id,employer_id,' . Auth::user()->employer->id,
+            ],
+
+            // 3. New Employees (JSON data from modal)
+            'attachments.new_employees' => ['nullable', 'array'],
+            // The controller will now handle the JSON decoding, so we just expect an array here.
+            'attachments.new_employees.*' => ['required', 'array'],
+            'attachments.new_employees.*.employeeTitleTh' => ['nullable', 'string', 'max:50'],
+            'attachments.new_employees.*.employeeNameTh' => ['nullable', 'string', 'max:255'],
+            'attachments.new_employees.*.employeeNationality' => ['nullable', 'string', 'max:100'],
+            'attachments.new_employees.*.employeePassport' => ['nullable', 'string', 'max:50'],
+            'attachments.new_employees.*.employeePhoto' => ['nullable', 'string'],
+            'attachments.new_employees.*.document_1' => ['nullable', 'string'],
+
         ];
+    }
+
+    /**
+     * V2.5-S8: Prepare the data for validation, decoding new_employee JSON.
+     */
+    protected function prepareForValidation(): void
+    {
+        $attachments = $this->input('attachments', []);
+
+        if (!empty($attachments['new_employees']) && is_array($attachments['new_employees'])) {
+            $attachments['new_employees'] = array_map(function ($item) {
+                if (is_string($item)) {
+                    $decoded = json_decode($item, true);
+                    return (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) ? $decoded : $item;
+                }
+                return $item;
+            }, $attachments['new_employees']);
+        }
+
+        $this->merge([
+            'attachments' => $attachments,
+        ]);
     }
 }

--- a/app/Models/JobTicket.php
+++ b/app/Models/JobTicket.php
@@ -162,9 +162,11 @@ class JobTicket extends Model
 
                 // 2. Eager Load Employee models and map back with message IDs
                 if (!empty($employeeMessageMap)) {
+                    // V2.5-S6 FIX: Chain append('photo_url') to add the accessor to the collection
                     $employeeModels = Employee::withoutGlobalScopes()->withTrashed()
                         ->whereIn('id', array_keys($employeeMessageMap))
                         ->get()
+                        ->append('photo_url')
                         ->keyBy('id');
 
                     foreach ($employeeMessageMap as $employeeId => $messageIds) {


### PR DESCRIPTION
This commit addresses several critical bugs in the job ticket creation process that affected all user roles (Employer, Admin, Staff).

The key fixes include:
- Corrected the API endpoint (`Api/EmployerEmployeeController`) to explicitly use the authenticated employer's ID, resolving the issue where the "existing employees" list would appear empty.
- Overhauled the `StoreTicketRequest` form request. It now properly decodes the `new_employees` JSON payload and applies flexible, nullable validation rules, allowing tickets with new employee attachments to be created successfully. A tenancy check was also added to prevent employers from attaching employees they do not own.
- Adjusted the `JobTicket` model's `categorizedAttachments` accessor to ensure the `photo_url` is always appended to employee data, preventing display errors in the ticket view.