### PR TITLE
Update employee download folder naming to use English name and title

### DIFF
--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -106,7 +106,15 @@ class ProcessDownload implements ShouldQueue
         }
 
         foreach ($employees as $employee) {
-            $folderName = $this->sanitizeFileName($employee->employeeNameTh ?? $employee->employeeNameEn ?? 'Employee_' . $employee->id);
+            // Use English Title + Name if available, per user request
+            if (!empty($employee->employeeNameEn)) {
+                $prefix = !empty($employee->employeeTitleEn) ? $employee->employeeTitleEn . ' ' : '';
+                $rawName = $prefix . $employee->employeeNameEn;
+            } else {
+                $rawName = $employee->employeeNameTh ?? 'Employee_' . $employee->id;
+            }
+
+            $folderName = $this->sanitizeFileName($rawName);
 
             foreach ($this->selectedFiles as $fileType) {
                 $this->addFilesToZip($zip, $employee, $fileType, $folderName);


### PR DESCRIPTION
Modified the `ProcessDownload` job to prioritize using the employee's English name and title (e.g., "MR. Name") when creating folders within the download zip file. This aligns with the user request to use English naming conventions for exported folders. A fallback to Thai name or ID is maintained for robustness.