### PR TITLE
feat: Add month filter to notifications and improve document renewal

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -81,6 +81,11 @@ class NotificationController extends Controller
             $query->where('status', '!=', 'cancelled')->where('type', $type)->latest('due_date');
         }
 
+        // Filter by month if provided
+        if ($request->filled('month')) {
+            $query->whereMonth('due_date', $request->input('month'));
+        }
+
         // --- NEW: Enhanced Search Logic ---
         if ($request->filled('search')) {
             $search = $request->input('search');
@@ -134,36 +139,92 @@ class NotificationController extends Controller
     // Add this new method to the controller
     public function renew(Request $request, \App\Models\Notification $notification)
     {
-        $request->validate(['new_due_date' => 'required|date']);
+        $request->validate([
+            'new_due_date' => 'required|date',
+            'attachment' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:10240', // 10MB max
+        ]);
 
         $employee = $notification->employee;
+        $employer = $notification->employer; // Get employer directly
         $fieldToUpdate = '';
+        $fileField = '';
+        $targetModel = null;
 
         switch ($notification->type) {
             case 'passport_expiry':
+            case 'ci_renewal': // Handle CI renewal as passport update
                 $fieldToUpdate = 'passportExpiryDate';
+                $fileField = 'passport_file_path';
+                $targetModel = $employee;
                 break;
             case 'work_permit_expiry':
-            case 'work_permit_mou': // Added to handle new type
-            case 'resolution_renewal': // Added to handle new type
+            case 'work_permit_mou':
+            case 'resolution_renewal':
+            case 'new_registration_renewal':
                 $fieldToUpdate = 'workPermitExpiryDate';
+                $fileField = 'work_permit_file_path';
+                $targetModel = $employee;
                 break;
             case 'visa_expiry':
                 $fieldToUpdate = 'visaExpiryDate';
+                $fileField = 'visa_file_path';
+                $targetModel = $employee;
                 break;
             case 'ninety_day_report':
                 $fieldToUpdate = 'ninetyDayReportDate';
+                // Use employee_doc_1 for 90-day reports if no specific column exists
+                $fileField = 'employee_doc_1';
+                $targetModel = $employee;
+                break;
+            case 'employee_insurance_expiry':
+                $fileField = 'insurance_attachment_path';
+                $targetModel = $employee;
+                // Determine which date field to update based on insurance type
+                if ($employee->insurance_type === 'ประกันเอกชน') {
+                    $fieldToUpdate = 'insurance_expiry_date_private';
+                } elseif ($employee->insurance_type === 'ประกันโรงพยาบาล') {
+                    $fieldToUpdate = 'insurance_expiry_date_hospital';
+                } else {
+                    $fieldToUpdate = 'insurance_expiry_date';
+                }
+                break;
+            case 'employer_document_expiry':
+                $fieldToUpdate = 'employer_doc_company_expiry';
+                $fileField = 'employer_doc_company';
+                $targetModel = $employer;
                 break;
         }
 
-        if ($fieldToUpdate && $employee) {
-            $employee->{$fieldToUpdate} = $request->new_due_date;
-            $employee->save();
+        if ($fieldToUpdate && $targetModel) {
+            $targetModel->{$fieldToUpdate} = $request->new_due_date;
+
+            // Handle file upload
+            if ($request->hasFile('attachment') && $fileField) {
+                // Delete old file if exists
+                if ($targetModel->{$fileField} && \Illuminate\Support\Facades\Storage::disk('public')->exists($targetModel->{$fileField})) {
+                    \Illuminate\Support\Facades\Storage::disk('public')->delete($targetModel->{$fileField});
+                }
+
+                $file = $request->file('attachment');
+                $filename = \Illuminate\Support\Str::random(20) . '.' . $file->getClientOriginalExtension();
+
+                // Determine storage path based on model type
+                if ($targetModel instanceof \App\Models\Employee) {
+                    $path = $file->storeAs("employee_files/{$targetModel->employer_id}", $filename, 'public');
+                } else {
+                     // Employer documents
+                    $path = $file->storeAs("employer_documents", $filename, 'public');
+                }
+
+                $targetModel->{$fileField} = $path;
+            }
+
+            $targetModel->save();
         }
 
         $notification->delete(); // Remove the notification after handling
 
-        return redirect()->route('notifications.index')->with('success', 'ต่ออายุข้อมูลเรียบร้อยแล้ว');
+        return redirect()->route('notifications.index')->with('success', 'ต่ออายุข้อมูลและบันทึกเอกสารเรียบร้อยแล้ว');
     }
 
     // Add this new method to the controller

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -293,7 +293,7 @@
         <div class="modal fade" id="renewNotificationModal" tabindex="-1" aria-labelledby="renewModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
-                    <form id="renew-form" method="POST">
+                    <form id="renew-form" method="POST" enctype="multipart/form-data">
                         @csrf
                         <div class="modal-header">
                             <h5 class="modal-title" id="renewModalLabel">ต่ออายุการแจ้งเตือน</h5>
@@ -303,6 +303,10 @@
                             <div class="mb-3">
                                 <label for="new_due_date" class="form-label">เลือกวันหมดอายุใหม่:</label>
                                 <input type="date" class="form-control" id="new_due_date" name="new_due_date" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="attachment" class="form-label">แนบไฟล์เอกสาร (ถ้ามี):</label>
+                                <input type="file" class="form-control" id="attachment" name="attachment" accept=".pdf,.jpg,.jpeg,.png">
                             </div>
                         </div>
                         <div class="modal-footer">

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -17,6 +17,12 @@
             <form action="{{ route('notifications.index') }}" method="GET" class="d-flex flex-column flex-md-row flex-wrap gap-2 align-items-md-center">
                 <input type="hidden" name="active_tab" id="active_tab_input" value="{{ request('active_tab', 'ninety_day_report') }}">
                 <input type="text" name="search" class="form-control form-control-sm" placeholder="ค้นหาชื่อ..." value="{{ request('search') }}" style="width: 200px;">
+                <select name="month" class="form-select form-select-sm" style="width: 150px;">
+                    <option value="">-- ทุกเดือน --</option>
+                    @foreach(range(1, 12) as $m)
+                        <option value="{{ $m }}" @selected(request('month') == $m)>เดือนที่ {{ $m }}</option>
+                    @endforeach
+                </select>
                 <select name="nationality" class="form-select form-select-sm" style="width: 150px;">
                     <option value="">-- ทุกสัญชาติ --</option>
                     <option value="เมียนมา" @selected(request('nationality') == 'เมียนมา')>เมียนมา</option>


### PR DESCRIPTION
- Add month filter dropdown (1-12) to notification index view.
- Update NotificationController index to filter by month.
- Update renewal modal to allow file attachment.
- Update NotificationController renew method to handle file uploads and map to correct Employee/Employer document fields.
- Support renewal for all notification types including employer documents.