### PR TITLE
feat: Add ability for admins to hide employer ticket boxes

### DIFF
--- a/app/Http/Controllers/Admin/AdminJobTicketController.php
+++ b/app/Http/Controllers/Admin/AdminJobTicketController.php
@@ -61,6 +61,11 @@ class AdminJobTicketController extends Controller
                 'employer_unread_count' => 1, // Admin creates -> Employer has 1 unread message
             ]);
 
+            // V2.6: Un-hide any previously hidden tickets for this employer
+            JobTicket::where('employer_user_id', $validated['employer_user_id'])
+                ->whereNotNull('hidden_by_admin_at')
+                ->update(['hidden_by_admin_at' => null]);
+
             // Define the permanent storage directory for this ticket
             $permanentBasePath = "ticket_attachments/{$ticket->id}";
 

--- a/app/Http/Controllers/Admin/TicketController.php
+++ b/app/Http/Controllers/Admin/TicketController.php
@@ -38,6 +38,8 @@ class TicketController extends Controller
             $perPage = request('per_page', 25);
             $ticketsQuery = JobTicket::with(['employerUser.employer', 'assignedStaff'])
                 ->where('employer_user_id', $employerId)
+                // V2.6: Also hide individual tickets from this list
+                ->whereNull('hidden_by_admin_at')
                 ->latest();
 
             // Apply Caretaker Scope if not Admin/Staff
@@ -66,7 +68,10 @@ class TicketController extends Controller
         $search = request('search');
 
         // Query Users who have submitted tickets
-        $query = User::whereHas('submittedTickets')
+        // V2.6: We only want to show employers who have VISIBLE tickets.
+        $query = User::whereHas('submittedTickets', function ($q) {
+                $q->whereNull('hidden_by_admin_at');
+            })
             ->with('employer'); // Eager load employer profile
 
         // V2.5-S15: Apply Caretaker Visibility Scope for non-admins/staff
@@ -181,5 +186,21 @@ class TicketController extends Controller
         ]);
 
         return redirect()->route('admin.tickets.show', $ticket)->with('success', 'Ticket assignment updated successfully.');
+    }
+
+    /**
+     * V2.6: Hide all tickets from an employer from the main inbox view.
+     */
+    public function hideEmployerTickets(User $user)
+    {
+        if (!Auth::user()->can('manage-tickets')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        JobTicket::where('employer_user_id', $user->id)
+            ->whereNull('hidden_by_admin_at') // Avoid re-hiding already hidden ones
+            ->update(['hidden_by_admin_at' => now()]);
+
+        return redirect()->route('admin.tickets.index')->with('success', 'กล่องตั๋วงานของ ' . ($user->employer->employerNameTh ?? $user->name) . ' ถูกซ่อนแล้ว');
     }
 }

--- a/app/Http/Controllers/Admin/TicketStatusController.php
+++ b/app/Http/Controllers/Admin/TicketStatusController.php
@@ -20,7 +20,10 @@ class TicketStatusController extends Controller
         }
 
         // 2. อัปเดตสถานะ
-        $ticket->update(['status' => 'resolved']);
+        $ticket->update([
+            'status' => 'resolved',
+            'hidden_by_admin_at' => null
+        ]);
 
         // 3. (ทางเลือก) เพิ่มข้อความ System ลงในแชท (ตามพิมพ์เขียว)
         $ticket->messages()->create([
@@ -43,7 +46,10 @@ class TicketStatusController extends Controller
         }
 
         // 2. อัปเดตสถานะ
-        $ticket->update(['status' => 'rejected']);
+        $ticket->update([
+            'status' => 'rejected',
+            'hidden_by_admin_at' => null
+        ]);
 
         // 3. (ทางเลือก) เพิ่มข้อความ System ลงในแชท
         $ticket->messages()->create([
@@ -65,7 +71,10 @@ class TicketStatusController extends Controller
         }
 
         // 1. อัปเดตสถานะเป็น in_progress
-        $ticket->update(['status' => 'in_progress']);
+        $ticket->update([
+            'status' => 'in_progress',
+            'hidden_by_admin_at' => null
+        ]);
 
         // 2. เพิ่มข้อความ System ลงในแชท
         $ticket->messages()->create([

--- a/app/Http/Controllers/TicketReplyController.php
+++ b/app/Http/Controllers/TicketReplyController.php
@@ -151,7 +151,11 @@ $ticket->messages()->create([
 // 5. Workflow Automation: Update Ticket Status & Unread Counts
 $newStatus = $isStaff ? 'pending_employer' : 'pending_staff';
 
-$updateData = ['status' => $newStatus];
+// V2.6: Any reply should un-hide the ticket.
+$updateData = [
+    'status' => $newStatus,
+    'hidden_by_admin_at' => null
+];
 
 if ($isStaff) {
     // Staff replied -> Increment Employer's unread count

--- a/app/Models/JobTicket.php
+++ b/app/Models/JobTicket.php
@@ -25,6 +25,7 @@ class JobTicket extends Model
         'assigned_staff_id',
         'admin_unread_count',
         'employer_unread_count',
+        'hidden_by_admin_at',
     ];
 
     // Ensure $casts array is either absent or empty if it was added. We don't need it for DB Enums.

--- a/database/migrations/2025_11_26_080500_add_hidden_by_admin_at_to_job_tickets_table.php
+++ b/database/migrations/2025_11_26_080500_add_hidden_by_admin_at_to_job_tickets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('job_tickets', function (Blueprint $table) {
+            $table->timestamp('hidden_by_admin_at')->nullable()->after('admin_unread_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('job_tickets', function (Blueprint $table) {
+            $table->dropColumn('hidden_by_admin_at');
+        });
+    }
+};

--- a/resources/views/admin/tickets/employers.blade.php
+++ b/resources/views/admin/tickets/employers.blade.php
@@ -42,8 +42,34 @@
         <div class="row g-4">
             @forelse ($employersWithTickets as $user)
                 <div class="col-12 col-md-6 col-xl-4">
-                    <a href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}" class="text-decoration-none">
-                        <div class="card h-100 border-0 shadow-sm hover-shadow transition-all">
+                    <div class="card h-100 border-0 shadow-sm hover-shadow transition-all position-relative">
+                        {{-- Action Dropdown --}}
+                        <div class="position-absolute top-0 end-0 p-2">
+                            <div class="dropdown">
+                                <button class="btn btn-sm btn-light" type="button" id="dropdownMenuButton-{{ $user->id }}" data-bs-toggle="dropdown" aria-expanded="false">
+                                    <i class="bi bi-three-dots-vertical"></i>
+                                </button>
+                                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton-{{ $user->id }}">
+                                    <li>
+                                        <a class="dropdown-item" href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}">
+                                            <i class="bi bi-folder2-open me-2"></i> ดูตั๋วงานทั้งหมด
+                                        </a>
+                                    </li>
+                                    <li><hr class="dropdown-divider"></li>
+                                    <li>
+                                        <form action="{{ route('admin.users.hide_tickets', $user) }}" method="POST" class="hide-ticket-box-form d-inline">
+                                            @csrf
+                                            <button type="submit" class="dropdown-item text-warning">
+                                                <i class="bi bi-eye-slash me-2"></i> ซ่อนกล่องตั๋วงาน
+                                            </button>
+                                        </form>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        {{-- Card Body (wrapped in a link) --}}
+                        <a href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}" class="text-decoration-none text-dark d-flex flex-column flex-grow-1">
                             <div class="card-body d-flex flex-column">
                                 <div class="d-flex justify-content-between align-items-start mb-3">
                                     <div class="d-flex align-items-center gap-3">
@@ -65,7 +91,6 @@
                                         </span>
                                     @endif
                                 </div>
-
                                 <div class="mt-auto pt-3 border-top">
                                     <div class="d-flex justify-content-between align-items-center">
                                         <span class="text-muted small">ตั๋วงานทั้งหมด</span>
@@ -73,8 +98,8 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    </a>
+                        </a>
+                    </div>
                 </div>
             @empty
                 <div class="col-12">
@@ -133,9 +158,27 @@
                                     ({{ \Carbon\Carbon::parse($user->last_activity)->diffForHumans() }})
                                 </td>
                                 <td class="text-end">
-                                    <a href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}" class="btn btn-sm btn-primary">
-                                        <i class="bi bi-eye me-1"></i> ดูตั๋วงาน
-                                    </a>
+                                    <div class="dropdown">
+                                        <button class="btn btn-sm btn-light" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                            <i class="bi bi-three-dots-vertical"></i>
+                                        </button>
+                                        <ul class="dropdown-menu dropdown-menu-end">
+                                            <li>
+                                                <a class="dropdown-item" href="{{ route('admin.tickets.index', ['employer_id' => $user->id]) }}">
+                                                    <i class="bi bi-folder2-open me-2"></i> ดูตั๋วงานทั้งหมด
+                                                </a>
+                                            </li>
+                                            <li><hr class="dropdown-divider"></li>
+                                            <li>
+                                                <form action="{{ route('admin.users.hide_tickets', $user) }}" method="POST" class="hide-ticket-box-form d-inline">
+                                                    @csrf
+                                                    <button type="submit" class="dropdown-item text-warning">
+                                                        <i class="bi bi-eye-slash me-2"></i> ซ่อนกล่องตั๋วงาน
+                                                    </button>
+                                                </form>
+                                            </li>
+                                        </ul>
+                                    </div>
                                 </td>
                             </tr>
                         @empty
@@ -184,3 +227,30 @@
     }
 </style>
 @endsection
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.hide-ticket-box-form').forEach(form => {
+        form.addEventListener('submit', function (event) {
+            event.preventDefault();
+
+            Swal.fire({
+                title: 'คุณแน่ใจหรือไม่?',
+                text: "คุณต้องการซ่อนกล่องตั๋วงานนี้ใช่ไหม? การดำเนินการนี้สามารถยกเลิกได้เมื่อมีการอัปเดตใหม่",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#3085d6',
+                cancelButtonColor: '#d33',
+                confirmButtonText: 'ใช่, ซ่อนเลย!',
+                cancelButtonText: 'ยกเลิก'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    form.submit();
+                }
+            })
+        });
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -140,6 +140,8 @@ Route::middleware(['auth', 'permission:manage-tickets'])->prefix('admin')->name(
     Route::post('tickets', [AdminJobTicketController::class, 'store'])->name('tickets.store');
 
     Route::get('tickets', [AdminTicketController::class, 'index'])->name('tickets.index');
+    // V2.6: Route to hide an employer's ticket box
+    Route::post('users/{user}/hide-tickets', [AdminTicketController::class, 'hideEmployerTickets'])->name('users.hide_tickets');
     Route::get('tickets/{ticket}', [AdminTicketController::class, 'show'])->name('tickets.show');
     Route::post('tickets/{ticket}/replies', [TicketReplyController::class, 'store'])->name('tickets.replies.store');
 


### PR DESCRIPTION
This commit introduces a "soft hide" feature for the admin ticket inbox. Admins can now hide an entire employer's ticket group to declutter their view of inactive or resolved conversations.

Key changes:
- Added a `hidden_by_admin_at` timestamp to the `job_tickets` table.
- Modified `TicketController` to filter the employer list, only showing employers with non-hidden tickets.
- Added a `hideEmployerTickets` method and a corresponding route to perform the hide action.
- Updated `TicketReplyController`, `AdminJobTicketController`, and `TicketStatusController` to set `hidden_by_admin_at` back to `null` on any new activity, ensuring the ticket box reappears.
- Added a dropdown menu with a "Hide" button to the employer ticket cards and table rows in the view.
- Implemented a SweetAlert confirmation dialog for the hide action.