### PR TITLE
Fix: Resolve blank drawer issue by ensuring unique DOM IDs for employ…

### DIFF
--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -172,7 +172,8 @@
                                                         'loop' => $loop,
                                                         'showLocateButton' => true,
                                                         'hideTeamTags' => true,
-                                                        'currentTeamId' => $team->id
+                                                        'currentTeamId' => $team->id,
+                                                        'idPrefix' => 'team-' . $team->id . '-'
                                                     ])
                                                 @endforeach
                                             </div>
@@ -191,7 +192,8 @@
                                                 'loop' => $loop,
                                                 'showLocateButton' => true,
                                                 'hideTeamTags' => true,
-                                                'currentTeamId' => $team->id
+                                                'currentTeamId' => $team->id,
+                                                'idPrefix' => 'team-' . $team->id . '-'
                                             ])
                                         @empty
                                             <div class="text-center text-muted py-4 border rounded bg-light">

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -1,8 +1,10 @@
 @php
     $employerName = $employee->employer->employerNameTh ?? 'N/A';
+    // Fix for duplicate IDs in list views
+    $cardId = 'employee-card-' . ($idPrefix ?? '') . $employee->id;
 @endphp
 
-<div id="employee-card-{{ $employee->id }}" class="employee-card card mb-3">
+<div id="{{ $cardId }}" class="employee-card card mb-3">
     <div class="card-body d-flex align-items-center">
         <div class="me-3">
             <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}" data-employer-id="{{ $employee->employer_id }}">


### PR DESCRIPTION
…ee cards

The issue where the "Group and Team" drawer content would flicker and disappear was caused by duplicate DOM IDs when the same employee appeared in multiple teams. This caused conflicts with the frontend rendering logic.

Changes:
- Modified `resources/views/partials/_employee_card.blade.php` to accept an optional `$idPrefix` parameter and append it to the card's ID attribute.
- Updated `resources/views/groups/manage.blade.php` to pass a unique prefix (based on the Team ID) when including the employee card partial.

This ensures all DOM elements have unique IDs, preventing layout engine failures and restoring correct visibility behavior.