### PR TITLE
Add notification badge counter to sidebar menu

### DIFF
--- a/app/Helpers/NotificationHelper.php
+++ b/app/Helpers/NotificationHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\Notification;
+use Illuminate\Support\Facades\Auth;
+
+class NotificationHelper
+{
+    public static function getTotalNotificationCount()
+    {
+        $query = Notification::with(['employee.employer', 'employer']);
+
+        // Apply tenancy scope for Employer role to prevent data leakage
+        if (Auth::check() && Auth::user()->hasRole('employer')) {
+            $employerId = Auth::user()->employer->id ?? null;
+            if ($employerId) {
+                $query->where(function($q) use ($employerId) {
+                    // 1. Notifications directly linked to the employer (e.g., employer_document_expiry)
+                    $q->where('employer_id', $employerId)
+                    // 2. Notifications linked to employees (respects Employee global scope)
+                      ->orWhereHas('employee');
+                });
+            } else {
+                // Fallback: If user is 'employer' but has no linked Employer record, show nothing.
+                $query->whereRaw('1 = 0');
+            }
+        }
+
+        // Count only active notifications (not cancelled)
+        $query->where('status', '!=', 'cancelled');
+
+        return $query->count();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,10 +30,18 @@ class AppServiceProvider extends ServiceProvider
 
         // Share incomplete employee count with specific views (layout)
         view()->composer('layouts.app', function ($view) {
-            // Only calculate if the user is logged in and has permission to view this
-            if (auth()->check() && auth()->user()->can('manage-tickets')) {
-                 $incompleteCount = \App\Helpers\CompletenessHelper::getIncompleteCount();
-                 $view->with('incompleteCount', $incompleteCount);
+            if (auth()->check()) {
+                // 1. Incomplete Data Count (Admin/Staff only)
+                if (auth()->user()->can('manage-tickets')) {
+                    $incompleteCount = \App\Helpers\CompletenessHelper::getIncompleteCount();
+                    $view->with('incompleteCount', $incompleteCount);
+                }
+
+                // 2. Notification Count (All users who can view notifications)
+                if (auth()->user()->can('view-notifications')) {
+                    $totalNotificationCount = \App\Helpers\NotificationHelper::getTotalNotificationCount();
+                    $view->with('totalNotificationCount', $totalNotificationCount);
+                }
             }
         });
     }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -182,7 +182,12 @@
                 @endcan
                 @can('view-notifications')
                     <a href="{{ route('notifications.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('notifications.*') ? 'active' : '' }}">
-                        <i class="bi bi-bell-fill me-2"></i>แจ้งเตือน
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span><i class="bi bi-bell-fill me-2"></i>แจ้งเตือน</span>
+                            @if(isset($totalNotificationCount) && $totalNotificationCount > 0)
+                                <span class="badge bg-danger rounded-pill">{{ $totalNotificationCount }}</span>
+                            @endif
+                        </div>
                     </a>
                     @can('manage-tickets')
                     <a href="{{ route('admin.incomplete_employees.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('admin.incomplete_employees.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">


### PR DESCRIPTION
- Created `App\Helpers\NotificationHelper` to calculate total active notifications.
- Updated `AppServiceProvider` to share `$totalNotificationCount` with the layout view via a view composer.
- Modified `resources/views/layouts/app.blade.php` to display a red badge with the count next to the "Notifications" menu item.
- Ensured the count respects user roles and tenancy (employer vs admin).