### PR TITLE
Fix notification count for delegated admins/caretakers

### DIFF
--- a/app/Helpers/NotificationHelper.php
+++ b/app/Helpers/NotificationHelper.php
@@ -9,22 +9,19 @@ class NotificationHelper
 {
     public static function getTotalNotificationCount()
     {
-        $query = Notification::with(['employee.employer', 'employer']);
+        $query = Notification::query();
 
-        // Apply tenancy scope for Employer role to prevent data leakage
-        if (Auth::check() && Auth::user()->hasRole('employer')) {
-            $employerId = Auth::user()->employer->id ?? null;
-            if ($employerId) {
-                $query->where(function($q) use ($employerId) {
-                    // 1. Notifications directly linked to the employer (e.g., employer_document_expiry)
-                    $q->where('employer_id', $employerId)
-                    // 2. Notifications linked to employees (respects Employee global scope)
-                      ->orWhereHas('employee');
-                });
-            } else {
-                // Fallback: If user is 'employer' but has no linked Employer record, show nothing.
-                $query->whereRaw('1 = 0');
-            }
+        // Apply filtering based on relationships to enforce Global Scopes of related models (Employer/Employee).
+        // This handles 'employer' tenancy AND 'caretaker' (delegated admin) tenancy automatically via the models' global scopes.
+        if (Auth::check()) {
+             $query->where(function($q) {
+                // 1. Notifications directly linked to the employer (e.g., employer_document_expiry)
+                // This respects the Employer global scope (e.g. assigned_staff_id check)
+                $q->whereHas('employer')
+                // 2. Notifications linked to employees
+                // This respects the Employee global scope (e.g. employer.assigned_staff_id check)
+                  ->orWhereHas('employee');
+            });
         }
 
         // Count only active notifications (not cancelled)


### PR DESCRIPTION
Updated NotificationHelper::getTotalNotificationCount() to use `whereHas` queries on relationships. This ensures that the global scopes defined on the Employer and Employee models (which filter based on assigned staff/caretaker logic) are correctly applied to the notification count query. This resolves the discrepancy where the sidebar count showed global totals while the list view showed filtered results.