### PR TITLE
Add Pink Card and Residence Notification types

### DIFF
--- a/app/Http/Controllers/Admin/NotificationSettingController.php
+++ b/app/Http/Controllers/Admin/NotificationSettingController.php
@@ -16,7 +16,8 @@ class NotificationSettingController extends Controller
 
     public function index()
     {
-        $settings = NotificationSetting::all();
+        $settings = NotificationSetting::all()->keyBy('notification_type');
+
         // A simple mapping for Thai labels in the view
         $typeLabels = [
             'ninety_day_report' => 'รายงานตัว 90 วัน',
@@ -28,7 +29,22 @@ class NotificationSettingController extends Controller
             'new_registration_renewal' => 'มติขึ้นทะเบียนใหม่',
             'employer_document_expiry' => 'เอกสารนายจ้าง',
             'employee_insurance_expiry' => 'ประกันลูกจ้าง',
+            'pink_card_missing' => 'แจ้งเตือนบัตรชมพู', // New Type
+            'residence_permit_missing' => 'แจ้งเตือนแจ้งที่พักอาศัย', // New Type
         ];
+
+        // Ensure all types are present in the settings collection, even if not in DB yet
+        // (Though migration should have seeded them, this is a fallback for display)
+        foreach ($typeLabels as $type => $label) {
+            if (!$settings->has($type)) {
+                $settings[$type] = new NotificationSetting([
+                    'notification_type' => $type,
+                    'days_before_expiry' => 30,
+                    'is_enabled' => true
+                ]);
+            }
+        }
+
         return view('admin.notification_settings.index', compact('settings', 'typeLabels'));
     }
 
@@ -36,12 +52,24 @@ class NotificationSettingController extends Controller
     {
         $request->validate([
             'settings' => 'required|array',
-            'settings.*.days_before_expiry' => 'required|integer|min:0',
+            'settings.*.days_before_expiry' => 'nullable|integer|min:0',
+            'settings.*.is_enabled' => 'nullable|boolean',
         ]);
 
         foreach ($request->settings as $type => $settingData) {
-            NotificationSetting::where('notification_type', $type)
-                ->update(['days_before_expiry' => $settingData['days_before_expiry']]);
+            $data = [];
+
+            if (isset($settingData['days_before_expiry'])) {
+                $data['days_before_expiry'] = $settingData['days_before_expiry'];
+            }
+
+            // Handle the checkbox (if unchecked, it won't be in the request, so default to 0/false)
+            $data['is_enabled'] = isset($settingData['is_enabled']) ? 1 : 0;
+
+            NotificationSetting::updateOrCreate(
+                ['notification_type' => $type],
+                $data
+            );
         }
 
         // Trigger the expiry check command

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -28,6 +28,8 @@ class NotificationController extends Controller
             'new_registration_renewal' => 'มติขึ้นทะเบียนใหม่',
             'employer_document_expiry' => 'เอกสารนายจ้าง',
             'employee_insurance_expiry' => 'ประกันลูกจ้าง',
+            'pink_card_missing' => 'บัตรชมพู', // New Tab
+            'residence_permit_missing' => 'แจ้งที่พักอาศัย', // New Tab
         ];
 
         $notificationsData = [];
@@ -95,6 +97,7 @@ class NotificationController extends Controller
             $query->where('status', 'cancelled')->orderBy('updated_at', 'desc');
         } else {
             // Modified sorting: Sort by due_date ASC (Earliest expiry first, expired items at top)
+            // For missing data types, due_date might be null or irrelevant, but we keep sorting for consistency
             $query->where('status', '!=', 'cancelled')->where('type', $type)->orderBy('due_date', 'asc');
         }
 
@@ -156,10 +159,22 @@ class NotificationController extends Controller
     // Add this new method to the controller
     public function renew(Request $request, \App\Models\Notification $notification)
     {
-        $request->validate([
-            'new_due_date' => 'required|date',
-            'attachment' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:10240', // 10MB max
-        ]);
+        // Validation rules adjusted for new types
+        $rules = [];
+
+        if (in_array($notification->type, ['pink_card_missing', 'residence_permit_missing'])) {
+            // For update action
+             $rules['attachment'] = 'required|file|mimes:pdf,jpg,jpeg,png|max:10240'; // Attachment required
+             if ($notification->type === 'pink_card_missing') {
+                 $rules['pink_card_number'] = 'required|string|max:255';
+             }
+        } else {
+            // For renewal action
+            $rules['new_due_date'] = 'required|date';
+            $rules['attachment'] = 'nullable|file|mimes:pdf,jpg,jpeg,png|max:10240';
+        }
+
+        $request->validate($rules);
 
         $employee = $notification->employee;
         $employer = $notification->employer; // Get employer directly
@@ -220,10 +235,29 @@ class NotificationController extends Controller
                 $fileField = 'employer_doc_company';
                 $targetModel = $employer;
                 break;
+
+            // --- New Types ---
+            case 'pink_card_missing':
+                // Updates pinkCardNo and employee_doc_4 (Pink Card File)
+                if ($request->filled('pink_card_number')) {
+                    $employee->pinkCardNo = $request->input('pink_card_number');
+                }
+                $fileField = 'employee_doc_4';
+                $targetModel = $employee;
+                // No date field to update for this type
+                break;
+            case 'residence_permit_missing':
+                // Updates employee_doc_7 (Residence Notification File)
+                $fileField = 'employee_doc_7';
+                $targetModel = $employee;
+                // No date field to update for this type
+                break;
         }
 
-        if ($fieldToUpdate && $targetModel) {
-            $targetModel->{$fieldToUpdate} = $request->new_due_date;
+        if ($targetModel) {
+            if ($fieldToUpdate && $request->has('new_due_date')) {
+                $targetModel->{$fieldToUpdate} = $request->new_due_date;
+            }
 
             // Handle file upload
             if ($request->hasFile('attachment') && $fileField) {
@@ -269,7 +303,15 @@ class NotificationController extends Controller
 
         $notification->delete(); // Remove the notification after handling
 
-        return redirect()->route('notifications.index', ['active_tab' => $activeTab])->with('success', 'ต่ออายุข้อมูลและบันทึกเอกสารเรียบร้อยแล้ว');
+        // Customize success message
+        $msg = 'ดำเนินการเรียบร้อยแล้ว';
+        if (in_array($notification->type, ['pink_card_missing', 'residence_permit_missing'])) {
+            $msg = 'อัพเดตข้อมูลและบันทึกเอกสารเรียบร้อยแล้ว';
+        } else {
+            $msg = 'ต่ออายุข้อมูลและบันทึกเอกสารเรียบร้อยแล้ว';
+        }
+
+        return redirect()->route('notifications.index', ['active_tab' => $activeTab])->with('success', $msg);
     }
 
     // Add this new method to the controller

--- a/app/Models/NotificationSetting.php
+++ b/app/Models/NotificationSetting.php
@@ -12,5 +12,6 @@ class NotificationSetting extends Model
     protected $fillable = [
         'notification_type',
         'days_before_expiry',
+        'is_enabled',
     ];
 }

--- a/app/Observers/EmployeeObserver.php
+++ b/app/Observers/EmployeeObserver.php
@@ -3,16 +3,29 @@
 namespace App\Observers;
 
 use App\Models\Employee;
+use App\Models\Notification;
+use App\Models\NotificationSetting;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 
 class EmployeeObserver
 {
     /**
+     * Handle the Employee "created" event.
+     */
+    public function created(Employee $employee): void
+    {
+        $this->checkMissingData($employee);
+    }
+
+    /**
      * Handle the Employee "updated" event.
      */
     public function updated(Employee $employee): void
     {
+        $this->checkMissingData($employee);
+
+        // Existing date expiry logic
         $dateFields = [
             'passportExpiryDate',
             'workPermitExpiryDate',
@@ -33,9 +46,83 @@ class EmployeeObserver
 
         if ($wasChanged) {
             Log::info("Expiry date changed for employee ID: {$employee->id}. Triggering notification re-check.");
-            // We can call the command directly.
-            // For a single employee, this is still very fast and ensures all logic is re-evaluated.
             Artisan::call('app:check-expiries');
+        }
+    }
+
+    /**
+     * Check for missing Pink Card or Residence Data and create/delete notifications.
+     */
+    private function checkMissingData(Employee $employee): void
+    {
+        $this->checkPinkCardMissing($employee);
+        $this->checkResidencePermitMissing($employee);
+    }
+
+    private function checkPinkCardMissing(Employee $employee): void
+    {
+        $type = 'pink_card_missing';
+
+        // Check if setting is enabled
+        $setting = NotificationSetting::where('notification_type', $type)->first();
+        if (!$setting || !$setting->is_enabled) {
+            // If disabled, ensure no notification exists
+            Notification::where('employee_id', $employee->id)->where('type', $type)->delete();
+            return;
+        }
+
+        // Logic: Missing if PinkCardNo is missing OR Pink Card File (employee_doc_4) is missing
+        // Note: employee_doc_4 is stored as path string
+        $isMissing = empty($employee->pinkCardNo) || empty($employee->employee_doc_4);
+
+        if ($isMissing) {
+            Notification::firstOrCreate(
+                [
+                    'employee_id' => $employee->id,
+                    'type' => $type,
+                ],
+                [
+                    'employer_id' => $employee->employer_id,
+                    'due_date' => null, // Not applicable
+                    'status' => 'unread',
+                    'days_remaining' => 0, // Not applicable, but useful for sorting if needed
+                ]
+            );
+        } else {
+            Notification::where('employee_id', $employee->id)->where('type', $type)->delete();
+        }
+    }
+
+    private function checkResidencePermitMissing(Employee $employee): void
+    {
+        $type = 'residence_permit_missing';
+
+        // Check if setting is enabled
+        $setting = NotificationSetting::where('notification_type', $type)->first();
+        if (!$setting || !$setting->is_enabled) {
+            // If disabled, ensure no notification exists
+            Notification::where('employee_id', $employee->id)->where('type', $type)->delete();
+            return;
+        }
+
+        // Logic: Missing if Residence File (employee_doc_7) is missing
+        $isMissing = empty($employee->employee_doc_7);
+
+        if ($isMissing) {
+             Notification::firstOrCreate(
+                [
+                    'employee_id' => $employee->id,
+                    'type' => $type,
+                ],
+                [
+                    'employer_id' => $employee->employer_id,
+                    'due_date' => null,
+                    'status' => 'unread',
+                    'days_remaining' => 0,
+                ]
+            );
+        } else {
+            Notification::where('employee_id', $employee->id)->where('type', $type)->delete();
         }
     }
 }

--- a/database/migrations/2025_11_21_000000_add_is_enabled_to_notification_settings.php
+++ b/database/migrations/2025_11_21_000000_add_is_enabled_to_notification_settings.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('notification_settings', function (Blueprint $table) {
+            $table->boolean('is_enabled')->default(true);
+        });
+
+        // Seed initial data for new types
+        $newTypes = [
+            'pink_card_missing' => 30, // Default days, though ignored for this type
+            'residence_permit_missing' => 30, // Default days, though ignored for this type
+        ];
+
+        foreach ($newTypes as $type => $days) {
+            if (DB::table('notification_settings')->where('notification_type', $type)->doesntExist()) {
+                DB::table('notification_settings')->insert([
+                    'notification_type' => $type,
+                    'days_before_expiry' => $days,
+                    'is_enabled' => true,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+
+        // Ensure existing types are also present if table was empty
+        $existingTypes = [
+            'ninety_day_report',
+            'passport_expiry',
+            'work_permit_mou',
+            'visa_expiry',
+            'ci_renewal',
+            'resolution_renewal',
+            'new_registration_renewal',
+            'employer_document_expiry',
+            'employee_insurance_expiry',
+        ];
+
+        foreach ($existingTypes as $type) {
+            if (DB::table('notification_settings')->where('notification_type', $type)->doesntExist()) {
+                DB::table('notification_settings')->insert([
+                    'notification_type' => $type,
+                    'days_before_expiry' => 30,
+                    'is_enabled' => true,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('notification_settings', function (Blueprint $table) {
+            $table->dropColumn('is_enabled');
+        });
+    }
+};

--- a/mockup_notifications.html
+++ b/mockup_notifications.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Notification Mockup</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <style>
+        :root { --bs-primary: #F97316; }
+        .nav-link.active { color: #fff; background-color: #F97316; border-color: #F97316; }
+        .nav-link { color: #F97316; }
+        .badge.bg-danger { background-color: #dc3545 !important; }
+        .alert-danger { color: #842029; background-color: #f8d7da; border-color: #f5c2c7; }
+    </style>
+</head>
+<body>
+<div class="container mt-4">
+    <h2>Notification List</h2>
+
+    <!-- Tabs -->
+    <ul class="nav nav-tabs mb-3">
+        <li class="nav-item"><a class="nav-link" href="#">90 Day Report</a></li>
+        <li class="nav-item"><a class="nav-link" href="#">Passport</a></li>
+        <li class="nav-item"><a class="nav-link active" href="#">Pink Card <span class="badge bg-danger rounded-pill">2</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="#">Residence Notification <span class="badge bg-danger rounded-pill">1</span></a></li>
+    </ul>
+
+    <!-- Tab Content: Pink Card -->
+    <div class="tab-content">
+        <div class="tab-pane show active">
+             <div class="d-flex justify-content-end mb-3">
+                <button class="btn btn-success btn-sm"><i class="bi bi-download"></i> Export Data (Pink Card)</button>
+            </div>
+
+            <!-- Item 1 -->
+            <div class="alert alert-danger notification-item">
+                <div class="d-flex align-items-center gap-3">
+                    <input type="checkbox" class="form-check-input">
+                    <img src="https://placehold.co/48x48/e2e8f0/6c757d?text=PIC" class="rounded-circle">
+                    <div class="d-flex justify-content-between align-items-start w-100">
+                        <div>
+                            <h5 class="alert-heading mb-1">1. Mr. John Doe <span class="badge bg-light text-dark">Myanmar</span></h5>
+                            <p class="mb-1 small">นาย จอห์น โด</p>
+                            <p class="mb-1 small"><strong>นายจ้าง:</strong> บริษัท ทดสอบ จำกัด</p>
+                            <p class="mb-0 small"><strong>สถานะ:</strong> <span class="text-danger">ข้อมูลยังไม่ครบถ้วน</span></p>
+                        </div>
+                        <div class="text-end">
+                            <span class="badge bg-danger mb-2 d-block">กรุณาอัพเดต</span>
+                            <div>
+                                <button class="btn btn-info"><i class="bi bi-rocket-takeoff-fill"></i></button>
+                                <button class="btn btn-success"><i class="bi bi-pencil-square"></i> อัพเดต</button>
+                                <button class="btn btn-primary"><i class="bi bi-geo-alt-fill"></i></button>
+                                <button class="btn btn-warning"><i class="bi bi-x-circle"></i></button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Item 2 -->
+            <div class="alert alert-danger notification-item">
+                <div class="d-flex align-items-center gap-3">
+                    <input type="checkbox" class="form-check-input">
+                    <img src="https://placehold.co/48x48/e2e8f0/6c757d?text=PIC" class="rounded-circle">
+                    <div class="d-flex justify-content-between align-items-start w-100">
+                        <div>
+                            <h5 class="alert-heading mb-1">2. Miss Jane Doe <span class="badge bg-light text-dark">Laos</span></h5>
+                            <p class="mb-1 small">นางสาว เจน โด</p>
+                            <p class="mb-1 small"><strong>นายจ้าง:</strong> ร้านอาหารอร่อย</p>
+                            <p class="mb-0 small"><strong>สถานะ:</strong> <span class="text-danger">ข้อมูลยังไม่ครบถ้วน</span></p>
+                        </div>
+                        <div class="text-end">
+                            <span class="badge bg-danger mb-2 d-block">กรุณาอัพเดต</span>
+                            <div>
+                                <button class="btn btn-info"><i class="bi bi-rocket-takeoff-fill"></i></button>
+                                <button class="btn btn-success"><i class="bi bi-pencil-square"></i> อัพเดต</button>
+                                <button class="btn btn-primary"><i class="bi bi-geo-alt-fill"></i></button>
+                                <button class="btn btn-warning"><i class="bi bi-x-circle"></i></button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/resources/views/admin/notification_settings/index.blade.php
+++ b/resources/views/admin/notification_settings/index.blade.php
@@ -31,20 +31,41 @@
                             <thead>
                                 <tr>
                                     <th>ประเภทการแจ้งเตือน</th>
-                                    <th>แจ้งเตือนล่วงหน้า (วัน)</th>
+                                    <th>การตั้งค่า</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                @foreach ($settings as $setting)
+                                @foreach ($typeLabels as $type => $label)
+                                    @php
+                                        $setting = $settings[$type] ?? new \App\Models\NotificationSetting(['days_before_expiry' => 30, 'is_enabled' => true]);
+                                        $isMissingDataType = in_array($type, ['pink_card_missing', 'residence_permit_missing']);
+                                    @endphp
                                     <tr>
-                                        <td>{{ $typeLabels[$setting->notification_type] ?? $setting->notification_type }}</td>
+                                        <td>{{ $label }}</td>
                                         <td>
-                                            <input type="number"
-                                                   name="settings[{{ $setting->notification_type }}][days_before_expiry]"
-                                                   class="form-control"
-                                                   value="{{ old('settings.'.$setting->notification_type.'.days_before_expiry', $setting->days_before_expiry) }}"
-                                                   min="0"
-                                                   required>
+                                            @if ($isMissingDataType)
+                                                {{-- Toggle Switch for New Types --}}
+                                                <div class="form-check form-switch">
+                                                    <input class="form-check-input" type="checkbox"
+                                                           id="switch_{{ $type }}"
+                                                           name="settings[{{ $type }}][is_enabled]"
+                                                           value="1"
+                                                           {{ old('settings.'.$type.'.is_enabled', $setting->is_enabled) ? 'checked' : '' }}>
+                                                    <label class="form-check-label" for="switch_{{ $type }}">เปิดใช้งานการแจ้งเตือน</label>
+                                                </div>
+                                            @else
+                                                {{-- Input for Days --}}
+                                                <div class="input-group" style="max-width: 200px;">
+                                                    <input type="number"
+                                                           name="settings[{{ $type }}][days_before_expiry]"
+                                                           class="form-control"
+                                                           value="{{ old('settings.'.$type.'.days_before_expiry', $setting->days_before_expiry) }}"
+                                                           min="0"
+                                                           required>
+                                                    <span class="input-group-text">วัน</span>
+                                                </div>
+                                                <input type="hidden" name="settings[{{ $type }}][is_enabled]" value="1"> {{-- Always enabled for expiry types for now --}}
+                                            @endif
                                         </td>
                                     </tr>
                                 @endforeach

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -344,13 +344,25 @@
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
-                            <div class="mb-3">
-                                <label for="new_due_date" class="form-label">{{ __('Select new expiry date') }}:</label>
-                                <input type="date" class="form-control" id="new_due_date" name="new_due_date" required>
+                            {{-- Dynamic Content Area --}}
+
+                            {{-- Field for Pink Card Number (Only for pink_card_missing) --}}
+                            <div class="mb-3 d-none" id="pink_card_number_group">
+                                <label for="pink_card_number" class="form-label">เลขบัตรชมพู <span class="text-danger">*</span></label>
+                                <input type="text" class="form-control" id="pink_card_number" name="pink_card_number">
                             </div>
+
+                            {{-- Field for Expiry Date (Hidden for missing data types) --}}
+                            <div class="mb-3" id="new_due_date_group">
+                                <label for="new_due_date" class="form-label">{{ __('Select new expiry date') }}: <span class="text-danger">*</span></label>
+                                <input type="date" class="form-control" id="new_due_date" name="new_due_date">
+                            </div>
+
+                            {{-- File Attachment --}}
                             <div class="mb-3">
-                                <label for="attachment" class="form-label">{{ __('Attach document (if any)') }}:</label>
+                                <label for="attachment" class="form-label" id="attachment_label">{{ __('Attach document (if any)') }}:</label>
                                 <input type="file" class="form-control" id="attachment" name="attachment" accept=".pdf,.jpg,.jpeg,.png">
+                                <div class="form-text text-muted" id="attachment_help"></div>
                             </div>
                         </div>
                         <div class="modal-footer">
@@ -456,9 +468,46 @@
                 renewModal.addEventListener('show.bs.modal', function (event) {
                     const button = event.relatedTarget;
                     const notificationId = button.getAttribute('data-notification-id');
+                    const notificationType = button.getAttribute('data-notification-type');
+
                     const form = document.getElementById('renew-form');
+                    const modalTitle = document.getElementById('renewModalLabel');
+                    const pinkCardGroup = document.getElementById('pink_card_number_group');
+                    const dueDateGroup = document.getElementById('new_due_date_group');
+                    const dueDateInput = document.getElementById('new_due_date');
+                    const attachmentLabel = document.getElementById('attachment_label');
+                    const attachmentInput = document.getElementById('attachment');
+                    const pinkCardInput = document.getElementById('pink_card_number');
+
+                    // Reset Fields
+                    pinkCardGroup.classList.add('d-none');
+                    dueDateGroup.classList.remove('d-none');
+                    dueDateInput.required = true;
+                    pinkCardInput.required = false;
+                    attachmentInput.required = false; // Default
+                    attachmentLabel.textContent = '{{ __('Attach document (if any)') }}:';
+
                     if(notificationId) {
                         form.action = `/notifications/${notificationId}/renew`;
+                    }
+
+                    // Adjust modal based on type
+                    if (notificationType === 'pink_card_missing') {
+                        modalTitle.textContent = 'อัพเดตข้อมูลบัตรชมพู';
+                        pinkCardGroup.classList.remove('d-none');
+                        pinkCardInput.required = true;
+                        dueDateGroup.classList.add('d-none');
+                        dueDateInput.required = false;
+                        attachmentLabel.innerHTML = 'แนบไฟล์บัตรชมพู <span class="text-danger">*</span>';
+                        attachmentInput.required = true;
+                    } else if (notificationType === 'residence_permit_missing') {
+                        modalTitle.textContent = 'อัพเดตใบแจ้งที่พักอาศัย';
+                        dueDateGroup.classList.add('d-none');
+                        dueDateInput.required = false;
+                        attachmentLabel.innerHTML = 'แนบไฟล์ใบแจ้งที่พักอาศัย <span class="text-danger">*</span>';
+                        attachmentInput.required = true;
+                    } else {
+                        modalTitle.textContent = '{{ __('Renew Notification') }}';
                     }
                 });
             }

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -5,9 +5,16 @@
     $days_remaining = $notification->days_remaining;
     $is_overdue = $days_remaining < 0;
 
+    // For missing data types, days_remaining is 0/irrelevant, so handle badge
+    $isMissingDataType = in_array($notification->type, ['pink_card_missing', 'residence_permit_missing']);
+
     $card_class = '';
     $badge_class = 'bg-info text-dark';
-    if ($is_overdue) {
+
+    if ($isMissingDataType) {
+        $card_class = 'alert-danger'; // Always red for missing data
+        $badge_class = 'bg-danger';
+    } elseif ($is_overdue) {
         $card_class = 'alert-dark';
         $badge_class = 'bg-dark';
     } elseif ($days_remaining <= 30) {
@@ -66,11 +73,19 @@
                     <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employer" data-model-id="{{ $employer->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
                     @endif
                 </p>
-                <p class="mb-0 small"><strong>วันครบกำหนด:</strong> {{ \Carbon\Carbon::parse($notification->due_date)->translatedFormat('d F Y') }}</p>
+                <p class="mb-0 small">
+                    @if($isMissingDataType)
+                        <strong>สถานะ:</strong> <span class="text-danger">ข้อมูลยังไม่ครบถ้วน</span>
+                    @else
+                        <strong>วันครบกำหนด:</strong> {{ \Carbon\Carbon::parse($notification->due_date)->translatedFormat('d F Y') }}
+                    @endif
+                </p>
             </div>
             <div class="text-end flex-shrink-0 ms-2">
                 <span class="badge {{ $badge_class }} mb-2 d-block text-nowrap fs-6">
-                    @if($is_overdue)
+                    @if($isMissingDataType)
+                        กรุณาอัพเดต
+                    @elseif($is_overdue)
                         หมดอายุ {{ abs($days_remaining) }} วัน
                     @else
                         เหลือ {{ $days_remaining }} วัน
@@ -89,7 +104,18 @@
                         </form>
                     @else
                         <a href="#" class="btn btn-info" title="สร้างงาน"><i class="bi bi-rocket-takeoff-fill"></i></a>
-                        <a href="#" class="btn btn-success" title="ต่ออายุ" data-bs-toggle="modal" data-bs-target="#renewNotificationModal" data-notification-id="{{ $notification->id }}"><i class="bi bi-calendar-check"></i></a>
+
+                        {{-- Update/Renew Button --}}
+                        <a href="#" class="btn btn-success"
+                           title="{{ $isMissingDataType ? 'อัพเดตข้อมูล' : 'ต่ออายุ' }}"
+                           data-bs-toggle="modal"
+                           data-bs-target="#renewNotificationModal"
+                           data-notification-id="{{ $notification->id }}"
+                           data-notification-type="{{ $notification->type }}">
+                           <i class="bi {{ $isMissingDataType ? 'bi-pencil-square' : 'bi-calendar-check' }}"></i>
+                           {{ $isMissingDataType ? 'อัพเดต' : '' }}
+                        </a>
+
                         {{-- Only show the 'Locate' button if there is an employee --}}
                         @if($employee)
                             <a href="{{ route('notifications.view-employee', $notification->id) }}" class="btn btn-primary" title="ค้นหาตำแหน่ง"><i class="bi bi-geo-alt-fill"></i></a>

--- a/verify_notifications.py
+++ b/verify_notifications.py
@@ -1,0 +1,21 @@
+from playwright.sync_api import sync_playwright
+import os
+
+def verify_notification_mockup():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # Load the mockup HTML file
+        file_path = os.path.abspath("mockup_notifications.html")
+        page.goto(f"file://{file_path}")
+
+        # Take a screenshot
+        screenshot_path = "/home/jules/verification/notification_mockup.png"
+        page.screenshot(path=screenshot_path, full_page=True)
+
+        print(f"Screenshot saved to {screenshot_path}")
+        browser.close()
+
+if __name__ == "__main__":
+    verify_notification_mockup()


### PR DESCRIPTION
- Added `pink_card_missing` and `residence_permit_missing` notification types.
- Added `is_enabled` column to `notification_settings` table.
- Updated `NotificationSettingController` to handle On/Off toggles for the new types.
- Updated `EmployeeObserver` to trigger notifications immediately when relevant data is missing or added.
- Updated `NotificationController` to handle the "Update" action for these new types, allowing specific file uploads and data entry.
- Updated frontend views to display new tabs, badges, and dynamic update modals.