### PR TITLE
feat: Add ability for admins to hide employer ticket boxes

### DIFF
--- a/app/Http/Controllers/Admin/TicketController.php
+++ b/app/Http/Controllers/Admin/TicketController.php
@@ -10,6 +10,8 @@ use App\Models\User;
 use Spatie\Permission\Models\Role;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\RedirectResponse;
+use Carbon\Carbon;
 
 class TicketController extends Controller
 {
@@ -65,9 +67,10 @@ class TicketController extends Controller
         $view = request('view', 'card');
         $search = request('search');
 
-        // Query Users who have submitted tickets
-        $query = User::whereHas('submittedTickets')
-            ->with('employer'); // Eager load employer profile
+        // Query Users who have submitted tickets that are not hidden
+        $query = User::whereHas('submittedTickets', function ($q) {
+            $q->whereNull('hidden_at');
+        })->with('employer'); // Eager load employer profile
 
         // V2.5-S15: Apply Caretaker Visibility Scope for non-admins/staff
         if (!$canViewAllTickets) {
@@ -89,17 +92,20 @@ class TicketController extends Controller
         }
 
         // Add Counts and Last Activity via Subqueries
-        $query->withCount(['submittedTickets as total_tickets']);
+        $query->withCount(['submittedTickets as total_tickets' => function ($q) {
+            $q->whereNull('hidden_at');
+        }]);
 
         // Count unread tickets (where admin_unread_count > 0)
         $query->withCount(['submittedTickets as unread_tickets_count' => function ($q) {
-            $q->where('admin_unread_count', '>', 0);
+            $q->where('admin_unread_count', '>', 0)->whereNull('hidden_at');
         }]);
 
         // Add Last Activity (Max updated_at of tickets)
         // We use addSelect with a subquery for sorting
         $query->addSelect(['last_activity' => JobTicket::selectRaw('MAX(updated_at)')
             ->whereColumn('employer_user_id', 'users.id')
+            ->whereNull('hidden_at')
         ]);
 
         // Order by Last Activity (Recent first)
@@ -181,5 +187,16 @@ class TicketController extends Controller
         ]);
 
         return redirect()->route('admin.tickets.show', $ticket)->with('success', 'Ticket assignment updated successfully.');
+    }
+
+    /**
+     * Hide all tickets for a specific employer.
+     */
+    public function hide(User $employer_user): RedirectResponse
+    {
+        JobTicket::where('employer_user_id', $employer_user->id)
+            ->update(['hidden_at' => Carbon::now()]);
+
+        return back()->with('success', 'กล่องตั๋วงานของ ' . ($employer_user->employer->employerNameTh ?? $employer_user->name) . ' ถูกซ่อนเรียบร้อยแล้ว');
     }
 }

--- a/app/Models/JobTicket.php
+++ b/app/Models/JobTicket.php
@@ -25,6 +25,7 @@ class JobTicket extends Model
         'assigned_staff_id',
         'admin_unread_count',
         'employer_unread_count',
+        'hidden_at',
     ];
 
     // Ensure $casts array is either absent or empty if it was added. We don't need it for DB Enums.

--- a/app/Observers/TicketMessageObserver.php
+++ b/app/Observers/TicketMessageObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\TicketMessage;
+
+class TicketMessageObserver
+{
+    /**
+     * Handle the TicketMessage "created" event.
+     */
+    public function created(TicketMessage $ticketMessage): void
+    {
+        $jobTicket = $ticketMessage->ticket;
+
+        if ($jobTicket && $jobTicket->hidden_at) {
+            $jobTicket->update(['hidden_at' => null]);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,7 +7,9 @@ use Illuminate\Pagination\Paginator;
 use App\Models\Employee;
 use App\Models\Employer;
 use App\Models\JobTicket;
+use App\Models\TicketMessage;
 use App\Observers\EmployerObserver;
+use App\Observers\TicketMessageObserver;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
@@ -32,6 +34,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Paginator::useBootstrapFive();
         Employer::observe(EmployerObserver::class);
+        TicketMessage::observe(TicketMessageObserver::class);
 
         Event::listen(Login::class, LogSuccessfulLogin::class);
         Event::listen(Logout::class, LogSuccessfulLogout::class);

--- a/database/migrations/2025_11_26_073200_add_hidden_at_to_job_tickets_table.php
+++ b/database/migrations/2025_11_26_073200_add_hidden_at_to_job_tickets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('job_tickets', function (Blueprint $table) {
+            $table->timestamp('hidden_at')->nullable()->after('employer_unread_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('job_tickets', function (Blueprint $table) {
+            $table->dropColumn('hidden_at');
+        });
+    }
+};

--- a/resources/views/admin/tickets/employers.blade.php
+++ b/resources/views/admin/tickets/employers.blade.php
@@ -42,18 +42,19 @@
         <div class="row g-4">
             @forelse ($employersWithTickets as $user)
                 <div class="col-12 col-md-6 col-xl-4">
-                    <a href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}" class="text-decoration-none">
-                        <div class="card h-100 border-0 shadow-sm hover-shadow transition-all">
-                            <div class="card-body d-flex flex-column">
-                                <div class="d-flex justify-content-between align-items-start mb-3">
-                                    <div class="d-flex align-items-center gap-3">
-                                        <div class="bg-primary bg-opacity-10 p-3 rounded-circle">
-                                            <i class="bi bi-building text-primary fs-4"></i>
-                                        </div>
-                                        <div>
-                                            <h5 class="card-title text-dark mb-1 fw-bold">
+                    <div class="card h-100 border-0 shadow-sm hover-shadow transition-all">
+                        <div class="card-body d-flex flex-column">
+                            <div class="d-flex justify-content-between align-items-start mb-3">
+                                <div class="d-flex align-items-center gap-3">
+                                    <div class="bg-primary bg-opacity-10 p-3 rounded-circle">
+                                        <i class="bi bi-building text-primary fs-4"></i>
+                                    </div>
+                                    <div>
+                                        <h5 class="card-title text-dark mb-1 fw-bold">
+                                            <a href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}" class="text-decoration-none stretched-link text-dark">
                                                 {{ $user->employer->employerNameTh ?? $user->name }}
-                                            </h5>
+                                            </a>
+                                        </h5>
                                             <p class="card-text text-muted small">
                                                 <i class="bi bi-clock me-1"></i> อัปเดตล่าสุด: {{ \Carbon\Carbon::parse($user->last_activity)->diffForHumans() }}
                                             </p>
@@ -66,6 +67,13 @@
                                     @endif
                                 </div>
 
+                                <form action="{{ route('admin.tickets.employer.hide', $user) }}" method="POST" class="hide-employer-form position-absolute top-0 end-0 p-2" style="z-index: 10;">
+                                    @csrf
+                                    <button type="submit" class="btn btn-sm btn-outline-danger border-0 rounded-circle" style="width: 30px; height: 30px;" title="ซ่อนกล่องตั๋วงานนี้">
+                                        <i class="bi bi-trash-fill"></i>
+                                    </button>
+                                </form>
+
                                 <div class="mt-auto pt-3 border-top">
                                     <div class="d-flex justify-content-between align-items-center">
                                         <span class="text-muted small">ตั๋วงานทั้งหมด</span>
@@ -74,7 +82,6 @@
                                 </div>
                             </div>
                         </div>
-                    </a>
                 </div>
             @empty
                 <div class="col-12">
@@ -133,9 +140,17 @@
                                     ({{ \Carbon\Carbon::parse($user->last_activity)->diffForHumans() }})
                                 </td>
                                 <td class="text-end">
-                                    <a href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}" class="btn btn-sm btn-primary">
-                                        <i class="bi bi-eye me-1"></i> ดูตั๋วงาน
-                                    </a>
+                                    <div class="d-flex justify-content-end gap-2">
+                                        <a href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}" class="btn btn-sm btn-primary">
+                                            <i class="bi bi-eye"></i>
+                                        </a>
+                                        <form action="{{ route('admin.tickets.employer.hide', $user) }}" method="POST" class="hide-employer-form">
+                                            @csrf
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="ซ่อนกล่องตั๋วงานนี้">
+                                                <i class="bi bi-trash-fill"></i>
+                                            </button>
+                                        </form>
+                                    </div>
                                 </td>
                             </tr>
                         @empty
@@ -184,3 +199,30 @@
     }
 </style>
 @endsection
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.hide-employer-form').forEach(form => {
+        form.addEventListener('submit', function (event) {
+            event.preventDefault();
+
+            Swal.fire({
+                title: 'ยืนยันการซ่อน?',
+                text: "คุณต้องการซ่อนกล่องตั๋วงานนี้ใช่หรือไม่?",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#3085d6',
+                confirmButtonText: 'ใช่, ซ่อนเลย!',
+                cancelButtonText: 'ยกเลิก'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    form.submit();
+                }
+            })
+        });
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -140,6 +140,7 @@ Route::middleware(['auth', 'permission:manage-tickets'])->prefix('admin')->name(
     Route::post('tickets', [AdminJobTicketController::class, 'store'])->name('tickets.store');
 
     Route::get('tickets', [AdminTicketController::class, 'index'])->name('tickets.index');
+    Route::post('tickets/employer/{employer_user}/hide', [AdminTicketController::class, 'hide'])->name('tickets.employer.hide');
     Route::get('tickets/{ticket}', [AdminTicketController::class, 'show'])->name('tickets.show');
     Route::post('tickets/{ticket}/replies', [TicketReplyController::class, 'store'])->name('tickets.replies.store');
 


### PR DESCRIPTION
This commit introduces a feature that allows administrators to hide an employer's entire ticket group from the main ticket inbox view.

- Adds a `hidden_at` timestamp column to the `job_tickets` table.
- Implements a controller action to set the `hidden_at` timestamp for all tickets belonging to a specific employer.
- Updates the ticket inbox query to filter out employers whose tickets are all hidden. This includes updating all relevant counts and the last activity timestamp.
- Adds a `TicketMessageObserver` to automatically clear the `hidden_at` timestamp on a ticket when a new message is created, causing the ticket group to reappear in the inbox.
- Adds hide buttons with confirmation dialogs to both the card and table views of the ticket inbox.