### PR TITLE
Fix filtering logic for Myanmar and Cambodia passport types by enforc…

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -126,11 +126,13 @@ public function reinstate(Employee $employee)
     }
 
     if ($request->filled('passport_type_myanmar')) {
-        $query->where('passportType', $request->input('passport_type_myanmar'));
+        $query->where('passportType', $request->input('passport_type_myanmar'))
+              ->where('employeeNationality', 'เมียนมา');
     }
 
     if ($request->filled('passport_type_cambodia')) {
-        $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'));
+        $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'))
+              ->where('employeeNationality', 'กัมพูชา');
     }
     // --- END: ADDED FILTERING LOGIC ---
 
@@ -557,11 +559,13 @@ public function create(Request $request) // เพิ่ม Request $request เ
         }
 
         if ($request->filled('passport_type_myanmar')) {
-            $query->where('passportType', $request->input('passport_type_myanmar'));
+            $query->where('passportType', $request->input('passport_type_myanmar'))
+                  ->where('employeeNationality', 'เมียนมา');
         }
 
         if ($request->filled('passport_type_cambodia')) {
-            $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'));
+            $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'))
+                  ->where('employeeNationality', 'กัมพูชา');
         }
 
         $employees = $query->with('employer')->get();
@@ -654,11 +658,13 @@ public function create(Request $request) // เพิ่ม Request $request เ
         }
 
         if ($request->filled('passport_type_myanmar')) {
-            $query->where('passportType', $request->input('passport_type_myanmar'));
+            $query->where('passportType', $request->input('passport_type_myanmar'))
+                  ->where('employeeNationality', 'เมียนมา');
         }
 
         if ($request->filled('passport_type_cambodia')) {
-            $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'));
+            $query->where('passport_type_cambodia', $request->input('passport_type_cambodia'))
+                  ->where('employeeNationality', 'กัมพูชา');
         }
 
         $totalEmployees = (clone $query)->count();


### PR DESCRIPTION
…ing nationality checks.

This commit updates the EmployeeController to strictly associate passport type filters with their corresponding nationalities.
- When filtering by `passport_type_myanmar`, the query now also enforces `employeeNationality = 'เมียนมา'`.
- When filtering by `passport_type_cambodia`, the query now also enforces `employeeNationality = 'กัมพูชา'`.

This prevents data cross-contamination where employees of one nationality might appear in the filter results of another if the database contains inconsistent data. The changes are applied to the `index`, `export`, and `historyIndex` methods.