### PR TITLE
Fix: Ensure attached employees are submitted in ticket replies

### DIFF
--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -370,6 +370,10 @@
                         @endphp
                         <form x-ref="replyForm" action="{{ route($replyRoute, $ticket->id) }}" method="POST">
                             @csrf
+
+                            {{-- Hidden inputs for basket items --}}
+                            @include('tickets.partials._basket_form_inputs')
+
                             {{-- Text Area --}}
                             <div class="mb-3">
                                 <label for="message" class="form-label">ข้อความ:</label>


### PR DESCRIPTION
The employer ticket view (tickets/show.blade.php) was displaying attachments in the basket but failing to include them in the form submission. This resulted in a validation error "Please enter a message or attach at least one file/employee" because the backend received no attachment data.

This commit adds the missing `@include('tickets.partials._basket_form_inputs')` directive inside the reply form. This partial generates the necessary hidden inputs for existing employees, new employees, external employees, and files, allowing the data to be correctly POSTed to the server.

Verified that `tickets.partials._basket_form_inputs` exists and contains the correct logic for all attachment types, including the recently added `external_employees`.