### PR TITLE
feat: Enable drag-and-drop from notifications to chat

### DIFF
--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -24,17 +24,21 @@
         $card_class = 'alert-warning';
         $badge_class = 'bg-warning text-dark';
     }
+
+    // NEW PAYLOAD STRUCTURE
+    $payload = [
+        'id' => $notification->id,
+        'type' => 'notification', // Keep a consistent main type
+        'render_as' => $employee ? 'employee_card' : 'simple_text', // Add a hint for the chat UI
+        'title' => $notification->type, // The raw notification type
+        'employee_name' => $employee ? ($employee->employeeNameTh ?? $employee->employeeNameEn) : null,
+        'employee_id' => $employee ? $employee->id : null,
+        'url' => route('notifications.view-employee', $notification->id), // Direct link for GPS/Locate
+    ];
 @endphp
 
 <div id="notification-item-{{ $notification->id }}" class="alert {{ $card_class }} notification-item" draggable="true"
-     data-drag-payload="{{ json_encode([
-        'id' => $notification->id,
-        'title' => $notification->type,
-        'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
-        'url' => route('notifications.index') . '?highlight=' . $notification->id,
-        'employee_id' => $employee ? $employee->id : null,
-        'employer_id' => $employer ? $employer->id : null
-     ]) }}"
+     data-drag-payload="{{ json_encode($payload) }}"
      ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
     <div class="d-flex align-items-center gap-3">
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -11,17 +11,21 @@
     } elseif ($days_remaining <= 30) {
         $text_class = 'text-warning';
     }
+
+    // NEW PAYLOAD STRUCTURE - Mirrored from _notification_item
+    $payload = [
+        'id' => $notification->id,
+        'type' => 'notification',
+        'render_as' => $employee ? 'employee_card' : 'simple_text',
+        'title' => $notification->type,
+        'employee_name' => $employee ? ($employee->employeeNameTh ?? $employee->employeeNameEn) : null,
+        'employee_id' => $employee ? $employee->id : null,
+        'url' => route('notifications.view-employee', $notification->id),
+    ];
 @endphp
 
 <tr id="notification-row-{{ $notification->id }}" draggable="true"
-    data-drag-payload="{{ json_encode([
-        'id' => $notification->id,
-        'title' => $notification->type,
-        'subtitle' => $employee ? $employee->employeeNameEn : ($employer->employerNameTh ?? ''),
-        'url' => route('notifications.index') . '?highlight=' . $notification->id,
-        'employee_id' => $employee ? $employee->id : null,
-        'employer_id' => $employer ? $employer->id : null
-    ]) }}"
+    data-drag-payload="{{ json_encode($payload) }}"
     ondragstart="window.startDragGlobal(event, 'notification', JSON.parse(this.dataset.dragPayload))">
     <td>
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}


### PR DESCRIPTION
This change implements the ability for users to drag employee information from all notification tabs (both card and table views) into the internal chat.

- The draggable payload now includes a richer JSON object with `render_as`, `employee_name`, `employee_id`, and a `url` for generating a preview button in the chat.
- The GPS/locate link is now consistently available on all notification items, allowing users to navigate directly to the relevant record.
- The changes were applied to the core `_notification_item.blade.php` and `_notification_table_row.blade.php` partials, ensuring the functionality is inherited by all notification tabs automatically.