### PR TITLE
Fix missing attachments for new employee in ticket reply and creation

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -141,8 +141,16 @@ class TicketController extends Controller
 
             // 5. Process New Employees (attachment_new_employee)
             if (!empty($attachments['new_employees'])) {
-                // Define fields within the JSON that might contain file paths
-                $fileFields = ['employeePhoto', 'document_1']; // Add other file fields here if needed
+                // Define all possible file fields that need to be processed
+                $fileFields = [
+                    'employeePhoto',
+                    'insurance_document_path_social',
+                    'insurance_document_path_hospital',
+                    'insurance_document_path_private'
+                ];
+                for ($i = 1; $i <= 12; $i++) {
+                    $fileFields[] = 'employee_doc_' . $i;
+                }
 
                 foreach ($attachments['new_employees'] as $newEmployeeJson) {
                     // Fix: Handle array (from validation) or string. StoreTicketRequest converts JSON strings to arrays.

--- a/app/Http/Requests/StoreTicketReplyRequest.php
+++ b/app/Http/Requests/StoreTicketReplyRequest.php
@@ -114,7 +114,21 @@ class StoreTicketReplyRequest extends FormRequest
             ...$this->buildNestedValidationRules('attachments.new_employees.*.', $newEmployeeRequiredFields),
             // Validate file paths
             'attachments.new_employees.*.employeePhoto' => $tempFileValidation,
-            'attachments.new_employees.*.document_1' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_social' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_hospital' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_private' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_1' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_2' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_3' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_4' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_5' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_6' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_7' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_8' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_9' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_10' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_11' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_12' => $tempFileValidation,
         ];
     }
 

--- a/app/Http/Requests/StoreTicketRequest.php
+++ b/app/Http/Requests/StoreTicketRequest.php
@@ -26,6 +26,18 @@ class StoreTicketRequest extends FormRequest
     public function rules(): array
     {
         // V2.5-S8: Loosen validation to match Admin side. Controller handles logic.
+
+        // Common validation for temporary files
+        $tempFileValidation = [
+            'nullable',
+            'string',
+            function ($attribute, $value, $fail) {
+                if ($value && (!str_starts_with($value, 'temp_uploads/') || !Storage::disk('public')->exists($value))) {
+                    $fail("The file attachment path ($value) is invalid or the file has expired.");
+                }
+            },
+        ];
+
         return [
             'subject' => ['required', 'string', 'max:255'],
             'message' => ['nullable', 'string', 'max:5000'],
@@ -63,9 +75,24 @@ class StoreTicketRequest extends FormRequest
             'attachments.new_employees.*.employeeNameTh' => ['nullable', 'string', 'max:255'],
             'attachments.new_employees.*.employeeNationality' => ['nullable', 'string', 'max:100'],
             'attachments.new_employees.*.employeePassport' => ['nullable', 'string', 'max:50'],
-            'attachments.new_employees.*.employeePhoto' => ['nullable', 'string'],
-            'attachments.new_employees.*.document_1' => ['nullable', 'string'],
 
+            // File validations
+            'attachments.new_employees.*.employeePhoto' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_social' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_hospital' => $tempFileValidation,
+            'attachments.new_employees.*.insurance_document_path_private' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_1' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_2' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_3' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_4' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_5' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_6' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_7' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_8' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_9' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_10' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_11' => $tempFileValidation,
+            'attachments.new_employees.*.employee_doc_12' => $tempFileValidation,
         ];
     }
 


### PR DESCRIPTION
This commit updates the ticket creation and reply logic to correctly process and validate all document attachments for new employees. Previously, only the photo and a generic 'document_1' field were processed, causing other uploaded documents (Visa, Work Permit, etc.) to be ignored.

Changes:
- Updated `StoreTicketReplyRequest.php` to include validation rules for `employee_doc_1` through `12` and insurance documents.
- Updated `StoreTicketRequest.php` to include validation rules for `employee_doc_1` through `12` and insurance documents.
- Updated `TicketController.php` to process the full list of attachment fields when moving files from temporary storage.