### PR TITLE
feat: Add delete functionality for groups and teams

### DIFF
--- a/app/Http/Controllers/GroupTeamController.php
+++ b/app/Http/Controllers/GroupTeamController.php
@@ -343,4 +343,72 @@ class GroupTeamController extends Controller
             ]);
         }
     }
+
+    public function destroyGroup(EmployeeGroup $group)
+    {
+        $user = auth()->user();
+        if ($group->type === 'affiliated') {
+            if (!$user->can('manage-tickets') && ($user->employer?->id !== $group->employer_id)) {
+                abort(403, 'Unauthorized action.');
+            }
+        } else { // independent
+            if (!$user->can('manage-tickets')) {
+                abort(403, 'Unauthorized action.');
+            }
+        }
+
+        DB::transaction(function () use ($group) {
+            // Detach all employees from all teams within this group
+            foreach ($group->teams as $team) {
+                $team->employees()->detach();
+            }
+            // Delete all teams in the group
+            $group->teams()->delete();
+            // Delete the group itself
+            $group->delete();
+        });
+
+        if ($group->type === 'affiliated') {
+            return redirect()->route('groups.affiliated.manage', [
+                'employer' => $group->employer_id,
+            ])->with('success', 'Group and all its teams have been deleted.');
+        } else {
+            return redirect()->route('groups.independent.manage')
+                           ->with('success', 'Group and all its teams have been deleted.');
+        }
+    }
+
+    public function destroyTeam(EmployeeTeam $team)
+    {
+        $user = auth()->user();
+        $group = $team->group;
+
+        if ($group->type === 'affiliated') {
+            if (!$user->can('manage-tickets') && ($user->employer?->id !== $group->employer_id)) {
+                abort(403, 'Unauthorized action.');
+            }
+        } else { // independent
+            if (!$user->can('manage-tickets')) {
+                abort(403, 'Unauthorized action.');
+            }
+        }
+
+        DB::transaction(function () use ($team) {
+            // Detach all employees from this team
+            $team->employees()->detach();
+            // Delete the team
+            $team->delete();
+        });
+
+        if ($group->type === 'affiliated') {
+            return redirect()->route('groups.affiliated.manage', [
+                'employer' => $group->employer_id,
+                'active_group' => $group->id
+            ])->with('success', 'Team has been deleted.');
+        } else {
+            return redirect()->route('groups.independent.manage', [
+                'active_group' => $group->id
+            ])->with('success', 'Team has been deleted.');
+        }
+    }
 }

--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -169,6 +169,13 @@
                                 @click="openEditGroupModal({{ $activeGroup->id }}, '{{ $activeGroup->name }}')">
                             <i class="bi bi-pencil"></i>
                         </button>
+                        <form action="{{ route('groups.destroy', $activeGroup->id) }}" method="POST" class="d-inline delete-group-form">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </form>
                     </div>
                     <button class="btn btn-outline-primary btn-sm"
                             data-bs-toggle="modal"
@@ -211,6 +218,13 @@
                                             @click="openEditTeamModal({{ $team->id }}, '{{ $team->name }}')">
                                         <i class="bi bi-pencil"></i> {{ __('Edit Team') }}
                                     </button>
+                                    <form action="{{ route('groups.teams.destroy', $team->id) }}" method="POST" class="d-inline delete-team-form">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">
+                                            <i class="bi bi-trash"></i> {{ __('Delete Team') }}
+                                        </button>
+                                    </form>
                                     <button class="btn btn-sm btn-success"
                                             @click="openAddMemberModal({{ $activeGroup->id }}, {{ $team->id }}, '{{ $team->name }}')">
                                         <i class="bi bi-person-plus-fill"></i> {{ __('Add Member') }}
@@ -520,12 +534,44 @@
             }
         }
 
-        // Handle Delete Member Confirmation
+        // V4: Final refactored and consolidated delegated event listener for all delete forms
         document.body.addEventListener('submit', function(e) {
-            if (e.target.matches('.delete-member-form')) {
-                e.preventDefault();
-                const form = e.target;
+            const form = e.target;
 
+            if (form.matches('.delete-group-form')) {
+                e.preventDefault();
+                Swal.fire({
+                    title: '{{ __('Are you sure?') }}',
+                    text: "{{ __('This will delete the entire group and all teams inside it. This action cannot be undone!') }}",
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonColor: '#d33',
+                    cancelButtonColor: '#6c757d',
+                    confirmButtonText: '{{ __('Yes, delete group!') }}',
+                    cancelButtonText: '{{ __('Cancel') }}'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        form.submit();
+                    }
+                });
+            } else if (form.matches('.delete-team-form')) {
+                e.preventDefault();
+                Swal.fire({
+                    title: '{{ __('Are you sure?') }}',
+                    text: "{{ __('Do you want to delete this team? This action cannot be undone.') }}",
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonColor: '#d33',
+                    cancelButtonColor: '#6c757d',
+                    confirmButtonText: '{{ __('Yes, delete team!') }}',
+                    cancelButtonText: '{{ __('Cancel') }}'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        form.submit();
+                    }
+                });
+            } else if (form.matches('.delete-member-form')) {
+                e.preventDefault();
                 Swal.fire({
                     title: '{{ __('Are you sure?') }}',
                     text: "{{ __('Do you want to remove this member from the team?') }}",
@@ -542,6 +588,7 @@
                 });
             }
         });
+
 
         // Bulk Actions Handlers
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -123,8 +123,10 @@ Route::middleware('auth')->group(function () {
     Route::get('/groups/independent/manage', [App\Http\Controllers\GroupTeamController::class, 'manageIndependent'])->name('groups.independent.manage');
     Route::post('/groups', [App\Http\Controllers\GroupTeamController::class, 'storeGroup'])->name('groups.store');
     Route::put('/groups/{group}', [App\Http\Controllers\GroupTeamController::class, 'updateGroup'])->name('groups.update');
+    Route::delete('/groups/{group}', [App\Http\Controllers\GroupTeamController::class, 'destroyGroup'])->name('groups.destroy');
     Route::post('/groups/{group}/teams', [App\Http\Controllers\GroupTeamController::class, 'storeTeam'])->name('groups.teams.store');
     Route::put('/groups/teams/{team}', [App\Http\Controllers\GroupTeamController::class, 'updateTeam'])->name('groups.teams.update');
+    Route::delete('/groups/teams/{team}', [App\Http\Controllers\GroupTeamController::class, 'destroyTeam'])->name('groups.teams.destroy');
     Route::get('/api-web/groups/employees/search', [App\Http\Controllers\GroupTeamController::class, 'searchEmployees'])->name('api-web.groups.employees.search');
     Route::post('/groups/teams/{team}/members', [App\Http\Controllers\GroupTeamController::class, 'addMember'])->name('groups.teams.members.add');
     Route::delete('/groups/teams/{team}/members/{employee}', [App\Http\Controllers\GroupTeamController::class, 'removeMember'])->name('groups.teams.members.remove');


### PR DESCRIPTION
Adds the ability for users to delete groups and teams.

- Implements `destroyGroup` and `destroyTeam` methods in `GroupTeamController` with proper authorization checks and transactional database operations.
- Defines `DELETE` routes for both groups and teams.
- Adds delete buttons to the `manage.blade.php` view.
- Includes SweetAlert confirmation modals to prevent accidental deletions.
- Refactors JavaScript to handle all delete confirmations in a single, clean event listener, fixing a regression in the "Remove Member" functionality.