### PR TITLE
Fix View Not Found error in Incomplete Employees menu

### DIFF
--- a/resources/views/admin/incomplete_employees/index.blade.php
+++ b/resources/views/admin/incomplete_employees/index.blade.php
@@ -34,7 +34,7 @@
         <div class="row g-3">
             @foreach($employees as $employee)
                 <div class="col-12 col-md-6 col-xl-4">
-                    @include('employees.partials._employee_card', ['employee' => $employee, 'is_incomplete_view' => true])
+                    @include('employees._employee_card', ['employee' => $employee, 'is_incomplete_view' => true])
                 </div>
             @endforeach
         </div>

--- a/resources/views/employees/_employee_card.blade.php
+++ b/resources/views/employees/_employee_card.blade.php
@@ -19,7 +19,7 @@
                 <h5 class="mb-1">
                     {{ $employee->employeeNameEn ?? 'N/A' }}
                     @if($employee->employeeNationality)
-                        @php $flagCode = \App\Helpers\CountryHelper::getFlagCode($employee->employeeNationality); @endphp
+                        @php $flagCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality); @endphp
                         @if($flagCode)
                             <img src="https://flagcdn.com/w20/{{ $flagCode }}.png" alt="{{ $employee->employeeNationality }}" title="{{ $employee->employeeNationality }}">
                         @endif


### PR DESCRIPTION
- Corrected the include path in `resources/views/admin/incomplete_employees/index.blade.php` from `employees.partials._employee_card` to `employees._employee_card`.
- Updated `resources/views/employees/_employee_card.blade.php` to use the correct helper method `App\Helpers\CountryHelper::getCountryCode` instead of the non-existent `getFlagCode`.