### PR TITLE
Improve document expiry check system to be more robust and run daily …

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -264,9 +264,11 @@ class CheckExpiries extends Command
 
         $threshold = $setting->days_before_expiry;
         $futureThreshold = $today->copy()->addDays($threshold);
+        // Look back 365 days to ensure we catch expired documents
+        $pastThreshold = $today->copy()->subDays(365);
 
         $employers = Employer::whereNotNull('employer_doc_company_expiry')
-            ->whereBetween('employer_doc_company_expiry', [$today, $futureThreshold])
+            ->whereBetween('employer_doc_company_expiry', [$pastThreshold, $futureThreshold])
             ->get();
 
         $this->info("Found {$employers->count()} employers with expiring documents within a {$threshold}-day threshold.");
@@ -312,6 +314,8 @@ class CheckExpiries extends Command
 
         $threshold = $setting->days_before_expiry;
         $futureThreshold = $today->copy()->addDays($threshold);
+        // Look back 365 days to ensure we catch expired documents
+        $pastThreshold = $today->copy()->subDays(365);
         $insuranceFields = ['insurance_expiry_date', 'insurance_expiry_date_hospital', 'insurance_expiry_date_private'];
 
         $allEmployeeIdsInScope = collect();
@@ -320,7 +324,7 @@ class CheckExpiries extends Command
             $employees = (clone $baseEmployeeQuery)
                 ->whereNotNull($field)
                 ->where('insurance_type', '!=', 'ประกันสังคม')
-                ->whereBetween($field, [$today, $futureThreshold])
+                ->whereBetween($field, [$pastThreshold, $futureThreshold])
                 ->get();
 
             $allEmployeeIdsInScope = $allEmployeeIdsInScope->merge($employees->pluck('id'));

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -25,7 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('app:check-expiries')->daily();
+        $schedule->command('app:check-expiries')->daily()->timezone('Asia/Bangkok');
         $schedule->command('app:prune-soft-deletes')->daily();
     }
 


### PR DESCRIPTION
…at 00:00 Bangkok time.

- Updated `app/Console/Commands/CheckExpiries.php` to include past dates (up to 365 days ago) when checking for expiring employer documents and employee insurance. This ensures that expired documents are correctly identified even if the initial check was missed.
- Updated `app/Console/Kernel.php` to explicitly set the timezone to 'Asia/Bangkok' for the `app:check-expiries` daily schedule.