### PR TITLE
Flatten Notifications menu and remove toggle in sidebar

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -181,20 +181,14 @@
                 <a href="#" class="list-group-item list-group-item-action"><i class="bi bi-pie-chart-fill me-2"></i>ภาพรวม</a>
                 @endcan
                 @can('view-notifications')
-                <a href="#notificationSubmenu" data-bs-toggle="collapse" aria-expanded="{{ request()->routeIs('notifications.*') || request()->routeIs('admin.incomplete_employees.*') ? 'true' : 'false' }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                    <span><i class="bi bi-bell-fill me-2"></i>แจ้งเตือน</span>
-                    <i class="bi bi-chevron-down" style="font-size: 0.8rem;"></i>
+                <a href="{{ route('notifications.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('notifications.*') ? 'active' : '' }}">
+                    <i class="bi bi-bell-fill me-2"></i>แจ้งเตือน
                 </a>
-                <div class="collapse {{ request()->routeIs('notifications.*') || request()->routeIs('admin.incomplete_employees.*') ? 'show' : '' }}" id="notificationSubmenu">
-                    <a href="{{ route('notifications.index') }}" class="list-group-item list-group-item-action border-0 {{ request()->routeIs('notifications.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
-                        <i class="bi bi-list-ul me-2"></i>รายการแจ้งเตือน
-                    </a>
-                    @can('manage-tickets')
-                    <a href="{{ route('admin.incomplete_employees.index') }}" class="list-group-item list-group-item-action border-0 {{ request()->routeIs('admin.incomplete_employees.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
-                        <i class="bi bi-exclamation-octagon-fill me-2"></i>ข้อมูลไม่ครบถ้วน
-                    </a>
-                    @endcan
-                </div>
+                @can('manage-tickets')
+                <a href="{{ route('admin.incomplete_employees.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('admin.incomplete_employees.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
+                    <i class="bi bi-exclamation-octagon-fill me-2"></i>ข้อมูลไม่ครบถ้วน
+                </a>
+                @endcan
                 @endcan
                 {{-- START V2.4: Smart Ticket Links --}}
                 {{-- V2.4: Admin/Staff Ticket Inbox --}}


### PR DESCRIPTION
This change modifies the sidebar navigation in `resources/views/layouts/app.blade.php` to remove the collapsible dropdown behavior from the "Notifications" menu. The "Incomplete Information" (ข้อมูลไม่ครบถ้วน) link is now permanently visible directly below the "Notifications" link, mimicking the layout of "Employment History". This ensures easier access to these items upon login without requiring manual toggling.