### PR TITLE
Fix syntax error in tickets/index.blade.php

### DIFF
--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -68,7 +68,7 @@
                 </tr>
                 @empty
                 <tr>
-                    <td colspan="5" class="text-center text-muted">{{ __('You haven't submitted any requests yet') }}</td>
+                    <td colspan="5" class="text-center text-muted">{{ __("You haven't submitted any requests yet") }}</td>
                 </tr>
                 @endforelse
             </tbody>


### PR DESCRIPTION
Corrected a PHP Parse Error caused by an unescaped single quote in a single-quoted string within the Blade `@empty` directive. Replaced the outer single quotes with double quotes to allow the apostrophe in "haven't" to be parsed correctly.