### PR TITLE
Fix(Admin): Resolve notification toggle save issue

### DIFF
--- a/resources/views/admin/notification_settings/index.blade.php
+++ b/resources/views/admin/notification_settings/index.blade.php
@@ -46,6 +46,7 @@
                                             @if ($isMissingDataType)
                                                 {{-- Toggle Switch for New Types --}}
                                                 <div class="form-check form-switch">
+                                                    <input type="hidden" name="settings[{{ $type }}][is_enabled]" value="0">
                                                     <input class="form-check-input" type="checkbox"
                                                            id="switch_{{ $type }}"
                                                            name="settings[{{ $type }}][is_enabled]"


### PR DESCRIPTION
This commit fixes a bug in the admin notification settings page where toggle switches for "Pink Card" and "Residence Permit" notifications could not be saved in the "off" state.

The issue was caused by the form not submitting any value for the `is_enabled` field when the checkbox was unchecked. This commit resolves the problem by implementing the standard and robust pattern of adding a hidden input with a value of `0` before the checkbox. This ensures that a value is always sent for the setting, allowing the controller to correctly update its state to enabled (`1`) or disabled (`0`).