### PR TITLE
Fix TypeError in activity logs month view by casting month to integer

### DIFF
--- a/resources/views/admin/activity_logs/month.blade.php
+++ b/resources/views/admin/activity_logs/month.blade.php
@@ -12,7 +12,7 @@
                 </ol>
             </nav>
             @php
-                $monthName = \Carbon\Carbon::create()->month($month)->locale('th')->translatedFormat('F');
+                $monthName = \Carbon\Carbon::create()->month((int)$month)->locale('th')->translatedFormat('F');
             @endphp
             <h2 class="fw-bold mb-3">เดือน {{ $monthName }} {{ $year }} - เลือกวัน (Day)</h2>
         </div>
@@ -24,7 +24,7 @@
                 <div class="row g-3">
                     @foreach($days as $day)
                     @php
-                        $date = \Carbon\Carbon::createFromDate($year, $month, $day);
+                        $date = \Carbon\Carbon::createFromDate($year, (int)$month, $day);
                         $dayName = $date->locale('th')->translatedFormat('l');
                         $fullDate = $date->locale('th')->translatedFormat('d F Y');
                     @endphp

--- a/resources/views/admin/activity_logs/year.blade.php
+++ b/resources/views/admin/activity_logs/year.blade.php
@@ -20,7 +20,7 @@
                 <div class="row g-3">
                     @foreach($months as $month)
                     @php
-                        $monthName = \Carbon\Carbon::create()->month($month)->locale('th')->translatedFormat('F');
+                        $monthName = \Carbon\Carbon::create()->month((int)$month)->locale('th')->translatedFormat('F');
                     @endphp
                     <div class="col-6 col-md-4 col-lg-3">
                         <a href="{{ route('admin.activity-logs.month', ['year' => $year, 'month' => $month]) }}" class="text-decoration-none">


### PR DESCRIPTION
The `Carbon\Carbon::month()` method expects an integer, but the route parameter `$month` is passed as a string, causing a `TypeError`. This change casts `$month` to an integer in both `month.blade.php` and `year.blade.php` to prevent the crash and ensure robust handling of date creation.