### PR TITLE
I've prepared the commit message for the new bulk edit functionality.…

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -804,11 +804,19 @@ public function create(Request $request) // เพิ่ม Request $request เ
     public function bulkEditSelectFields(Request $request)
     {
         $request->validate([
-            'employee_ids' => 'required|array',
+            'employee_ids' => 'sometimes|required|array',
             'employee_ids.*' => 'exists:employees,id',
+            'notification_ids' => 'sometimes|required|array',
+            'notification_ids.*' => 'exists:notifications,id',
         ]);
 
-        $employeeIds = $request->input('employee_ids');
+        if ($request->has('notification_ids')) {
+            $notificationIds = $request->input('notification_ids');
+            $employeeIds = \App\Models\Notification::whereIn('id', $notificationIds)->pluck('employee_id')->unique()->toArray();
+            session(['notification_ids_for_bulk_edit' => $notificationIds]);
+        } else {
+            $employeeIds = $request->input('employee_ids');
+        }
 
         // Define all available fields grouped by category
         $fieldGroups = [
@@ -1043,6 +1051,13 @@ public function create(Request $request) // เพิ่ม Request $request เ
                 $employee->update($updateData);
                 $updatedCount++;
             }
+        }
+
+        if (session()->has('notification_ids_for_bulk_edit')) {
+            $notificationIds = session('notification_ids_for_bulk_edit');
+            \App\Models\Notification::whereIn('id', $notificationIds)->delete();
+            session()->forget('notification_ids_for_bulk_edit');
+            return redirect()->route('notifications.index')->with('success', "Bulk updated {$updatedCount} employees successfully and notifications cleared.");
         }
 
         return redirect()->route('employees.index')->with('success', "Bulk updated {$updatedCount} employees successfully.");

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -256,14 +256,14 @@
                 const selected = Array.from(activePane.querySelectorAll('.bulk-action-checkbox:checked')).map(cb => cb.value);
 
                 if (selected.length === 0) {
-                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    showToast('{{ __('Please select items first.') }}', 'danger');
                     return;
                 }
 
                 // Create a form dynamically and submit POST
                 const form = document.createElement('form');
                 form.method = 'POST';
-                form.action = '{{ route('employees.bulk_edit.select_fields') }}';
+                form.action = '{{ route('notifications.bulk_edit.select_fields') }}';
 
                 const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
                 const csrfInput = document.createElement('input');
@@ -275,7 +275,7 @@
                 selected.forEach(id => {
                     const input = document.createElement('input');
                     input.type = 'hidden';
-                    input.name = 'employee_ids[]';
+                    input.name = 'notification_ids[]';
                     input.value = id;
                     form.appendChild(input);
                 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -74,6 +74,11 @@ Route::middleware('auth')->group(function () {
     Route::post('employees/bulk-edit/form', [EmployeeController::class, 'bulkEditForm'])->name('employees.bulk_edit.form');
     Route::put('employees/bulk-update', [EmployeeController::class, 'bulkUpdate'])->name('employees.bulk_update');
 
+    // Notification Bulk Edit Routes
+    Route::post('notifications/bulk-edit/select-fields', [EmployeeController::class, 'bulkEditSelectFields'])->name('notifications.bulk_edit.select_fields');
+    Route::post('notifications/bulk-edit/form', [EmployeeController::class, 'bulkEditForm'])->name('notifications.bulk_edit.form');
+    Route::put('notifications/bulk-update', [EmployeeController::class, 'bulkUpdate'])->name('notifications.bulk_update');
+
     Route::resource('employees', EmployeeController::class);
     Route::resource('importers', ImporterController::class);
     Route::resource('agents', AgentController::class);


### PR DESCRIPTION
… Here is the summary of the changes:

feat: Add advanced bulk edit functionality to notifications page

This commit introduces the "Advanced Edit" feature to the notifications page, allowing users to bulk-edit employee information directly from the notification list.

-   Adds new routes for `notifications/bulk-edit` that leverage the existing `EmployeeController` bulk edit logic.
-   Updates `EmployeeController` to handle requests originating from the notifications page by accepting `notification_ids`.
-   The `bulkUpdate` method is enhanced to delete the processed notifications from the database after a successful update and redirect the user back to the notifications index.
-   Modifies the `notifications.index.blade.php` view to correctly point the "Advanced Edit" form to the new route and send `notification_ids`.

This change streamlines the workflow for updating employee data related to expiring documents, improving user efficiency.