### PR TITLE
Fix bulk update functionality and improve employee list display

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -930,49 +930,46 @@ public function create(Request $request) // เพิ่ม Request $request เ
     public function bulkUpdate(Request $request)
     {
         $request->validate([
-            'data' => 'required|array',
+            // We rely on 'employee_ids' to iterate, as 'data' might be partial or empty if only files are uploaded
+            'employee_ids' => 'required|array',
             'selected_fields' => 'required|array',
         ]);
 
-        $data = $request->input('data');
+        // $data contains text inputs. Files are in $request->file('data')
+        $inputData = $request->input('data', []);
+        $employeeIds = $request->input('employee_ids');
         $selectedFields = $request->input('selected_fields');
         $updatedCount = 0;
 
-        // Define file fields mapping to storage paths
-        // Note: The form submits files via `data[id][field]`, handled by PHP automatically in $request->file('data.id.field')
-
-        foreach ($data as $id => $fields) {
+        foreach ($employeeIds as $id) {
             $employee = Employee::find($id);
             if (!$employee) continue;
 
             // Authorize
-             // $this->authorize('update', $employee); // Assuming policy exists, otherwise check ownership manually
             if (!auth()->user()->can('manage-tickets') && $employee->employer->user_id !== auth()->id()) {
                 continue;
             }
 
             $updateData = [];
+            $employeeInput = $inputData[$id] ?? [];
 
             foreach ($selectedFields as $field) {
-                // Handle File Uploads
+                // 1. Handle File Uploads
                 if ($request->hasFile("data.{$id}.{$field}")) {
                     $file = $request->file("data.{$id}.{$field}");
-                    // Determine storage path (logic from update method)
-                    $storageFolder = "employee_documents";
-                    // Use public disk for doc_1-12, private for others (based on legacy logic)
-                    // For simplicity in this feature, let's follow the update method logic for known fields
 
-                    // Logic copied/adapted from update method:
+                    // Logic adapted from update method:
                     if (in_array($field, ['passport_file', 'visa_file', 'work_permit_file', 'pink_card_file', 'insurance_attachment'])) {
-                        // These are private
-                         if ($employee->{$field . '_path'}) {
+                        // These are private files
+                        if ($employee->{$field . '_path'}) {
                             Storage::disk('private')->delete($employee->{$field . '_path'});
                         }
                         $path = $file->store('employee_documents', 'private');
                         $updateData[$field . '_path'] = $path;
 
-                    } elseif (str_starts_with($field, 'employee_doc_')) {
-                        // These are public
+                    } elseif (str_starts_with($field, 'employee_doc_') || in_array($field, ['employeePhoto', 'insurance_document_path', 'insurance_document_path_private'])) {
+                        // These are public files
+                        // Check if old file exists and delete it
                         if ($employee->$field && Storage::disk('public')->exists($employee->$field)) {
                             Storage::disk('public')->delete($employee->$field);
                         }
@@ -980,9 +977,12 @@ public function create(Request $request) // เพิ่ม Request $request เ
                         $path = $file->storeAs("employee_files/{$employee->employer_id}", $filename, 'public');
                         $updateData[$field] = $path;
                     }
-                } elseif (isset($fields[$field])) {
-                    // Handle Text/Date
-                    $updateData[$field] = $fields[$field];
+
+                }
+                // 2. Handle Text/Date Inputs
+                // We check array_key_exists because the value might be null or empty string, which we want to save.
+                elseif (array_key_exists($field, $employeeInput)) {
+                    $updateData[$field] = $employeeInput[$field];
                 }
             }
 

--- a/resources/views/employees/bulk_edit_form.blade.php
+++ b/resources/views/employees/bulk_edit_form.blade.php
@@ -124,8 +124,27 @@
                         <button class="accordion-button {{ $index === 0 ? '' : 'collapsed' }}" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ $employee->id }}" aria-expanded="{{ $index === 0 ? 'true' : 'false' }}" aria-controls="collapse{{ $employee->id }}">
                             <div class="d-flex align-items-center w-100">
                                 <span class="badge bg-secondary me-3 rounded-pill">{{ $index + 1 }}</span>
-                                <span class="fw-bold me-3">{{ $employee->employeeNameTh ?? $employee->employeeNameEn }}</span>
-                                <span class="text-muted small me-auto"><i class="bi bi-person-badge"></i> {{ $employee->employeeCode ?? $employee->employeePassport ?? 'N/A' }}</span>
+
+                                {{-- Name Thai --}}
+                                <div class="me-3">
+                                    <span class="fw-bold d-block">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }}</span>
+                                </div>
+
+                                {{-- Name English --}}
+                                <div class="me-3 d-none d-md-block">
+                                    <span class="text-muted small d-block">{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}</span>
+                                </div>
+
+                                {{-- Nationality & Flag --}}
+                                <div class="me-auto d-flex align-items-center">
+                                    @php
+                                        $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
+                                    @endphp
+                                    @if($countryCode)
+                                        <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" class="me-2" style="width: 24px; height: 16px;">
+                                    @endif
+                                    <span class="badge bg-info text-dark">{{ $employee->employeeNationality ?? 'N/A' }}</span>
+                                </div>
 
                                 @if($employee->employer)
                                     <span class="badge bg-light text-dark border me-3 d-none d-md-inline-block">

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,12 @@ Route::middleware('auth')->group(function () {
     Route::get('/employees/export', [EmployeeController::class, 'export'])->name('employees.export');
     Route::get('/employees/history', [EmployeeController::class, 'historyIndex'])->name('employees.history');
     Route::get('/employees/{employee}/documents/{field}', [EmployeeController::class, 'serveDocument'])->name('employees.documents.serve');
+
+    // Advanced Bulk Edit Routes (Must come BEFORE resource route)
+    Route::post('employees/bulk-edit/select-fields', [EmployeeController::class, 'bulkEditSelectFields'])->name('employees.bulk_edit.select_fields');
+    Route::post('employees/bulk-edit/form', [EmployeeController::class, 'bulkEditForm'])->name('employees.bulk_edit.form');
+    Route::put('employees/bulk-update', [EmployeeController::class, 'bulkUpdate'])->name('employees.bulk_update');
+
     Route::resource('employees', EmployeeController::class);
     Route::resource('importers', ImporterController::class);
     Route::resource('agents', AgentController::class);
@@ -107,11 +113,6 @@ Route::middleware('auth')->group(function () {
         // V2.4-S6: New Route for Temporary Uploads (POST)
         Route::post('temp-upload', [TemporaryUploadController::class, 'store'])->name('temp_upload.store');
     });
-
-    // Advanced Bulk Edit Routes (Must come BEFORE resource route)
-    Route::post('employees/bulk-edit/select-fields', [EmployeeController::class, 'bulkEditSelectFields'])->name('employees.bulk_edit.select_fields');
-    Route::post('employees/bulk-edit/form', [EmployeeController::class, 'bulkEditForm'])->name('employees.bulk_edit.form');
-    Route::put('employees/bulk-update', [EmployeeController::class, 'bulkUpdate'])->name('employees.bulk_update');
 
     // Employee Transfer Route
     Route::post('employees/{employee}/transfer', [EmployeeController::class, 'transfer'])->name('employees.transfer');


### PR DESCRIPTION
- Moved `employees/bulk-update` routes before `employees` resource route to prevent 404 errors.
- Updated `EmployeeController::bulkUpdate` to iterate over `employee_ids` ensuring updates occur even when only files are uploaded.
- Improved `bulk_edit_form.blade.php` to display Thai Name, English Name, and Nationality Flag as requested.