### PR TITLE
Add StabilityTestSeeder and Feature Test

### DIFF
--- a/database/seeders/StabilityTestSeeder.php
+++ b/database/seeders/StabilityTestSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Employer;
+use App\Models\Employee;
+use Illuminate\Support\Facades\DB;
+
+class StabilityTestSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // Disable query logging to save memory
+        DB::disableQueryLog();
+
+        $totalEmployers = 100;
+        $employeesPerEmployer = 100;
+
+        $this->command->info("Starting Stability Test Seeding...");
+        $this->command->info("Creating {$totalEmployers} Employers with {$employeesPerEmployer} Employees each.");
+
+        // Create employers in chunks to manage memory if needed, though 100 is small for employers.
+        // We iterate to create employees for each.
+
+        $bar = $this->command->getOutput()->createProgressBar($totalEmployers);
+        $bar->start();
+
+        for ($i = 0; $i < $totalEmployers; $i++) {
+            $employer = Employer::factory()->create();
+
+            // Create 100 employees for this employer
+            // Using createMany or just factory count
+            Employee::factory()
+                ->count($employeesPerEmployer)
+                ->create(['employer_id' => $employer->id]);
+
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->command->newLine();
+        $this->command->info("Seeding complete.");
+    }
+}

--- a/tests/Feature/StabilityTest.php
+++ b/tests/Feature/StabilityTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Employer;
+use App\Models\Employee;
+use Database\Seeders\StabilityTestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class StabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that the StabilityTestSeeder creates the correct amount of data.
+     *
+     * @return void
+     */
+    public function test_create_large_scale_data()
+    {
+        // Assert initial state
+        $this->assertEquals(0, Employer::count());
+        $this->assertEquals(0, Employee::count());
+
+        // Run the seeder
+        $this->seed(StabilityTestSeeder::class);
+
+        // Assert final state
+        $expectedEmployers = 100;
+        $expectedEmployees = 100 * 100; // 10,000
+
+        $this->assertEquals($expectedEmployers, Employer::count(), "Employer count should be {$expectedEmployers}");
+        $this->assertEquals($expectedEmployees, Employee::count(), "Employee count should be {$expectedEmployees}");
+    }
+}


### PR DESCRIPTION
- Adds `database/seeders/StabilityTestSeeder.php` to generate 100 Employers and 10,000 Employees.
- Adds `tests/Feature/StabilityTest.php` to verify the seeder's output.
- Uses `DB::disableQueryLog()` for memory efficiency during seeding.