### PR TITLE
Update chat employee links to redirect to locate route

### DIFF
--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -111,7 +111,7 @@
                                         id: {{ $employee->id }},
                                         title: '{{ $employee->employeeNameTh }}',
                                         subtitle: '{{ $employee->employeeNameEn }}',
-                                        url: '{{ route('employees.show', $employee->id) }}'
+                                        url: '{{ route('employees.locate', $employee->id) }}'
                                      })">
                                     <div class="form-check mb-0">
                                         <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}">
@@ -160,7 +160,7 @@
                                         id: {{ $employee->id }},
                                         title: '{{ $employee->employeeNameTh }}',
                                         subtitle: '{{ $employee->employeeNameEn }}',
-                                        url: '{{ route('employees.show', $employee->id) }}'
+                                        url: '{{ route('employees.locate', $employee->id) }}'
                                      })">
                                     {{-- External employees don't have bulk actions for now --}}
                                     <div class="position-relative">
@@ -473,7 +473,7 @@
                                                 id: item.id,
                                                 title: item.employeeNameTh || item.employeeNameEn,
                                                 subtitle: item.employeeNameEn ? item.employeeNameEn : item.employeeCode,
-                                                url: item.url || '#'
+                                                url: '/employees/' + item.id + '/locate'
                                              })">
                                             <div class="d-flex align-items-center gap-3">
                                                 <img :src="item.photo_url" alt="Photo" class="rounded-circle" style="width: 35px; height: 35px; object-fit: cover;">
@@ -495,7 +495,7 @@
                                                 id: item.id,
                                                 title: item.employeeNameTh || item.employeeNameEn,
                                                 subtitle: (item.employer_name || 'Ext') + (item.employeeNameEn ? ' - ' + item.employeeNameEn : ''),
-                                                url: item.url || '#'
+                                                url: '/employees/' + item.id + '/locate'
                                              })">
                                             <div class="d-flex align-items-center gap-3">
                                                 <img :src="item.photo_url" alt="Photo" class="rounded-circle" style="width: 35px; height: 35px; object-fit: cover;">

--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -241,7 +241,7 @@
                                     <template x-if="msg.context_data.type === 'employee'">
                                         <div class="d-flex flex-column gap-1 p-1 border-start border-3 border-warning bg-white bg-opacity-75 rounded-end text-dark">
                                             <div class="d-flex align-items-center justify-content-between">
-                                                <a :href="msg.context_data.url" class="fw-bold text-decoration-none text-dark d-flex align-items-center gap-2 text-truncate" style="font-size: 0.9rem;">
+                                                <a :href="'/employees/' + msg.context_data.id + '/locate'" class="fw-bold text-decoration-none text-dark d-flex align-items-center gap-2 text-truncate" style="font-size: 0.9rem;">
                                                      <i class="bi bi-person-badge-fill text-warning"></i>
                                                      <span x-text="msg.context_data.name"></span>
                                                 </a>
@@ -593,10 +593,7 @@
                     }
                     else if (data.type === 'employee') {
                         contextType = 'employee';
-                         // Only use locate URL if data.url is NOT provided (fallback)
-                         if (!contextUrl || contextUrl === window.location.href) {
-                             contextUrl = `/employees/${data.id}/locate`;
-                         }
+                        contextUrl = `/employees/${data.id}/locate`;
                     }
                     else if (data.type === 'employer') {
                         contextType = 'employer';

--- a/resources/views/tickets/partials/_basket_display_templates.blade.php
+++ b/resources/views/tickets/partials/_basket_display_templates.blade.php
@@ -11,7 +11,7 @@
             id: item.id,
             title: item.employeeNameTh || item.employeeNameEn,
             subtitle: item.employeeNameEn ? item.employeeNameEn : item.employeeCode,
-            url: item.url || '#'
+            url: '/employees/' + item.id + '/locate'
          })">
         <div class="d-flex align-items-center gap-3">
             <img :src="item.photo_url" alt="Photo" class="rounded-circle" style="width: 35px; height: 35px; object-fit: cover;">
@@ -35,7 +35,7 @@
             id: item.id,
             title: item.employeeNameTh || item.employeeNameEn,
             subtitle: (item.employer_name || 'Ext') + (item.employeeNameEn ? ' - ' + item.employeeNameEn : ''),
-            url: item.url || '#'
+            url: '/employees/' + item.id + '/locate'
          })">
         <div class="d-flex align-items-center gap-3">
              <div class="position-relative">


### PR DESCRIPTION
Modified the chat widget and ticket attachment views to ensure that clicking on an employee name navigates to the 'employees.locate' route instead of the generic show page. This ensures users are directed to the specific employee context within the employer edit page.

- Updated `resources/views/components/chat-widget.blade.php` to force `/employees/{id}/locate` URL.
- Updated `resources/views/admin/tickets/show.blade.php` to use `route('employees.locate')` in drag handlers.
- Updated `resources/views/tickets/partials/_basket_display_templates.blade.php` to use locate URL in drag handlers.