### PR TITLE
feat: Enable drag-and-drop from menu

### DIFF
--- a/mock_notifications.html
+++ b/mock_notifications.html
@@ -1,125 +1,59 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Notification List Mock</title>
+    <title>Mock Notifications</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <style>
-        :root {
-            --bs-primary: #F97316;
-            --bs-primary-rgb: 249, 115, 22;
-        }
-        body {
-            font-family: 'Inter', 'Sarabun', sans-serif;
-            background-color: #f8fafc;
-            padding: 20px;
-        }
-    </style>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body>
+    <div x-data="{
+        handleDrop(e, targetType, targetId) {
+            let rawData = e.dataTransfer.getData('application/json');
+            if (!rawData) {
+                console.log('no raw data');
+                return;
+            }
 
-<div class="container">
-    <h2>Notification List</h2>
+            let data;
+            try {
+                data = JSON.parse(rawData);
+            } catch (err) { console.error('Invalid drop data', err); return; }
 
-    <!-- Bulk Action Bar (Initially Hidden via JS, but we test visibility logic) -->
-    <div id="bulk-action-bar-notifications" class="d-flex flex-column flex-md-row justify-content-between align-items-center mb-3 py-2 px-3 bg-light border rounded gap-2" style="display: none;">
-        <div>
-            <input class="form-check-input" type="checkbox" id="select-all-checkbox-notifications">
-            <label class="form-check-label ms-2" for="select-all-checkbox-notifications">
-                Select All (<span id="selected-count-notifications">0</span>)
-            </label>
-        </div>
+            const chat = { contextToAttach: null };
 
-        <div class="dropdown w-100 w-md-auto" style="max-width: 300px;">
-            <button class="btn btn-primary btn-sm dropdown-toggle w-100" type="button" id="notificationBulkActionBtn" data-bs-toggle="dropdown" aria-expanded="false" disabled>
-                Action on selected items
-            </button>
-            <ul class="dropdown-menu w-100" aria-labelledby="notificationBulkActionBtn">
-                <li><a class="dropdown-item" href="#" id="notification-bulk-download-btn"><i class="bi bi-download me-2"></i>Download Files</a></li>
-                <li><a class="dropdown-item" href="#" id="notification-bulk-advanced-export-btn"><i class="bi bi-file-earmark-spreadsheet me-2"></i>Advanced Export</a></li>
-            </ul>
+            chat.contextToAttach = {
+                type: 'link', // Default
+                id: data.id,
+                url: data.url,
+                text: `[${data.type.toUpperCase()}] ${data.title}`,
+                name: data.title,
+                subtitle: data.subtitle || data.code || '',
+                employee_id: data.employee_id || null,
+                employer_id: data.employer_id || null
+            };
+
+            if (data.type === 'notification') {
+                chat.contextToAttach.type = 'notification';
+                chat.contextToAttach.name = `Notification: ${data.title}`;
+            }
+
+            const attachedItem = document.createElement('div');
+            attachedItem.id = 'attached-item';
+            attachedItem.innerText = chat.contextToAttach.name;
+            attachedItem.dataset.employeeId = chat.contextToAttach.employee_id;
+            document.querySelector('.chat-window').appendChild(attachedItem);
+        }
+    }">
+        <div class="chat-window" style="height: 500px; width: 300px; border: 1px solid black;"
+             @drop.prevent="handleDrop($event, 'chat_window', 1)">
+            Drop here
         </div>
     </div>
 
-    <!-- Mock Tab Content -->
-    <div class="tab-content pt-4">
-        <div class="tab-pane fade show active" id="ninety_day_report-pane" role="tabpanel">
-
-            <!-- Mock Item 1 -->
-            <div class="alert alert-dark notification-item">
-                <div class="d-flex align-items-center gap-3">
-                    <input class="form-check-input bulk-action-checkbox" type="checkbox" value="1" id="notification_checkbox_1">
-                    <div class="flex-grow-1">
-                        <h5 class="alert-heading mb-1">1. Employee One</h5>
-                        <p class="mb-1 small">Employer: Company A</p>
-                        <p class="mb-0 small">Due Date: 2025-01-01</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Mock Item 2 -->
-            <div class="alert alert-dark notification-item">
-                <div class="d-flex align-items-center gap-3">
-                    <input class="form-check-input bulk-action-checkbox" type="checkbox" value="2" id="notification_checkbox_2">
-                    <div class="flex-grow-1">
-                        <h5 class="alert-heading mb-1">2. Employee Two</h5>
-                        <p class="mb-1 small">Employer: Company B</p>
-                        <p class="mb-0 small">Due Date: 2025-01-02</p>
-                    </div>
-                </div>
-            </div>
-
-        </div>
-    </div>
-
-</div>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-    // Mocking the JS Logic from index.blade.php
-    const container = document.querySelector('.tab-content');
-    const actionBar = document.getElementById('bulk-action-bar-notifications');
-    const selectAllCheckbox = document.getElementById('select-all-checkbox-notifications');
-    const selectedCountSpan = document.getElementById('selected-count-notifications');
-    const actionButton = document.getElementById('notificationBulkActionBtn');
-
-    function updateActionBar() {
-        const activePane = container.querySelector('.tab-pane.active');
-        if (!activePane) return;
-
-        const itemCheckboxes = activePane.querySelectorAll('.bulk-action-checkbox');
-        const selectedCheckboxes = activePane.querySelectorAll('.bulk-action-checkbox:checked');
-        const count = selectedCheckboxes.length;
-
-        if (count > 0) {
-            actionBar.style.display = 'flex';
-            selectedCountSpan.textContent = count;
-            actionButton.disabled = false;
-        } else {
-            actionBar.style.display = 'none';
-            selectedCountSpan.textContent = 0;
-            actionButton.disabled = true;
-        }
-        selectAllCheckbox.checked = itemCheckboxes.length > 0 && count === itemCheckboxes.length;
-    }
-
-    container.addEventListener('change', function(e) {
-        if (e.target.classList.contains('bulk-action-checkbox')) {
-            updateActionBar();
-        }
+    <script>
+    document.addEventListener('alpine:init', () => {
+        // No need for full chat manager, just the drop handler
     });
-
-    selectAllCheckbox.addEventListener('change', function() {
-        const activePane = container.querySelector('.tab-pane.active');
-        if (!activePane) return;
-        const itemCheckboxes = activePane.querySelectorAll('.bulk-action-checkbox');
-        itemCheckboxes.forEach(checkbox => {
-            checkbox.checked = this.checked;
-        });
-        updateActionBar();
-    });
-</script>
+    </script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1431,6 +1431,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001735",
                 "electron-to-chromium": "^1.5.204",
@@ -2930,6 +2931,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -3448,6 +3450,7 @@
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -3586,6 +3589,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3674,6 +3678,7 @@
             "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -3778,6 +3783,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -661,13 +661,37 @@
                         attachmentName = `Ticket #${data.id}`;
                         attachmentText = `[TICKET] ${data.title}`;
                     }
+                    // First, set up the basic context object
+                    chat.contextToAttach = {
+                        type: 'link', // Default
+                        id: data.id,
+                        url: data.url,
+                        text: `[${data.type.toUpperCase()}] ${data.title}`,
+                        name: data.title,
+                        subtitle: data.subtitle || data.code || '',
+                        employee_id: data.employee_id || null,
+                        employer_id: data.employer_id || null
+                    };
+
+                    // Then, customize it based on the type
+                    if (data.type === 'employees_bulk') {
+                         chat.contextToAttach.name = `${data.count} Employees`;
+                         chat.contextToAttach.text = `[BULK] ${data.count} Employees Selected`;
+                    }
+                    else if (data.type === 'employee') {
+                        chat.contextToAttach.type = 'employee';
+                        chat.contextToAttach.url = `/employees/${data.id}/locate`;
+                    }
+                    else if (data.type === 'employer') {
+                        chat.contextToAttach.type = 'employer';
+                    }
+                    else if (data.type === 'ticket') {
+                        chat.contextToAttach.type = 'ticket';
+                        chat.contextToAttach.name = `Ticket #${data.id}`;
+                    }
                     else if (data.type === 'notification') {
-                        contextType = 'notification';
-                        attachmentName = `Notification: ${data.title}`;
-                        attachmentText = `[ALERT] ${data.title}`;
-                        // Add extra data for preview
-                        if(data.employee_id) chat.contextToAttach.employee_id = data.employee_id;
-                        if(data.employer_id) chat.contextToAttach.employer_id = data.employer_id;
+                        chat.contextToAttach.type = 'notification';
+                        chat.contextToAttach.name = `Notification: ${data.title}`;
                     }
                     else if (data.type === 'new_employee_draft') {
                         contextType = 'new_employee_draft';


### PR DESCRIPTION
Refactor the handleDrop function in the chat widget to correctly handle dropped notification items.

The original implementation had a logical error where it attempted to modify the `contextToAttach` object before it was created, causing a runtime error. This change initializes the object first, then populates it, ensuring that notification data, including `employee_id` and `employer_id`, is correctly attached to the chat context.