### PR TITLE
Add drag-and-drop support for internal chat to key admin menus

### DIFF
--- a/resources/views/admin/incomplete_employees/index.blade.php
+++ b/resources/views/admin/incomplete_employees/index.blade.php
@@ -116,7 +116,12 @@
                         </thead>
                         <tbody>
                             @foreach($employees as $employee)
-                            <tr>
+                            <tr draggable="true"
+                                ondragstart="window.startDragGlobal(event, 'employee', {
+                                    id: {{ $employee->id }},
+                                    title: '{{ addslashes($employee->employeeNameTh) }}',
+                                    subtitle: '{{ addslashes($employee->employeeNameEn) }}'
+                                })">
                                 <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}"></td>
                                 <td>
                                     <div class="d-flex align-items-center">

--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -56,7 +56,14 @@
     @endif
 
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>{{ $ticket->subject }}</h2>
+        <h2 draggable="true"
+            ondragstart="window.startDragGlobal(event, 'ticket', {
+                id: {{ $ticket->id }},
+                title: '{{ addslashes($ticket->subject) }}',
+                subtitle: 'Ticket #{{ $ticket->id }}',
+                url: '{{ route('admin.tickets.show', $ticket) }}'
+            })"
+            style="cursor: grab;">{{ $ticket->subject }}</h2>
         {{-- Display Status Badge --}}
         <span class="badge bg-{{ $ticket->status_color }} fs-5">
             {{ $ticket->status_name }}
@@ -100,7 +107,13 @@
 
                             @foreach($attachments->existing_employees as $item)
                                 @php $employee = $item->employee; @endphp
-                                <div class="list-group-item d-flex align-items-center gap-3 py-2">
+                                <div class="list-group-item d-flex align-items-center gap-3 py-2"
+                                     draggable="true"
+                                     ondragstart="window.startDragGlobal(event, 'employee', {
+                                        id: {{ $employee->id }},
+                                        title: '{{ addslashes($employee->employeeNameTh) }}',
+                                        subtitle: '{{ addslashes($employee->employeeNameEn) }}'
+                                     })">
                                     <div class="form-check mb-0">
                                         <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}">
                                     </div>

--- a/resources/views/employees/_history_card.blade.php
+++ b/resources/views/employees/_history_card.blade.php
@@ -5,7 +5,13 @@
     $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
 @endphp
 
-<div id="history-row-{{ $employee->id }}" class="list-group-item list-group-item-action">
+<div id="history-row-{{ $employee->id }}" class="list-group-item list-group-item-action"
+     draggable="true"
+     ondragstart="window.startDragGlobal(event, 'employee', {
+        id: {{ $employee->id }},
+        title: '{{ addslashes($employee->employeeNameTh) }}',
+        subtitle: '{{ addslashes($employee->employeeNameEn) }}'
+     })">
     <div class="d-flex w-100">
         {{-- Checkbox --}}
         <div class="me-3 d-flex align-items-center">

--- a/resources/views/employees/history.blade.php
+++ b/resources/views/employees/history.blade.php
@@ -95,7 +95,13 @@
                 </thead>
                 <tbody id="historyTableBody">
                     @forelse($employees as $employee)
-                    <tr id="history-row-{{ $employee->id }}">
+                    <tr id="history-row-{{ $employee->id }}"
+                        draggable="true"
+                        ondragstart="window.startDragGlobal(event, 'employee', {
+                            id: {{ $employee->id }},
+                            title: '{{ addslashes($employee->employeeNameTh) }}',
+                            subtitle: '{{ addslashes($employee->employeeNameEn) }}'
+                        })">
                         <td><input class="form-check-input history-employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}"></td>
                         <td>
                             <div class="d-flex align-items-center">

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -23,7 +23,16 @@
 
 {{-- Employer Info Form --}}
 <div class="content-section">
-    <h2 class="mb-4">{{ __('Edit Employer') }}</h2>
+    <h2 class="mb-4"
+        draggable="true"
+        ondragstart="window.startDragGlobal(event, 'employer', {
+            id: {{ $employer->id }},
+            title: '{{ addslashes($employer->employerNameTh) }}',
+            subtitle: '{{ addslashes($employer->employerNameEn) }}'
+        })"
+        style="cursor: grab; display: inline-block;">
+        {{ __('Edit Employer') }}
+    </h2>
     <form id="employerForm" action="{{ route('employers.update', $employer->id) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')

--- a/resources/views/groups/index.blade.php
+++ b/resources/views/groups/index.blade.php
@@ -11,7 +11,12 @@
     <div class="row g-4">
         <!-- Affiliated with Employer -->
         <div class="col-md-6">
-            <div class="card h-100 shadow-sm hover-shadow transition-all">
+            <div class="card h-100 shadow-sm hover-shadow transition-all"
+                 draggable="true"
+                 ondragstart="window.startDragGlobal(event, 'link', {
+                    title: '{{ __('สังกัดภายใต้นายจ้าง') }}',
+                    url: '{{ route('groups.affiliated.index') }}'
+                 })">
                 <div class="card-body text-center p-5">
                     <div class="mb-4">
                         <i class="bi bi-building-fill text-primary" style="font-size: 4rem;"></i>
@@ -29,7 +34,12 @@
 
         <!-- Independent / No Employer -->
         <div class="col-md-6">
-            <div class="card h-100 shadow-sm hover-shadow transition-all">
+            <div class="card h-100 shadow-sm hover-shadow transition-all"
+                 draggable="true"
+                 ondragstart="window.startDragGlobal(event, 'link', {
+                    title: '{{ __('ไม่สังกัดนายจ้าง') }}',
+                    url: '{{ route('groups.independent.manage') }}'
+                 })">
                 <div class="card-body text-center p-5">
                     <div class="mb-4">
                         <i class="bi bi-diagram-3-fill text-success" style="font-size: 4rem;"></i>

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -26,7 +26,13 @@
     }
 @endphp
 
-<div class="alert {{ $card_class }} notification-item">
+<div class="alert {{ $card_class }} notification-item"
+     draggable="true"
+     ondragstart="window.startDragGlobal(event, 'notification', {
+        id: {{ $notification->id }},
+        title: '{{ addslashes($notification->type) }}',
+        subtitle: '{{ addslashes($employee ? $employee->employeeNameTh : ($employer->employerNameTh ?? '')) }}'
+     })">
     <div class="d-flex align-items-center gap-3">
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
         @if($employee)

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -13,7 +13,12 @@
     }
 @endphp
 
-<tr>
+<tr draggable="true"
+    ondragstart="window.startDragGlobal(event, 'notification', {
+        id: {{ $notification->id }},
+        title: '{{ addslashes($notification->type) }}',
+        subtitle: '{{ addslashes($employee ? $employee->employeeNameTh : ($employer->employerNameTh ?? '')) }}'
+    })">
     <td>
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
         @if($employee)

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -2,7 +2,13 @@
     $employerName = $employee->employer->employerNameTh ?? 'N/A';
 @endphp
 
-<div id="employee-card-{{ $employee->id }}" class="employee-card card mb-3">
+<div id="employee-card-{{ $employee->id }}" class="employee-card card mb-3"
+     draggable="true"
+     ondragstart="window.startDragGlobal(event, 'employee', {
+        id: {{ $employee->id }},
+        title: '{{ addslashes($employee->employeeNameTh) }}',
+        subtitle: '{{ addslashes($employee->employeeNameEn) }}'
+     })">
     <div class="card-body d-flex align-items-center">
         <div class="me-3">
             <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}" data-employer-id="{{ $employee->employer_id }}">


### PR DESCRIPTION
- Enabled draggable items in Notifications, Incomplete Data, Employment History, Employer Edit, Ticket Details, and Group Selection menus.
- Implemented `startDragGlobal` triggers on relevant rows and cards.
- Ensured data passed to `ondragstart` is safe from syntax errors and XSS by using `addslashes` for user-generated content.
- Verified frontend functionality via Playwright script.