### PR TITLE
Update chat navigation logic and fix drag-and-drop issues

### DIFF
--- a/resources/views/admin/incomplete_employees/index.blade.php
+++ b/resources/views/admin/incomplete_employees/index.blade.php
@@ -99,7 +99,7 @@
                             'id' => $employee->id,
                             'title' => $employee->employeeNameEn,
                             'subtitle' => optional($employee->employer)->employerNameTh,
-                            'url' => route('employees.show', $employee->id)
+                            'url' => route('employers.edit', $employee->employer_id) . '?highlight_employee=' . $employee->id
                          ]) }}"
                          ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                         @include('employees._employee_card', ['employee' => $employee, 'is_incomplete_view' => true])
@@ -130,7 +130,7 @@
                                     'id' => $employee->id,
                                     'title' => $employee->employeeNameEn,
                                     'subtitle' => optional($employee->employer)->employerNameTh,
-                                    'url' => route('employees.show', $employee->id)
+                                    'url' => route('employers.edit', $employee->employer_id) . '?highlight_employee=' . $employee->id
                                 ]) }}"
                                 ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                                 <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}"></td>

--- a/resources/views/employees/_history_card.blade.php
+++ b/resources/views/employees/_history_card.blade.php
@@ -11,7 +11,7 @@
         'id' => $employee->id,
         'title' => $employeeFullNameEn,
         'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
-        'url' => route('employees.show', $employee->id)
+        'url' => route('employees.history') . '?highlight_employee=' . $employee->id
     ]) }}"
     ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
     <div class="d-flex w-100">

--- a/resources/views/employees/history.blade.php
+++ b/resources/views/employees/history.blade.php
@@ -78,7 +78,7 @@
                         'id' => $employee->id,
                         'title' => $employee->employeeFullName,
                         'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
-                        'url' => route('employees.show', $employee->id)
+                        'url' => route('employees.history') . '?highlight_employee=' . $employee->id
                      ]) }}"
                      ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                     @include('employees._history_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees])
@@ -107,7 +107,7 @@
                             'id' => $employee->id,
                             'title' => $employee->employeeFullName,
                             'subtitle' => 'Terminated: ' . ($employee->terminated_at ? $employee->terminated_at->format('d/m/Y') : ''),
-                            'url' => route('employees.show', $employee->id)
+                            'url' => route('employees.history') . '?highlight_employee=' . $employee->id
                         ]) }}"
                         ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                         <td><input class="form-check-input history-employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}"></td>
@@ -154,6 +154,38 @@
 @push('scripts')
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+    // Highlight Logic
+    const highlightEmployeeId = "{{ request('highlight_employee') }}";
+    if (highlightEmployeeId) {
+        let target = document.getElementById(`history-row-${highlightEmployeeId}`);
+        if (target) {
+            setTimeout(() => {
+                target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                // Add highlight style or class
+                target.classList.add('table-primary'); // Using bootstrap class for table row
+                target.style.transition = 'background-color 0.5s ease';
+
+                // If it's a card view, it might need different styling
+                if (!target.classList.contains('list-group-item')) {
+                     // Table row logic
+                     // Maybe add border
+                     target.style.outline = '2px solid #F97316';
+                } else {
+                     // Card view logic
+                     target.style.border = '2px solid #F97316';
+                     target.style.backgroundColor = '#fff7ed';
+                }
+
+                // Remove highlight after some time? User usually prefers persistence until click
+                // setTimeout(() => {
+                //    target.classList.remove('table-primary');
+                //    target.style.outline = '';
+                //    target.style.backgroundColor = '';
+                // }, 5000);
+            }, 500);
+        }
+    }
+
     const bulkExportBtn = document.getElementById('history-bulk-advanced-export-btn');
     if (bulkExportBtn) {
         bulkExportBtn.addEventListener('click', function(e) {

--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -232,23 +232,25 @@
                                             <div class="mb-3">
                                                 <h5 class="bg-light p-2 rounded border-start border-4 border-primary"
                                                     draggable="true"
-                                                    @dragstart="startDragGlobal($event, 'employees_bulk', {
-                                                        title: '{{ $employerName }} - {{ $team->name }}',
-                                                        count: {{ $members->count() }},
-                                                        subtitle: '{{ $members->count() }} members',
-                                                        url: '#'
-                                                    })">
+                                                    data-drag-payload="{{ json_encode([
+                                                        'title' => $employerName . ' - ' . $team->name,
+                                                        'count' => $members->count(),
+                                                        'subtitle' => $members->count() . ' members',
+                                                        'url' => '#'
+                                                    ]) }}"
+                                                    ondragstart="window.startDragGlobal(event, 'employees_bulk', JSON.parse(this.dataset.dragPayload))">
                                                     <i class="bi bi-building me-2"></i>{{ $employerName }}
                                                 </h5>
                                                 <div class="list-group">
                                                     @foreach($members as $member)
                                                         <div draggable="true"
-                                                             @dragstart="startDragGlobal($event, 'employee', {
-                                                                id: {{ $member->id }},
-                                                                title: '{{ $member->employeeFullName }}',
-                                                                subtitle: '{{ $team->name }}',
-                                                                url: '{{ route('employees.show', $member->id) }}'
-                                                             })">
+                                                             data-drag-payload="{{ json_encode([
+                                                                'id' => $member->id,
+                                                                'title' => $member->employeeFullName,
+                                                                'subtitle' => $team->name,
+                                                                'url' => route('employees.show', $member->id)
+                                                             ]) }}"
+                                                             ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                                                             @include('partials._employee_card', [
                                                                 'employee' => $member,
                                                                 'loop' => $loop,
@@ -271,12 +273,13 @@
                                         <div class="list-group">
                                             @forelse($team->employees as $member)
                                                 <div draggable="true"
-                                                     @dragstart="startDragGlobal($event, 'employee', {
-                                                        id: {{ $member->id }},
-                                                        title: '{{ $member->employeeFullName }}',
-                                                        subtitle: '{{ $team->name }}',
-                                                        url: '{{ route('employees.show', $member->id) }}'
-                                                     })">
+                                                     data-drag-payload="{{ json_encode([
+                                                        'id' => $member->id,
+                                                        'title' => $member->employeeFullName,
+                                                        'subtitle' => $team->name,
+                                                        'url' => route('employees.show', $member->id)
+                                                     ]) }}"
+                                                     ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                                                     @include('partials._employee_card', [
                                                         'employee' => $member,
                                                         'loop' => $loop,

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -26,12 +26,12 @@
     }
 @endphp
 
-<div class="alert {{ $card_class }} notification-item" draggable="true"
+<div id="notification-item-{{ $notification->id }}" class="alert {{ $card_class }} notification-item" draggable="true"
      data-drag-payload="{{ json_encode([
         'id' => $notification->id,
         'title' => $notification->type,
         'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
-        'url' => route('notifications.index')
+        'url' => route('notifications.index') . '?highlight=' . $notification->id
      ]) }}"
      ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
     <div class="d-flex align-items-center gap-3">

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -13,12 +13,12 @@
     }
 @endphp
 
-<tr draggable="true"
+<tr id="notification-row-{{ $notification->id }}" draggable="true"
     data-drag-payload="{{ json_encode([
         'id' => $notification->id,
         'title' => $notification->type,
         'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
-        'url' => route('notifications.index')
+        'url' => route('notifications.index') . '?highlight=' . $notification->id
     ]) }}"
     ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
     <td>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -531,6 +531,36 @@
         // Initial check in case of page reload with an active tab
         // Use a small timeout to ensure tab activation script has run
         setTimeout(updateActionBar, 100);
+
+        // Highlight Notification
+        const highlightId = "{{ request('highlight') }}";
+        if (highlightId) {
+            // Check for card view item
+            let target = document.getElementById(`notification-item-${highlightId}`);
+            // If not found, check for table row
+            if (!target) {
+                target = document.getElementById(`notification-row-${highlightId}`);
+            }
+
+            if (target) {
+                setTimeout(() => {
+                    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    target.classList.add('highlight-pulse');
+                    // Define keyframes if not exists or rely on class
+                    // We'll add inline style for the pulse or use standard class if available.
+                    // Let's add a temporary style block for this page if global style is missing
+                    target.style.transition = 'box-shadow 0.5s ease-in-out';
+                    target.style.boxShadow = '0 0 15px rgba(249, 115, 22, 0.8)';
+                    target.style.border = '2px solid #F97316';
+
+                    setTimeout(() => {
+                        target.style.boxShadow = '';
+                        // Keep border to show selection? Or remove it?
+                        // User usually likes persistent highlight until clicked elsewhere
+                    }, 5000);
+                }, 500);
+            }
+        }
     });
 </script>
 @endpush


### PR DESCRIPTION
- Modify notification chat items to navigate to the notification page with a highlight parameter instead of opening a preview.
- Update drag payloads for incomplete employees to redirect to the employer edit page with highlighting.
- Update drag payloads for employment history to redirect to the history page with highlighting.
- Fix drag-and-drop functionality in Group & Team management by replacing Alpine directives with native event handlers.
- Implement highlighting logic in notifications and employment history views.