### PR TITLE
Fix bulk update error by adding private disk and correcting file links

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -38,6 +38,14 @@ return [
             'report' => false,
         ],
 
+        'private' => [
+            'driver' => 'local',
+            'root' => storage_path('app/private'),
+            'visibility' => 'private',
+            'throw' => false,
+            'report' => false,
+        ],
+
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),

--- a/resources/views/employees/bulk_edit_form.blade.php
+++ b/resources/views/employees/bulk_edit_form.blade.php
@@ -166,10 +166,28 @@
                                             <div class="input-group">
                                                 <input type="file" class="form-control individual-input" name="data[{{ $employee->id }}][{{ $field }}]" data-field="{{ $field }}">
                                             </div>
-                                            @if($employee->$field)
+                                            @php
+                                                $isPrivateFile = in_array($field, ['passport_file', 'visa_file', 'work_permit_file', 'pink_card_file', 'insurance_attachment']);
+                                                // Determine path attribute: for private files, it's field_path. For public, it's just the field.
+                                                // However, Employee model accessors might handle $employee->$field if defined,
+                                                // but the DB column for private files is usually suffixed with _path.
+                                                // Let's check if we can access the path directly or via attribute.
+                                                // Based on controller logic: $updateData[$field . '_path'] = $path;
+                                                // So the column is likely passport_file_path, etc.
+                                                // But in the view $employee->$field might be null if the accessor doesn't exist.
+                                                // Let's try to access the correct attribute.
+                                                $pathAttribute = $isPrivateFile ? $field . '_path' : $field;
+                                                $filePath = $employee->$pathAttribute ?? $employee->$field;
+                                            @endphp
+
+                                            @if($filePath)
                                                 <div class="mt-1 text-success small">
                                                     <i class="bi bi-check-circle-fill"></i> {{ __('File exists') }}
-                                                    <a href="{{ Storage::disk('public')->url($employee->$field) }}" target="_blank" class="text-decoration-none ms-1">({{ __('View') }})</a>
+                                                    @if($isPrivateFile)
+                                                        <a href="{{ route('employees.documents.serve', ['employee' => $employee->id, 'field' => $pathAttribute]) }}" target="_blank" class="text-decoration-none ms-1">({{ __('View') }})</a>
+                                                    @else
+                                                        <a href="{{ Storage::disk('public')->url($filePath) }}" target="_blank" class="text-decoration-none ms-1">({{ __('View') }})</a>
+                                                    @endif
                                                 </div>
                                             @else
                                                 <div class="mt-1 text-muted small">


### PR DESCRIPTION
- Defined 'private' disk in config/filesystems.php to resolve InvalidArgumentException.
- Updated bulk_edit_form.blade.php to correctly generate links for private files using the secure serve route instead of public storage URLs.
- Ensured consistency in file path resolution for private vs public documents in the view.