### PR TITLE
Fix hospital insurance file attachment in notification renewal

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -233,8 +233,8 @@ class NotificationController extends Controller
                     $fileField = 'insurance_document_path_private';
                 } elseif ($employee->insurance_type === 'ประกันโรงพยาบาล') {
                     $fieldToUpdate = 'insurance_expiry_date_hospital';
-                    // Fix: Reverted to 'insurance_attachment_path' as 'insurance_document_path' column is missing in some environments
-                    $fileField = 'insurance_attachment_path';
+                    // User instruction: Use same file field as private insurance
+                    $fileField = 'insurance_document_path_private';
                 } else {
                     $fieldToUpdate = 'insurance_expiry_date';
                     // Fix: Reverted to 'insurance_attachment_path' as 'insurance_document_path' column is missing in some environments


### PR DESCRIPTION
Use `insurance_document_path_private` for storing hospital insurance files, aligning it with private insurance behavior as requested. This resolves the error where updating both date and file for hospital insurance would fail.