### PR TITLE
feat: Auto-update notifications on employee change

### DIFF
--- a/app/Observers/EmployeeObserver.php
+++ b/app/Observers/EmployeeObserver.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Employee;
+use Illuminate\Support\Facades\Artisan;
+
+class EmployeeObserver
+{
+    /**
+     * Handle the Employee "updated" event.
+     *
+     * @param  \App\Models\Employee  $employee
+     * @return void
+     */
+    public function updated(Employee $employee)
+    {
+        $fieldsToMonitor = [
+            'passportExpiryDate',
+            'workPermitExpiryDate',
+            'visaExpiryDate',
+            'ninetyDayReportDate',
+            'insurance_expiry_date',
+            'insurance_expiry_date_hospital',
+            'insurance_expiry_date_private',
+            'pinkCardNo',
+            'employee_doc_7', // Residence Permit
+            'workPermitMOUGroup',
+            'passportType',
+        ];
+
+        // isDirty() checks if any of the given attributes have changed.
+        if ($employee->isDirty($fieldsToMonitor)) {
+            // Queue the command to run asynchronously in the background.
+            // This prevents blocking the user's request and causing timeouts.
+            Artisan::queue('app:check-expiries');
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Models\Employee;
 use App\Models\Employer;
 use App\Models\JobTicket;
 use App\Observers\EmployerObserver;
+use App\Observers\EmployeeObserver;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
@@ -32,6 +33,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Paginator::useBootstrapFive();
         Employer::observe(EmployerObserver::class);
+        Employee::observe(EmployeeObserver::class);
 
         Event::listen(Login::class, LogSuccessfulLogin::class);
         Event::listen(Logout::class, LogSuccessfulLogout::class);


### PR DESCRIPTION
Creates an EmployeeObserver to monitor changes to notification-related fields.

When an employee's data is updated, the observer checks if any of the monitored fields (e.g., passport expiry, visa date, insurance dates) have changed.

If a relevant field is modified, the `app:check-expiries` command is queued to run asynchronously in the background. This ensures that notifications are regenerated immediately and accurately without blocking the user's request or causing performance issues.