### PR TITLE
Add indicators and badges for incomplete employee data

### DIFF
--- a/app/Helpers/CompletenessHelper.php
+++ b/app/Helpers/CompletenessHelper.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\Employee;
+use App\Models\SystemConfig;
+use Illuminate\Support\Facades\Schema;
+
+class CompletenessHelper
+{
+    /**
+     * Get the list of missing fields for a specific employee.
+     *
+     * @param Employee $employee
+     * @param array|null $mandatoryFields
+     * @return array
+     */
+    public static function getMissingFields(Employee $employee, ?array $mandatoryFields = null): array
+    {
+        if ($mandatoryFields === null) {
+            $config = SystemConfig::where('key', 'employee_mandatory_fields')->first();
+            $mandatoryFields = $config ? json_decode($config->value, true) : [];
+        }
+
+        if (empty($mandatoryFields)) {
+            return [];
+        }
+
+        $validColumns = Schema::getColumnListing('employees');
+        $validMandatoryFields = array_intersect($mandatoryFields, $validColumns);
+
+        $missing = [];
+        foreach ($validMandatoryFields as $field) {
+            // Check if the field is null or empty string
+            if (is_null($employee->$field) || (is_string($employee->$field) && trim($employee->$field) === '')) {
+                $missing[] = $field;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * Get total count of incomplete employees.
+     *
+     * @return int
+     */
+    public static function getIncompleteCount(): int
+    {
+        $config = SystemConfig::where('key', 'employee_mandatory_fields')->first();
+        $mandatoryFields = $config ? json_decode($config->value, true) : [];
+
+        if (empty($mandatoryFields)) {
+            return 0;
+        }
+
+        $validColumns = Schema::getColumnListing('employees');
+        $mandatoryFields = array_intersect($mandatoryFields, $validColumns);
+
+        if (empty($mandatoryFields)) {
+            return 0;
+        }
+
+        return Employee::whereNull('terminated_at')
+            ->where(function ($query) use ($mandatoryFields) {
+                foreach ($mandatoryFields as $field) {
+                    $query->orWhereNull($field)
+                          ->orWhere($field, '');
+                }
+            })
+            ->count();
+    }
+}

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -307,7 +307,11 @@ public function create(Request $request) // เพิ่ม Request $request เ
     public function edit(Employee $employee)
     {
         $employers = \App\Models\Employer::orderBy('employerNameTh')->get();
-        return view('employees.edit', compact('employee', 'employers'));
+
+        // Fetch missing fields to highlight in the view
+        $missingFields = \App\Helpers\CompletenessHelper::getMissingFields($employee);
+
+        return view('employees.edit', compact('employee', 'employers', 'missingFields'));
     }
 
     public function update(Request $request, Employee $employee)

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -27,5 +27,14 @@ class AppServiceProvider extends ServiceProvider
         Paginator::useBootstrapFive();
         Employee::observe(EmployeeObserver::class);
         Employer::observe(EmployerObserver::class);
+
+        // Share incomplete employee count with specific views (layout)
+        view()->composer('layouts.app', function ($view) {
+            // Only calculate if the user is logged in and has permission to view this
+            if (auth()->check() && auth()->user()->can('manage-tickets')) {
+                 $incompleteCount = \App\Helpers\CompletenessHelper::getIncompleteCount();
+                 $view->with('incompleteCount', $incompleteCount);
+            }
+        });
     }
 }

--- a/resources/views/employees/_employee_card.blade.php
+++ b/resources/views/employees/_employee_card.blade.php
@@ -2,7 +2,21 @@
     // Helper to prevent errors if employer relationship is not loaded
     $employerName = $employee->employer->employerNameTh ?? 'N/A';
 @endphp
-<div id="employee-card-{{ $employee->id }}" class="list-group-item list-group-item-action">
+@php
+    // V2.5: Check completeness for badge display (Only in Incomplete View)
+    $missingCount = 0;
+    if (isset($is_incomplete_view) && $is_incomplete_view) {
+        $missingCount = count(\App\Helpers\CompletenessHelper::getMissingFields($employee, $mandatoryFields ?? null));
+    }
+@endphp
+
+<div id="employee-card-{{ $employee->id }}" class="list-group-item list-group-item-action position-relative">
+    @if($missingCount > 0)
+        <span class="position-absolute top-0 start-0 translate-middle badge rounded-pill bg-warning text-dark border border-light shadow-sm" style="z-index: 10; margin-left: 15px; margin-top: 15px; font-size: 0.8rem;">
+            {{ $missingCount }}
+            <span class="visually-hidden">missing fields</span>
+        </span>
+    @endif
     <div class="d-flex align-items-center">
         {{-- Checkbox for Bulk Actions --}}
         <div class="me-3">

--- a/resources/views/employees/edit.blade.php
+++ b/resources/views/employees/edit.blade.php
@@ -9,6 +9,15 @@
         <a href="{{ route('employers.edit', $employee->employer_id) }}#employee-card-{{ $employee->id }}" class="btn btn-secondary">กลับไปที่นายจ้าง</a>
     </div>
 
+    @if(isset($missingFields) && count($missingFields) > 0)
+        <div class="alert alert-warning d-flex align-items-center" role="alert">
+             <i class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2"></i>
+             <div>
+                 <strong>Data Incomplete:</strong> This employee is missing {{ count($missingFields) }} required fields. Please fill in the fields marked with <i class="bi bi-exclamation-circle-fill text-warning"></i>.
+             </div>
+        </div>
+    @endif
+
     @if ($errors->any())
         <div class="alert alert-danger">
             <ul class="mb-0">
@@ -33,7 +42,9 @@
             <div class="col-md-8">
                 <div class="row">
                     <div class="col-md-6 mb-3">
-                        <label for="employeeTitleTh" class="form-label">คำนำหน้าชื่อ (ไทย) <span class="text-danger">*</span></label>
+                        <label for="employeeTitleTh" class="form-label">คำนำหน้าชื่อ (ไทย) <span class="text-danger">*</span>
+                            @if(isset($missingFields) && in_array('employeeTitleTh', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                        </label>
                         <select class="form-select" id="employeeTitleTh" name="employeeTitleTh" required>
                             <option value="นาย" @selected(old('employeeTitleTh', $employee->employeeTitleTh) == 'นาย')>นาย</option>
                             <option value="นางสาว" @selected(old('employeeTitleTh', $employee->employeeTitleTh) == 'นางสาว')>นางสาว</option>
@@ -41,14 +52,18 @@
                         </select>
                     </div>
                     <div class="col-md-6 mb-3">
-                        <label for="employeeNameTh" class="form-label">ชื่อ-สกุล (ไทย) <span class="text-danger">*</span></label>
+                        <label for="employeeNameTh" class="form-label">ชื่อ-สกุล (ไทย) <span class="text-danger">*</span>
+                            @if(isset($missingFields) && in_array('employeeNameTh', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                        </label>
                         <input type="text" class="form-control" id="employeeNameTh" name="employeeNameTh" value="{{ old('employeeNameTh', $employee->employeeNameTh) }}" required>
                     </div>
                 </div>
 
                 <div class="row">
                      <div class="col-md-6 mb-3">
-                        <label for="employeeTitleEn" class="form-label">Prefix (EN)</label>
+                        <label for="employeeTitleEn" class="form-label">Prefix (EN)
+                            @if(isset($missingFields) && in_array('employeeTitleEn', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                        </label>
                         <select class="form-select" id="employeeTitleEn" name="employeeTitleEn">
                              <option value="Mr." @selected(old('employeeTitleEn', $employee->employeeTitleEn) == 'Mr.')>Mr.</option>
                              <option value="Miss" @selected(old('employeeTitleEn', $employee->employeeTitleEn) == 'Miss')>Miss</option>
@@ -56,18 +71,24 @@
                         </select>
                     </div>
                     <div class="col-md-6 mb-3">
-                        <label for="employeeNameEn" class="form-label">Full Name (EN)</label>
+                        <label for="employeeNameEn" class="form-label">Full Name (EN)
+                            @if(isset($missingFields) && in_array('employeeNameEn', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                        </label>
                         <input type="text" class="form-control" id="employeeNameEn" name="employeeNameEn" value="{{ old('employeeNameEn', $employee->employeeNameEn) }}">
                     </div>
                 </div>
 
                  <div class="row">
                     <div class="col-md-6 mb-3">
-                        <label for="father_name" class="form-label">ชื่อพ่อ</label>
+                        <label for="father_name" class="form-label">ชื่อพ่อ
+                            @if(isset($missingFields) && in_array('father_name', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                        </label>
                         <input type="text" class="form-control" id="father_name" name="father_name" value="{{ old('father_name', $employee->father_name) }}">
                     </div>
                     <div class="col-md-6 mb-3">
-                        <label for="mother_name" class="form-label">ชื่อแม่</label>
+                        <label for="mother_name" class="form-label">ชื่อแม่
+                            @if(isset($missingFields) && in_array('mother_name', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                        </label>
                         <input type="text" class="form-control" id="mother_name" name="mother_name" value="{{ old('mother_name', $employee->mother_name) }}">
                     </div>
                 </div>
@@ -78,7 +99,9 @@
                         <input type="text" class="form-control" id="employeeGender" name="employeeGender" value="{{ old('employeeGender', $employee->employeeGender) }}" readonly>
                      </div>
                      <div class="col-md-5 mb-3">
-                        <label for="employeeDob" class="form-label">วันเดือนปีเกิด</label>
+                        <label for="employeeDob" class="form-label">วันเดือนปีเกิด
+                            @if(isset($missingFields) && in_array('employeeDob', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                        </label>
                         <input type="date" class="form-control" id="employeeDob" name="employeeDob" value="{{ old('employeeDob', optional($employee->employeeDob)->format('Y-m-d')) }}">
                     </div>
                     <div class="col-md-3 mb-3">
@@ -89,7 +112,9 @@
             </div>
             {{-- Right Column --}}
             <div class="col-md-4 d-flex flex-column justify-content-center align-items-center">
-                <label for="employeePhoto" class="form-label">รูปภาพพนักงาน</label>
+                <label for="employeePhoto" class="form-label">รูปภาพพนักงาน
+                    @if(isset($missingFields) && in_array('employeePhoto', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <img id="employeePhotoPreview" src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/150x180/f8fafc/6c757d?text=Photo' }}" class="img-thumbnail mb-2" style="width: 150px; height: 180px; object-fit: cover;">
                 <input type="file" class="form-control form-control-sm w-75" id="employeePhoto" name="employeePhoto" accept="image/*" capture="environment">
             </div>
@@ -101,11 +126,15 @@
         <hr class="mb-4">
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="employeePhone" class="form-label">เบอร์โทรศัพท์</label>
+                <label for="employeePhone" class="form-label">เบอร์โทรศัพท์
+                    @if(isset($missingFields) && in_array('employeePhone', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="tel" class="form-control" id="employeePhone" name="employeePhone" value="{{ old('employeePhone', $employee->employeePhone) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="employeeNationality" class="form-label">สัญชาติ</label>
+                <label for="employeeNationality" class="form-label">สัญชาติ
+                    @if(isset($missingFields) && in_array('employeeNationality', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <select class="form-select" id="employeeNationality" name="employeeNationality">
                     <option value="">-- เลือกสัญชาติ --</option>
                     <option value="เมียนมา" @selected(old('employeeNationality', $employee->employeeNationality) == 'เมียนมา')>เมียนมา</option>
@@ -115,7 +144,9 @@
                 </select>
             </div>
              <div class="col-md-4 mb-3 d-none" id="passportTypeContainer">
-                <label for="passportType" class="form-label">ประเภทหนังสือเดินทาง (สำหรับเมียนมา)</label>
+                <label for="passportType" class="form-label">ประเภทหนังสือเดินทาง (สำหรับเมียนมา)
+                    @if(isset($missingFields) && in_array('passportType', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <select class="form-select" id="passportType" name="passportType">
                     <option value="">-- เลือกประเภท --</option>
                     <option value="PJ" @selected(old('passportType', $employee->passportType) == 'PJ')>เล่ม PJ</option>
@@ -123,7 +154,9 @@
                 </select>
             </div>
             <div class="col-md-4 mb-3 d-none" id="passportTypeCambodiaContainer">
-                <label for="passport_type_cambodia" class="form-label">ประเภทหนังสือเดินทาง (สำหรับกัมพูชา)</label>
+                <label for="passport_type_cambodia" class="form-label">ประเภทหนังสือเดินทาง (สำหรับกัมพูชา)
+                    @if(isset($missingFields) && in_array('passport_type_cambodia', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <select class="form-select" id="passport_type_cambodia" name="passport_type_cambodia">
                     <option value="">-- เลือกประเภท --</option>
                     <option value="เล่ม TD" @selected(old('passport_type_cambodia', $employee->passport_type_cambodia) == 'เล่ม TD')>เล่ม TD</option>
@@ -137,29 +170,41 @@
         <hr class="mb-4">
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="employeePassport" class="form-label">เลขพาสปอร์ต</label>
+                <label for="employeePassport" class="form-label">เลขพาสปอร์ต
+                    @if(isset($missingFields) && in_array('employeePassport', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="text" class="form-control" id="employeePassport" name="employeePassport" value="{{ old('employeePassport', $employee->employeePassport) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="passport_issue_date" class="form-label">วันออกพาสปอร์ต</label>
+                <label for="passport_issue_date" class="form-label">วันออกพาสปอร์ต
+                    @if(isset($missingFields) && in_array('passport_issue_date', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="date" class="form-control" id="passport_issue_date" name="passport_issue_date" value="{{ old('passport_issue_date', optional($employee->passport_issue_date)->format('Y-m-d')) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="passportExpiryDate" class="form-label">วันหมดอายุพาสปอร์ต</label>
+                <label for="passportExpiryDate" class="form-label">วันหมดอายุพาสปอร์ต
+                    @if(isset($missingFields) && in_array('passportExpiryDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="date" class="form-control" id="passportExpiryDate" name="passportExpiryDate" value="{{ old('passportExpiryDate', optional($employee->passportExpiryDate)->format('Y-m-d')) }}">
             </div>
         </div>
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="pinkCardNo" class="form-label">เลขบัตรชมพู</label>
+                <label for="pinkCardNo" class="form-label">เลขบัตรชมพู
+                    @if(isset($missingFields) && in_array('pinkCardNo', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="text" class="form-control" id="pinkCardNo" name="pinkCardNo" value="{{ old('pinkCardNo', $employee->pinkCardNo) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="visaType" class="form-label">ประเภทวีซ่า</label>
+                <label for="visaType" class="form-label">ประเภทวีซ่า
+                    @if(isset($missingFields) && in_array('visaType', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="text" class="form-control" id="visaType" name="visaType" value="{{ old('visaType', $employee->visaType) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="visaExpiryDate" class="form-label">วันหมดอายุวีซ่า</label>
+                <label for="visaExpiryDate" class="form-label">วันหมดอายุวีซ่า
+                    @if(isset($missingFields) && in_array('visaExpiryDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="date" class="form-control" id="visaExpiryDate" name="visaExpiryDate" value="{{ old('visaExpiryDate', optional($employee->visaExpiryDate)->format('Y-m-d')) }}">
             </div>
         </div>
@@ -169,35 +214,49 @@
         <hr class="mb-4">
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="job_title" class="form-label">ตำแหน่งงาน</label>
+                <label for="job_title" class="form-label">ตำแหน่งงาน
+                    @if(isset($missingFields) && in_array('job_title', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="text" class="form-control" id="job_title" name="job_title" value="{{ old('job_title', $employee->job_title) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="job_description" class="form-label">ลักษณะงาน</label>
+                <label for="job_description" class="form-label">ลักษณะงาน
+                    @if(isset($missingFields) && in_array('job_description', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="text" class="form-control" id="job_description" name="job_description" value="{{ old('job_description', $employee->job_description) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="startDate" class="form-label">วันที่เริ่มงาน</label>
+                <label for="startDate" class="form-label">วันที่เริ่มงาน
+                    @if(isset($missingFields) && in_array('startDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="date" class="form-control" id="startDate" name="startDate" value="{{ old('startDate', optional($employee->startDate)->format('Y-m-d')) }}">
             </div>
         </div>
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="employeeWorkPermit" class="form-label">เลข Work Permit</label>
+                <label for="employeeWorkPermit" class="form-label">เลข Work Permit
+                    @if(isset($missingFields) && in_array('employeeWorkPermit', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="text" class="form-control" id="employeeWorkPermit" name="employeeWorkPermit" value="{{ old('employeeWorkPermit', $employee->employeeWorkPermit) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="workPermitExpiryDate" class="form-label">วันหมดอายุ Work Permit</label>
+                <label for="workPermitExpiryDate" class="form-label">วันหมดอายุ Work Permit
+                    @if(isset($missingFields) && in_array('workPermitExpiryDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="date" class="form-control" id="workPermitExpiryDate" name="workPermitExpiryDate" value="{{ old('workPermitExpiryDate', optional($employee->workPermitExpiryDate)->format('Y-m-d')) }}">
             </div>
              <div class="col-md-4 mb-3">
-                <label for="ninetyDayReportDate" class="form-label">วันรายงานตัว 90 วัน</label>
+                <label for="ninetyDayReportDate" class="form-label">วันรายงานตัว 90 วัน
+                    @if(isset($missingFields) && in_array('ninetyDayReportDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="date" class="form-control" id="ninetyDayReportDate" name="ninetyDayReportDate" value="{{ old('ninetyDayReportDate', optional($employee->ninetyDayReportDate)->format('Y-m-d')) }}">
             </div>
         </div>
         <div class="row">
              <div class="col-md-6 mb-3">
-                <label for="workPermitType" class="form-label">ประเภทใบอนุญาตทำงาน</label>
+                <label for="workPermitType" class="form-label">ประเภทใบอนุญาตทำงาน
+                    @if(isset($missingFields) && in_array('workPermitMOUGroup', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <select class="form-select" id="workPermitMOUGroup" name="workPermitMOUGroup">
                     <option value="">-- กรุณาเลือก --</option>
                     <option value="MOU" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'MOU')>MOU</option>
@@ -207,17 +266,31 @@
                 </select>
             </div>
             <div class="col-md-6 mb-3 d-none" id="workPermitMOUGroupOtherContainer">
-                <label for="workPermitMOUGroupOther" class="form-label">ระบุประเภทอื่นๆ</label>
+                <label for="workPermitMOUGroupOther" class="form-label">ระบุประเภทอื่นๆ
+                    @if(isset($missingFields) && in_array('workPermitMOUGroupOther', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                  <input type="text" class="form-control" id="workPermitMOUGroupOther" name="workPermitMOUGroupOther" value="{{ old('workPermitMOUGroupOther', $employee->workPermitMOUGroupOther) }}">
             </div>
         </div>
         <div class="row">
-             <div class="col-md-4 mb-3"><label for="name_list_number" class="form-label">เลข Name List</label><input type="text" class="form-control" id="name_list_number" name="name_list_number" value="{{ old('name_list_number', $employee->name_list_number) }}"></div>
-             <div class="col-md-4 mb-3"><label for="request_number" class="form-label">เลขที่คำขอ</label><input type="text" class="form-control" id="request_number" name="request_number" value="{{ old('request_number', $employee->request_number) }}"></div>
-             <div class="col-md-4 mb-3"><label for="employee_id_number" class="form-label">เลขประจำตัว</label><input type="text" class="form-control" id="employee_id_number" name="employee_id_number" value="{{ old('employee_id_number', $employee->employee_id_number) }}"></div>
-             <div class="col-md-4 mb-3"><label for="tax_id_number" class="form-label">เลขประจำตัวผู้เสียภาษี</label><input type="text" class="form-control" id="tax_id_number" name="tax_id_number" value="{{ old('tax_id_number', $employee->tax_id_number) }}"></div>
-             <div class="col-md-4 mb-3"><label for="employer_employee_id" class="form-label">รหัสคนงาน - ของนายจ้าง</label><input type="text" class="form-control" id="employer_employee_id" name="employer_employee_id" value="{{ old('employer_employee_id', $employee->employer_employee_id) }}"></div>
-             <div class="col-md-4 mb-3"><label for="employee_reference_id" class="form-label">เลขอ้างอิงคนงาน</label><input type="text" class="form-control" id="employee_reference_id" name="employee_reference_id" value="{{ old('employee_reference_id', $employee->employee_reference_id) }}"></div>
+             <div class="col-md-4 mb-3"><label for="name_list_number" class="form-label">เลข Name List
+                 @if(isset($missingFields) && in_array('name_list_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+             </label><input type="text" class="form-control" id="name_list_number" name="name_list_number" value="{{ old('name_list_number', $employee->name_list_number) }}"></div>
+             <div class="col-md-4 mb-3"><label for="request_number" class="form-label">เลขที่คำขอ
+                 @if(isset($missingFields) && in_array('request_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+             </label><input type="text" class="form-control" id="request_number" name="request_number" value="{{ old('request_number', $employee->request_number) }}"></div>
+             <div class="col-md-4 mb-3"><label for="employee_id_number" class="form-label">เลขประจำตัว
+                 @if(isset($missingFields) && in_array('employee_id_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+             </label><input type="text" class="form-control" id="employee_id_number" name="employee_id_number" value="{{ old('employee_id_number', $employee->employee_id_number) }}"></div>
+             <div class="col-md-4 mb-3"><label for="tax_id_number" class="form-label">เลขประจำตัวผู้เสียภาษี
+                 @if(isset($missingFields) && in_array('tax_id_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+             </label><input type="text" class="form-control" id="tax_id_number" name="tax_id_number" value="{{ old('tax_id_number', $employee->tax_id_number) }}"></div>
+             <div class="col-md-4 mb-3"><label for="employer_employee_id" class="form-label">รหัสคนงาน - ของนายจ้าง
+                 @if(isset($missingFields) && in_array('employer_employee_id', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+             </label><input type="text" class="form-control" id="employer_employee_id" name="employer_employee_id" value="{{ old('employer_employee_id', $employee->employer_employee_id) }}"></div>
+             <div class="col-md-4 mb-3"><label for="employee_reference_id" class="form-label">เลขอ้างอิงคนงาน
+                 @if(isset($missingFields) && in_array('employee_reference_id', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+             </label><input type="text" class="form-control" id="employee_reference_id" name="employee_reference_id" value="{{ old('employee_reference_id', $employee->employee_reference_id) }}"></div>
         </div>
 
 
@@ -226,7 +299,9 @@
         <hr class="mb-4">
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="insurance_type" class="form-label">ประเภทประกัน</label>
+                <label for="insurance_type" class="form-label">ประเภทประกัน
+                    @if(isset($missingFields) && in_array('insurance_type', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <select class="form-select" id="insurance_type" name="insurance_type">
                     <option value="">-- เลือกประเภท --</option>
                     <option value="ประกันสังคม" @selected(old('insurance_type', $employee->insurance_type) == 'ประกันสังคม')>ประกันสังคม</option>
@@ -239,54 +314,58 @@
         <div id="insuranceSocialSecurity" class="d-none">
              <div class="row">
                 <div class="col-md-4 mb-3">
-                    <label for="social_security_number" class="form-label">เลขประกันสังคม</label>
+                    <label for="social_security_number" class="form-label">เลขประกันสังคม
+                        @if(isset($missingFields) && in_array('social_security_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                    </label>
                     <input type="text" class="form-control" id="social_security_number" name="social_security_number" value="{{ old('social_security_number', $employee->social_security_number) }}">
                 </div>
                 <div class="col-md-4 mb-3">
-                    <label for="insurance_detail" class="form-label">สิทธิ์โรงพยาบาล</label>
+                    <label for="insurance_detail" class="form-label">สิทธิ์โรงพยาบาล
+                        @if(isset($missingFields) && in_array('insurance_detail', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                    </label>
                     <input type="text" class="form-control" name="insurance_detail" value="{{ old('insurance_detail', $employee->insurance_detail) }}">
                 </div>
-                <!-- <div class="col-md-4 mb-3">
-                    <label for="insurance_document_path_social" class="form-label">แนบไฟล์เอกสารประกัน</label>
-                     @if($employee->insurance_document_path && $employee->insurance_type == 'ประกันสังคม') <div class="small mb-1"><a href="{{ asset('storage/' . $employee->insurance_document_path) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูไฟล์ปัจจุบัน</a></div> @endif
-                    <input type="file" class="form-control form-control-sm" name="insurance_document_path_social">
-                </div> -->
              </div>
         </div>
         {{-- Hospital Insurance Container --}}
         <div id="insuranceHospital" class="d-none">
             <div class="row">
                 <div class="col-md-4 mb-3">
-                    <label for="insurance_detail_hospital" class="form-label">ชื่อโรงพยาบาล</label>
+                    <label for="insurance_detail_hospital" class="form-label">ชื่อโรงพยาบาล
+                        @if(isset($missingFields) && in_array('insurance_detail_hospital', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                    </label>
                     <input type="text" class="form-control" name="insurance_detail_hospital" value="{{ old('insurance_detail_hospital', $employee->insurance_detail_hospital) }}">
                 </div>
                 <div class="col-md-4 mb-3">
-                    <label for="insurance_expiry_date_hospital" class="form-label">วันหมดอายุประกัน</label>
+                    <label for="insurance_expiry_date_hospital" class="form-label">วันหมดอายุประกัน
+                        @if(isset($missingFields) && in_array('insurance_expiry_date_hospital', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                    </label>
                     <input type="date" class="form-control" name="insurance_expiry_date_hospital" value="{{ old('insurance_expiry_date_hospital', optional($employee->insurance_expiry_date_hospital)->format('Y-m-d')) }}">
                 </div>
-                 <!-- <div class="col-md-4 mb-3">
-                    <label for="insurance_document_path_hospital" class="form-label">แนบไฟล์เอกสารประกัน</label>
-                     @if($employee->insurance_document_path && $employee->insurance_type == 'ประกันโรงพยาบาล') <div class="small mb-1"><a href="{{ asset('storage/' . $employee->insurance_document_path) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูไฟล์ปัจจุบัน</a></div> @endif
-                    <input type="file" class="form-control form-control-sm" name="insurance_document_path_hospital">
-                </div> -->
             </div>
         </div>
         {{-- Private Insurance Container --}}
         <div id="insurancePrivate" class="d-none">
             <div class="row">
                 <div class="col-md-4 mb-3">
-                    <label for="insurance_detail_private" class="form-label">บริษัทประกัน</label>
+                    <label for="insurance_detail_private" class="form-label">บริษัทประกัน
+                        @if(isset($missingFields) && in_array('insurance_detail_private', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                    </label>
                     <input type="text" class="form-control" name="insurance_detail_private" value="{{ old('insurance_detail_private', $employee->insurance_detail_private) }}">
                 </div>
                 <div class="col-md-4 mb-3">
-                    <label for="insurance_expiry_date_private" class="form-label">วันหมดอายุประกัน</label>
+                    <label for="insurance_expiry_date_private" class="form-label">วันหมดอายุประกัน
+                        @if(isset($missingFields) && in_array('insurance_expiry_date_private', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                    </label>
                     <input type="date" class="form-control" name="insurance_expiry_date_private" value="{{ old('insurance_expiry_date_private', optional($employee->insurance_expiry_date_private)->format('Y-m-d')) }}">
                 </div>
             </div>
         </div>
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="insurance_document_path_private" class="form-label">แนบไฟล์เอกสารประกัน</label>
+                <label for="insurance_document_path_private" class="form-label">แนบไฟล์เอกสารประกัน
+                    @if(isset($missingFields) && in_array('insurance_document_path_private', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 @if($employee->insurance_document_path_private) <div class="small mb-1"><a href="{{ asset('storage/' . $employee->insurance_document_path_private) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูไฟล์ปัจจุบัน</a></div> @endif
                 <input type="file" class="form-control form-control-sm" name="insurance_document_path_private">
             </div>
@@ -297,11 +376,15 @@
         <hr class="mb-4">
         <div class="row">
             <div class="col-md-6 mb-3">
-                <label for="employeeEmail" class="form-label">อีเมล</label>
+                <label for="employeeEmail" class="form-label">อีเมล
+                    @if(isset($missingFields) && in_array('email', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="email" class="form-control" id="employeeEmail" name="employeeEmail" value="{{ old('employeeEmail', $employee->email) }}">
             </div>
             <div class="col-md-6 mb-3">
-                <label for="password" class="form-label">รหัสผ่าน (Password) </label>
+                <label for="password" class="form-label">รหัสผ่าน (Password)
+                    @if(isset($missingFields) && in_array('password', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                </label>
                 <input type="text" class="form-control" id="password" name="password"
                        value="{{ $employee->password }}" placeholder="กรอกรหัสผ่าน">
                 {{-- Note: type="text" creates a plain text box as requested --}}
@@ -326,7 +409,9 @@
                     $descField = 'other_doc_' . ($i - 8) . '_desc';
                 @endphp
                 <div class="{{ in_array($i, $descSlots) ? 'col-md-6' : 'col-md-4' }} mb-3">
-                    <label for="{{ $docField }}" class="form-label fw-bold">{{ $i }}. {{ $label }}</label>
+                    <label for="{{ $docField }}" class="form-label fw-bold">{{ $i }}. {{ $label }}
+                        @if(isset($missingFields) && in_array($docField, $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
+                    </label>
                     @if($employee->{$docField})
                         <div class="small mb-1">
                             <a href="{{ asset('storage/' . $employee->{$docField}) }}" target="_blank"><i class="bi bi-file-earmark-text"></i> ดูไฟล์ปัจจุบัน</a>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -186,7 +186,12 @@
                     </a>
                     @can('manage-tickets')
                     <a href="{{ route('admin.incomplete_employees.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('admin.incomplete_employees.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
-                        <i class="bi bi-exclamation-octagon-fill me-2"></i>ข้อมูลไม่ครบถ้วน
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span><i class="bi bi-exclamation-octagon-fill me-2"></i>ข้อมูลไม่ครบถ้วน</span>
+                            @if(isset($incompleteCount) && $incompleteCount > 0)
+                                <span class="badge bg-warning text-dark rounded-pill">{{ $incompleteCount }}</span>
+                            @endif
+                        </div>
                     </a>
                     @endcan
                 @endcan


### PR DESCRIPTION
- Created `CompletenessHelper` to calculate missing fields and incomplete employee counts.
- Updated `EmployeeController` to pass missing fields to the edit view.
- Updated `_employee_card.blade.php` to display an orange badge with the count of missing fields on the Incomplete Data page.
- Updated `edit.blade.php` to highlight missing mandatory fields with a yellow exclamation icon and show a summary alert.
- Updated `AppServiceProvider` and `layouts/app.blade.php` to display the total count of incomplete employees in the sidebar menu.