### PR TITLE
Fix chat navigation, highlighting, and drag-and-drop functionality

### DIFF
--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -243,13 +243,15 @@
                                             </div>
                                             <div class="d-flex align-items-center justify-content-between mt-1">
                                                 <small class="text-muted text-truncate" style="max-width: 100px;" x-text="msg.context_data.subtitle"></small>
-                                                <button type="button" class="btn btn-sm btn-outline-info btn-preview py-0 px-1 ms-2"
-                                                        style="font-size: 0.7rem;"
-                                                        :data-model-id="msg.context_data.id"
-                                                        data-model-type="employee"
-                                                        title="{{ __('Preview') }}">
-                                                    <i class="bi bi-eye"></i> {{ __('Preview') }}
-                                                </button>
+                                                <template x-if="!msg.context_data.hide_preview">
+                                                    <button type="button" class="btn btn-sm btn-outline-info btn-preview py-0 px-1 ms-2"
+                                                            style="font-size: 0.7rem;"
+                                                            :data-model-id="msg.context_data.id"
+                                                            data-model-type="employee"
+                                                            title="{{ __('Preview') }}">
+                                                        <i class="bi bi-eye"></i> {{ __('Preview') }}
+                                                    </button>
+                                                </template>
                                             </div>
                                         </div>
                                     </template>

--- a/resources/views/employees/_history_card.blade.php
+++ b/resources/views/employees/_history_card.blade.php
@@ -5,13 +5,14 @@
     $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
 @endphp
 
-<div id="history-row-{{ $employee->id }}" class="list-group-item list-group-item-action"
+<div id="history-card-{{ $employee->id }}" class="list-group-item list-group-item-action"
     draggable="true"
     data-drag-payload="{{ json_encode([
         'id' => $employee->id,
         'title' => $employeeFullNameEn,
         'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
-        'url' => route('employees.show', $employee->id)
+        'url' => route('employees.history', ['highlight_employee_id' => $employee->id]),
+        'photo_url' => $employee->photo_url
     ]) }}"
     ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
     <div class="d-flex w-100">

--- a/resources/views/employees/history.blade.php
+++ b/resources/views/employees/history.blade.php
@@ -78,7 +78,8 @@
                         'id' => $employee->id,
                         'title' => $employee->employeeFullName,
                         'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
-                        'url' => route('employees.show', $employee->id)
+                        'url' => route('employees.history', ['highlight_employee_id' => $employee->id]),
+                        'photo_url' => $employee->photo_url
                      ]) }}"
                      ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                     @include('employees._history_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees])
@@ -107,7 +108,8 @@
                             'id' => $employee->id,
                             'title' => $employee->employeeFullName,
                             'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
-                            'url' => route('employees.show', $employee->id)
+                            'url' => route('employees.history', ['highlight_employee_id' => $employee->id]),
+                            'photo_url' => $employee->photo_url
                         ]) }}"
                         ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                         <td><input class="form-check-input history-employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}"></td>

--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -116,11 +116,12 @@
                     aria-controls="group-content-{{ $group->id }}"
                     aria-selected="{{ $index === 0 ? 'true' : 'false' }}"
                     draggable="true"
-                    @dragstart="startDragGlobal($event, 'link', {
-                        title: '{{ $group->name }}',
-                        subtitle: 'Group',
-                        url: '{{ request()->fullUrlWithQuery(['active_group' => $group->id]) }}'
-                    })">
+                    data-drag-payload="{{ json_encode([
+                        'title' => $group->name,
+                        'subtitle' => 'Group',
+                        'url' => request()->fullUrlWithQuery(['active_group' => $group->id])
+                    ]) }}"
+                    ondragstart="window.startDragGlobal(event, 'link', JSON.parse(this.dataset.dragPayload))">
                 {{ $group->name }}
             </button>
         </li>
@@ -163,11 +164,12 @@
                 <div class="accordion-item">
                     <h2 class="accordion-header" id="headingTeam{{ $team->id }}"
                         draggable="true"
-                        @dragstart="startDragGlobal($event, 'link', {
-                            title: '{{ $team->name }}',
-                            subtitle: 'Team in {{ $group->name }}',
-                            url: '{{ request()->fullUrlWithQuery(['active_group' => $group->id, 'active_team' => $team->id]) }}'
-                        })">
+                        data-drag-payload="{{ json_encode([
+                            'title' => $team->name,
+                            'subtitle' => 'Team in ' . $group->name,
+                            'url' => request()->fullUrlWithQuery(['active_group' => $group->id, 'active_team' => $team->id])
+                        ]) }}"
+                        ondragstart="window.startDragGlobal(event, 'link', JSON.parse(this.dataset.dragPayload))">
                         <button class="accordion-button {{ request('active_team') == $team->id ? '' : 'collapsed' }}"
                                 type="button"
                                 data-bs-toggle="collapse"
@@ -211,24 +213,26 @@
                                         <div class="mb-3">
                                             <h5 class="bg-light p-2 rounded border-start border-4 border-primary"
                                                 draggable="true"
-                                                @dragstart="startDragGlobal($event, 'employees_bulk', {
-                                                    title: '{{ $employerName }} - {{ $team->name }}',
-                                                    count: {{ $members->count() }},
-                                                    subtitle: '{{ $members->count() }} members',
-                                                    // In a real scenario, we might need a specific URL or data structure to handle a group of employees
-                                                    url: '#'
-                                                })">
+                                                data-drag-payload="{{ json_encode([
+                                                    'title' => $employerName . ' - ' . $team->name,
+                                                    'count' => $members->count(),
+                                                    'subtitle' => $members->count() . ' members',
+                                                    'url' => '#'
+                                                ]) }}"
+                                                ondragstart="window.startDragGlobal(event, 'employees_bulk', JSON.parse(this.dataset.dragPayload))">
                                                 <i class="bi bi-building me-2"></i>{{ $employerName }}
                                             </h5>
                                             <div class="list-group">
                                                 @foreach($members as $member)
                                                     <div draggable="true"
-                                                         @dragstart="startDragGlobal($event, 'employee', {
-                                                            id: {{ $member->id }},
-                                                            title: '{{ $member->employeeFullName }}',
-                                                            subtitle: '{{ $team->name }}',
-                                                            url: '{{ route('employees.show', $member->id) }}'
-                                                         })">
+                                                         data-drag-payload="{{ json_encode([
+                                                            'id' => $member->id,
+                                                            'title' => $member->employeeFullName,
+                                                            'subtitle' => $team->name,
+                                                            'url' => route('employees.show', $member->id),
+                                                            'photo_url' => $member->photo_url
+                                                         ]) }}"
+                                                         ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                                                         @include('partials._employee_card', [
                                                             'employee' => $member,
                                                             'loop' => $loop,
@@ -251,12 +255,14 @@
                                     <div class="list-group">
                                         @forelse($team->employees as $member)
                                             <div draggable="true"
-                                                 @dragstart="startDragGlobal($event, 'employee', {
-                                                    id: {{ $member->id }},
-                                                    title: '{{ $member->employeeFullName }}',
-                                                    subtitle: '{{ $team->name }}',
-                                                    url: '{{ route('employees.show', $member->id) }}'
-                                                 })">
+                                                 data-drag-payload="{{ json_encode([
+                                                    'id' => $member->id,
+                                                    'title' => $member->employeeFullName,
+                                                    'subtitle' => $team->name,
+                                                    'url' => route('employees.show', $member->id),
+                                                    'photo_url' => $member->photo_url
+                                                 ]) }}"
+                                                 ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                                                 @include('partials._employee_card', [
                                                     'employee' => $member,
                                                     'loop' => $loop,

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -490,6 +490,63 @@
         e.dataTransfer.setData('application/json', jsonPayload);
         e.dataTransfer.setData('text/plain', jsonPayload); // Fallback for broader compatibility
     }
+
+    // Global Highlight Helper
+    document.addEventListener('DOMContentLoaded', function() {
+        const highlightElement = (id) => {
+            const el = document.getElementById(id);
+            if (el) {
+                el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                el.classList.add('highlight');
+                // Remove highlight after 5 seconds if desired, or keep it. User asked to "highlight", usually implies keeping it or long duration.
+                // We'll keep it or let CSS handle it.
+            }
+        };
+
+        const urlParams = new URLSearchParams(window.location.search);
+
+        // 1. Check for Notification Highlight
+        const notifId = urlParams.get('highlight_notification_id');
+        if (notifId) {
+            // Try both row and item IDs
+            if (document.getElementById('notification-row-' + notifId)) {
+                highlightElement('notification-row-' + notifId);
+            } else if (document.getElementById('notification-item-' + notifId)) {
+                highlightElement('notification-item-' + notifId);
+            }
+        }
+
+        // 2. Check for Employee Highlight (Query Param)
+        const empId = urlParams.get('highlight_employee_id');
+        if (empId) {
+             if (document.getElementById('history-row-' + empId)) {
+                highlightElement('history-row-' + empId);
+            } else if (document.getElementById('history-card-' + empId)) {
+                 highlightElement('history-card-' + empId);
+            } else if (document.getElementById('employee-card-' + empId)) { // Standard card
+                 highlightElement('employee-card-' + empId);
+            }
+        }
+
+        // 3. Check for Session Flash (Existing Controller Logic)
+        @if(session('highlight_employee'))
+            const sessionEmpId = "{{ session('highlight_employee') }}";
+            // Check prefix scenarios if necessary, but usually standard ID
+            // Partial _employee_card uses 'employee-card-' + id
+            // But sometimes prefix is empty.
+            // Let's try standard ID first.
+             if (document.getElementById('employee-card-' + sessionEmpId)) {
+                 highlightElement('employee-card-' + sessionEmpId);
+            } else {
+                 // Try looking for any element with data-employee-id that matches
+                 const card = document.querySelector(`.employee-card [data-employee-id="${sessionEmpId}"]`)?.closest('.employee-card');
+                 if(card) {
+                     card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                     card.classList.add('highlight');
+                 }
+            }
+        @endif
+    });
     </script>
 
     <script>

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -24,16 +24,30 @@
         $card_class = 'alert-warning';
         $badge_class = 'bg-warning text-dark';
     }
+
+    $dragType = 'notification';
+    $dragUrl = route('notifications.index', ['highlight_notification_id' => $notification->id]);
+    $hidePreview = false;
+
+    if ($employee) {
+        $dragType = 'employee';
+        $hidePreview = true;
+        if ($isMissingDataType) {
+             $dragUrl = route('employees.locate', $employee->id);
+        }
+    }
 @endphp
 
-<div class="alert {{ $card_class }} notification-item" draggable="true"
+<div id="notification-item-{{ $notification->id }}" class="alert {{ $card_class }} notification-item" draggable="true"
      data-drag-payload="{{ json_encode([
-        'id' => $notification->id,
-        'title' => $notification->type,
-        'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
-        'url' => route('notifications.index')
+        'id' => $employee ? $employee->id : $notification->id,
+        'title' => $employee ? $employee->employeeFullName : $notification->type,
+        'subtitle' => $employee ? ($employer->employerNameTh ?? '') : ($employer->employerNameTh ?? ''),
+        'url' => $dragUrl,
+        'hide_preview' => $hidePreview,
+        'photo_url' => $employee ? $employee->photo_url : null
      ]) }}"
-     ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
+     ondragstart="window.startDragGlobal(event, '{{ $dragType }}', JSON.parse(this.dataset.dragPayload))">
     <div class="d-flex align-items-center gap-3">
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
         @if($employee)

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -13,14 +13,30 @@
     }
 @endphp
 
-<tr draggable="true"
+@php
+    $dragType = 'notification';
+    $dragUrl = route('notifications.index', ['highlight_notification_id' => $notification->id]);
+    $hidePreview = false;
+
+    if ($employee) {
+        $dragType = 'employee';
+        $hidePreview = true;
+        if (in_array($notification->type, ['pink_card_missing', 'residence_permit_missing'])) {
+            // Incomplete info -> Go to Employer Edit
+            $dragUrl = route('employees.locate', $employee->id);
+        }
+    }
+@endphp
+<tr id="notification-row-{{ $notification->id }}" draggable="true"
     data-drag-payload="{{ json_encode([
-        'id' => $notification->id,
-        'title' => $notification->type,
-        'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
-        'url' => route('notifications.index')
+        'id' => $employee ? $employee->id : $notification->id, // If employee, use employee ID for card logic
+        'title' => $employee ? $employee->employeeFullName : $notification->type,
+        'subtitle' => $employee ? ($employer->employerNameTh ?? '') : ($employer->employerNameTh ?? ''),
+        'url' => $dragUrl,
+        'hide_preview' => $hidePreview,
+        'photo_url' => $employee ? $employee->photo_url : null // Ensure photo is passed for employee card
     ]) }}"
-    ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
+    ondragstart="window.startDragGlobal(event, '{{ $dragType }}', JSON.parse(this.dataset.dragPayload))">
     <td>
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
         @if($employee)


### PR DESCRIPTION
- Added global highlighting script in app layout to handle URL params and session flash.
- Fixed Group/Team drag-and-drop by using native `ondragstart` instead of Alpine's `@dragstart` inside `x-ignore` blocks.
- Updated Notification chat payloads to navigate to specific rows/items and hide preview button.
- Updated Employment History chat payloads to navigate to history page and highlight row/card.
- Implemented `hide_preview` support in Chat Widget.