### PR TITLE
Add migration to ensure insurance document columns exist

### DIFF
--- a/database/migrations/2025_11_25_120000_ensure_insurance_columns_exist.php
+++ b/database/migrations/2025_11_25_120000_ensure_insurance_columns_exist.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            if (!Schema::hasColumn('employees', 'insurance_document_path')) {
+                $table->string('insurance_document_path')->nullable();
+            }
+            if (!Schema::hasColumn('employees', 'insurance_document_path_private')) {
+                $table->string('insurance_document_path_private')->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            if (Schema::hasColumn('employees', 'insurance_document_path')) {
+                $table->dropColumn('insurance_document_path');
+            }
+            if (Schema::hasColumn('employees', 'insurance_document_path_private')) {
+                $table->dropColumn('insurance_document_path_private');
+            }
+        });
+    }
+};


### PR DESCRIPTION
This commit adds a new migration `2025_11_25_120000_ensure_insurance_columns_exist` which safely checks for and adds the `insurance_document_path` and `insurance_document_path_private` columns to the `employees` table if they are missing.

This resolves a `Column not found` QueryException encountered when renewing employee insurance notifications and attaching files, as reported by the user. The migration logic includes `Schema::hasColumn` checks to prevent errors if the columns already exist from previous partial migrations.