### PR TITLE
Fix discrepancy in notification count

### DIFF
--- a/app/Helpers/NotificationHelper.php
+++ b/app/Helpers/NotificationHelper.php
@@ -27,6 +27,21 @@ class NotificationHelper
             }
         }
 
+        // Fix: Ensure we only count notifications where the related model still exists.
+        // This matches the logic in NotificationController::getFilteredQuery.
+        $query->where(function($q) {
+            // Case 1: Employer Document Expiry - Must have valid Employer
+            $q->where(function($sub) {
+                $sub->where('type', 'employer_document_expiry')
+                    ->whereHas('employer');
+            })
+            // Case 2: All other types - Must have valid Employee
+            ->orWhere(function($sub) {
+                $sub->where('type', '!=', 'employer_document_expiry')
+                    ->whereHas('employee');
+            });
+        });
+
         // Count only active notifications (not cancelled)
         $query->where('status', '!=', 'cancelled');
 


### PR DESCRIPTION
Updated NotificationHelper to filter out notifications with missing related models (employees or employers), aligning the total count logic with the list view logic. This resolves the issue where the notification badge displayed an incorrect, higher number due to orphaned records.