### PR TITLE
feat: Consistent Drag-to-Chat & Preview in Notifications

### DIFF
--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -203,6 +203,25 @@
                                             </div>
                                             <div class="d-flex align-items-center justify-content-between mt-1">
                                                 <small class="text-muted text-truncate" style="max-width: 100px;" x-text="msg.context_data.subtitle"></small>
+                                                <!-- Add Preview Button for Employees/Employers -->
+                                                <template x-if="msg.context_data.employee_id">
+                                                    <button type="button" class="btn btn-sm btn-outline-info btn-preview py-0 px-1 ms-2"
+                                                            style="font-size: 0.7rem;"
+                                                            :data-model-id="msg.context_data.employee_id"
+                                                            data-model-type="employee"
+                                                            title="{{ __('Preview') }}">
+                                                        <i class="bi bi-eye"></i> {{ __('Preview') }}
+                                                    </button>
+                                                </template>
+                                                <template x-if="!msg.context_data.employee_id && msg.context_data.employer_id">
+                                                    <button type="button" class="btn btn-sm btn-outline-info btn-preview py-0 px-1 ms-2"
+                                                            style="font-size: 0.7rem;"
+                                                            :data-model-id="msg.context_data.employer_id"
+                                                            data-model-type="employer"
+                                                            title="{{ __('Preview') }}">
+                                                        <i class="bi bi-eye"></i> {{ __('Preview') }}
+                                                    </button>
+                                                </template>
                                             </div>
                                         </div>
                                     </template>
@@ -607,6 +626,9 @@
                         contextType = 'notification';
                         attachmentName = `Notification: ${data.title}`;
                         attachmentText = `[ALERT] ${data.title}`;
+                        // Add extra data for preview
+                        if(data.employee_id) chat.contextToAttach.employee_id = data.employee_id;
+                        if(data.employer_id) chat.contextToAttach.employer_id = data.employer_id;
                     }
                     else if (data.type === 'new_employee_draft') {
                         contextType = 'new_employee_draft';
@@ -627,7 +649,9 @@
                         url: contextUrl,
                         text: attachmentText,
                         name: attachmentName,
-                        subtitle: data.subtitle || data.code || ''
+                        subtitle: data.subtitle || data.code || '',
+                        employee_id: data.employee_id || null,
+                        employer_id: data.employer_id || null
                     };
 
                     this.bringToFront(chat.id);

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -31,7 +31,9 @@
         'id' => $notification->id,
         'title' => $notification->type,
         'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
-        'url' => route('notifications.index') . '?highlight=' . $notification->id
+        'url' => route('notifications.index') . '?highlight=' . $notification->id,
+        'employee_id' => $employee ? $employee->id : null,
+        'employer_id' => $employer ? $employer->id : null
      ]) }}"
      ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
     <div class="d-flex align-items-center gap-3">
@@ -54,7 +56,9 @@
                     {{ $itemNumber }}.
                     {{-- Display Employee Name or Employer Document Type --}}
                     @if($employee)
-                        {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
+                        <a href="{{ route('notifications.view-employee', $notification->id) }}" class="text-decoration-none text-dark fw-bold">
+                            {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
+                        </a>
                         <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
                         @if(optional($employee)->employeeNationality)
                             @php

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -18,7 +18,9 @@
         'id' => $notification->id,
         'title' => $notification->type,
         'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
-        'url' => route('notifications.index') . '?highlight=' . $notification->id
+        'url' => route('notifications.index') . '?highlight=' . $notification->id,
+        'employee_id' => $employee ? $employee->id : null,
+        'employer_id' => $employer ? $employer->id : null
     ]) }}"
     ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
     <td>
@@ -36,7 +38,9 @@
                 <img src="{{ $employee->photo_url }}" alt="Photo" class="employee-photo-thumb" style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; margin-right: 1rem;">
                 <div>
                     <div>
-                        {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
+                        <a href="{{ route('notifications.view-employee', $notification->id) }}" class="text-decoration-none text-dark fw-bold">
+                            {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
+                        </a>
                         <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
                     </div>
                     <div class="small text-muted">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }}</div>

--- a/resources/views/notifications/_renew_modal.blade.php
+++ b/resources/views/notifications/_renew_modal.blade.php
@@ -1,0 +1,17 @@
+<!-- Renew Notification Modal -->
+<div class="modal fade" id="renewNotificationModal" tabindex="-1" aria-labelledby="renewModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="renewModalLabel">{{ __('Renew Notification') }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>{{ __('This feature is coming soon.') }}</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Close') }}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -152,8 +152,9 @@
                                     <tr>
                                         <th style="width: 1%;"><input class="form-check-input" type="checkbox" id="select-all-checkbox-notifications-employer"></th>
                                         <th style="width: 1%;">#</th>
-                                        <th>{{ __('Employer Name') }}</th>
-                                        <th>{{ __('Document') }}</th>
+                                        <th>{{ __('Employee Name') }} / {{ __('Document') }}</th>
+                                        <th>{{ __('Nationality') }}</th>
+                                        <th>{{ __('Employer') }}</th>
                                         <th>{{ __('Expiry Date') }}</th>
                                         <th>{{ __('Status / Days Remaining') }}</th>
                                         <th class="text-center">{{ __('Manage') }}</th>
@@ -164,46 +165,9 @@
                                         @php
                                             $itemNumber = $loop->iteration + ($notifications->perPage() * ($notifications->currentPage() - 1));
                                         @endphp
-                                        <tr>
-                                            <td><input class="form-check-input bulk-action-checkbox" type="checkbox" value="{{ $notification->id }}"></td>
-                                            <td>{{ $itemNumber }}</td>
-                                            <td>{{ optional($notification->employer)->employerNameTh ?? '-' }}</td>
-                                            <td>{{ __('Company Certificate / ID Card') }}</td>
-                                            <td>{{ $notification->due_date ? \Carbon\Carbon::parse($notification->due_date)->format('d/m/Y') : '-' }}</td>
-                                            <td>
-                                                 @if($notification->days_remaining <= 0)
-                                                    <span class="badge bg-danger">{{ __('Expired') }}</span>
-                                                 @else
-                                                    <span class="badge bg-warning text-dark">{{ __('Expires in') }} {{ $notification->days_remaining }} {{ __('days') }}</span>
-                                                 @endif
-                                            </td>
-                                            <td class="text-center">
-                                                {{-- Reuse the standard notification action buttons or simplified ones --}}
-                                                 <div class="dropdown">
-                                                    <button class="btn btn-sm btn-light border dropdown-toggle" type="button" data-bs-toggle="dropdown">
-                                                        <i class="bi bi-three-dots-vertical"></i>
-                                                    </button>
-                                                    <ul class="dropdown-menu dropdown-menu-end">
-                                                        <li>
-                                                            <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#renewModal-{{ $notification->id }}">
-                                                                <i class="bi bi-arrow-repeat text-success me-2"></i> {{ __('Renew') }}
-                                                            </button>
-                                                        </li>
-                                                         <li>
-                                                            <form action="{{ route('notifications.cancel', $notification->id) }}" method="POST" class="d-inline">
-                                                                @csrf
-                                                                <button type="submit" class="dropdown-item text-warning" onclick="return confirm('{{ __('Are you sure you want to cancel this notification?') }}')">
-                                                                    <i class="bi bi-x-circle me-2"></i> {{ __('Cancel') }}
-                                                                </button>
-                                                            </form>
-                                                        </li>
-                                                    </ul>
-                                                </div>
-                                                @include('notifications._renew_modal', ['notification' => $notification])
-                                            </td>
-                                        </tr>
+                                        @include('notifications._notification_table_row', ['notification' => $notification, 'itemNumber' => $itemNumber])
                                     @empty
-                                        <tr><td colspan="7" class="text-center text-muted py-4">{{ __('No data found') }}</td></tr>
+                                        <tr><td colspan="8" class="text-center text-muted py-4">{{ __('No data found') }}</td></tr>
                                     @endforelse
                                 </tbody>
                             </table>


### PR DESCRIPTION
- Refactored `index.blade.php` to use standard `_notification_table_row` for `employer_document_expiry` ensuring consistency.
- Updated `_notification_item` and `_notification_table_row` to include `employee_id`/`employer_id` in drag payloads and link names to locate route.
- Updated `chat-widget.blade.php` to render Preview button for notifications with attached employee/employer IDs.
- Fixed 500 error by adding missing `_renew_modal.blade.php` (as fallback).