### PR TITLE
Update chat UI behavior and permissions

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -18,9 +18,8 @@ class ChatController extends Controller
     {
         $currentUser = Auth::user();
 
-        // Permission Check: User must have 'use-chat' permission (Admin, Staff, or allowed Employer)
-        // If Admin, bypass specific permission check if they are superadmin, but standard is 'use-chat'
-        if (!$currentUser->can('use-chat') && !$currentUser->hasRole('admin')) {
+        // Permission Check: User must have 'use-chat' permission OR be Admin/Staff explicitly
+        if (!$currentUser->can('use-chat') && !$currentUser->hasRole(['admin', 'staff'])) {
             return response()->json([], 403);
         }
 
@@ -68,11 +67,6 @@ class ChatController extends Controller
 
             $query->where(function($q) use ($assignedStaffId) {
                 // 1. See System Users (Admin, Staff, Caretaker) - Generally support team
-                // Note: User said "Admin, Staff and Caretaker codes must see each other".
-                // Does Employer see Caretaker? Usually yes if assigned.
-                // Assuming Employer sees 'admin', 'staff' generally, and specific 'caretaker' if assigned?
-                // Or maybe sees all staff/caretakers?
-                // Let's stick to: See Admins and Staff generally.
                 $q->whereHas('roles', function($r) {
                     $r->whereIn('name', ['admin', 'staff']);
                 });
@@ -120,7 +114,7 @@ class ChatController extends Controller
         $currentUser = Auth::user();
 
         // Basic Permission Check
-        if (!$currentUser->can('use-chat') && !$currentUser->hasRole('admin')) {
+        if (!$currentUser->can('use-chat') && !$currentUser->hasRole(['admin', 'staff'])) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -194,7 +188,7 @@ class ChatController extends Controller
         ]);
 
         $currentUser = Auth::user();
-        if (!$currentUser->can('use-chat') && !$currentUser->hasRole('admin')) {
+        if (!$currentUser->can('use-chat') && !$currentUser->hasRole(['admin', 'staff'])) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 

--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -6,12 +6,13 @@
      style="position: fixed; top: 0; left: 0; width: 0; height: 0; z-index: 1040;">
 
     <!-- 1. Main Launcher Button (Floating & Draggable) -->
+    <!-- Always visible unless docked. Toggles the entire system (Contact List + Open Chats). -->
     <div x-show="!isLauncherDocked"
          x-transition:enter="transition ease-out duration-300"
          x-transition:enter-start="opacity-0 scale-90"
          x-transition:enter-end="opacity-100 scale-100"
          class="position-fixed shadow-lg rounded-circle bg-primary text-white d-flex flex-column align-items-center justify-content-center cursor-pointer chat-launcher-btn"
-         :style="`width: 60px; height: 60px; left: ${launcher.x}px; top: ${launcher.y}px; z-index: 2000; cursor: move;`"
+         :style="`width: 60px; height: 60px; left: ${launcher.x}px; top: ${launcher.y}px; z-index: 2100; cursor: move;`"
          @mousedown="startDrag($event, 'launcher')"
          @click="if(!isDragging) toggleContactList()"
          title="{{ __('Open Chat') }}">
@@ -136,134 +137,143 @@
         </div>
     </div>
 
-    <!-- 3. Individual Chat Windows -->
-    <template x-for="chat in openChats" :key="chat.id">
-        <div x-show="!chat.minimized"
-             class="chat-window shadow rounded-3 flex-column border bg-white"
-             :class="{ 'd-flex': !chat.minimized, 'd-none': chat.minimized }"
-             :style="`position: fixed; left: ${chat.x}px; top: ${chat.y}px; width: ${chat.w}px; height: ${chat.h}px; z-index: ${chat.zIndex};`"
-             @mousedown="bringToFront(chat.id)">
+    <!-- CHAT SYSTEM CONTAINER: Visible only when Contact List (Main System) is Open -->
+    <template x-if="isContactListOpen">
+        <div>
+            <!-- 3. Individual Chat Windows -->
+            <template x-for="chat in openChats" :key="chat.id">
+                <div x-show="!chat.minimized"
+                     class="chat-window shadow rounded-3 flex-column border bg-white"
+                     :class="{ 'd-flex': !chat.minimized, 'd-none': chat.minimized }"
+                     :style="`position: fixed; left: ${chat.x}px; top: ${chat.y}px; width: ${chat.w}px; height: ${chat.h}px; z-index: ${chat.zIndex};`"
+                     @mousedown="bringToFront(chat.id)">
 
-            <!-- Header -->
-            <div class="chat-header d-flex justify-content-between align-items-center p-2 bg-white border-bottom cursor-grab"
-                 @mousedown="startDrag($event, chat.id)">
-                <div class="d-flex align-items-center gap-2 overflow-hidden">
-                    <img :src="chat.user.avatar_url" class="rounded-circle object-fit-cover" width="32" height="32"
-                         onerror="this.src='https://ui-avatars.com/api/?name=User&color=7F9CF5&background=EBF4FF'">
-                    <div class="lh-1">
-                        <div class="fw-bold text-truncate" style="max-width: 150px;" x-text="chat.user.name"></div>
-                        <small class="text-success" style="font-size: 0.7rem;" x-show="chat.user.is_online">{{ __('Online') }}</small>
+                    <!-- Header -->
+                    <div class="chat-header d-flex justify-content-between align-items-center p-2 bg-white border-bottom cursor-grab"
+                         @mousedown="startDrag($event, chat.id)">
+                        <div class="d-flex align-items-center gap-2 overflow-hidden">
+                            <img :src="chat.user.avatar_url" class="rounded-circle object-fit-cover" width="32" height="32"
+                                 onerror="this.src='https://ui-avatars.com/api/?name=User&color=7F9CF5&background=EBF4FF'">
+                            <div class="lh-1">
+                                <div class="fw-bold text-truncate" style="max-width: 150px;" x-text="chat.user.name"></div>
+                                <small class="text-success" style="font-size: 0.7rem;" x-show="chat.user.is_online">{{ __('Online') }}</small>
+                            </div>
+                        </div>
+                        <div class="d-flex align-items-center gap-1">
+                            <!-- Minimize Button -->
+                            <button type="button" class="btn btn-sm btn-link text-secondary p-0" @click.stop="chat.minimized = true; saveState()">
+                                <i class="bi bi-dash-lg"></i>
+                            </button>
+                            <!-- Close Button -->
+                            <button type="button" class="btn btn-sm btn-link text-secondary p-0 ms-1" @click.stop="closeChat(chat.id)">
+                                <i class="bi bi-x-lg"></i>
+                            </button>
+                        </div>
                     </div>
-                </div>
-                <div class="d-flex align-items-center gap-1">
-                    <button type="button" class="btn btn-sm btn-link text-secondary p-0" @click.stop="chat.minimized = true; saveState()">
-                        <i class="bi bi-dash-lg"></i>
-                    </button>
-                    <button type="button" class="btn btn-sm btn-link text-secondary p-0 ms-1" @click.stop="closeChat(chat.id)">
-                        <i class="bi bi-x-lg"></i>
-                    </button>
-                </div>
-            </div>
 
-            <!-- Messages Area -->
-            <div class="chat-messages flex-grow-1 overflow-auto p-3 bg-light d-flex flex-column" :id="'msg-container-'+chat.id">
-                <template x-for="msg in chat.messages" :key="msg.id">
-                    <div class="mb-2 d-flex" :class="msg.sender_id == currentUserId ? 'justify-content-end' : 'justify-content-start'">
-                         <!-- Message Bubble -->
-                         <div class="p-2 rounded shadow-sm"
-                              :class="msg.sender_id == currentUserId ? 'bg-primary text-white' : 'bg-white text-dark'"
-                              style="max-width: 85%; word-wrap: break-word;">
+                    <!-- Messages Area -->
+                    <div class="chat-messages flex-grow-1 overflow-auto p-3 bg-light d-flex flex-column" :id="'msg-container-'+chat.id">
+                        <template x-for="msg in chat.messages" :key="msg.id">
+                            <div class="mb-2 d-flex" :class="msg.sender_id == currentUserId ? 'justify-content-end' : 'justify-content-start'">
+                                 <!-- Message Bubble -->
+                                 <div class="p-2 rounded shadow-sm"
+                                      :class="msg.sender_id == currentUserId ? 'bg-primary text-white' : 'bg-white text-dark'"
+                                      style="max-width: 85%; word-wrap: break-word;">
 
-                            <!-- Attachments/Context -->
-                            <template x-if="msg.context_data">
-                                <div class="mb-1 p-1 rounded bg-opacity-10" :class="msg.sender_id == currentUserId ? 'bg-black' : 'bg-secondary'">
-                                    <template x-if="msg.context_data.type === 'link'">
-                                        <a :href="msg.context_data.url" target="_blank" class="d-flex align-items-center text-decoration-none small" :class="msg.sender_id == currentUserId ? 'text-white' : 'text-primary'">
-                                            <i class="bi bi-link-45deg me-1"></i><span x-text="msg.context_data.text || 'Link'"></span>
-                                        </a>
+                                    <!-- Attachments/Context -->
+                                    <template x-if="msg.context_data">
+                                        <div class="mb-1 p-1 rounded bg-opacity-10" :class="msg.sender_id == currentUserId ? 'bg-black' : 'bg-secondary'">
+                                            <template x-if="msg.context_data.type === 'link'">
+                                                <a :href="msg.context_data.url" target="_blank" class="d-flex align-items-center text-decoration-none small" :class="msg.sender_id == currentUserId ? 'text-white' : 'text-primary'">
+                                                    <i class="bi bi-link-45deg me-1"></i><span x-text="msg.context_data.text || 'Link'"></span>
+                                                </a>
+                                            </template>
+                                            <template x-if="msg.context_data.type === 'image'">
+                                                <a :href="msg.context_data.url" target="_blank"><img :src="msg.context_data.url" class="img-fluid rounded" style="max-height: 120px;"></a>
+                                            </template>
+                                            <template x-if="msg.context_data.type === 'file'">
+                                                <a :href="msg.context_data.url" target="_blank" class="d-flex align-items-center text-decoration-none small" :class="msg.sender_id == currentUserId ? 'text-white' : 'text-primary'">
+                                                    <i class="bi bi-file-earmark-text me-1"></i><span x-text="msg.context_data.name || 'File'"></span>
+                                                </a>
+                                            </template>
+                                        </div>
                                     </template>
-                                    <template x-if="msg.context_data.type === 'image'">
-                                        <a :href="msg.context_data.url" target="_blank"><img :src="msg.context_data.url" class="img-fluid rounded" style="max-height: 120px;"></a>
-                                    </template>
-                                    <template x-if="msg.context_data.type === 'file'">
-                                        <a :href="msg.context_data.url" target="_blank" class="d-flex align-items-center text-decoration-none small" :class="msg.sender_id == currentUserId ? 'text-white' : 'text-primary'">
-                                            <i class="bi bi-file-earmark-text me-1"></i><span x-text="msg.context_data.name || 'File'"></span>
-                                        </a>
-                                    </template>
+
+                                    <div x-text="msg.message"></div>
+                                    <small class="d-block text-end opacity-50" style="font-size: 0.65rem;" x-text="formatTime(msg.created_at)"></small>
                                 </div>
-                            </template>
-
-                            <div x-text="msg.message"></div>
-                            <small class="d-block text-end opacity-50" style="font-size: 0.65rem;" x-text="formatTime(msg.created_at)"></small>
-                        </div>
+                            </div>
+                        </template>
                     </div>
-                </template>
-            </div>
 
-            <!-- Input Area -->
-            <div class="p-2 border-top bg-white">
-                <!-- Attachment Preview -->
-                <template x-if="chat.contextToAttach">
-                     <div class="mb-2 p-1 border rounded bg-light d-flex justify-content-between align-items-center">
-                        <div class="d-flex align-items-center small text-primary text-truncate" style="max-width: 90%;">
-                            <i class="bi" :class="getAttachmentIcon(chat.contextToAttach.type)"></i>
-                            <span class="ms-1 text-truncate" x-text="chat.contextToAttach.name || chat.contextToAttach.text"></span>
+                    <!-- Input Area -->
+                    <div class="p-2 border-top bg-white">
+                        <!-- Attachment Preview -->
+                        <template x-if="chat.contextToAttach">
+                             <div class="mb-2 p-1 border rounded bg-light d-flex justify-content-between align-items-center">
+                                <div class="d-flex align-items-center small text-primary text-truncate" style="max-width: 90%;">
+                                    <i class="bi" :class="getAttachmentIcon(chat.contextToAttach.type)"></i>
+                                    <span class="ms-1 text-truncate" x-text="chat.contextToAttach.name || chat.contextToAttach.text"></span>
+                                </div>
+                                <button type="button" class="btn-close btn-close-sm" @click="chat.contextToAttach = null"></button>
+                            </div>
+                        </template>
+
+                        <!-- Upload Progress -->
+                        <div x-show="chat.isUploading" class="progress mb-2" style="height: 3px;">
+                            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%"></div>
                         </div>
-                        <button type="button" class="btn-close btn-close-sm" @click="chat.contextToAttach = null"></button>
-                    </div>
-                </template>
 
-                <!-- Upload Progress -->
-                <div x-show="chat.isUploading" class="progress mb-2" style="height: 3px;">
-                    <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%"></div>
+                        <form @submit.prevent="sendMessage(chat.id)" class="d-flex gap-2 align-items-end">
+                            <div class="dropup">
+                                <button class="btn btn-sm btn-light text-secondary" type="button" data-bs-toggle="dropdown"><i class="bi bi-paperclip"></i></button>
+                                <ul class="dropdown-menu">
+                                     <li><a class="dropdown-item small" href="#" @click.prevent="attachContext(chat.id)"><i class="bi bi-link-45deg me-2"></i>{{ __('Link Page') }}</a></li>
+                                     <li><a class="dropdown-item small" href="#" @click.prevent="triggerFileUpload(chat.id)"><i class="bi bi-file-earmark me-2"></i>{{ __('Upload File') }}</a></li>
+                                </ul>
+                            </div>
+                            <input type="file" :id="'file-input-'+chat.id" class="d-none" @change="handleFileUpload($event, chat.id)">
+
+                            <textarea class="form-control form-control-sm" rows="1" style="resize: none;"
+                                      placeholder="{{ __('Type...') }}"
+                                      x-model="chat.newMessage"
+                                      @keydown.enter.prevent="if(!$event.shiftKey) sendMessage(chat.id)"></textarea>
+
+                            <button type="submit" class="btn btn-sm btn-primary" :disabled="chat.isUploading || (!chat.newMessage && !chat.contextToAttach)">
+                                <i class="bi bi-send-fill"></i>
+                            </button>
+                        </form>
+                    </div>
+
+                    <!-- Resize Handles -->
+                    <div class="resize-handle-r" @mousedown.stop.prevent="startResize($event, chat.id, 'r')"></div>
+                    <div class="resize-handle-b" @mousedown.stop.prevent="startResize($event, chat.id, 'b')"></div>
+                    <div class="resize-handle-rb" @mousedown.stop.prevent="startResize($event, chat.id, 'rb')"></div>
                 </div>
+            </template>
 
-                <form @submit.prevent="sendMessage(chat.id)" class="d-flex gap-2 align-items-end">
-                    <div class="dropup">
-                        <button class="btn btn-sm btn-light text-secondary" type="button" data-bs-toggle="dropdown"><i class="bi bi-paperclip"></i></button>
-                        <ul class="dropdown-menu">
-                             <li><a class="dropdown-item small" href="#" @click.prevent="attachContext(chat.id)"><i class="bi bi-link-45deg me-2"></i>{{ __('Link Page') }}</a></li>
-                             <li><a class="dropdown-item small" href="#" @click.prevent="triggerFileUpload(chat.id)"><i class="bi bi-file-earmark me-2"></i>{{ __('Upload File') }}</a></li>
-                        </ul>
+            <!-- 4. Minimized Chat Stack (Top Right, Vertical Stack) -->
+            <!-- Modified to show only round bubbles -->
+            <div class="position-fixed top-0 end-0 mt-5 pt-5 me-2 d-flex flex-column gap-2" style="z-index: 2060; pointer-events: none;">
+                <template x-for="chat in openChats" :key="chat.id">
+                    <div x-show="chat.minimized"
+                         class="position-relative shadow rounded-circle bg-white border d-flex align-items-center justify-content-center cursor-pointer slide-in-right overflow-hidden"
+                         style="pointer-events: auto; width: 50px; height: 50px; background-color: rgba(255,255,255,0.95) !important;"
+                         @click="chat.minimized = false; saveState(); bringToFront(chat.id)"
+                         :title="chat.user.name">
+                        <img :src="chat.user.avatar_url" class="w-100 h-100 object-fit-cover"
+                             onerror="this.src='https://ui-avatars.com/api/?name=User&color=7F9CF5&background=EBF4FF'">
+                        <span x-show="chat.unreadCount > 0"
+                              class="position-absolute top-0 end-0 translate-middle p-1 badge rounded-circle bg-danger border border-white"
+                              style="width: 12px; height: 12px; transform: translate(25%, -25%) !important;">
+                            <span class="visually-hidden">New messages</span>
+                        </span>
                     </div>
-                    <input type="file" :id="'file-input-'+chat.id" class="d-none" @change="handleFileUpload($event, chat.id)">
-
-                    <textarea class="form-control form-control-sm" rows="1" style="resize: none;"
-                              placeholder="{{ __('Type...') }}"
-                              x-model="chat.newMessage"
-                              @keydown.enter.prevent="if(!$event.shiftKey) sendMessage(chat.id)"></textarea>
-
-                    <button type="submit" class="btn btn-sm btn-primary" :disabled="chat.isUploading || (!chat.newMessage && !chat.contextToAttach)">
-                        <i class="bi bi-send-fill"></i>
-                    </button>
-                </form>
+                </template>
             </div>
-
-            <!-- Resize Handles -->
-            <div class="resize-handle-r" @mousedown.stop.prevent="startResize($event, chat.id, 'r')"></div>
-            <div class="resize-handle-b" @mousedown.stop.prevent="startResize($event, chat.id, 'b')"></div>
-            <div class="resize-handle-rb" @mousedown.stop.prevent="startResize($event, chat.id, 'rb')"></div>
         </div>
     </template>
-
-    <!-- 4. Minimized Chat Stack (Top Right, Vertical Stack) -->
-    <div class="position-fixed top-0 end-0 mt-5 pt-5 me-2 d-flex flex-column gap-2" style="z-index: 1990; pointer-events: none;">
-        <template x-for="chat in openChats" :key="chat.id">
-            <div x-show="chat.minimized"
-                 class="position-relative shadow rounded-pill bg-white border d-flex align-items-center p-1 gap-2 cursor-pointer slide-in-right"
-                 style="pointer-events: auto; max-width: 150px; background-color: rgba(255,255,255,0.95) !important;"
-                 @click="chat.minimized = false; saveState(); bringToFront(chat.id)"
-                 :title="chat.user.name">
-                <img :src="chat.user.avatar_url" class="rounded-circle object-fit-cover" width="30" height="30"
-                     onerror="this.src='https://ui-avatars.com/api/?name=User&color=7F9CF5&background=EBF4FF'">
-                <span class="text-truncate small fw-bold" style="max-width: 80px;" x-text="chat.user.name"></span>
-                <span x-show="chat.unreadCount > 0"
-                      class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger border border-white p-1"
-                      style="font-size: 0.6rem;"
-                      x-text="chat.unreadCount"></span>
-            </div>
-        </template>
-    </div>
+    <!-- END CHAT SYSTEM CONTAINER -->
 
      <!-- Profile Modal (Reused) -->
     <div x-show="showProfileModal"


### PR DESCRIPTION
- Modified `ChatController` to explicitly grant chat access to 'staff' and 'admin' roles, simplifying permission checks.
- Updated `chat-widget.blade.php` to implement a "Master Toggle" behavior: closing the contact list now also hides all active chat windows and minimized bubbles.
- Redesigned the minimized chat view to be a circular avatar bubble instead of a text pill.
- Adjusted Z-Index values to ensure the launcher button remains accessible above the sidebar.