### PR TITLE
Fix: Correct Giphy proxy route name in chat widget

### DIFF
--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -1082,7 +1082,7 @@
 
             searchGifs(chatId) {
                 const query = new URLSearchParams({ query: this.gifSearchQuery }).toString();
-                fetch(`{{ route('giphy.proxy') }}?${query}`)
+                fetch(`{{ route('chat.giphy.proxy') }}?${query}`)
                     .then(res => res.json())
                     .then(data => {
                         this.gifs = data.data;


### PR DESCRIPTION
The chat widget was causing a `RouteNotDefinedException` because it was attempting to call the route `giphy.proxy`.

Investigation revealed that the correct route name, as defined in `routes/web.php`, is `chat.giphy.proxy`.

This commit corrects the route name in the `fetch` call within the `chat-widget.blade.php` component, resolving the error and restoring the GIF search functionality.