### PR TITLE
Fix bulk action bar syntax error and add download to history

### DIFF
--- a/resources/js/employment-history.js
+++ b/resources/js/employment-history.js
@@ -11,7 +11,8 @@
 document.addEventListener('DOMContentLoaded', () => {
     // --- STATE AND CONSTANTS ---
     const historyModalEl = document.getElementById('employmentHistoryModal');
-    if (!historyModalEl) return;
+    // If modal doesn't exist, we might be on the standalone page, but this script is primarily for the modal.
+    // However, we should check if we need to run safely.
 
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     let currentEmployerId = null;
@@ -21,11 +22,15 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- DOM ELEMENT SELECTORS ---
     const tableBody = document.getElementById('historyTableBody');
     const searchInput = document.getElementById('history-search-input');
-    const bulkActionBar = document.getElementById('history-bulk-action-bar');
-    const selectedCountSpan = document.getElementById('history-selected-count');
-    const mainSelectAllCheckbox = document.getElementById('history-select-all-checkbox-main');
+
+    // REFACTOR: The bulk action bar is now a component. We don't manage its visibility manually.
+    // We just need to find the "Transfer" button which is now inside the component's dropdown (or slot).
+    // The ID we gave it in the blade file is 'history-bulk-transfer-btn'.
+    const bulkTransferBtn = document.getElementById('history-bulk-transfer-btn');
+
+    // We still have the table header checkbox
     const tableSelectAllCheckbox = document.getElementById('history-select-all-checkbox-table');
-    const bulkActionButton = document.getElementById('history-bulk-action-btn');
+
     const transferModalEl = document.getElementById('transferEmployeeModal');
     const employeeToTransferIdInput = document.getElementById('employee-to-transfer-id');
     const employeeToTransferNameSpan = document.getElementById('employee-to-transfer-name');
@@ -40,11 +45,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- RENDERING LOGIC ---
     const fetchAndRenderHistory = (employerId, searchTerm = '') => {
         if (!employerId) {
-            tableBody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">Error: Employer ID not found.</td></tr>`;
+            if(tableBody) tableBody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">Error: Employer ID not found.</td></tr>`;
             return;
         }
         if (searchTerm === '') {
-            tableBody.innerHTML = `<tr><td colspan="6" class="text-center">Loading...</td></tr>`;
+            if(tableBody) tableBody.innerHTML = `<tr><td colspan="6" class="text-center">Loading...</td></tr>`;
         }
 
         const fetchUrl = `/employers/${employerId}/history?search=${encodeURIComponent(searchTerm)}`;
@@ -52,9 +57,16 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch(fetchUrl)
             .then(response => response.ok ? response.json() : Promise.reject(response.status))
             .then(data => {
+                if (!tableBody) return;
                 tableBody.innerHTML = '';
                 if (!data.data || data.data.length === 0) {
                     tableBody.innerHTML = `<tr><td colspan="6" class="text-center">No employment history found ${searchTerm ? 'matching search' : ''}.</td></tr>`;
+                    // Ensure component hides itself if it was showing (by unchecking everything)
+                    // The component logic listens to changes, so if we clear checkboxes, we might need to trigger an update.
+                    // But since the DOM elements are gone, the component's `querySelectorAll` will find nothing.
+                    // We can trigger a fake change event on body to force component update?
+                    // Or just rely on the user not being able to select anything.
+                     document.body.dispatchEvent(new Event('change'));
                     return;
                 }
                 data.data.forEach((employee, index) => {
@@ -80,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     const row = `
                         <tr id="history-row-${employee.id}">
-                            <td><input class="form-check-input history-employee-checkbox" type="checkbox" data-employee-id="${employee.id}"></td>
+                            <td><input class="form-check-input history-employee-checkbox" type="checkbox" value="${employee.id}" data-employee-id="${employee.id}"></td>
                             <td>${index + 1}</td>
                             <td>${employeeCellHTML}</td>
                             <td>${terminatedDate}${daysSinceTerminationText}</td>
@@ -89,27 +101,16 @@ document.addEventListener('DOMContentLoaded', () => {
                         </tr>`;
                     tableBody.insertAdjacentHTML('beforeend', row);
                 });
-                updateBulkActionBar();
+                // Trigger update for the component to see new checkboxes (it calculates count)
+                document.dispatchEvent(new Event('bulk-action-bar:update'));
             })
             .catch(error => {
                 console.error('Error fetching employment history:', error);
-                tableBody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">Error loading data.</td></tr>`;
+                if(tableBody) tableBody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">Error loading data.</td></tr>`;
             });
     };
 
-    // --- BULK ACTION & TRANSFER MODAL LOGIC ---
-    const updateBulkActionBar = () => {
-        const selectedCheckboxes = document.querySelectorAll('.history-employee-checkbox:checked');
-        const count = selectedCheckboxes.length;
-        bulkActionBar.style.display = count > 0 ? 'flex' : 'none';
-        selectedCountSpan.textContent = count;
-        bulkActionButton.disabled = count === 0;
-        const allCheckboxes = document.querySelectorAll('.history-employee-checkbox');
-        const isAllSelected = allCheckboxes.length > 0 && count === allCheckboxes.length;
-        mainSelectAllCheckbox.checked = isAllSelected;
-        tableSelectAllCheckbox.checked = isAllSelected;
-    };
-
+    // --- MODAL OPEN LOGIC ---
     const openTransferModal = () => {
         employerSearchInput.value = '';
         employerSearchResultsDiv.innerHTML = '';
@@ -157,59 +158,62 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     // --- EVENT LISTENERS ---
-    historyModalEl.addEventListener('show.bs.modal', function (event) {
-        currentEmployerId = event.relatedTarget?.getAttribute('data-employer-id');
-        searchInput.value = '';
-        tableBody.innerHTML = '';
-        fetchAndRenderHistory(currentEmployerId, '');
-        updateBulkActionBar();
-    });
-
-    searchInput?.addEventListener('keyup', () => fetchAndRenderHistory(currentEmployerId, searchInput.value.trim()));
-
-    tableBody.addEventListener('click', (event) => {
-        const target = event.target.closest('button');
-        if (!target) return;
-        const employeeId = target.dataset.employeeId;
-        if (target.classList.contains('btn-reinstate')) {
-            Swal.fire({ title: 'ยืนยันการคืนสถานะ', text: "ลูกจ้างจะถูกย้ายกลับไปอยู่ในรายชื่อลูกจ้างปัจจุบัน", icon: 'question', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
-                .then(result => result.isConfirmed && performAction(`/employees/${employeeId}/reinstate`));
-        } else if (target.classList.contains('btn-move-to-trash')) {
-            Swal.fire({ title: 'ยืนยันการย้ายไปถังขยะ', text: "ลูกจ้างจะถูกย้ายไปที่ถังขยะส่วนกลาง", icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก', confirmButtonColor: '#d33' })
-                .then(result => result.isConfirmed && performAction(`/employees/${employeeId}`, { _method: 'DELETE' }));
-        } else if (target.classList.contains('btn-transfer-employee')) {
-            isBulkTransfer = false;
-            employeeToTransferIdInput.value = employeeId;
-            employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้าง: ${target.dataset.employeeName}`;
-            openTransferModal();
-        }
-    });
-
-    tableBody.addEventListener('change', (event) => {
-        if (event.target.classList.contains('history-employee-checkbox')) {
-            updateBulkActionBar();
-        }
-    });
-
-    [mainSelectAllCheckbox, tableSelectAllCheckbox].forEach(checkbox => {
-        checkbox.addEventListener('change', (event) => {
-            const isChecked = event.target.checked;
-            document.querySelectorAll('.history-employee-checkbox').forEach(cb => cb.checked = isChecked);
-            mainSelectAllCheckbox.checked = isChecked;
-            tableSelectAllCheckbox.checked = isChecked;
-            updateBulkActionBar();
+    if (historyModalEl) {
+        historyModalEl.addEventListener('show.bs.modal', function (event) {
+            currentEmployerId = event.relatedTarget?.getAttribute('data-employer-id');
+            if(searchInput) searchInput.value = '';
+            if(tableBody) tableBody.innerHTML = '';
+            fetchAndRenderHistory(currentEmployerId, '');
         });
-    });
+    }
 
-    bulkActionButton.addEventListener('click', () => {
-        const selectedCheckboxes = document.querySelectorAll('.history-employee-checkbox:checked');
-        if (selectedCheckboxes.length === 0) return;
-        isBulkTransfer = true;
-        const employeeIds = Array.from(selectedCheckboxes).map(cb => cb.dataset.employeeId);
-        employeeToTransferIdInput.value = JSON.stringify(employeeIds);
-        employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้างที่เลือกจำนวน ${selectedCheckboxes.length} คน`;
-        openTransferModal();
-    });
+    if(searchInput) searchInput.addEventListener('keyup', () => fetchAndRenderHistory(currentEmployerId, searchInput.value.trim()));
+
+    if(tableBody) {
+        tableBody.addEventListener('click', (event) => {
+            const target = event.target.closest('button');
+            if (!target) return;
+            const employeeId = target.dataset.employeeId;
+            if (target.classList.contains('btn-reinstate')) {
+                Swal.fire({ title: 'ยืนยันการคืนสถานะ', text: "ลูกจ้างจะถูกย้ายกลับไปอยู่ในรายชื่อลูกจ้างปัจจุบัน", icon: 'question', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
+                    .then(result => result.isConfirmed && performAction(`/employees/${employeeId}/reinstate`));
+            } else if (target.classList.contains('btn-move-to-trash')) {
+                Swal.fire({ title: 'ยืนยันการย้ายไปถังขยะ', text: "ลูกจ้างจะถูกย้ายไปที่ถังขยะส่วนกลาง", icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก', confirmButtonColor: '#d33' })
+                    .then(result => result.isConfirmed && performAction(`/employees/${employeeId}`, { _method: 'DELETE' }));
+            } else if (target.classList.contains('btn-transfer-employee')) {
+                isBulkTransfer = false;
+                employeeToTransferIdInput.value = employeeId;
+                employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้าง: ${target.dataset.employeeName}`;
+                openTransferModal();
+            }
+        });
+    }
+
+    // Sync table header checkbox with component
+    if (tableSelectAllCheckbox) {
+        tableSelectAllCheckbox.addEventListener('change', (event) => {
+            const isChecked = event.target.checked;
+            document.querySelectorAll('.history-employee-checkbox').forEach(cb => {
+                cb.checked = isChecked;
+                // Dispatch change event so the component updates
+                cb.dispatchEvent(new Event('change', { bubbles: true }));
+            });
+        });
+    }
+
+    // Updated Bulk Transfer Listener for the component's button
+    if (bulkTransferBtn) {
+        bulkTransferBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            const selectedCheckboxes = document.querySelectorAll('.history-employee-checkbox:checked');
+            if (selectedCheckboxes.length === 0) return;
+            isBulkTransfer = true;
+            const employeeIds = Array.from(selectedCheckboxes).map(cb => cb.dataset.employeeId || cb.value);
+            employeeToTransferIdInput.value = JSON.stringify(employeeIds);
+            employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้างที่เลือกจำนวน ${selectedCheckboxes.length} คน`;
+            openTransferModal();
+        });
+    }
 
     const handleEmployerSearch = debounce(() => {
         const searchTerm = employerSearchInput.value.trim();
@@ -250,56 +254,58 @@ document.addEventListener('DOMContentLoaded', () => {
             });
     }, 300);
 
-    employerSearchInput.addEventListener('keyup', handleEmployerSearch);
+    if(employerSearchInput) employerSearchInput.addEventListener('keyup', handleEmployerSearch);
 
+    if(employerSearchResultsDiv) {
+        employerSearchResultsDiv.addEventListener('click', (event) => {
+            const target = event.target.closest('button');
+            if (!target) return;
 
-    employerSearchResultsDiv.addEventListener('click', (event) => {
-        const target = event.target.closest('button');
-        if (!target) return;
+            // Store selected employer and update UI
+            selectedEmployer = {
+                id: target.dataset.employerId,
+                name: target.dataset.employerName // Use the stored name
+            };
 
-        // Store selected employer and update UI
-        selectedEmployer = {
-            id: target.dataset.employerId,
-            name: target.dataset.employerName // Use the stored name
-        };
+            selectedEmployerNameSpan.textContent = selectedEmployer.name;
+            selectedEmployerDisplay.style.display = 'block';
+            confirmTransferBtn.disabled = false;
+            employerSearchResultsDiv.style.display = 'none'; // Hide search results
+            employerSearchResultsDiv.innerHTML = ''; // Clear search results
+            employerSearchInput.value = ''; // Clear search input
+        });
+    }
 
-        selectedEmployerNameSpan.textContent = selectedEmployer.name;
-        selectedEmployerDisplay.style.display = 'block';
-        confirmTransferBtn.disabled = false;
-        employerSearchResultsDiv.style.display = 'none'; // Hide search results
-        employerSearchResultsDiv.innerHTML = ''; // Clear search results
-        employerSearchInput.value = ''; // Clear search input
-    });
+    if(confirmTransferBtn) {
+        confirmTransferBtn.addEventListener('click', () => {
+            if (!selectedEmployer) {
+                showToast('กรุณาเลือกนายจ้างใหม่ก่อน', 'danger');
+                return;
+            }
 
-    confirmTransferBtn.addEventListener('click', () => {
-        if (!selectedEmployer) {
-            showToast('กรุณาเลือกนายจ้างใหม่ก่อน', 'danger');
-            return;
-        }
+            const { id: newEmployerId, name: newEmployerName } = selectedEmployer;
 
-        const { id: newEmployerId, name: newEmployerName } = selectedEmployer;
+            const swalHtml = isBulkTransfer
+                ? `คุณต้องการย้ายลูกจ้างที่เลือกทั้งหมดไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`
+                : `คุณต้องการย้ายลูกจ้างไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`;
 
-        const swalHtml = isBulkTransfer
-            ? `คุณต้องการย้ายลูกจ้างที่เลือกทั้งหมดไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`
-            : `คุณต้องการย้ายลูกจ้างไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`;
-
-        Swal.fire({ title: 'ยืนยันการย้ายนายจ้าง', html: swalHtml, icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
-            .then(result => {
-                if (result.isConfirmed) {
-                    if (isBulkTransfer) {
-                        const employeeIds = JSON.parse(employeeToTransferIdInput.value);
-                        performAction('/employees/bulk-transfer', { employee_ids: employeeIds, new_employer_id: newEmployerId });
-                    } else {
-                        const employeeId = employeeToTransferIdInput.value;
-                        performAction(`/employees/${employeeId}/transfer`, { new_employer_id: newEmployerId });
+            Swal.fire({ title: 'ยืนยันการย้ายนายจ้าง', html: swalHtml, icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
+                .then(result => {
+                    if (result.isConfirmed) {
+                        if (isBulkTransfer) {
+                            const employeeIds = JSON.parse(employeeToTransferIdInput.value);
+                            performAction('/employees/bulk-transfer', { employee_ids: employeeIds, new_employer_id: newEmployerId });
+                        } else {
+                            const employeeId = employeeToTransferIdInput.value;
+                            performAction(`/employees/${employeeId}/transfer`, { new_employer_id: newEmployerId });
+                        }
                     }
-                }
-            });
-    });
-
+                });
+        });
+    }
 
     // Modal stacking fix
-    if (transferModalEl) {
+    if (transferModalEl && historyModalEl) {
         transferModalEl.addEventListener('show.bs.modal', () => historyModalEl.classList.add('modal-behind'));
         transferModalEl.addEventListener('hidden.bs.modal', () => historyModalEl.classList.remove('modal-behind'));
     }

--- a/resources/views/components/bulk-action-bar.blade.php
+++ b/resources/views/components/bulk-action-bar.blade.php
@@ -19,97 +19,8 @@
     </div>
 </div>
 
-@once
-@push('scripts')
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    function initBulkBar(barId, selector) {
-        const bar = document.getElementById(barId);
-        if (!bar) return;
-
-        const selectAll = document.getElementById(barId + '-select-all');
-        const countSpan = document.getElementById(barId + '-count');
-        const downloadBtn = bar.querySelector('.btn-bulk-download');
-
-        function update() {
-            const checkboxes = document.querySelectorAll(selector);
-            const checked = document.querySelectorAll(selector + ':checked');
-            const count = checked.length;
-
-            countSpan.textContent = count;
-
-            if (count > 0) {
-                bar.style.display = 'flex';
-            } else {
-                bar.style.display = 'none';
-            }
-
-            if (checkboxes.length > 0 && checked.length === checkboxes.length) {
-                selectAll.checked = true;
-                selectAll.indeterminate = false;
-            } else if (count > 0) {
-                selectAll.checked = false;
-                selectAll.indeterminate = true;
-            } else {
-                selectAll.checked = false;
-                selectAll.indeterminate = false;
-            }
-        }
-
-        if (selectAll) {
-            selectAll.addEventListener('change', function() {
-                const checkboxes = document.querySelectorAll(selector);
-                checkboxes.forEach(cb => cb.checked = this.checked);
-                update();
-            });
-        }
-
-        // Use event delegation for dynamically added checkboxes
-        document.body.addEventListener('change', function(e) {
-            if (e.target.matches(selector)) {
-                update();
-            }
-        });
-
-        if (downloadBtn) {
-            downloadBtn.addEventListener('click', function(e) {
-                e.preventDefault();
-                const checked = Array.from(document.querySelectorAll(selector + ':checked')).map(cb => cb.value);
-                if (window.openBulkDownloadModal) {
-                    window.openBulkDownloadModal(checked);
-                } else {
-                    console.error('Download modal not found');
-                    // Fallback if showToast is available
-                    if (typeof showToast === 'function') {
-                        showToast('Download function not ready', 'danger');
-                    }
-                }
-            });
-        }
-
-        // Initial update
-        update();
-    }
-
-    // Initialize specific instances based on data attributes or props passed from Blade
-    // Since we can't easily pass data from Blade to this once-only script block for every instance,
-    // we will auto-initialize based on a convention or data attribute on the bar itself.
-
-    // Better approach: Loop through all .bulk-action-bar and init them.
-    // But we need to know the selector for each.
-    // Let's add a data-selector attribute to the main div in the component HTML.
-});
-</script>
-@endpush
-@endonce
-
-{{-- We add a specific script for this instance to initialize it --}}
 <script>
     document.addEventListener('DOMContentLoaded', function() {
-        // We define the init function globally (or accessible) or just run logic here.
-        // To reuse the logic defined in @once, let's expose it or just structure it differently.
-        // Actually, simply duplicating the init logic per instance in a closure is fine and robust.
-
         (function() {
             const barId = '{{ $id }}';
             const selector = '{{ $checkboxSelector }}';
@@ -126,7 +37,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const checked = document.querySelectorAll(selector + ':checked');
                 const count = checked.length;
 
-                countSpan.textContent = count;
+                if (countSpan) countSpan.textContent = count;
 
                 if (count > 0) {
                     bar.style.display = 'flex';
@@ -134,15 +45,17 @@ document.addEventListener('DOMContentLoaded', function() {
                     bar.style.display = 'none';
                 }
 
-                if (checkboxes.length > 0 && checked.length === checkboxes.length) {
-                    selectAll.checked = true;
-                    selectAll.indeterminate = false;
-                } else if (count > 0) {
-                    selectAll.checked = false;
-                    selectAll.indeterminate = true;
-                } else {
-                    selectAll.checked = false;
-                    selectAll.indeterminate = false;
+                if (selectAll) {
+                    if (checkboxes.length > 0 && checked.length === checkboxes.length) {
+                        selectAll.checked = true;
+                        selectAll.indeterminate = false;
+                    } else if (count > 0) {
+                        selectAll.checked = false;
+                        selectAll.indeterminate = true;
+                    } else {
+                        selectAll.checked = false;
+                        selectAll.indeterminate = false;
+                    }
                 }
             }
 
@@ -160,18 +73,29 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             });
 
+            // Listen for a custom event to force update (useful for AJAX reloads)
+            document.addEventListener('bulk-action-bar:update', function() {
+                update();
+            });
+
             if (downloadBtn) {
                 downloadBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     const checked = Array.from(document.querySelectorAll(selector + ':checked')).map(cb => cb.value);
+
                     if (window.openBulkDownloadModal) {
                         window.openBulkDownloadModal(checked);
                     } else {
-                        alert('Download modal function missing.');
+                        console.error('Download modal function missing.');
+                         // Fallback if showToast is available
+                        if (typeof showToast === 'function') {
+                            showToast('Download function not ready', 'danger');
+                        }
                     }
                 });
             }
 
+            // Initial update
             update();
         })();
     });

--- a/resources/views/employees/history.blade.php
+++ b/resources/views/employees/history.blade.php
@@ -59,21 +59,25 @@
     </div>
 </div>
 
-<div class="bulk-action-bar mb-3" id="history-bulk-action-bar" style="display: none;">
-    <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="history-select-all-checkbox-main">
-        <label class="form-check-label" for="history-select-all-checkbox-main">
-            เลือกทั้งหมด (<span id="history-selected-count">0</span>)
-        </label>
-    </div>
-    <button id="history-bulk-action-btn" class="btn btn-sm btn-info" disabled><i class="bi bi-person-up"></i> ย้ายนายจ้าง</button>
-</div>
+{{-- Use the component with a slot for the transfer action --}}
+<x-bulk-action-bar id="history-bulk-action-bar" checkboxSelector=".history-employee-checkbox">
+    <li>
+        <a class="dropdown-item" href="#" id="history-bulk-transfer-btn">
+            <i class="bi bi-person-up me-2"></i>{{ __('ย้ายนายจ้าง') }}
+        </a>
+    </li>
+</x-bulk-action-bar>
 
 <div id="employeeListContainer">
     @if($currentView === 'card')
         <div class="list-group">
             @forelse($employees as $employee)
-                @include('employees._history_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees])
+                <div class="position-relative">
+                    <div class="position-absolute top-0 end-0 p-2" style="z-index: 10;">
+                        <input class="form-check-input history-employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}">
+                    </div>
+                    @include('employees._history_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees])
+                </div>
             @empty
                 <p class="text-center text-muted">ไม่พบประวัติการจ้างงาน</p>
             @endforelse
@@ -94,7 +98,7 @@
                 <tbody id="historyTableBody">
                     @forelse($employees as $employee)
                     <tr id="history-row-{{ $employee->id }}">
-                        <td><input class="form-check-input history-employee-checkbox" type="checkbox" data-employee-id="{{ $employee->id }}"></td>
+                        <td><input class="form-check-input history-employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}"></td>
                         <td>
                             <div class="d-flex align-items-center">
                                 <img src="{{ $employee->photo_url }}" alt="Photo" class="employee-photo-thumb" style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; margin-right: 0.75rem;">
@@ -141,12 +145,13 @@ document.addEventListener('DOMContentLoaded', () => {
     let transferModalInstance = null;
     let isBulkTransfer = false;
 
-    const tableBody = document.getElementById('historyTableBody');
-    const bulkActionBar = document.getElementById('history-bulk-action-bar');
-    const selectedCountSpan = document.getElementById('history-selected-count');
-    const mainSelectAllCheckbox = document.getElementById('history-select-all-checkbox-main');
+    // We no longer need to manually manage the bulk action bar display, as the component does it.
+    // However, we need to hook up the "Transfer" button in the dropdown.
+
+    const transferBtn = document.getElementById('history-bulk-transfer-btn');
     const tableSelectAllCheckbox = document.getElementById('history-select-all-checkbox-table');
-    const bulkActionButton = document.getElementById('history-bulk-action-btn');
+
+    // Modal elements
     const transferModalEl = document.getElementById('transferEmployeeModal');
     const employeeToTransferIdInput = document.getElementById('employee-to-transfer-id');
     const employeeToTransferNameSpan = document.getElementById('employee-to-transfer-name');
@@ -157,21 +162,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const confirmTransferBtn = document.getElementById('confirm-transfer-btn');
 
     let selectedEmployer = null;
-
-    function updateBulkActionBar() {
-        const container = document.getElementById('employeeListContainer');
-        const selectedCheckboxes = container.querySelectorAll('.history-employee-checkbox:checked');
-        const count = selectedCheckboxes.length;
-        bulkActionBar.style.display = count > 0 ? 'flex' : 'none';
-        selectedCountSpan.textContent = count;
-        bulkActionButton.disabled = count === 0;
-        const allCheckboxes = container.querySelectorAll('.history-employee-checkbox');
-        if (allCheckboxes.length > 0) {
-            const isAllSelected = count === allCheckboxes.length;
-            if(mainSelectAllCheckbox) mainSelectAllCheckbox.checked = isAllSelected;
-            if(tableSelectAllCheckbox) tableSelectAllCheckbox.checked = isAllSelected;
-        }
-    }
 
     function openTransferModal() {
         employerSearchInput.value = '';
@@ -215,66 +205,65 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
-    document.getElementById('employeeListContainer').addEventListener('click', (event) => {
-        const target = event.target.closest('button');
-        if (!target) return;
-        const employeeId = target.dataset.employeeId;
+    // List container event delegation for individual actions
+    const listContainer = document.getElementById('employeeListContainer');
+    if (listContainer) {
+        listContainer.addEventListener('click', (event) => {
+            const target = event.target.closest('button');
+            if (!target) return;
+            const employeeId = target.dataset.employeeId;
 
-        if (target.classList.contains('btn-reinstate')) {
-            Swal.fire({ title: 'ยืนยันการคืนสถานะ', text: "ลูกจ้างจะถูกย้ายกลับไปอยู่ในรายชื่อลูกจ้างปัจจุบัน", icon: 'question', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
-                .then(result => {
-                    if (result.isConfirmed) {
-                        performAction(`/employees/${employeeId}/reinstate`);
-                    }
-                });
-        } else if (target.classList.contains('btn-move-to-trash')) {
-            Swal.fire({ title: 'ยืนยันการย้ายไปถังขยะ', text: "ลูกจ้างจะถูกย้ายไปที่ถังขยะส่วนกลาง", icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก', confirmButtonColor: '#d33' })
-                .then(result => {
-                    if (result.isConfirmed) {
-                         performAction(`/employees/${employeeId}`, { _method: 'DELETE' });
-                    }
-                });
-        } else if (target.classList.contains('btn-transfer-employee')) {
-            isBulkTransfer = false;
-            employeeToTransferIdInput.value = employeeId;
-            employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้าง: ${target.dataset.employeeName}`;
-            openTransferModal();
-        }
-    });
-
-    document.getElementById('employeeListContainer').addEventListener('change', (event) => {
-        if (event.target.classList.contains('history-employee-checkbox')) {
-            updateBulkActionBar();
-        }
-    });
-
-    if(mainSelectAllCheckbox) {
-        mainSelectAllCheckbox.addEventListener('change', (event) => {
-            const isChecked = event.target.checked;
-            document.querySelectorAll('.history-employee-checkbox').forEach(cb => cb.checked = isChecked);
-            if(tableSelectAllCheckbox) tableSelectAllCheckbox.checked = isChecked;
-            updateBulkActionBar();
+            if (target.classList.contains('btn-reinstate')) {
+                Swal.fire({ title: 'ยืนยันการคืนสถานะ', text: "ลูกจ้างจะถูกย้ายกลับไปอยู่ในรายชื่อลูกจ้างปัจจุบัน", icon: 'question', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
+                    .then(result => {
+                        if (result.isConfirmed) {
+                            performAction(`/employees/${employeeId}/reinstate`);
+                        }
+                    });
+            } else if (target.classList.contains('btn-move-to-trash')) {
+                Swal.fire({ title: 'ยืนยันการย้ายไปถังขยะ', text: "ลูกจ้างจะถูกย้ายไปที่ถังขยะส่วนกลาง", icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก', confirmButtonColor: '#d33' })
+                    .then(result => {
+                        if (result.isConfirmed) {
+                            performAction(`/employees/${employeeId}`, { _method: 'DELETE' });
+                        }
+                    });
+            } else if (target.classList.contains('btn-transfer-employee')) {
+                isBulkTransfer = false;
+                employeeToTransferIdInput.value = employeeId;
+                employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้าง: ${target.dataset.employeeName}`;
+                openTransferModal();
+            }
         });
     }
 
+    // Sync table header checkbox with the component's logic if needed,
+    // but the component handles its own select all.
+    // However, if we have a table view, we might have a checkbox in the thead.
+    // The component has a "select all" inside it.
+    // If we want the table header checkbox to also work, we need to listen to it.
     if(tableSelectAllCheckbox) {
         tableSelectAllCheckbox.addEventListener('change', (event) => {
             const isChecked = event.target.checked;
-            document.querySelectorAll('.history-employee-checkbox').forEach(cb => cb.checked = isChecked);
-            if(mainSelectAllCheckbox) mainSelectAllCheckbox.checked = isChecked;
-            updateBulkActionBar();
+            document.querySelectorAll('.history-employee-checkbox').forEach(cb => {
+                cb.checked = isChecked;
+                // Dispatch change event so the component updates its count
+                cb.dispatchEvent(new Event('change', { bubbles: true }));
+            });
         });
     }
 
-    bulkActionButton.addEventListener('click', () => {
-        const selectedCheckboxes = document.querySelectorAll('.history-employee-checkbox:checked');
-        if (selectedCheckboxes.length === 0) return;
-        isBulkTransfer = true;
-        const employeeIds = Array.from(selectedCheckboxes).map(cb => cb.dataset.employeeId);
-        employeeToTransferIdInput.value = JSON.stringify(employeeIds);
-        employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้างที่เลือกจำนวน ${selectedCheckboxes.length} คน`;
-        openTransferModal();
-    });
+    if (transferBtn) {
+        transferBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            const selectedCheckboxes = document.querySelectorAll('.history-employee-checkbox:checked');
+            if (selectedCheckboxes.length === 0) return;
+            isBulkTransfer = true;
+            const employeeIds = Array.from(selectedCheckboxes).map(cb => cb.dataset.employeeId);
+            employeeToTransferIdInput.value = JSON.stringify(employeeIds);
+            employeeToTransferNameSpan.textContent = `คุณกำลังจะย้ายลูกจ้างที่เลือกจำนวน ${selectedCheckboxes.length} คน`;
+            openTransferModal();
+        });
+    }
 
     const debounce = (func, delay) => {
         let timeout;
@@ -312,47 +301,51 @@ document.addEventListener('DOMContentLoaded', () => {
             });
     }, 300);
 
-    employerSearchInput.addEventListener('keyup', handleEmployerSearch);
+    if(employerSearchInput) {
+        employerSearchInput.addEventListener('keyup', handleEmployerSearch);
+    }
 
-    employerSearchResultsDiv.addEventListener('click', (event) => {
-        const target = event.target.closest('button');
-        if (!target) return;
-        selectedEmployer = { id: target.dataset.employerId, name: target.dataset.employerName };
-        selectedEmployerNameSpan.textContent = selectedEmployer.name;
-        selectedEmployerDisplay.style.display = 'block';
-        confirmTransferBtn.disabled = false;
-        employerSearchResultsDiv.style.display = 'none';
-        employerSearchInput.value = '';
-    });
+    if(employerSearchResultsDiv) {
+        employerSearchResultsDiv.addEventListener('click', (event) => {
+            const target = event.target.closest('button');
+            if (!target) return;
+            selectedEmployer = { id: target.dataset.employerId, name: target.dataset.employerName };
+            selectedEmployerNameSpan.textContent = selectedEmployer.name;
+            selectedEmployerDisplay.style.display = 'block';
+            confirmTransferBtn.disabled = false;
+            employerSearchResultsDiv.style.display = 'none';
+            employerSearchInput.value = '';
+        });
+    }
 
-    confirmTransferBtn.addEventListener('click', () => {
-        if (!selectedEmployer) return showToast('กรุณาเลือกนายจ้างใหม่ก่อน', 'danger');
-        const { id: newEmployerId, name: newEmployerName } = selectedEmployer;
+    if(confirmTransferBtn) {
+        confirmTransferBtn.addEventListener('click', () => {
+            if (!selectedEmployer) return showToast('กรุณาเลือกนายจ้างใหม่ก่อน', 'danger');
+            const { id: newEmployerId, name: newEmployerName } = selectedEmployer;
 
-        const swalHtml = isBulkTransfer
-            ? `คุณต้องการย้ายลูกจ้างที่เลือกทั้งหมดไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`
-            : `คุณต้องการย้ายลูกจ้างไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`;
+            const swalHtml = isBulkTransfer
+                ? `คุณต้องการย้ายลูกจ้างที่เลือกทั้งหมดไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`
+                : `คุณต้องการย้ายลูกจ้างไปยัง <strong>${newEmployerName}</strong> ใช่หรือไม่?`;
 
-        Swal.fire({ title: 'ยืนยันการย้ายนายจ้าง', html: swalHtml, icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
-            .then(result => {
-                if (result.isConfirmed) {
-                    if (isBulkTransfer) {
-                        const employeeIds = JSON.parse(employeeToTransferIdInput.value);
-                        performAction('/employees/bulk-transfer', { employee_ids: employeeIds, new_employer_id: newEmployerId });
-                    } else {
-                        const employeeId = employeeToTransferIdInput.value;
-                        performAction(`/employees/${employeeId}/transfer`, { new_employer_id: newEmployerId });
+            Swal.fire({ title: 'ยืนยันการย้ายนายจ้าง', html: swalHtml, icon: 'warning', showCancelButton: true, confirmButtonText: 'ยืนยัน', cancelButtonText: 'ยกเลิก' })
+                .then(result => {
+                    if (result.isConfirmed) {
+                        if (isBulkTransfer) {
+                            const employeeIds = JSON.parse(employeeToTransferIdInput.value);
+                            performAction('/employees/bulk-transfer', { employee_ids: employeeIds, new_employer_id: newEmployerId });
+                        } else {
+                            const employeeId = employeeToTransferIdInput.value;
+                            performAction(`/employees/${employeeId}/transfer`, { new_employer_id: newEmployerId });
+                        }
                     }
-                }
-            });
-    });
+                });
+        });
+    }
 
     if (transferModalEl) {
         transferModalEl.addEventListener('show.bs.modal', () => document.body.classList.add('modal-stack-active'));
         transferModalEl.addEventListener('hidden.bs.modal', () => document.body.classList.remove('modal-stack-active'));
     }
-
-    updateBulkActionBar();
 });
 </script>
 <style>

--- a/resources/views/partials/_employee_action_modals.blade.php
+++ b/resources/views/partials/_employee_action_modals.blade.php
@@ -78,17 +78,14 @@ document.addEventListener('DOMContentLoaded', function () {
                     <input type="text" id="history-search-input" class="form-control" style="max-width: 300px;" placeholder="ค้นหาตามชื่อ หรือ เลขพาสปอร์ต...">
                 </div>
 
-                <div id="history-bulk-action-bar" class="d-flex justify-content-between align-items-center bg-light p-2 rounded mb-3" style="display: none;">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" id="history-select-all-checkbox-main">
-                        <label class="form-check-label" for="history-select-all-checkbox-main">
-                            เลือกทั้งหมด (<span id="history-selected-count">0</span>)
-                        </label>
-                    </div>
-                    <button id="history-bulk-action-btn" class="btn btn-sm btn-primary" disabled>
-                        <i class="bi bi-person-check-fill me-1"></i> ดำเนินการกับรายการที่เลือก
-                    </button>
-                </div>
+                {{-- REPLACED: Use the component instead of manual HTML --}}
+                <x-bulk-action-bar id="history-bulk-action-bar" checkboxSelector=".history-employee-checkbox">
+                    <li>
+                        <a class="dropdown-item" href="#" id="history-bulk-transfer-btn">
+                            <i class="bi bi-person-up me-2"></i>{{ __('ย้ายนายจ้าง') }}
+                        </a>
+                    </li>
+                </x-bulk-action-bar>
 
                 <div class="table-responsive">
                     <table class="table table-hover">


### PR DESCRIPTION
- Fixed `ParseError` in `bulk-action-bar.blade.php` by removing `@once` directive which caused issues in some contexts.
- Added `<x-bulk-action-bar>` to `resources/views/employees/history.blade.php` and `resources/views/partials/_employee_action_modals.blade.php`.
- Updated `resources/js/employment-history.js` to integrate with the new component structure and fix logic for updating the bulk bar after AJAX loads.
- Added a custom event `bulk-action-bar:update` to reliably refresh the bulk bar state.