### PR TITLE
Fix undefined variable $employer in employee-action-buttons component

### DIFF
--- a/resources/views/components/employee-action-buttons.blade.php
+++ b/resources/views/components/employee-action-buttons.blade.php
@@ -1,4 +1,4 @@
-@props(['employee', 'employer'])
+@props(['employee', 'employer' => null])
 
 @php
     $containerClass = $employer ? "d-grid d-md-flex gap-2 justify-content-md-end" : "d-flex flex-column flex-md-row gap-2 justify-content-end";


### PR DESCRIPTION
The `employee-action-buttons` component was causing an `Undefined variable $employer` exception in views where the `employer` prop was not explicitly passed (e.g., Employee List, Edit Employer, Groups Management).

This commit modifies the component's `@props` definition to set a default value of `null` for `employer`, ensuring safe access to the variable within the component's logic.