### PR TITLE
feat: Enhance chat drag-and-drop from notifications

### DIFF
--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -473,18 +473,20 @@
                                                 id: item.id,
                                                 title: item.employeeNameTh || item.employeeNameEn,
                                                 subtitle: item.employeeNameEn ? item.employeeNameEn : item.employeeCode,
-                                                url: '/employees/' + item.id + '/locate'
+                                                url: item.url || ('/employees/' + item.id + '/locate')
                                              })">
                                             <div class="d-flex align-items-center gap-3">
                                                 <img :src="item.photo_url" alt="Photo" class="rounded-circle" style="width: 35px; height: 35px; object-fit: cover;">
                                                 <span>
                                                     <i class="bi bi-person-check me-1 text-primary"></i>
-                                                    <span x-text="item.employeeNameTh"></span>
+                                                    <a :href="item.url || '#'" x-text="item.employeeNameTh" :target="item.url ? '_blank' : '_self'" class="text-decoration-none text-dark fw-bold"></a>
                                                     <span class="text-muted" x-text="item.employeeNameEn ? '(' + item.employeeNameEn + ')' : ''"></span>
+                                                    <button type="button" class="btn btn-sm btn-outline-info btn-preview ms-2" :data-model-id="item.id" data-model-type="employee">Preview</button>
                                                 </span>
                                             </div>
                                             <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('existing_employees', index, item.employeeNameTh)">ลบ</button>
-                                            <input type="hidden" :name="'attachments[existing_employees][' + index + ']'" :value="item.id">
+                                            <input type="hidden" :name="'attachments[existing_employees][' + index + '][id]'" :value="item.id">
+                                            <input type="hidden" :name="'attachments[existing_employees][' + index + '][url]'" :value="item.url || ''">
                                         </div>
                                     </template>
                                     {{-- 1.5 Display External Employees --}}
@@ -495,18 +497,20 @@
                                                 id: item.id,
                                                 title: item.employeeNameTh || item.employeeNameEn,
                                                 subtitle: (item.employer_name || 'Ext') + (item.employeeNameEn ? ' - ' + item.employeeNameEn : ''),
-                                                url: '/employees/' + item.id + '/locate'
+                                                url: item.url || ('/employees/' + item.id + '/locate')
                                              })">
                                             <div class="d-flex align-items-center gap-3">
                                                 <img :src="item.photo_url" alt="Photo" class="rounded-circle" style="width: 35px; height: 35px; object-fit: cover;">
                                                 <span>
                                                     <i class="bi bi-search me-1 text-warning"></i>
-                                                    <span x-text="item.employeeNameTh"></span>
+                                                    <a :href="item.url || '#'" x-text="item.employeeNameTh" :target="item.url ? '_blank' : '_self'" class="text-decoration-none text-dark fw-bold"></a>
                                                     <span class="text-muted" x-text="'(Ext)'"></span>
+                                                    <button type="button" class="btn btn-sm btn-outline-info btn-preview ms-2" :data-model-id="item.id" data-model-type="employee">Preview</button>
                                                 </span>
                                             </div>
                                             <button type="button" class="btn btn-sm btn-danger" @click="removeConfirm('external_employees', index, item.employeeNameTh)">ลบ</button>
-                                            <input type="hidden" :name="'attachments[external_employees][' + index + ']'" :value="item.id">
+                                            <input type="hidden" :name="'attachments[external_employees][' + index + '][id]'" :value="item.id">
+                                            <input type="hidden" :name="'attachments[external_employees][' + index + '][url]'" :value="item.url || ''">
                                         </div>
                                     </template>
                                     {{-- 2. Display New Employees --}}

--- a/resources/views/components/hybrid-attachment-scripts.blade.php
+++ b/resources/views/components/hybrid-attachment-scripts.blade.php
@@ -206,8 +206,13 @@ function hybridAttachmentManager(config = {}) {
             this.isLoading = true;
             try {
                 const params = new URLSearchParams();
-                // Pass the IDs as array
-                this.selectedEmployeeIds.forEach(id => params.append('ids[]', id));
+                // V2.5-S18-FIX: Handle both simple IDs and {id, url} objects
+                const idMap = new Map(this.selectedEmployeeIds.map(item => [
+                    (typeof item === 'object' ? item.id : item),
+                    (typeof item === 'object' ? item.url : null)
+                ]));
+                idMap.forEach((_, id) => params.append('ids[]', id));
+
 
                 const response = await fetch(`{{ route('api-web.employer.employees.index') }}?${params.toString()}`);
                 if (!response.ok) throw new Error('Network response was not ok');
@@ -221,15 +226,18 @@ function hybridAttachmentManager(config = {}) {
                      const inExternal = this.basket.external_employees.some(e => e.id == emp.id);
 
                      if (!inExisting && !inExternal) {
+                        const sourceUrl = idMap.get(emp.id); // V2.5-S18-FIX: Get the URL from our map
+                        const employeeWithUrl = { ...emp, url: sourceUrl }; // Attach the URL
+
                         // If forceToExisting is true (from matching employer logic), put in existing
                         if (forceToExisting) {
-                            this.basket.existing_employees.push(emp);
+                            this.basket.existing_employees.push(employeeWithUrl);
                         } else {
                             // Otherwise check context
                             if (this.contextEmployerId && emp.employer_id == this.contextEmployerId) {
-                                this.basket.existing_employees.push(emp);
+                                this.basket.existing_employees.push(employeeWithUrl);
                             } else {
-                                this.basket.external_employees.push(emp);
+                                this.basket.external_employees.push(employeeWithUrl);
                             }
                         }
                     }
@@ -553,11 +561,15 @@ function hybridAttachmentManager(config = {}) {
                 return;
             }
 
-            // 1. Handle Employee Drop -> Add to Basket
-            if (data.type === 'employee') {
+            // 1. Handle Employee Drop (from anywhere) -> Add to Basket
+            // This now also handles notifications that represent an employee
+            if (data.type === 'employee' || (data.type === 'notification' && data.render_as === 'employee_card' && data.employee_id)) {
+                const employeeId = data.type === 'employee' ? data.id : data.employee_id;
+                const sourceUrl = data.url || null; // V2.5-S18-FIX: Capture the source URL
+
                 // Check if already in either basket
-                const inExisting = this.basket.existing_employees.some(emp => emp.id == data.id);
-                const inExternal = this.basket.external_employees.some(emp => emp.id == data.id);
+                const inExisting = this.basket.existing_employees.some(emp => emp.id == employeeId);
+                const inExternal = this.basket.external_employees.some(emp => emp.id == employeeId);
 
                 if (inExisting || inExternal) {
                     Swal.fire({
@@ -567,14 +579,14 @@ function hybridAttachmentManager(config = {}) {
                     return;
                 }
 
-                // Add to selection and fetch details
-                this.selectedEmployeeIds = [data.id];
+                // Add to selection and fetch details, passing the URL along
+                this.selectedEmployeeIds = [{ id: employeeId, url: sourceUrl }];
                 this.fetchPreselectedEmployees(); // Auto determines destination based on context
                 return;
             }
 
             // 2. Handle Other Types -> Append Link to Message
-            // We need to find the textarea. Since it's standard DOM inside the x-data scope:
+            // (This includes notifications that are not employee-cards)
             const messageBox = document.getElementById('message');
             if (messageBox) {
                 let textToAppend = '';
@@ -583,6 +595,7 @@ function hybridAttachmentManager(config = {}) {
                 } else if (data.type === 'ticket') {
                      textToAppend = `[Ticket #${data.id}: ${data.title}](${data.url}) `;
                 } else if (data.type === 'notification') {
+                     // This will now only catch non-employee notifications
                      textToAppend = `[Notification: ${data.title}](${data.url}) `;
                 } else {
                     // Default / Link / File

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -33,7 +33,7 @@
         'title' => $notification->type, // The raw notification type
         'employee_name' => $employee ? ($employee->employeeNameTh ?? $employee->employeeNameEn) : null,
         'employee_id' => $employee ? $employee->id : null,
-        'url' => route('notifications.view-employee', $notification->id), // Direct link for GPS/Locate
+        'url' => route('notifications.index') . '#notification-item-' . $notification->id, // V2.5-S18-FIX: Link back to the specific notification card
     ];
 @endphp
 


### PR DESCRIPTION
This commit improves the chat functionality by enabling full employee card previews when dragging items from the notification panel.

Previously, dragging a notification related to an employee would only create a simple text link in the chat.

This change modifies the drag-and-drop payload from notification items to include all necessary data for rendering a full employee card in the chat. It also adds a URL with a fragment identifier to link back to the specific notification card.

The chat's drop handler and attachment processing logic have been updated to recognize this new payload, fetch the employee data, and render the complete card with a "Preview" button and a direct link to the source notification. This ensures a consistent user experience across the application.