### PR TITLE
Fix drag-and-drop functionality for chat widget across multiple menus

### DIFF
--- a/resources/views/admin/incomplete_employees/index.blade.php
+++ b/resources/views/admin/incomplete_employees/index.blade.php
@@ -96,12 +96,13 @@
             <div class="row g-3">
                 @foreach($employees as $employee)
                     <div class="col-12 col-md-6 col-xl-4 position-relative" draggable="true"
-                         @dragstart="startDragGlobal($event, 'employee', {
-                            id: {{ $employee->id }},
-                            title: '{{ $employee->employeeNameEn }}',
-                            subtitle: '{{ optional($employee->employer)->employerNameTh }}',
-                            url: '{{ route('employees.show', $employee->id) }}'
-                         })">
+                         data-drag-payload="{{ json_encode([
+                            'id' => $employee->id,
+                            'title' => $employee->employeeNameEn,
+                            'subtitle' => optional($employee->employer)->employerNameTh,
+                            'url' => route('employees.show', $employee->id)
+                         ]) }}"
+                         ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                         @include('employees._employee_card', ['employee' => $employee, 'is_incomplete_view' => true])
                     </div>
                 @endforeach
@@ -126,12 +127,13 @@
                         <tbody>
                             @foreach($employees as $employee)
                             <tr draggable="true"
-                                @dragstart="startDragGlobal($event, 'employee', {
-                                    id: {{ $employee->id }},
-                                    title: '{{ $employee->employeeNameEn }}',
-                                    subtitle: '{{ optional($employee->employer)->employerNameTh }}',
-                                    url: '{{ route('employees.show', $employee->id) }}'
-                                })">
+                                data-drag-payload="{{ json_encode([
+                                    'id' => $employee->id,
+                                    'title' => $employee->employeeNameEn,
+                                    'subtitle' => optional($employee->employer)->employerNameTh,
+                                    'url' => route('employees.show', $employee->id)
+                                ]) }}"
+                                ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                                 <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}"></td>
                                 <td>
                                     <div class="d-flex align-items-center">

--- a/resources/views/admin/tickets/index.blade.php
+++ b/resources/views/admin/tickets/index.blade.php
@@ -52,12 +52,13 @@
                 @forelse ($tickets as $ticket)
                 <tr class="{{ $ticket->admin_unread_count > 0 ? 'table-info' : '' }}"
                     draggable="true"
-                    ondragstart="window.startDragGlobal(event, 'ticket', {
-                        id: {{ $ticket->id }},
-                        title: @json($ticket->subject),
-                        subtitle: 'Ticket #{{ $ticket->id }}',
-                        url: '{{ route('admin.tickets.show', $ticket) }}'
-                    })"
+                    data-drag-payload="{{ json_encode([
+                        'id' => $ticket->id,
+                        'title' => $ticket->subject,
+                        'subtitle' => 'Ticket #' . $ticket->id,
+                        'url' => route('admin.tickets.show', $ticket)
+                    ]) }}"
+                    ondragstart="window.startDragGlobal(event, 'ticket', JSON.parse(this.dataset.dragPayload))"
                     style="cursor: grab;">
                     <td>{{ $ticket->id }}</td>
                     <td>

--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -545,7 +545,12 @@
             // --- Drag & Drop for Data Sharing ---
             handleDrop(e, targetType, targetId) {
                 e.preventDefault();
-                const rawData = e.dataTransfer.getData('application/json');
+                // Try to get data from application/json, fallback to text/plain
+                let rawData = e.dataTransfer.getData('application/json');
+                if (!rawData) {
+                    rawData = e.dataTransfer.getData('text/plain');
+                }
+
                 if (!rawData) return;
 
                 let data;

--- a/resources/views/employees/_history_card.blade.php
+++ b/resources/views/employees/_history_card.blade.php
@@ -5,7 +5,15 @@
     $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
 @endphp
 
-<div id="history-row-{{ $employee->id }}" class="list-group-item list-group-item-action">
+<div id="history-row-{{ $employee->id }}" class="list-group-item list-group-item-action"
+    draggable="true"
+    data-drag-payload="{{ json_encode([
+        'id' => $employee->id,
+        'title' => $employeeFullNameEn,
+        'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
+        'url' => route('employees.show', $employee->id)
+    ]) }}"
+    ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
     <div class="d-flex w-100">
         {{-- Checkbox --}}
         <div class="me-3 d-flex align-items-center">

--- a/resources/views/employees/history.blade.php
+++ b/resources/views/employees/history.blade.php
@@ -74,12 +74,13 @@
         <div class="list-group">
             @forelse($employees as $employee)
                 <div class="position-relative" draggable="true"
-                     @dragstart="startDragGlobal($event, 'employee', {
-                        id: {{ $employee->id }},
-                        title: '{{ $employee->employeeFullName }}',
-                        subtitle: 'Terminated: {{ $employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : '' }}',
-                        url: '{{ route('employees.show', $employee->id) }}'
-                     })">
+                     data-drag-payload="{{ json_encode([
+                        'id' => $employee->id,
+                        'title' => $employee->employeeFullName,
+                        'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
+                        'url' => route('employees.show', $employee->id)
+                     ]) }}"
+                     ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                     @include('employees._history_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees])
                 </div>
             @empty
@@ -102,12 +103,13 @@
                 <tbody id="historyTableBody">
                     @forelse($employees as $employee)
                     <tr id="history-row-{{ $employee->id }}" draggable="true"
-                        @dragstart="startDragGlobal($event, 'employee', {
-                            id: {{ $employee->id }},
-                            title: '{{ $employee->employeeFullName }}',
-                            subtitle: 'Terminated: {{ $employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : '' }}',
-                            url: '{{ route('employees.show', $employee->id) }}'
-                        })">
+                        data-drag-payload="{{ json_encode([
+                            'id' => $employee->id,
+                            'title' => $employee->employeeFullName,
+                            'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
+                            'url' => route('employees.show', $employee->id)
+                        ]) }}"
+                        ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                         <td><input class="form-check-input history-employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}"></td>
                         <td>
                             <div class="d-flex align-items-center">

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -23,12 +23,13 @@
 
 {{-- Employer Info Form --}}
 <div class="content-section" draggable="true"
-     @dragstart="startDragGlobal($event, 'employer', {
-        id: {{ $employer->id }},
-        title: '{{ $employer->employerNameTh }}',
-        subtitle: '{{ $employer->employerNameEn }}',
-        url: '{{ route('employers.edit', $employer->id) }}'
-     })">
+     data-drag-payload="{{ json_encode([
+        'id' => $employer->id,
+        'title' => $employer->employerNameTh,
+        'subtitle' => $employer->employerNameEn,
+        'url' => route('employers.edit', $employer->id)
+     ]) }}"
+     ondragstart="window.startDragGlobal(event, 'employer', JSON.parse(this.dataset.dragPayload))">
     <h2 class="mb-4">{{ __('Edit Employer') }}</h2>
     <form id="employerForm" action="{{ route('employers.update', $employer->id) }}" method="POST" enctype="multipart/form-data">
         @csrf
@@ -420,12 +421,13 @@
             <div class="list-group">
             @forelse($employees as $employee)
                 <div class="position-relative" draggable="true"
-                     @dragstart="startDragGlobal($event, 'employee', {
-                        id: {{ $employee->id }},
-                        title: '{{ $employee->employeeFullName }}',
-                        subtitle: '{{ $employer->employerNameTh }}',
-                        url: '{{ route('employees.show', $employee->id) }}'
-                     })">
+                     data-drag-payload="{{ json_encode([
+                        'id' => $employee->id,
+                        'title' => $employee->employeeFullName,
+                        'subtitle' => $employer->employerNameTh,
+                        'url' => route('employees.show', $employee->id)
+                     ]) }}"
+                     ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                     {{-- DEFINITIVE FIX: Use the single, unified partial --}}
                     @include('partials._employee_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees, 'showLocateButton' => false])
                 </div>
@@ -451,12 +453,13 @@
                     <tbody>
                         @forelse($employees as $employee)
                             <tr id="employee-row-{{ $employee->id }}" draggable="true"
-                                @dragstart="startDragGlobal($event, 'employee', {
-                                    id: {{ $employee->id }},
-                                    title: '{{ $employee->employeeFullName }}',
-                                    subtitle: '{{ $employer->employerNameTh }}',
-                                    url: '{{ route('employees.show', $employee->id) }}'
-                                })">
+                                data-drag-payload="{{ json_encode([
+                                    'id' => $employee->id,
+                                    'title' => $employee->employeeFullName,
+                                    'subtitle' => $employer->employerNameTh,
+                                    'url' => route('employees.show', $employee->id)
+                                ]) }}"
+                                ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                                 {{-- DEFINITIVE FIX: Add checkbox for bulk actions --}}
                                 <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}"></td>
                                 <td>{{ $employees->firstItem() + $loop->index }}</td>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -486,7 +486,9 @@
             ...data
         };
         e.dataTransfer.effectAllowed = 'copy';
-        e.dataTransfer.setData('application/json', JSON.stringify(payload));
+        const jsonPayload = JSON.stringify(payload);
+        e.dataTransfer.setData('application/json', jsonPayload);
+        e.dataTransfer.setData('text/plain', jsonPayload); // Fallback for broader compatibility
     }
     </script>
 

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -27,12 +27,13 @@
 @endphp
 
 <div class="alert {{ $card_class }} notification-item" draggable="true"
-     @dragstart="startDragGlobal($event, 'notification', {
-        id: {{ $notification->id }},
-        title: '{{ $notification->type }}',
-        subtitle: '{{ $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? '') }}',
-        url: '{{ route('notifications.index') }}'
-    })">
+     data-drag-payload="{{ json_encode([
+        'id' => $notification->id,
+        'title' => $notification->type,
+        'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
+        'url' => route('notifications.index')
+     ]) }}"
+     ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
     <div class="d-flex align-items-center gap-3">
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
         @if($employee)

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -14,12 +14,13 @@
 @endphp
 
 <tr draggable="true"
-    @dragstart="startDragGlobal($event, 'notification', {
-        id: {{ $notification->id }},
-        title: '{{ $notification->type }}',
-        subtitle: '{{ $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? '') }}',
-        url: '{{ route('notifications.index') }}' // Ideally link to specific item
-    })">
+    data-drag-payload="{{ json_encode([
+        'id' => $notification->id,
+        'title' => $notification->type,
+        'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
+        'url' => route('notifications.index')
+    ]) }}"
+    ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
     <td>
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
         @if($employee)


### PR DESCRIPTION
- Switched from framework-specific `@dragstart` to native `ondragstart` in Blade templates for Notification, Employee History, Incomplete Data, Employer Edit, and Ticket Box menus.
- Implemented `text/plain` fallback for drag data transfer to improve browser compatibility.
- Refactored `ondragstart` handlers to use `data-drag-payload` attribute with `json_encode` to robustly handle special characters (like single quotes) in data fields.
- Updated `layouts/app.blade.php` and `components/chat-widget.blade.php` to support the new data transfer logic.