### PR TITLE
feat: add customizable trash retention settings for admin

### DIFF
--- a/app/Console/Commands/PruneSoftDeletes.php
+++ b/app/Console/Commands/PruneSoftDeletes.php
@@ -9,6 +9,7 @@ use App\Models\Importer;
 use App\Models\Delegate;
 use App\Models\Address;
 use App\Models\Employee;
+use App\Models\SystemConfig;
 
 class PruneSoftDeletes extends Command
 {
@@ -24,40 +25,44 @@ class PruneSoftDeletes extends Command
      *
      * @var string
      */
-    protected $description = 'Permanently delete soft-deleted records older than 30 days';
+    protected $description = 'Permanently delete soft-deleted records based on configured retention days';
 
     /**
      * Execute the console command.
      */
     public function handle()
     {
-        $this->info('Pruning soft-deleted records older than 30 days...');
+        $this->info('Starting soft delete pruning...');
 
-        $cutoffDate = now()->subDays(30);
+        $models = [
+            'employees' => Employee::class,
+            'employers' => Employer::class,
+            'agents' => Agent::class,
+            'importers' => Importer::class,
+            'delegates' => Delegate::class,
+            'addresses' => Address::class,
+        ];
 
-        // Prune Employers
-        $employerCount = Employer::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
-        $this->info("Pruned $employerCount Employers.");
+        foreach ($models as $key => $modelClass) {
+            // Fetch retention setting from SystemConfig
+            // Key format: trash_retention_days_{model_key}
+            // Value: integer (days) or null/'forever' (keep forever)
+            $configKey = "trash_retention_days_{$key}";
+            $retentionDays = SystemConfig::where('key', $configKey)->value('value');
 
-        // Prune Agents
-        $agentCount = Agent::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
-        $this->info("Pruned $agentCount Agents.");
+            // If setting is null, 'forever', or <= 0, we skip pruning for this model.
+            // This effectively means "Keep Forever" is the default if not configured, preventing accidental data loss.
+            if ($retentionDays === null || strtolower($retentionDays) === 'forever' || (int)$retentionDays <= 0) {
+                $this->info("Skipping pruning for {$key}. Retention setting: " . ($retentionDays ?? 'Not Set (Keep Forever)'));
+                continue;
+            }
 
-        // Prune Importers
-        $importerCount = Importer::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
-        $this->info("Pruned $importerCount Importers.");
+            $days = (int)$retentionDays;
+            $cutoffDate = now()->subDays($days);
 
-        // Prune Delegates
-        $delegateCount = Delegate::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
-        $this->info("Pruned $delegateCount Delegates.");
-
-        // Prune Addresses
-        $addressCount = Address::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
-        $this->info("Pruned $addressCount Addresses.");
-
-        // Prune Trashed Employees (using default 'deleted_at' column)
-        $employeeCount = Employee::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
-        $this->info("Pruned $employeeCount Trashed Employees.");
+            $count = $modelClass::onlyTrashed()->where('deleted_at', '<=', $cutoffDate)->forceDelete();
+            $this->info("Pruned {$count} {$key} older than {$days} days.");
+        }
 
         $this->info('Soft delete pruning complete.');
         return 0;

--- a/app/Http/Controllers/Admin/TrashController.php
+++ b/app/Http/Controllers/Admin/TrashController.php
@@ -14,6 +14,7 @@ use App\Models\Agent;
 use App\Models\Importer;
 use App\Models\Delegate;
 use App\Models\Address;
+use App\Models\SystemConfig;
 
 class TrashController extends Controller
 {
@@ -31,6 +32,7 @@ class TrashController extends Controller
         $trashedData = [];
         $models = $this->getPrunableModels();
         $searchTerm = $request->input('search');
+        $retentionSettings = [];
 
         foreach ($models as $modelName => $modelClass) {
             $query = $modelClass::onlyTrashed();
@@ -73,15 +75,59 @@ class TrashController extends Controller
             }
 
             $trashedData[$modelName] = $query->paginate(10, ['*'], $modelName . '_page')->withQueryString();
+
+            // Fetch retention settings for the view
+            $retentionSettings[$modelName] = SystemConfig::where('key', "trash_retention_days_{$modelName}")->value('value');
         }
 
         return view('admin.trash.index', [
             'trashedData' => $trashedData,
             'search' => $searchTerm,
-            'currentView' => $request->input('view', 'table') // Pass the view state
+            'currentView' => $request->input('view', 'table'), // Pass the view state
+            'retentionSettings' => $retentionSettings,
         ]);
     }
 
+    /**
+     * Update the retention settings for trash.
+     */
+    public function updateSettings(Request $request)
+    {
+        if (Gate::denies('view-trash')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        $data = $request->validate([
+            'retention_days' => 'required|array',
+            'retention_days.*' => 'nullable|string', // Can be number string or 'forever' or null
+        ]);
+
+        foreach ($data['retention_days'] as $modelName => $value) {
+            // Ensure the model name is valid
+            if (!array_key_exists($modelName, $this->getPrunableModels())) {
+                continue;
+            }
+
+            // If value is 'forever' or empty, save it as 'forever' or null.
+            // If it is a number, save it.
+            // We'll sanitize: if empty/null -> 'forever'.
+            if (empty($value) || $value === 'forever') {
+                $valueToSave = 'forever';
+            } else {
+                $valueToSave = (int)$value;
+                if ($valueToSave <= 0) {
+                    $valueToSave = 'forever';
+                }
+            }
+
+            SystemConfig::updateOrCreate(
+                ['key' => "trash_retention_days_{$modelName}"],
+                ['value' => $valueToSave]
+            );
+        }
+
+        return redirect()->route('admin.trash.index')->with('success', 'Trash retention settings updated successfully.');
+    }
 
     /**
      * Exports the filtered soft-deleted items to a CSV file.

--- a/resources/views/admin/trash/index.blade.php
+++ b/resources/views/admin/trash/index.blade.php
@@ -19,6 +19,9 @@
                     <input type="text" name="search" class="form-control" placeholder="Search in trash..." value="{{ $search ?? '' }}">
                     <button type="submit" class="btn btn-primary">Search</button>
                     <a href="{{ route('admin.trash.export', request()->query()) }}" class="btn btn-info">Export</a>
+                    <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#trashSettingsModal">
+                        <i class="bi bi-gear"></i>
+                    </button>
                 </form>
 
                 {{-- View Toggle --}}
@@ -180,6 +183,8 @@
 </div>
 
 @endsection
+
+@include('admin.trash.partials._settings_modal')
 
 @push('scripts')
 <script>

--- a/resources/views/admin/trash/partials/_settings_modal.blade.php
+++ b/resources/views/admin/trash/partials/_settings_modal.blade.php
@@ -1,0 +1,46 @@
+<!-- Modal for Trash Retention Settings -->
+<div class="modal fade" id="trashSettingsModal" tabindex="-1" aria-labelledby="trashSettingsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="trashSettingsModalLabel">Trash Retention Settings</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form action="{{ route('admin.trash.updateSettings') }}" method="POST">
+                @csrf
+                <div class="modal-body">
+                    <div class="alert alert-info text-sm">
+                        Specify how many days soft-deleted items should be kept before being permanently deleted. Leave blank or set to 'forever' to keep items indefinitely.
+                    </div>
+
+                    @foreach(['employees', 'employers', 'agents', 'importers', 'delegates', 'addresses'] as $model)
+                        <div class="mb-3 row align-items-center">
+                            <label for="retention_{{ $model }}" class="col-sm-4 col-form-label text-capitalize">
+                                {{ Str::plural(ucfirst($model)) }}
+                            </label>
+                            <div class="col-sm-8">
+                                <div class="input-group">
+                                    <input type="number"
+                                           class="form-control"
+                                           id="retention_{{ $model }}"
+                                           name="retention_days[{{ $model }}]"
+                                           value="{{ $retentionSettings[$model] === 'forever' ? '' : $retentionSettings[$model] }}"
+                                           min="1"
+                                           placeholder="Forever">
+                                    <span class="input-group-text">days</span>
+                                </div>
+                                <div class="form-text">
+                                    Current: <span class="fw-bold">{{ $retentionSettings[$model] === 'forever' || $retentionSettings[$model] === null ? 'Forever' : $retentionSettings[$model] . ' days' }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save Settings</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -177,6 +177,8 @@ Route::middleware(['auth', 'permission:view-trash'])->prefix('admin')->name('adm
 
     Route::get('/trash/export', [\App\Http\Controllers\Admin\TrashController::class, 'exportTrash'])->name('trash.export');
 
+    Route::post('/trash/settings', [\App\Http\Controllers\Admin\TrashController::class, 'updateSettings'])->name('trash.updateSettings');
+
     Route::post('/trash/{model}/{id}/restore', [\App\Http\Controllers\Admin\TrashController::class, 'restore'])
          ->name('trash.restore')
          ->withTrashed(); // Important for finding soft-deleted models


### PR DESCRIPTION
- Update `PruneSoftDeletes` command to use configurable retention days from `SystemConfig`.
- Add `updateSettings` method to `TrashController` to save retention settings.
- Add `getSettings` logic to `TrashController@index` to pass settings to the view.
- Add `admin.trash.updateSettings` route.
- Create `_settings_modal.blade.php` partial for the settings UI.
- Add "Settings" button to `admin/trash/index.blade.php`.
- Defaults to "Forever" (no pruning) if no setting is configured for a model.

Note: Relies on existing `SystemConfig` model and migration.