### PR TITLE
Fix blank drawer content in Group & Team management

### DIFF
--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -150,7 +150,7 @@
                             </div>
 
                             <!-- Members Cards -->
-                            <div class="employee-list">
+                            <div class="employee-list" x-ignore>
                                 @if($type === 'independent')
                                     {{-- Group by Employer --}}
                                     @php


### PR DESCRIPTION
When expanding an accordion drawer in the Group & Team management page, the content would flash briefly and then disappear. This was caused by a conflict between Alpine.js (initialized on the parent container) and Bootstrap's collapse plugin/DOM updates. Alpine.js was likely attempting to scan or manage the large server-rendered employee list during the animation, resulting in a layout recalculation error or DOM interference.

This change adds `x-ignore` to the `.employee-list` container. This directive instructs Alpine.js to skip initializing or managing that specific DOM subtree, allowing the server-rendered HTML to persist correctly after the Bootstrap collapse animation completes. The `employee-list` does not contain any Alpine-dependent functionality (it uses standard Blade loops, native/SweetAlert JS events, and Bootstrap toggles), so excluding it from Alpine's scope is safe and resolves the issue.