### PR TITLE
feat(chat): Enhance notification drag-and-drop

### DIFF
--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -237,6 +237,16 @@
                                             </div>
                                             <div class="d-flex align-items-center justify-content-between mt-1">
                                                 <small class="text-muted text-truncate" style="max-width: 100px;" x-text="msg.context_data.subtitle"></small>
+                                                <!-- V2.5-S18-FIX: Add Preview Button for Notifications with Employees -->
+                                                <template x-if="msg.context_data.employee_id">
+                                                    <button type="button" class="btn btn-sm btn-outline-info btn-preview py-0 px-1 ms-2"
+                                                            style="font-size: 0.7rem;"
+                                                            :data-model-id="msg.context_data.employee_id"
+                                                            data-model-type="employee"
+                                                            title="{{ __('Preview') }}">
+                                                        <i class="bi bi-eye"></i> {{ __('Preview') }}
+                                                    </button>
+                                                </template>
                                             </div>
                                         </div>
                                     </template>

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -33,7 +33,7 @@
         'title' => $notification->type, // The raw notification type
         'employee_name' => $employee ? ($employee->employeeNameTh ?? $employee->employeeNameEn) : null,
         'employee_id' => $employee ? $employee->id : null,
-        'url' => route('notifications.index') . '#notification-item-' . $notification->id, // V2.5-S18-FIX: Link back to the specific notification card
+        'url' => route('notifications.index', ['highlight' => $notification->id]),
     ];
 @endphp
 


### PR DESCRIPTION
This commit improves the chat functionality for notifications.

- When an employee notification is dragged into the chat, the resulting bubble now includes a "Preview" button, allowing users to quickly view employee details.
- Clicking the employee's name in the chat bubble now correctly navigates to the notifications page and applies a visual highlight to the corresponding notification card, improving context and workflow.