### PR TITLE
feat: Implement rich notification cards in chat

### DIFF
--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -377,8 +377,27 @@
                                         </div>
                                     </div>
                                     <div class="p-3 rounded" style="background-color: #f1f5f9;">
-                                        {{-- Use nl2br to respect line breaks in the message body --}}
-                                        {!! nl2br(e($message->body)) !!}
+                                        @php
+                                            $body = $message->body;
+                                            // V2.5-S20: Regex to find the special notification card format
+                                            $pattern = '/\[\[--NOTIFICATION_CARD--\]\](.*?)\[\[--\/NOTIFICATION_CARD--\]\]/s';
+
+                                            // Replace all occurrences of the pattern with the rendered partial
+                                            $formattedBody = preg_replace_callback($pattern, function ($matches) {
+                                                $jsonData = $matches[1];
+                                                $notificationData = json_decode($jsonData);
+
+                                                if (json_last_error() === JSON_ERROR_NONE) {
+                                                    return view('tickets.partials._chat_notification_card', ['notification' => $notificationData])->render();
+                                                }
+                                                // If JSON is invalid, return a placeholder or the raw content
+                                                return '<div class="alert alert-danger">ไม่สามารถแสดงข้อมูลการแจ้งเตือนได้</div>';
+                                            }, $body);
+
+                                            // Convert remaining text line breaks to <br> tags, ensuring HTML is not escaped
+                                            echo nl2br(e(preg_replace($pattern, '', $body))); // Display non-matching text safely
+                                            echo $formattedBody; // Display the rendered cards
+                                        @endphp
                                     </div>
                                 </div>
                             </div>

--- a/resources/views/components/hybrid-attachment-scripts.blade.php
+++ b/resources/views/components/hybrid-attachment-scripts.blade.php
@@ -548,7 +548,7 @@ function hybridAttachmentManager(config = {}) {
             this.isUploading = false;
         },
 
-        // --- Drag & Drop Handler (V2.5-S18) ---
+        // --- Drag & Drop Handler (V2.5-S18 & V2.5-S20) ---
         handleDrop(e) {
             const rawData = e.dataTransfer.getData('application/json');
             if (!rawData) return;
@@ -561,52 +561,62 @@ function hybridAttachmentManager(config = {}) {
                 return;
             }
 
-            // 1. Handle Employee Drop (from anywhere) -> Add to Basket
-            // This now also handles notifications that represent an employee
-            if (data.type === 'employee' || (data.type === 'notification' && data.render_as === 'employee_card' && data.employee_id)) {
-                const employeeId = data.type === 'employee' ? data.id : data.employee_id;
-                const sourceUrl = data.url || null; // V2.5-S18-FIX: Capture the source URL
+            const messageBox = document.getElementById('message');
 
-                // Check if already in either basket
+            // 1. SPECIAL CASE: Notification Card dropped into message box
+            if (data.type === 'notification' && data.render_as === 'employee_card' && messageBox) {
+                // Create a special formatted string with the rich payload
+                const textToAppend = `[[--NOTIFICATION_CARD--]]${JSON.stringify(data)}[[--/NOTIFICATION_CARD--]]`;
+
+                // Append it to the message box
+                const currentVal = messageBox.value;
+                messageBox.value = currentVal + (currentVal ? '\n' : '') + textToAppend;
+                messageBox.dispatchEvent(new Event('input')); // for auto-resize
+                return; // Done
+            }
+
+            // 2. Handle Employee Drop (from anywhere) -> Add to Basket
+            if (data.type === 'employee') {
+                const employeeId = data.id;
+                const sourceUrl = data.url || null;
+
                 const inExisting = this.basket.existing_employees.some(emp => emp.id == employeeId);
                 const inExternal = this.basket.external_employees.some(emp => emp.id == employeeId);
 
                 if (inExisting || inExternal) {
-                    Swal.fire({
-                        toast: true, position: 'top-end', showConfirmButton: false, timer: 3000,
-                        icon: 'info', title: 'ลูกจ้างนี้ถูกเลือกแล้ว'
-                    });
+                    Swal.fire({ toast: true, position: 'top-end', showConfirmButton: false, timer: 3000, icon: 'info', title: 'ลูกจ้างนี้ถูกเลือกแล้ว' });
                     return;
                 }
 
-                // Add to selection and fetch details, passing the URL along
                 this.selectedEmployeeIds = [{ id: employeeId, url: sourceUrl }];
-                this.fetchPreselectedEmployees(); // Auto determines destination based on context
+                this.fetchPreselectedEmployees();
                 return;
             }
 
-            // 2. Handle Other Types -> Append Link to Message
-            // (This includes notifications that are not employee-cards)
-            const messageBox = document.getElementById('message');
+            // 3. Handle Other Types -> Append as a simple link to Message
             if (messageBox) {
                 let textToAppend = '';
                 if (data.type === 'employer') {
-                    textToAppend = `[Employer: ${data.title}](${data.url}) `;
+                    textToAppend = `[นายจ้าง: ${data.title}](${data.url}) `;
                 } else if (data.type === 'ticket') {
-                     textToAppend = `[Ticket #${data.id}: ${data.title}](${data.url}) `;
-                } else if (data.type === 'notification') {
-                     // This will now only catch non-employee notifications
-                     textToAppend = `[Notification: ${data.title}](${data.url}) `;
+                     textToAppend = `[ตั๋วงาน #${data.id}: ${data.title}](${data.url}) `;
+                } else if (data.type === 'notification') { // This now only catches non-employee (simple_text) notifications
+                     textToAppend = `[การแจ้งเตือน: ${data.title}](${data.url}) `;
+                } else if (data.type === 'file' && data.url) {
+                    textToAppend = `[ไฟล์: ${data.title}](${data.url}) `;
+                } else if (data.type === 'new_employee_draft') {
+                    textToAppend = `[ลูกจ้างใหม่ (ร่าง): ${data.title}] `;
                 } else {
-                    // Default / Link / File
-                    textToAppend = `[${data.title}](${data.url}) `;
+                    // Default / Link / Other draggable items without a specific handler
+                    if (data.url && data.title) {
+                        textToAppend = `[${data.title}](${data.url}) `;
+                    } else {
+                        textToAppend = `${data.title || 'Attached Item'} `;
+                    }
                 }
 
-                // Append text
                 const currentVal = messageBox.value;
                 messageBox.value = currentVal + (currentVal ? '\n' : '') + textToAppend;
-
-                // Trigger input event for any auto-resize listeners
                 messageBox.dispatchEvent(new Event('input'));
             }
         },

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -25,15 +25,33 @@
         $badge_class = 'bg-warning text-dark';
     }
 
-    // NEW PAYLOAD STRUCTURE
+    // V2.5-S20: Enhanced payload for rich chat messages
+    $notificationTypeLabels = [
+        'ninety_day_report' => 'ครบกำหนดรายงานตัว 90 วัน',
+        'work_permit_expiry' => 'ใบอนุญาตทำงานหมดอายุ',
+        'visa_expiry' => 'วีซ่าหมดอายุ',
+        'passport_expiry' => 'หนังสือเดินทางหมดอายุ',
+        'pink_card_missing' => 'ไม่มีข้อมูลบัตรชมพู',
+        'residence_permit_missing' => 'ไม่มีข้อมูลใบอนุญาตพำนัก',
+        'work_permit_mou' => 'Work Permit (MOU)',
+        'employer_document_expiry' => 'เอกสารนายจ้างหมดอายุ',
+        'insurance_expiry' => 'ประกันหมดอายุ'
+    ];
+    $notification_title_th = $notificationTypeLabels[$notification->type] ?? ucfirst(str_replace('_', ' ', $notification->type));
+
     $payload = [
         'id' => $notification->id,
-        'type' => 'notification', // Keep a consistent main type
-        'render_as' => $employee ? 'employee_card' : 'simple_text', // Add a hint for the chat UI
-        'title' => $notification->type, // The raw notification type
-        'employee_name' => $employee ? ($employee->employeeNameTh ?? $employee->employeeNameEn) : null,
-        'employee_id' => $employee ? $employee->id : null,
-        'url' => route('notifications.index', ['highlight' => $notification->id]),
+        'type' => 'notification',
+        'render_as' => $employee ? 'employee_card' : 'simple_text',
+        'title' => $notification->type, // raw type
+        'notification_title_th' => $notification_title_th,
+        'employee_id' => optional($employee)->id,
+        'employee_name_th' => optional($employee)->employeeNameTh,
+        'employee_name_en' => optional($employee)->employeeNameEn,
+        'employee_photo_url' => optional($employee)->photo_url,
+        'employee_nationality' => optional($employee)->employeeNationality,
+        'employer_name_th' => optional($employer)->employerNameTh,
+        'url' => route('notifications.index', ['highlight' => $notification->id, 'active_tab' => $notification->status]),
     ];
 @endphp
 

--- a/resources/views/tickets/partials/_chat_notification_card.blade.php
+++ b/resources/views/tickets/partials/_chat_notification_card.blade.php
@@ -1,0 +1,62 @@
+{{-- resources/views/tickets/partials/_chat_notification_card.blade.php --}}
+{{-- This partial is used to render the special notification card in the chat history. --}}
+{{-- It receives the parsed JSON data as a $notification variable (stdClass object). --}}
+
+@php
+    // Get the country code for the flag image
+    $flagCode = App\Helpers\CountryHelper::getCountryCode($notification->employee_nationality);
+@endphp
+
+<div class="p-3 my-2 rounded border border-info" style="background-color: #f0f9ff;">
+    <h6 class="text-info fw-bold mb-2">
+        <i class="bi bi-bell-fill me-2"></i> การแจ้งเตือน: {{ $notification->notification_title_th ?? 'N/A' }}
+    </h6>
+    <div class="d-flex align-items-center gap-3">
+        <div class="flex-shrink-0">
+            <img src="{{ $notification->employee_photo_url ?? 'https://placehold.co/64x64/e2e8f0/6c757d?text=PIC' }}"
+                 alt="Photo"
+                 class="rounded-circle"
+                 style="width: 64px; height: 64px; object-fit: cover;">
+        </div>
+        <div class="flex-grow-1">
+            <div class="fw-bold">
+                {{-- The URL in the notification payload is the highlight link --}}
+                <a href="{{ $notification->url ?? '#' }}" class="text-dark text-decoration-none">
+                    <i class="bi bi-person"></i> {{ $notification->employee_name_th ?? 'N/A' }}
+                </a>
+                @if($notification->employee_name_en)
+                    <span class="text-muted">({{ $notification->employee_name_en }})</span>
+                @endif
+            </div>
+
+            <div class="small text-muted mb-2">
+                <i class="bi bi-building"></i> {{ $notification->employer_name_th ?? 'N/A' }}
+                @if($flagCode)
+                    <span class="badge bg-light text-dark ms-2 d-inline-flex align-items-center">
+                        <img src="{{ asset('images/flags/' . strtolower($flagCode) . '.png') }}"
+                             alt="{{ $notification->employee_nationality }}"
+                             title="{{ $notification->employee_nationality }}"
+                             style="width: 16px; height: 12px; margin-right: 5px;">
+                        <span>{{ $notification->employee_nationality }}</span>
+                    </span>
+                @endif
+            </div>
+
+            <div class="d-flex gap-2">
+                {{-- Preview button --}}
+                @if($notification->employee_id)
+                    <button type="button" class="btn btn-sm btn-outline-info btn-preview"
+                            data-model-type="employee"
+                            data-model-id="{{ $notification->employee_id }}">
+                        <i class="bi bi-search"></i> พรีวิว
+                    </button>
+                @endif
+
+                {{-- Link to highlight notification --}}
+                <a href="{{ $notification->url ?? '#' }}" class="btn btn-sm btn-outline-primary">
+                    <i class="bi bi-box-arrow-up-right"></i> ไปยังการแจ้งเตือน
+                </a>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Improves the user experience by allowing employee-related notifications to be dragged into a ticket chat, where they are now rendered as a detailed, interactive card instead of a simple link.

This commit introduces the following changes:

1.  **Enriched Notification Payload:** The draggable notification items in `_notification_item.blade.php` now include a richer JSON payload, containing the employee's photo URL, nationality, employer name, and a direct URL to highlight the notification on the notifications page.

2.  **Updated Drop Logic:** The `handleDrop` function in `hybrid-attachment-scripts.blade.php` is updated to detect these specific notification payloads. It embeds the full JSON data into the message box, wrapped in special tags (`[[--NOTIFICATION_CARD--]]`), for server-side processing.

3.  **New Chat Card Partial:** A new partial, `_chat_notification_card.blade.php`, has been created to serve as the dedicated template for rendering the notification card within the chat history. It displays the employee's details, a "Preview" button that integrates with the existing global preview system, and a "Go to Notification" link.

4.  **Server-Side Rendering:** The ticket chat view (`show.blade.php`) now includes logic to parse the chat message body for the special notification card tags. It extracts the JSON data and uses the new partial to render the rich card directly into the chat history, ensuring a seamless and informative display.