### PR TITLE
feat: allow admin/staff to attach external employees to tickets

### DIFF
--- a/app/Http/Controllers/Admin/AdminJobTicketController.php
+++ b/app/Http/Controllers/Admin/AdminJobTicketController.php
@@ -113,7 +113,24 @@ class AdminJobTicketController extends Controller
                 TicketMessage::insert($messagesToInsert);
             }
 
-            // 5. Process New Employees (attachment_new_employee)
+            // 5. Process External Employees (attachment_employee - V2.5-S17)
+            // Stored as regular employee attachments, categorization happens in the Model/View
+            if (!empty($attachments['external_employees'])) {
+                $messagesToInsert = [];
+                foreach ($attachments['external_employees'] as $employeeId) {
+                    $messagesToInsert[] = [
+                        'job_ticket_id' => $ticket->id,
+                        'user_id' => $adminUser->id, // Admin is attacher
+                        'message_type' => 'attachment_employee', // Same type
+                        'body' => $employeeId,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+                }
+                TicketMessage::insert($messagesToInsert);
+            }
+
+            // 6. Process New Employees (attachment_new_employee)
             if (!empty($attachments['new_employees'])) {
                 // Define all possible file fields that need to be processed
                 $fileFields = [

--- a/app/Http/Controllers/Api/EmployerEmployeeController.php
+++ b/app/Http/Controllers/Api/EmployerEmployeeController.php
@@ -138,6 +138,8 @@ class EmployerEmployeeController extends Controller
 
             return [
                 'id' => $employee->id,
+                // V2.5-S17 FIX: Include employer_id for frontend affiliation checks
+                'employer_id' => $employee->employer_id,
                 'employer_name' => $employee->employer->employerNameTh ?? 'N/A', // Useful for admins to see owner
                 'employeeNameTh' => $employee->employeeNameTh,
                 'employeeNameEn' => $employee->employeeNameEn,

--- a/app/Http/Requests/Admin/StoreAdminJobTicketRequest.php
+++ b/app/Http/Requests/Admin/StoreAdminJobTicketRequest.php
@@ -58,7 +58,7 @@ class StoreAdminJobTicketRequest extends FormRequest
                 },
             ],
 
-            // 2. Existing Employees
+            // 2. Existing Employees (Strict Affiliation Check)
             'attachments.existing_employees' => ['nullable', 'array'],
             'attachments.existing_employees.*' => [
                 'required',
@@ -77,7 +77,16 @@ class StoreAdminJobTicketRequest extends FormRequest
                 }),
             ],
 
-            // 3. New Employees (JSON data from modal)
+            // 3. External Employees (V2.5-S17: Exception for Admin/Staff - No Affiliation Check)
+            'attachments.external_employees' => ['nullable', 'array'],
+            'attachments.external_employees.*' => [
+                'required',
+                'integer',
+                'distinct',
+                'exists:employees,id', // Just check existence, ignore employer
+            ],
+
+            // 4. New Employees (JSON data from modal)
             'attachments.new_employees' => ['nullable', 'array'],
             'attachments.new_employees.*' => ['required', 'array'], // ตรวจสอบว่าเป็น array ที่ถูก decode แล้ว
 
@@ -138,6 +147,7 @@ class StoreAdminJobTicketRequest extends FormRequest
         return [
             'employer_user_id.required' => 'กรุณาเลือกนายจ้าง',
             'attachments.existing_employees.*.exists' => 'ลูกจ้างที่เลือกไม่ถูกต้อง หรือไม่ได้อยู่ในสังกัดของนายจ้างที่เลือก',
+            'attachments.external_employees.*.exists' => 'ลูกจ้างภายนอกที่เลือกไม่ถูกต้อง (ไม่พบในระบบ)',
             'attachments.new_employees.*.employeeNameTh.required' => 'กรุณากรอกชื่อ-สกุล (ภาษาไทย) สำหรับลูกจ้างใหม่',
             'attachments.new_employees.*.employeePassport.required' => 'กรุณากรอก Passport สำหรับลูกจ้างใหม่',
             'attachments.new_employees.*.employeeNationality.required' => 'กรุณาเลือกสัญชาติสำหรับลูกจ้างใหม่',

--- a/app/Models/JobTicket.php
+++ b/app/Models/JobTicket.php
@@ -100,9 +100,10 @@ class JobTicket extends Model
         return Attribute::make(
             get: function () {
                 $attachments = [
-                    'existing_employees' => collect(), // Will hold objects { employee: Employee, message_id: int }
-                    'new_employees' => collect(),      // Will hold objects { data: object, message_id: int }
-                    'files' => collect(),              // Will hold objects { data: object, message_id: int }
+                    'existing_employees' => collect(), // Affiliated employees
+                    'external_employees' => collect(), // V2.5-S17: Non-affiliated employees (Exception for Admin/Staff)
+                    'new_employees' => collect(),
+                    'files' => collect(),
                 ];
 
                 $employeeMessageMap = []; // [employee_id => [message_id1, message_id2, ...]]
@@ -172,11 +173,22 @@ class JobTicket extends Model
                         ->append('photo_url')
                         ->keyBy('id');
 
+                    // V2.5-S17: Determine affiliation
+                    // Get the ticket's employer ID
+                    $ticketEmployerId = $this->employerUser?->employer?->id;
+
                     foreach ($employeeMessageMap as $employeeId => $messageIds) {
                         if (isset($employeeModels[$employeeId])) {
+                            $emp = $employeeModels[$employeeId];
+
+                            // Check affiliation (Handle case where ticket employer might be null/deleted)
+                            $isAffiliated = $ticketEmployerId && ($emp->employer_id === $ticketEmployerId);
+
+                            $targetCollection = $isAffiliated ? 'existing_employees' : 'external_employees';
+
                             foreach ($messageIds as $messageId) {
-                                $attachments['existing_employees']->push((object)[
-                                    'employee' => $employeeModels[$employeeId],
+                                $attachments[$targetCollection]->push((object)[
+                                    'employee' => $emp,
                                     'message_id' => $messageId
                                 ]);
                             }

--- a/resources/views/admin/tickets/create.blade.php
+++ b/resources/views/admin/tickets/create.blade.php
@@ -119,6 +119,12 @@
                             <button type="button" class="btn btn-outline-primary" @click="openExistingEmployeeModal" :disabled="isUploading || !contextEmployerId" title="กรุณาเลือกนายจ้างก่อน">
                                 <i class="bi bi-person-check me-2"></i> แนบลูกจ้างที่มีอยู่
                             </button>
+
+                            {{-- V2.5-S17: New Button for External Employees --}}
+                            <button type="button" class="btn btn-outline-warning text-dark" @click="openGlobalEmployeeSearch" :disabled="isUploading" title="ค้นหาลูกจ้างทั้งระบบ">
+                                <i class="bi bi-search me-2"></i> แนบลูกจ้างภายนอก
+                            </button>
+
                             <button type="button" class="btn btn-outline-success" @click="openNewEmployeeModal" :disabled="isUploading || !contextEmployerId" title="กรุณาเลือกนายจ้างก่อน">
                                 <i class="bi bi-person-plus me-2"></i> แจ้งเข้าลูกจ้างใหม่
                             </button>
@@ -134,7 +140,7 @@
                             <template x-if="totalItemsCount() === 0">
                                 <div class="text-muted fst-italic text-center py-3">ยังไม่มีรายการที่แนบ</div>
                             </template>
-                            {{-- Templates for existing_employees, new_employees, and files are identical to the employer view --}}
+                            {{-- Templates for existing_employees, external_employees, new_employees, and files --}}
                             @include('tickets.partials._basket_display_templates')
                         </div>
                         <hr>

--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -68,14 +68,14 @@
         <div class="col-lg-8">
 
             {{-- Section 1: Triage (Attachments Summary) --}}
-            @if($attachments->existing_employees->isNotEmpty() || $attachments->new_employees->isNotEmpty() || $attachments->files->isNotEmpty())
+            @if($attachments->existing_employees->isNotEmpty() || $attachments->external_employees->isNotEmpty() || $attachments->new_employees->isNotEmpty() || $attachments->files->isNotEmpty())
             <div class="card mb-4 border-info">
                 <div class="card-header bg-info text-white">
                     <h5 class="mb-0"><i class="bi bi-paperclip me-2"></i>สิ่งที่แนบมา (Attachments Triage)</h5>
                 </div>
                 <div class="card-body">
 
-                    {{-- 1.1 Existing Employees --}}
+                    {{-- 1.1 Existing Employees (Affiliated) --}}
                     @if($attachments->existing_employees->isNotEmpty())
                         <h6 class="text-primary mt-3">ลูกจ้างที่มีอยู่ ({{ $attachments->existing_employees->count() }} คน)</h6>
 
@@ -112,6 +112,50 @@
                                     @if($employee->trashed())
                                         <span class="badge bg-danger me-2">ลบ/จำหน่ายแล้ว</span>
                                     @endif
+                                    <div class="ms-auto btn-group">
+                                        <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}">
+                                            <i class="bi bi-search"></i>
+                                        </button>
+                                        @if(!$isClosed && (auth()->id() === $ticket->employer_user_id || auth()->user()->can('manage-tickets')))
+                                        <form action="{{ route('admin.tickets.messages.destroy', $item->message_id) }}" method="POST" class="d-inline">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="button" class="btn btn-sm btn-outline-danger btn-submit-swal"
+                                                    data-swal-title="ยืนยันการลบ"
+                                                    data-swal-text="ต้องการลบ '{{ $employee->employeeNameTh }}' ออกจากตั๋วนี้ใช่หรือไม่?"
+                                                    data-swal-icon="warning"
+                                                    data-swal-confirm-text="ใช่, ลบเลย">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </form>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+
+                    {{-- 1.1.5 External Employees (Non-Affiliated) --}}
+                    @if($attachments->external_employees->isNotEmpty())
+                        <h6 class="text-warning text-dark mt-3"><i class="bi bi-exclamation-triangle-fill me-2"></i>ลูกจ้างภายนอก (External) ({{ $attachments->external_employees->count() }} คน)</h6>
+                        <div class="list-group mb-3 border border-warning rounded">
+                            @foreach($attachments->external_employees as $item)
+                                @php $employee = $item->employee; @endphp
+                                <div class="list-group-item d-flex align-items-center gap-3 py-2 bg-light">
+                                    {{-- External employees don't have bulk actions for now --}}
+                                    <div class="position-relative">
+                                        <img src="{{ $employee->photo_url }}" alt="Photo" class="rounded-circle" style="width: 40px; height: 40px; object-fit: cover;">
+                                        <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-warning text-dark" style="font-size: 0.6em;">Ext</span>
+                                    </div>
+                                    <span class="flex-grow-1">
+                                        <strong class="text-dark">{{ $employee->employeeNameTh }}</strong>
+                                        <small class="text-muted d-block">Passport: {{ $employee->employeePassport }}</small>
+                                        <small class="text-info d-block" style="font-size: 0.8rem;">
+                                            <i class="bi bi-building me-1"></i>
+                                            {{ optional($employee->employer)->employerNameTh ?? 'ไม่ทราบสังกัด' }}
+                                        </small>
+                                    </span>
+
                                     <div class="ms-auto btn-group">
                                         <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}">
                                             <i class="bi bi-search"></i>

--- a/resources/views/components/hybrid-attachment-scripts.blade.php
+++ b/resources/views/components/hybrid-attachment-scripts.blade.php
@@ -1,9 +1,8 @@
-{{-- resources/views/components/hybrid-attachment-scripts.blade.php --}}
 <script>
 function hybridAttachmentManager(config = {}) {
     return {
         // --- Core States ---
-        basket: { existing_employees: [], new_employees: [], files: [] },
+        basket: { existing_employees: [], external_employees: [], new_employees: [], files: [] },
         isUploading: false,
         uploadProgress: 0,
         filesToUploadCount: 0,
@@ -136,6 +135,8 @@ function hybridAttachmentManager(config = {}) {
             if (oldAttachments) {
                 this.basket.files = oldAttachments.files || [];
                 this.basket.existing_employees = oldAttachments.existing_employees || [];
+                // V2.5-S17: Restore external employees
+                this.basket.external_employees = oldAttachments.external_employees || [];
 
                 if (oldAttachments.new_employees) {
                     this.basket.new_employees = oldAttachments.new_employees.map(item => {
@@ -153,6 +154,7 @@ function hybridAttachmentManager(config = {}) {
 
         totalItemsCount() {
             return (this.basket.existing_employees?.length || 0) +
+                   (this.basket.external_employees?.length || 0) +
                    (this.basket.new_employees?.length || 0) +
                    (this.basket.files?.length || 0);
         },
@@ -208,8 +210,17 @@ function hybridAttachmentManager(config = {}) {
 
                 // Add them to basket immediately
                 employees.forEach(emp => {
-                     if (!this.basket.existing_employees.some(e => e.id == emp.id)) {
-                        this.basket.existing_employees.push(emp);
+                     // Check if already in either basket
+                     const inExisting = this.basket.existing_employees.some(e => e.id == emp.id);
+                     const inExternal = this.basket.external_employees.some(e => e.id == emp.id);
+
+                     if (!inExisting && !inExternal) {
+                        // Determine where to put it
+                        if (this.contextEmployerId && emp.employer_id == this.contextEmployerId) {
+                            this.basket.existing_employees.push(emp);
+                        } else {
+                            this.basket.external_employees.push(emp);
+                        }
                     }
                 });
 
@@ -261,24 +272,26 @@ function hybridAttachmentManager(config = {}) {
             }
         },
 
+        // Open Modal for Existing Employees (Affiliated)
         openExistingEmployeeModal() {
              if (this.isContextAdminCreate && !this.contextEmployerId) {
-                // V2.5-S16: Allow opening if intended for global search?
-                // Actually, user can start with global search immediately.
-                // But default behavior is still valid. Let's allow opening but check later.
-                // If we want to FORCE selecting employer first, we keep the check.
-                // But for "Attach External Employee", maybe we don't need an employer selected first?
-                // The controller store method REQUIRES an employer_user_id.
-                // So we should enforce employer selection first, then allow searching others.
                 Swal.fire({ icon: 'warning', title: 'กรุณาเลือกนายจ้าง', text: 'โปรดเลือกนายจ้างหลักสำหรับตั๋วก่อนทำการแนบลูกจ้าง' });
                 return;
             }
 
-            // If not global search, fetch defaults. If global, wait for input.
-            if (!this.isGlobalSearch) {
-                this.fetchEmployees();
-            }
+            // Switch to Local Mode
+            this.isGlobalSearch = false;
+            this.searchQuery = '';
 
+            this.fetchEmployees();
+            if (this.modalInstances.existing) this.modalInstances.existing.show();
+        },
+
+        // V2.5-S17: Open Modal for Global Search (External Employees)
+        openGlobalEmployeeSearch() {
+            this.isGlobalSearch = true;
+            this.searchQuery = ''; // Clear query
+            this.availableEmployees = []; // Clear list until typed
             if (this.modalInstances.existing) this.modalInstances.existing.show();
         },
 
@@ -313,11 +326,22 @@ function hybridAttachmentManager(config = {}) {
             this.selectedEmployeeIds.forEach(id => {
                 // V2.5-FIX: Use loose comparison for ID finding (String vs Int)
                 const employee = this.availableEmployees.find(e => e.id == id);
-                // Prevent duplicates
-                if (employee && !this.basket.existing_employees.some(e => e.id == employee.id)) {
-                    // V2.5-FIX: Deep clone the object to prevent reference issues when availableEmployees is cleared
+                if (!employee) return;
+
+                // V2.5-S17: Determine destination basket (Existing vs External) based on Affiliation
+                // We use weak comparison for IDs just in case
+                const isAffiliated = this.contextEmployerId && (employee.employer_id == this.contextEmployerId);
+                const targetBasket = isAffiliated ? this.basket.existing_employees : this.basket.external_employees;
+
+                // Prevent duplicates in the target basket
+                if (!targetBasket.some(e => e.id == employee.id)) {
+                    // Also check if it's in the OTHER basket (e.g. moved?) - Optional, but let's allow it to move if logic dictates
+                    // If it was in External but now is Affiliated (e.g. employer changed context?), we should probably handle that,
+                    // but for now, simple add is enough.
+
+                    // Deep clone
                     const employeeClone = JSON.parse(JSON.stringify(employee));
-                    this.basket.existing_employees.push(employeeClone);
+                    targetBasket.push(employeeClone);
                 }
             });
             this.selectedEmployeeIds = []; // Reset selection

--- a/resources/views/tickets/partials/_basket_display_templates.blade.php
+++ b/resources/views/tickets/partials/_basket_display_templates.blade.php
@@ -3,7 +3,7 @@
 {{-- This partial contains the x-template definitions for displaying items in the attachment basket. --}}
 {{-- It's used by both resources/views/tickets/create.blade.php and resources/views/admin/tickets/create.blade.php --}}
 
-<!-- 1. Template for Existing Employees -->
+<!-- 1. Template for Existing Employees (Affiliated) -->
 <template x-for="(item, index) in basket.existing_employees" :key="'e-' + item.id">
     <div class="list-group-item d-flex justify-content-between align-items-center py-2">
         <div class="d-flex align-items-center gap-3">
@@ -14,16 +14,35 @@
                      <span x-text="item.employeeNameTh"></span>
                      <span class="text-muted ms-1" x-text="item.employeeNameEn ? '(' + item.employeeNameEn + ')' : ''"></span>
                 </div>
-                {{-- V2.5-S16: Show External Tag/Employer Name if available and possibly external --}}
-                <template x-if="item.employer_name">
-                    <small class="d-block text-info" style="font-size: 0.8rem;">
-                        <i class="bi bi-building me-1"></i> <span x-text="item.employer_name"></span>
-                    </small>
-                </template>
             </span>
         </div>
         <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('existing_employees', index, item.employeeNameTh)">ลบ</button>
-        {{-- Hidden inputs have been moved to _basket_form_inputs.blade.php to ensure reliable form submission --}}
+    </div>
+</template>
+
+<!-- 1.5 Template for External Employees (Non-Affiliated) -->
+<template x-for="(item, index) in basket.external_employees" :key="'ext-' + item.id">
+    <div class="list-group-item d-flex justify-content-between align-items-center py-2 bg-light border-warning">
+        <div class="d-flex align-items-center gap-3">
+             <div class="position-relative">
+                <img :src="item.photo_url" alt="Photo" class="rounded-circle" style="width: 35px; height: 35px; object-fit: cover;">
+                <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-warning text-dark" style="font-size: 0.6em;">
+                    Ext
+                </span>
+            </div>
+            <span>
+                <div class="d-flex align-items-center">
+                     <i class="bi bi-person-exclamation me-1 text-warning"></i>
+                     <span class="fw-bold text-dark" x-text="item.employeeNameTh"></span>
+                     <span class="text-muted ms-1" x-text="item.employeeNameEn ? '(' + item.employeeNameEn + ')' : ''"></span>
+                </div>
+                {{-- Show Employer Name --}}
+                <small class="d-block text-muted" style="font-size: 0.8rem;">
+                    <i class="bi bi-building me-1"></i> <span x-text="item.employer_name || 'ไม่ทราบสังกัด'"></span>
+                </small>
+            </span>
+        </div>
+        <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('external_employees', index, item.employeeNameTh)">ลบ</button>
     </div>
 </template>
 
@@ -38,7 +57,6 @@
             </span>
         </div>
         <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('new_employees', index, item.employeeNameTh)">ลบ</button>
-        {{-- Hidden inputs have been moved to _basket_form_inputs.blade.php to ensure reliable form submission --}}
     </div>
 </template>
 
@@ -53,6 +71,5 @@
             </span>
         </div>
         <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('files', index, item.name)">ลบ</button>
-        {{-- Hidden inputs have been moved to _basket_form_inputs.blade.php to ensure reliable form submission --}}
     </div>
 </template>

--- a/resources/views/tickets/partials/_basket_form_inputs.blade.php
+++ b/resources/views/tickets/partials/_basket_form_inputs.blade.php
@@ -11,6 +11,11 @@
     <input type="hidden" :name="'attachments[existing_employees][' + index + ']'" :value="item.id">
 </template>
 
+<!-- External Employees Inputs (V2.5-S17) -->
+<template x-for="(item, index) in basket.external_employees" :key="'input-ext-' + item.id">
+    <input type="hidden" :name="'attachments[external_employees][' + index + ']'" :value="item.id">
+</template>
+
 <!-- New Employees Inputs -->
 <template x-for="(item, index) in basket.new_employees" :key="'input-n-' + index">
     <input type="hidden" :name="'attachments[new_employees][' + index + ']'" :value="JSON.stringify(item)">


### PR DESCRIPTION
- Updated `JobTicket` model to categorize attachments into 'existing' (affiliated) and 'external' (non-affiliated) employees.
- Modified `StoreAdminJobTicketRequest` to validate `external_employees` without strict employer checks.
- Updated `AdminJobTicketController` to process and store external employee attachments.
- Enhanced `EmployerEmployeeController` API to return `employer_id` for frontend logic.
- Updated `hybridAttachmentManager` (JS) to support global search and auto-categorize employees.
- Added UI for "Attach External Employee" button and distinct display sections in Create and Show views.
- Removed strict employer validation for Admin-created tickets to allow flexibility.