### PR TITLE
Fix employer search error and team drawer UI glitch in Group & Team m…

### DIFF
--- a/app/Http/Controllers/GroupTeamController.php
+++ b/app/Http/Controllers/GroupTeamController.php
@@ -23,9 +23,8 @@ class GroupTeamController extends Controller
 
         if ($search) {
             $employers = Employer::query()
-                ->where('name_th', 'like', "%{$search}%")
-                ->orWhere('name_en', 'like', "%{$search}%")
-                ->orWhere('company_name', 'like', "%{$search}%")
+                ->where('employerNameTh', 'like', "%{$search}%")
+                ->orWhere('employerNameEn', 'like', "%{$search}%")
                 ->limit(20)
                 ->get();
         }

--- a/resources/views/groups/affiliated/index.blade.php
+++ b/resources/views/groups/affiliated/index.blade.php
@@ -34,10 +34,9 @@
         <div class="col-md-4">
             <div class="card h-100 shadow-sm border-0 bg-white">
                 <div class="card-body">
-                    <h5 class="card-title fw-bold text-primary">{{ $employer->name_th }}</h5>
-                    <h6 class="card-subtitle mb-2 text-muted">{{ $employer->company_name }}</h6>
+                    <h5 class="card-title fw-bold text-primary">{{ $employer->employerNameTh }}</h5>
+                    <h6 class="card-subtitle mb-2 text-muted">{{ $employer->employerNameEn }}</h6>
                     <p class="card-text small text-muted">
-                        {{ $employer->name_en }} <br>
                         {{ __('Employees') }}: {{ $employer->employees()->count() }}
                     </p>
                     <a href="{{ route('groups.affiliated.manage', $employer->id) }}" class="btn btn-outline-primary w-100 stretched-link">

--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -12,7 +12,7 @@
             </a>
             <h1 class="h3 mt-2 text-gray-800">
                 @if($type === 'affiliated')
-                    <span class="text-muted">{{ __('Employer') }}:</span> {{ $employer->name_th }} ({{ $employer->company_name }})
+                    <span class="text-muted">{{ __('Employer') }}:</span> {{ $employer->employerNameTh }} ({{ $employer->employerNameEn }})
                 @else
                     {{ __('Independent Groups Management') }}
                 @endif
@@ -81,8 +81,7 @@
                     </h2>
                     <div id="collapseTeam{{ $team->id }}"
                          class="accordion-collapse collapse {{ request('active_team') == $team->id ? 'show' : '' }}"
-                         aria-labelledby="headingTeam{{ $team->id }}"
-                         data-bs-parent="#accordionGroup{{ $group->id }}">
+                         aria-labelledby="headingTeam{{ $team->id }}">
                         <div class="accordion-body">
                             <!-- Team Actions -->
                             <div class="d-flex justify-content-end mb-3">


### PR DESCRIPTION
…odule

- Updated `GroupTeamController` and associated views to use correct `Employer` model attributes (`employerNameTh`, `employerNameEn`) instead of invalid column names, resolving the search error.
- Removed `data-bs-parent` attribute from the team details accordion in `manage.blade.php` to prevent the drawer from immediately auto-closing, ensuring stable UI interaction.