### PR TITLE
Fix Admin ticket creation: resolve API syntax error and support all a…

### DIFF
--- a/app/Http/Controllers/Admin/AdminJobTicketController.php
+++ b/app/Http/Controllers/Admin/AdminJobTicketController.php
@@ -114,7 +114,17 @@ class AdminJobTicketController extends Controller
 
             // 5. Process New Employees (attachment_new_employee)
             if (!empty($attachments['new_employees'])) {
-                $fileFields = ['employeePhoto', 'document_1']; // ตรงกับใน Modal (snippet 56)
+                // Define all possible file fields that need to be processed
+                $fileFields = [
+                    'employeePhoto',
+                    'insurance_document_path_social',
+                    'insurance_document_path_hospital',
+                    'insurance_document_path_private',
+                    'employee_doc_1', 'employee_doc_2', 'employee_doc_3',
+                    'employee_doc_4', 'employee_doc_5', 'employee_doc_6',
+                    'employee_doc_7', 'employee_doc_8', 'employee_doc_9',
+                    'employee_doc_10', 'employee_doc_11', 'employee_doc_12'
+                ];
 
                 // V2.5-PATCH: $validated['attachments']['new_employees'] คือ array of arrays (ไม่ใช่ JSON string)
                 foreach ($attachments['new_employees'] as $newEmployeeData) {

--- a/app/Http/Controllers/Api/EmployerEmployeeController.php
+++ b/app/Http/Controllers/Api/EmployerEmployeeController.php
@@ -47,7 +47,7 @@ class EmployerEmployeeController extends Controller
             }
         }
         // V2.5-S7 FIX: Explicitly apply tenancy for employers to prevent global scope issues.
-        } else if ($user->hasRole('employer')) {
+        else if ($user->hasRole('employer')) {
             if ($user->employer) {
                 $query->where('employer_id', $user->employer->id);
             } else {

--- a/app/Http/Requests/Admin/StoreAdminJobTicketRequest.php
+++ b/app/Http/Requests/Admin/StoreAdminJobTicketRequest.php
@@ -80,15 +80,30 @@ class StoreAdminJobTicketRequest extends FormRequest
             // 3. New Employees (JSON data from modal)
             'attachments.new_employees' => ['nullable', 'array'],
             'attachments.new_employees.*' => ['required', 'array'], // ตรวจสอบว่าเป็น array ที่ถูก decode แล้ว
-            // V2.5-PATCH: ตรวจสอบ field ตามฟอร์มใน _new_employee_modal.blade.php (snippet 56)
-            // เราไม่ต้องการ employeeDob ที่นี่
+
+            // Validation for text fields
             'attachments.new_employees.*.employeeTitleTh' => ['nullable', 'string', 'max:50'],
             'attachments.new_employees.*.employeeNameTh' => ['nullable', 'string', 'max:255'],
             'attachments.new_employees.*.employeeNationality' => ['nullable', 'string', 'max:100'],
             'attachments.new_employees.*.employeePassport' => ['nullable', 'string', 'max:50'],
-            // ตรวจสอบไฟล์ที่แนบมาใน JSON
+
+            // Validation for all file attachments
             'attachments.new_employees.*.employeePhoto' => $tempFileValidation,
-            'attachments.new_employees.*.document_1' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_social' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_hospital' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_private' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_1' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_2' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_3' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_4' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_5' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_6' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_7' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_8' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_9' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_10' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_11' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_12' => $tempFileValidation,
         ];
     }
 


### PR DESCRIPTION
…ttachment types

- Fixed a syntax error in `EmployerEmployeeController` (extra closing brace) that caused a 500 error when fetching employees.
- Updated `StoreAdminJobTicketRequest` to validate all file fields for new employees (employee_doc_1-12, insurance docs).
- Updated `AdminJobTicketController` to process and move all new employee file attachments from temporary to permanent storage.