### PR TITLE
feat: add Group and Team management feature

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -141,7 +141,7 @@ public function reinstate(Employee $employee)
     $perPageOptions = [25, 50, 100]; // Defined options here
     $currentPerPage = $request->input('per_page', 25);
 
-    $employees = $query->with('employer')->latest()->paginate($currentPerPage)->withQueryString(); // Added withQueryString() to preserve filters on pagination
+    $employees = $query->with(['employer', 'teams.group'])->latest()->paginate($currentPerPage)->withQueryString(); // Added withQueryString() to preserve filters on pagination
 
     return view('employees.index', compact(
         'employees',

--- a/app/Http/Controllers/GroupTeamController.php
+++ b/app/Http/Controllers/GroupTeamController.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Employer;
+use App\Models\Employee;
+use App\Models\EmployeeGroup;
+use App\Models\EmployeeTeam;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class GroupTeamController extends Controller
+{
+    public function index()
+    {
+        return view('groups.index');
+    }
+
+    public function indexAffiliated(Request $request)
+    {
+        $search = $request->input('search');
+        $employers = collect();
+
+        if ($search) {
+            $employers = Employer::query()
+                ->where('name_th', 'like', "%{$search}%")
+                ->orWhere('name_en', 'like', "%{$search}%")
+                ->orWhere('company_name', 'like', "%{$search}%")
+                ->limit(20)
+                ->get();
+        }
+
+        return view('groups.affiliated.index', compact('employers', 'search'));
+    }
+
+    public function manageAffiliated(Employer $employer)
+    {
+        $groups = EmployeeGroup::where('employer_id', $employer->id)
+            ->where('type', 'affiliated')
+            ->with(['teams.employees'])
+            ->get();
+
+        return view('groups.manage', [
+            'type' => 'affiliated',
+            'employer' => $employer,
+            'groups' => $groups
+        ]);
+    }
+
+    public function manageIndependent()
+    {
+        $groups = EmployeeGroup::where('type', 'independent')
+            ->with(['teams.employees'])
+            ->get();
+
+        return view('groups.manage', [
+            'type' => 'independent',
+            'employer' => null,
+            'groups' => $groups
+        ]);
+    }
+
+    public function storeGroup(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'type' => 'required|in:affiliated,independent',
+            'employer_id' => 'required_if:type,affiliated|nullable|exists:employers,id',
+        ]);
+
+        EmployeeGroup::create($request->all());
+
+        return back()->with('success', 'Group created successfully.');
+    }
+
+    public function storeTeam(Request $request, EmployeeGroup $group)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+
+        $group->teams()->create([
+            'name' => $request->name,
+        ]);
+
+        return back()->with('success', 'Team created successfully.');
+    }
+
+    public function searchEmployees(Request $request)
+    {
+        $term = $request->input('term');
+        $employerId = $request->input('employer_id');
+        $groupId = $request->input('group_id');
+
+        $query = Employee::query()
+            ->where(function($q) use ($term) {
+                $q->where('employeeNameTh', 'like', "%{$term}%")
+                  ->orWhere('employeeNameEn', 'like', "%{$term}%")
+                  ->orWhere('employeePassport', 'like', "%{$term}%");
+            });
+
+        // If affiliated, limit to employer
+        if ($employerId) {
+            $query->where('employer_id', $employerId);
+        }
+
+        // Exclude employees who are already in a team WITHIN THIS GROUP
+        if ($groupId) {
+            $query->whereDoesntHave('teams.group', function ($q) use ($groupId) {
+                $q->where('id', $groupId);
+            });
+        }
+
+        $employees = $query->limit(50)->get(['id', 'employeeNameTh', 'employeeNameEn', 'employeePassport', 'employeePhoto']);
+
+        // Transform for frontend
+        $results = $employees->map(function ($emp) {
+            return [
+                'id' => $emp->id,
+                'name' => $emp->employeeNameTh . ' (' . $emp->employeeNameEn . ')',
+                'passport' => $emp->employeePassport,
+                'photo' => $emp->photo_url,
+            ];
+        });
+
+        return response()->json($results);
+    }
+
+    public function addMember(Request $request, EmployeeTeam $team)
+    {
+        $request->validate([
+            'employee_id' => 'required|exists:employees,id',
+        ]);
+
+        $employee = Employee::findOrFail($request->employee_id);
+        $group = $team->group;
+
+        // Verify constraint: Employee cannot be in another team in this group
+        $alreadyInGroup = $employee->teams()->where('employee_group_id', $group->id)->exists();
+
+        if ($alreadyInGroup) {
+            return response()->json(['message' => 'Employee is already in a team within this group.'], 422);
+        }
+
+        $team->employees()->attach($employee->id);
+
+        return response()->json(['success' => true]);
+    }
+
+    public function removeMember(EmployeeTeam $team, Employee $employee)
+    {
+        $team->employees()->detach($employee->id);
+        return back()->with('success', 'Member removed.');
+    }
+
+    // For navigation via Tags
+    public function locateMember(Employee $employee, EmployeeGroup $group)
+    {
+        // Find which team in this group the employee belongs to
+        $team = $employee->teams()->where('employee_group_id', $group->id)->first();
+
+        if (!$team) {
+            return back()->with('error', 'Employee not found in this group.');
+        }
+
+        if ($group->type === 'affiliated') {
+            return redirect()->route('groups.affiliated.manage', [
+                'employer' => $group->employer_id,
+                'active_group' => $group->id,
+                'active_team' => $team->id
+            ]);
+        } else {
+             return redirect()->route('groups.independent.manage', [
+                'active_group' => $group->id,
+                'active_team' => $team->id
+            ]);
+        }
+    }
+}

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -221,6 +221,12 @@ class Employee extends Model
         return $this->hasMany(Notification::class);
     }
 
+    public function teams()
+    {
+        return $this->belongsToMany(EmployeeTeam::class, 'employee_team_members', 'employee_id', 'employee_team_id')
+                    ->withTimestamps();
+    }
+
     /**
      * Get the number of days since the employee was terminated.
      * Usage in Blade/API: $employee->days_since_termination

--- a/app/Models/EmployeeGroup.php
+++ b/app/Models/EmployeeGroup.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class EmployeeGroup extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = ['name', 'type', 'employer_id'];
+
+    public function employer()
+    {
+        return $this->belongsTo(Employer::class);
+    }
+
+    public function teams()
+    {
+        return $this->hasMany(EmployeeTeam::class);
+    }
+}

--- a/app/Models/EmployeeTeam.php
+++ b/app/Models/EmployeeTeam.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class EmployeeTeam extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = ['name', 'employee_group_id'];
+
+    public function group()
+    {
+        return $this->belongsTo(EmployeeGroup::class, 'employee_group_id');
+    }
+
+    public function employees()
+    {
+        return $this->belongsToMany(Employee::class, 'employee_team_members', 'employee_team_id', 'employee_id')
+                    ->withTimestamps();
+    }
+}

--- a/database/migrations/2025_11_27_000000_create_employee_groups_and_teams_tables.php
+++ b/database/migrations/2025_11_27_000000_create_employee_groups_and_teams_tables.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->enum('type', ['affiliated', 'independent']);
+            $table->foreignId('employer_id')->nullable()->constrained()->onDelete('cascade');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('employee_teams', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('employee_group_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('employee_team_members', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employee_team_id')->constrained()->onDelete('cascade');
+            $table->foreignId('employee_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+
+            // Note: We'll enforce the "one team per group" constraint in the application logic
+            // because checking it at database level across these tables is complex for a constraint.
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_team_members');
+        Schema::dropIfExists('employee_teams');
+        Schema::dropIfExists('employee_groups');
+    }
+};

--- a/resources/views/groups/affiliated/index.blade.php
+++ b/resources/views/groups/affiliated/index.blade.php
@@ -1,0 +1,57 @@
+@extends('layouts.app')
+
+@section('title', 'Select Employer - Group & Team')
+
+@section('content')
+<div class="container-fluid">
+    <div class="mb-4">
+        <a href="{{ route('groups.index') }}" class="text-decoration-none text-muted">
+            <i class="bi bi-arrow-left"></i> {{ __('Back to Selection') }}
+        </a>
+        <h1 class="h3 mt-2 text-gray-800">{{ __('Select Employer for Group Management') }}</h1>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <form action="{{ route('groups.affiliated.index') }}" method="GET" class="row g-3">
+                <div class="col-md-10">
+                    <input type="text" name="search" class="form-control form-control-lg"
+                           placeholder="{{ __('Search by Employer Name or Company Name...') }}"
+                           value="{{ $search }}">
+                </div>
+                <div class="col-md-2 d-grid">
+                    <button type="submit" class="btn btn-primary btn-lg">
+                        <i class="bi bi-search"></i> {{ __('Search') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    @if($employers->count() > 0)
+    <div class="row g-3">
+        @foreach($employers as $employer)
+        <div class="col-md-4">
+            <div class="card h-100 shadow-sm border-0 bg-white">
+                <div class="card-body">
+                    <h5 class="card-title fw-bold text-primary">{{ $employer->name_th }}</h5>
+                    <h6 class="card-subtitle mb-2 text-muted">{{ $employer->company_name }}</h6>
+                    <p class="card-text small text-muted">
+                        {{ $employer->name_en }} <br>
+                        {{ __('Employees') }}: {{ $employer->employees()->count() }}
+                    </p>
+                    <a href="{{ route('groups.affiliated.manage', $employer->id) }}" class="btn btn-outline-primary w-100 stretched-link">
+                        {{ __('Manage Groups') }}
+                    </a>
+                </div>
+            </div>
+        </div>
+        @endforeach
+    </div>
+    @elseif($search)
+        <div class="alert alert-info text-center">
+            {{ __('No employers found matching your search.') }}
+        </div>
+    @endif
+</div>
+@endsection

--- a/resources/views/groups/index.blade.php
+++ b/resources/views/groups/index.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.app')
+
+@section('title', 'Group & Team')
+
+@section('content')
+<div class="container-fluid">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3 mb-0 text-gray-800">{{ __('Group & Team Management') }}</h1>
+    </div>
+
+    <div class="row g-4">
+        <!-- Affiliated with Employer -->
+        <div class="col-md-6">
+            <div class="card h-100 shadow-sm hover-shadow transition-all">
+                <div class="card-body text-center p-5">
+                    <div class="mb-4">
+                        <i class="bi bi-building-fill text-primary" style="font-size: 4rem;"></i>
+                    </div>
+                    <h3 class="card-title fw-bold mb-3">{{ __('สังกัดภายใต้นายจ้าง') }}</h3>
+                    <p class="card-text text-muted mb-4">
+                        {{ __('Manage groups and teams specific to an employer. Employees must belong to the selected employer.') }}
+                    </p>
+                    <a href="{{ route('groups.affiliated.index') }}" class="btn btn-primary btn-lg w-100">
+                        {{ __('Select Employer') }} <i class="bi bi-arrow-right ms-2"></i>
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <!-- Independent / No Employer -->
+        <div class="col-md-6">
+            <div class="card h-100 shadow-sm hover-shadow transition-all">
+                <div class="card-body text-center p-5">
+                    <div class="mb-4">
+                        <i class="bi bi-diagram-3-fill text-success" style="font-size: 4rem;"></i>
+                    </div>
+                    <h3 class="card-title fw-bold mb-3">{{ __('ไม่สังกัดนายจ้าง') }}</h3>
+                    <p class="card-text text-muted mb-4">
+                        {{ __('Manage independent groups. Add any employee from the system regardless of their employer.') }}
+                    </p>
+                    <a href="{{ route('groups.independent.manage') }}" class="btn btn-success btn-lg w-100">
+                        {{ __('Manage Independent Groups') }} <i class="bi bi-arrow-right ms-2"></i>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .hover-shadow:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 .5rem 1rem rgba(0,0,0,.15)!important;
+    }
+    .transition-all {
+        transition: all 0.3s ease;
+    }
+</style>
+@endsection

--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -1,0 +1,365 @@
+@extends('layouts.app')
+
+@section('title', 'Manage Groups & Teams')
+
+@section('content')
+<div class="container-fluid" x-data="groupTeamManager()">
+    <!-- Header -->
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <a href="{{ $type === 'affiliated' ? route('groups.affiliated.index') : route('groups.index') }}" class="text-decoration-none text-muted">
+                <i class="bi bi-arrow-left"></i> {{ __('Back') }}
+            </a>
+            <h1 class="h3 mt-2 text-gray-800">
+                @if($type === 'affiliated')
+                    <span class="text-muted">{{ __('Employer') }}:</span> {{ $employer->name_th }} ({{ $employer->company_name }})
+                @else
+                    {{ __('Independent Groups Management') }}
+                @endif
+            </h1>
+        </div>
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createGroupModal">
+            <i class="bi bi-plus-lg"></i> {{ __('Create New Group') }}
+        </button>
+    </div>
+
+    <!-- Groups Tabs -->
+    <ul class="nav nav-tabs mb-3" id="groupTabs" role="tablist">
+        @foreach($groups as $index => $group)
+        <li class="nav-item" role="presentation">
+            <button class="nav-link {{ $index === 0 || request('active_group') == $group->id ? 'active' : '' }}"
+                    id="group-tab-{{ $group->id }}"
+                    data-bs-toggle="tab"
+                    data-bs-target="#group-content-{{ $group->id }}"
+                    type="button"
+                    role="tab"
+                    aria-controls="group-content-{{ $group->id }}"
+                    aria-selected="{{ $index === 0 ? 'true' : 'false' }}">
+                {{ $group->name }}
+            </button>
+        </li>
+        @endforeach
+        @if($groups->isEmpty())
+        <li class="nav-item">
+            <span class="nav-link disabled">{{ __('No Groups Created Yet') }}</span>
+        </li>
+        @endif
+    </ul>
+
+    <!-- Groups Content -->
+    <div class="tab-content" id="groupTabsContent">
+        @forelse($groups as $index => $group)
+        <div class="tab-pane fade {{ $index === 0 || request('active_group') == $group->id ? 'show active' : '' }}"
+             id="group-content-{{ $group->id }}"
+             role="tabpanel"
+             aria-labelledby="group-tab-{{ $group->id }}">
+
+            <div class="d-flex justify-content-between align-items-center my-3 bg-light p-3 rounded">
+                <h4 class="mb-0">{{ $group->name }} <span class="text-muted fs-6">({{ __('Group') }})</span></h4>
+                <button class="btn btn-outline-primary btn-sm"
+                        data-bs-toggle="modal"
+                        data-bs-target="#createTeamModal"
+                        @click="setGroupId({{ $group->id }})">
+                    <i class="bi bi-plus-circle"></i> {{ __('Create Team') }}
+                </button>
+            </div>
+
+            <!-- Teams List (Accordion) -->
+            <div class="accordion" id="accordionGroup{{ $group->id }}">
+                @forelse($group->teams as $team)
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="headingTeam{{ $team->id }}">
+                        <button class="accordion-button {{ request('active_team') == $team->id ? '' : 'collapsed' }}"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#collapseTeam{{ $team->id }}"
+                                aria-expanded="{{ request('active_team') == $team->id ? 'true' : 'false' }}"
+                                aria-controls="collapseTeam{{ $team->id }}">
+                            <span class="fw-bold">{{ $team->name }}</span>
+                            <span class="badge bg-secondary ms-2 rounded-pill">{{ $team->employees->count() }} {{ __('Members') }}</span>
+                        </button>
+                    </h2>
+                    <div id="collapseTeam{{ $team->id }}"
+                         class="accordion-collapse collapse {{ request('active_team') == $team->id ? 'show' : '' }}"
+                         aria-labelledby="headingTeam{{ $team->id }}"
+                         data-bs-parent="#accordionGroup{{ $group->id }}">
+                        <div class="accordion-body">
+                            <!-- Team Actions -->
+                            <div class="d-flex justify-content-end mb-3">
+                                <button class="btn btn-sm btn-success"
+                                        @click="openAddMemberModal({{ $group->id }}, {{ $team->id }}, '{{ $team->name }}')">
+                                    <i class="bi bi-person-plus-fill"></i> {{ __('Add Member') }}
+                                </button>
+                            </div>
+
+                            <!-- Members Table -->
+                            <div class="table-responsive">
+                                <table class="table table-hover align-middle">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th>{{ __('Photo') }}</th>
+                                            <th>{{ __('Name') }}</th>
+                                            <th>{{ __('Passport') }}</th>
+                                            <th class="text-end">{{ __('Actions') }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @forelse($team->employees as $member)
+                                        <tr>
+                                            <td>
+                                                <img src="{{ $member->photo_url }}" class="rounded-circle" width="32" height="32" alt="avatar">
+                                            </td>
+                                            <td>
+                                                <div>{{ $member->employeeNameTh }}</div>
+                                                <small class="text-muted">{{ $member->employeeNameEn }}</small>
+                                            </td>
+                                            <td>{{ $member->employeePassport }}</td>
+                                            <td class="text-end">
+                                                <form action="{{ route('groups.teams.members.remove', ['team' => $team->id, 'employee' => $member->id]) }}" method="POST" class="d-inline" onsubmit="return confirm('{{ __('Are you sure you want to remove this member?') }}')">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="btn btn-outline-danger btn-sm">
+                                                        <i class="bi bi-x-lg"></i>
+                                                    </button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                        @empty
+                                        <tr>
+                                            <td colspan="4" class="text-center text-muted py-4">
+                                                {{ __('No members in this team yet.') }}
+                                            </td>
+                                        </tr>
+                                        @endforelse
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                @empty
+                <div class="alert alert-secondary text-center">
+                    {{ __('No teams created in this group yet.') }}
+                </div>
+                @endforelse
+            </div>
+
+        </div>
+        @empty
+        <div class="text-center py-5 text-muted">
+            <i class="bi bi-collection fs-1 d-block mb-3"></i>
+            <p>{{ __('Get started by creating a new Group tab above.') }}</p>
+        </div>
+        @endforelse
+    </div>
+
+    <!-- Modals -->
+
+    <!-- Create Group Modal -->
+    <div class="modal fade" id="createGroupModal" tabindex="-1">
+        <div class="modal-dialog modal-dialog-centered">
+            <form action="{{ route('groups.store') }}" method="POST" class="modal-content">
+                @csrf
+                <input type="hidden" name="type" value="{{ $type }}">
+                @if($employer)
+                    <input type="hidden" name="employer_id" value="{{ $employer->id }}">
+                @endif
+                <div class="modal-header">
+                    <h5 class="modal-title">{{ __('Create New Group') }}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">{{ __('Group Name') }}</label>
+                        <input type="text" name="name" class="form-control" placeholder="e.g. Passport Work, Start Date Group" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Cancel') }}</button>
+                    <button type="submit" class="btn btn-primary">{{ __('Create') }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Create Team Modal -->
+    <div class="modal fade" id="createTeamModal" tabindex="-1">
+        <div class="modal-dialog modal-dialog-centered">
+            <form :action="`/groups/${selectedGroupId}/teams`" method="POST" class="modal-content">
+                @csrf
+                <div class="modal-header">
+                    <h5 class="modal-title">{{ __('Create New Team') }}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">{{ __('Team Name') }}</label>
+                        <input type="text" name="name" class="form-control" placeholder="e.g. Team A, Start Nov 12" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Cancel') }}</button>
+                    <button type="submit" class="btn btn-primary">{{ __('Create') }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Add Member Modal -->
+    <div class="modal fade" id="addMemberModal" tabindex="-1">
+        <div class="modal-dialog modal-lg modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        {{ __('Add Member to') }} <span x-text="selectedTeamName" class="fw-bold"></span>
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <!-- Search -->
+                    <div class="input-group mb-3">
+                        <span class="input-group-text"><i class="bi bi-search"></i></span>
+                        <input type="text"
+                               class="form-control"
+                               placeholder="{{ __('Search employee by name or passport...') }}"
+                               x-model="searchTerm"
+                               @input.debounce.500ms="searchEmployees()">
+                    </div>
+
+                    <!-- Results List -->
+                    <div class="list-group overflow-auto" style="max-height: 400px;">
+                        <template x-if="isLoading">
+                            <div class="text-center py-3">
+                                <div class="spinner-border text-primary" role="status"></div>
+                            </div>
+                        </template>
+
+                        <template x-for="employee in searchResults" :key="employee.id">
+                            <div class="list-group-item d-flex justify-content-between align-items-center">
+                                <div class="d-flex align-items-center">
+                                    <img :src="employee.photo" class="rounded-circle me-3" width="40" height="40">
+                                    <div>
+                                        <div class="fw-bold" x-text="employee.name"></div>
+                                        <div class="text-muted small">
+                                            <i class="bi bi-passport"></i> <span x-text="employee.passport"></span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <button class="btn btn-sm btn-primary"
+                                        @click="addMember(employee.id)"
+                                        :disabled="addingMemberId === employee.id">
+                                    <span x-show="addingMemberId !== employee.id">{{ __('Add') }}</span>
+                                    <span x-show="addingMemberId === employee.id" class="spinner-border spinner-border-sm"></span>
+                                </button>
+                            </div>
+                        </template>
+
+                        <template x-if="!isLoading && searchResults.length === 0 && searchTerm.length > 0">
+                            <div class="text-center text-muted py-3">
+                                {{ __('No employees found or all matched employees are already in a team in this group.') }}
+                            </div>
+                        </template>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+
+@push('scripts')
+<script>
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('groupTeamManager', () => ({
+            selectedGroupId: null,
+            selectedTeamId: null,
+            selectedTeamName: '',
+            searchTerm: '',
+            searchResults: [],
+            isLoading: false,
+            addingMemberId: null,
+            employerId: {{ $employer ? $employer->id : 'null' }},
+            hasChanges: false, // Track if members were added
+
+            setGroupId(id) {
+                this.selectedGroupId = id;
+            },
+
+            openAddMemberModal(groupId, teamId, teamName) {
+                this.selectedGroupId = groupId;
+                this.selectedTeamId = teamId;
+                this.selectedTeamName = teamName;
+                this.searchTerm = '';
+                this.searchResults = [];
+                this.hasChanges = false;
+
+                const modalEl = document.getElementById('addMemberModal');
+                const modal = new bootstrap.Modal(modalEl);
+                modal.show();
+
+                // Reload page on close if changes were made
+                modalEl.addEventListener('hidden.bs.modal', () => {
+                    if (this.hasChanges) {
+                        window.location.reload();
+                    }
+                }, { once: true });
+
+                // Load initial suggestions (optional)
+                this.searchEmployees();
+            },
+
+            searchEmployees() {
+                this.isLoading = true;
+
+                const params = new URLSearchParams({
+                    term: this.searchTerm,
+                    group_id: this.selectedGroupId
+                });
+
+                if (this.employerId) {
+                    params.append('employer_id', this.employerId);
+                }
+
+                fetch(`{{ route('api-web.groups.employees.search') }}?${params.toString()}`)
+                    .then(res => res.json())
+                    .then(data => {
+                        this.searchResults = data;
+                        this.isLoading = false;
+                    });
+            },
+
+            addMember(employeeId) {
+                this.addingMemberId = employeeId;
+
+                fetch(`/groups/teams/${this.selectedTeamId}/members`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                    },
+                    body: JSON.stringify({ employee_id: employeeId })
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success) {
+                        showToast('Member added successfully', 'success');
+                        // Remove from search results to prevent double add
+                        this.searchResults = this.searchResults.filter(e => e.id !== employeeId);
+                        // Mark that changes were made so we reload on close
+                        this.hasChanges = true;
+                    } else {
+                        showToast(data.message, 'danger');
+                    }
+                })
+                .catch(err => {
+                    showToast('Error adding member', 'danger');
+                })
+                .finally(() => {
+                    this.addingMemberId = null;
+                });
+            }
+        }));
+    });
+</script>
+@endpush
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -254,6 +254,9 @@
                 <a href="{{ route('employees.history') }}" class="list-group-item list-group-item-action {{ request()->routeIs('employees.history') ? 'active' : '' }}" style="padding-left: 2.5rem;">
                     <i class="bi bi-person-badge me-2"></i>{{ __('Employment History') }}
                 </a>
+                <a href="{{ route('groups.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('groups.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
+                    <i class="bi bi-people-fill me-2"></i>{{ __('Group & Team') }}
+                </a>
                 @endcan
                 @can('view-importers')
                 <a href="{{ route('importers.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('importers.*') ? 'active' : '' }}"><i class="bi bi-box-arrow-in-down-left me-2"></i>{{ __('Importers') }}</a>

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -11,7 +11,24 @@
         <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : asset('images/default-profile.png') }}"
             alt="Photo" class="employee-photo-thumb" style="width: 48px; height: 48px; object-fit: cover; border-radius: 50%; margin-right: 1rem;">
 
-        <div class="employee-info flex-grow-1">
+        <div class="employee-info flex-grow-1 position-relative">
+            {{-- Group & Team Tags --}}
+            @if($employee->teams && $employee->teams->count() > 0)
+                <div class="position-absolute top-0 end-0 mt-0 me-2 d-flex flex-wrap justify-content-end gap-1" style="max-width: 250px;">
+                    @foreach($employee->teams as $team)
+                        @if($team->group)
+                        <a href="{{ route('groups.locate_member', ['group' => $team->group->id, 'employee' => $employee->id]) }}"
+                           class="badge text-decoration-none"
+                           style="background-color: #e0f2fe; color: #0369a1; border: 1px solid #bae6fd; font-weight: normal; font-size: 0.75rem;"
+                           title="{{ __('Group') }}: {{ $team->group->name }} | {{ __('Team') }}: {{ $team->name }}"
+                           onclick="return confirm('{{ __('Go to group') }}: {{ $team->group->name }}?')">
+                            <i class="bi bi-tag-fill me-1"></i>{{ $team->group->name }}
+                        </a>
+                        @endif
+                    @endforeach
+                </div>
+            @endif
+
             <span class="employee-name-en">
                 @if(isset($pagination) && $pagination instanceof \Illuminate\Pagination\LengthAwarePaginator)
                     {{ ($pagination->currentPage() - 1) * $pagination->perPage() + $loop->iteration }}.

--- a/routes/web.php
+++ b/routes/web.php
@@ -115,6 +115,19 @@ Route::middleware('auth')->group(function () {
     Route::post('employees/{employee}/transfer', [EmployeeController::class, 'transfer'])->name('employees.transfer');
     Route::post('employees/bulk-transfer', [EmployeeController::class, 'bulkTransfer'])->name('employees.bulkTransfer');
     Route::post('employees/bulk-to-ticket', [App\Http\Controllers\TicketRedirectController::class, 'bulkToTicket'])->name('employees.bulk_to_ticket');
+
+    // === Group & Team Routes ===
+    Route::get('/groups', [App\Http\Controllers\GroupTeamController::class, 'index'])->name('groups.index');
+    Route::get('/groups/affiliated', [App\Http\Controllers\GroupTeamController::class, 'indexAffiliated'])->name('groups.affiliated.index');
+    Route::get('/groups/affiliated/{employer}/manage', [App\Http\Controllers\GroupTeamController::class, 'manageAffiliated'])->name('groups.affiliated.manage');
+    Route::get('/groups/independent/manage', [App\Http\Controllers\GroupTeamController::class, 'manageIndependent'])->name('groups.independent.manage');
+    Route::post('/groups', [App\Http\Controllers\GroupTeamController::class, 'storeGroup'])->name('groups.store');
+    Route::post('/groups/{group}/teams', [App\Http\Controllers\GroupTeamController::class, 'storeTeam'])->name('groups.teams.store');
+    Route::get('/api-web/groups/employees/search', [App\Http\Controllers\GroupTeamController::class, 'searchEmployees'])->name('api-web.groups.employees.search');
+    Route::post('/groups/teams/{team}/members', [App\Http\Controllers\GroupTeamController::class, 'addMember'])->name('groups.teams.members.add');
+    Route::delete('/groups/teams/{team}/members/{employee}', [App\Http\Controllers\GroupTeamController::class, 'removeMember'])->name('groups.teams.members.remove');
+    // Route for "Tag" click
+    Route::get('/groups/{group}/locate/{employee}', [App\Http\Controllers\GroupTeamController::class, 'locateMember'])->name('groups.locate_member');
 });
 
 // === V2.4: Admin/Staff Ticket Management Routes (NEW Group) ===


### PR DESCRIPTION
- Create `employee_groups`, `employee_teams`, `employee_team_members` tables.
- Add `EmployeeGroup` and `EmployeeTeam` models.
- Update `Employee` model with relationships.
- Create `GroupTeamController` for managing groups/teams and searching members.
- Add views for Group Management (Affiliated/Independent) using Alpine.js.
- Add "Tags" to `_employee_card.blade.php` linking to group views.
- Implement "one team per group" constraint logic.
- Optimize UX for bulk member addition (reload on modal close).
- Update sidebar navigation.