### PR TITLE
Fix employer access to file download functionality

### DIFF
--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -29,6 +29,21 @@ class DownloadController extends Controller
             'type' => 'required|in:zip,pdf',
         ]);
 
+        // Authorization Logic:
+        // If user is NOT admin/staff (can't manage tickets), we must filter the IDs to ensure they own them.
+        // Using Employee::whereIn automatically applies the 'employerTenancy' global scope for employers.
+        // This means querying for IDs that don't belong to the employer will return nothing.
+        $authorizedEmployeeIds = Employee::whereIn('id', $validated['employee_ids'])
+            ->pluck('id')
+            ->toArray();
+
+        if (empty($authorizedEmployeeIds)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No valid employees selected or you do not have permission to view them.'
+            ], 403);
+        }
+
         $task = DownloadTask::create([
             'user_id' => Auth::id(),
             'type' => $validated['type'],
@@ -37,7 +52,7 @@ class DownloadController extends Controller
 
         // Use dispatchSync to ensure immediate execution, avoiding stuck "pending" tasks
         // if the queue worker is not running.
-        ProcessDownload::dispatchSync($task->id, $validated['employee_ids'], $validated['selected_files']);
+        ProcessDownload::dispatchSync($task->id, $authorizedEmployeeIds, $validated['selected_files']);
 
         $task->refresh();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -159,8 +159,12 @@ Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->grou
     Route::prefix('settings')->name('settings.')->group(function () {
         Route::resource('notifications', App\Http\Controllers\Admin\NotificationSettingController::class);
     });
+});
 
-    // Download Center Routes
+// === Download Center Routes (Accessible by both Admin and Employers) ===
+// We keep the 'admin' prefix/name to match existing frontend logic, but allow 'auth' users.
+// Authorization is handled inside the controller.
+Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('/downloads/tasks', [App\Http\Controllers\DownloadController::class, 'index'])->name('downloads.index');
     Route::post('/downloads/initiate', [App\Http\Controllers\DownloadController::class, 'initiate'])->name('downloads.initiate');
     Route::get('/downloads/{task}/file', [App\Http\Controllers\DownloadController::class, 'download'])->name('downloads.download');


### PR DESCRIPTION
- Move download routes from `role:admin` middleware group to general `auth` middleware group in `routes/web.php`.
- Implement authorization check in `DownloadController@initiate` to verify users own the requested employee IDs.
- Relies on existing `Employee` global scope for filtering data.
- Fixes issue where employers saw generic errors when attempting downloads.