### PR TITLE
Implement read receipts and fix notification counters for chat

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use App\Models\ChatMessage;
+use App\Models\ChatMessageRead; // Added
 use App\Models\ChatGroup;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -20,11 +21,6 @@ class ChatController extends Controller
         $currentUser = Auth::user();
 
         // 1. STRICT BLOCK: Employers cannot access chat at all
-        // The previous logic blocked employers completely unless they had admin/staff roles.
-        // However, the user request says "admin code can see context but not open chat".
-        // This implies the admin MIGHT be using an account that has 'employer' role attached?
-        // Or maybe just a UI bug.
-        // But for "Manager Code", they should have 'admin' role.
         if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
             return response()->json([], 403);
         }
@@ -71,50 +67,43 @@ class ChatController extends Controller
 
         // --- Groups Logic ---
         // 1. Community Group (Always one, auto-generated if missing)
-        // Check if community group exists, create if not (and if admin/staff)
         $communityGroup = ChatGroup::firstOrCreate(
             ['type' => 'community'],
             ['name' => 'Community Chat', 'created_by' => 1] // Assuming ID 1 is superadmin
         );
 
         // 2. Fetch Groups user is part of OR is Community
-        // Admin always sees Community.
-        // For private groups, must be member or admin.
-
         $groups = ChatGroup::query()
             ->where(function($q) use ($currentUser) {
                 $q->where('type', 'community'); // Everyone (who has access to chat) sees community
-                // OR is a member
                 $q->orWhereHas('members', function($m) use ($currentUser) {
                     $m->where('user_id', $currentUser->id);
                 });
-                // OR is admin (can see all private groups? Usually yes for management, but for chat list maybe only if joined?
-                // Let's assume admins should see all groups to manage them, or at least be able to join.
-                // For now, let's stick to "Member OR Community". Admins can create/join groups separately.
             })
             ->withCount(['messages as unread_count' => function($q) use ($currentUser) {
-                 // Logic for unread group messages is complex without a read_receipts table.
-                 // For now, we'll return 0 or implement a simple check later.
-                 $q->whereRaw('1=0');
+                 // UPDATED Logic for unread group messages:
+                 // Count messages NOT read by this user
+                 $q->whereDoesntHave('reads', function($r) use ($currentUser) {
+                     $r->where('user_id', $currentUser->id);
+                 })->where('sender_id', '!=', $currentUser->id);
             }])
             ->get()
             ->map(function($group) use ($currentUser) {
                 return [
                     'id' => $group->id,
                     'type' => 'group',
-                    'group_type' => $group->type, // 'community' or 'private_group'
+                    'group_type' => $group->type,
                     'name' => $group->name,
                     'avatar_url' => $group->avatar_url,
                     'position_title' => $group->type === 'community' ? 'Public Channel' : 'Group Chat',
-                    'is_online' => true, // Groups always "online"
-                    'unread_count' => 0, // Placeholder
+                    'is_online' => true,
+                    'unread_count' => $group->unread_count, // Now accurate
                     'last_message_time' => null,
                     'is_admin' => $currentUser->hasRole('admin') || $group->members()->where('user_id', $currentUser->id)->where('role', 'admin')->exists()
                 ];
             });
 
         // Merge Groups and Users
-        // We want Groups at the top, then Users.
         $allContacts = $groups->merge($contacts);
 
         return response()->json($allContacts);
@@ -139,19 +128,39 @@ class ChatController extends Controller
             $group = ChatGroup::find($id);
             if (!$group) return response()->json(['error' => 'Group not found'], 404);
 
-            // Authorization:
-            // Community: Open to all allowed roles.
-            // Private: Must be member OR Admin.
+            // Authorization
             if ($group->type !== 'community') {
                 if (!$group->members()->where('user_id', $currentUserId)->exists() && !$currentUser->hasRole(['admin'])) {
                      return response()->json(['error' => 'Not a member of this group'], 403);
                 }
             }
 
+            // Mark unread messages as read (excluding own messages)
+            $unreadMessages = ChatMessage::where('chat_group_id', $id)
+                ->where('sender_id', '!=', $currentUserId)
+                ->whereDoesntHave('reads', function($q) use ($currentUserId) {
+                    $q->where('user_id', $currentUserId);
+                })
+                ->pluck('id');
+
+            foreach ($unreadMessages as $msgId) {
+                ChatMessageRead::firstOrCreate([
+                    'chat_message_id' => $msgId,
+                    'user_id' => $currentUserId
+                ]);
+            }
+
             $messages = ChatMessage::where('chat_group_id', $id)
                 ->orderBy('created_at', 'asc')
                 ->with('sender:id,name,avatar_path')
+                ->withCount('reads') // Get count of reads
                 ->get();
+
+            // Transform to include read info for UI
+            $messages = $messages->map(function($msg) {
+                $msg->read_count = $msg->reads_count; // "Read X"
+                return $msg;
+            });
 
             return response()->json($messages);
 
@@ -159,6 +168,12 @@ class ChatController extends Controller
             // Direct Message Logic (Existing)
             $targetUser = User::find($id);
             if (!$targetUser) return response()->json(['error' => 'User not found'], 404);
+
+            // Mark as read (Simple 1-on-1 logic)
+            ChatMessage::where('sender_id', $id)
+                ->where('receiver_id', $currentUserId)
+                ->where('is_read', false)
+                ->update(['is_read' => true]);
 
             $messages = ChatMessage::where(function ($q) use ($currentUserId, $id) {
                     $q->where('sender_id', $currentUserId)->where('receiver_id', $id);
@@ -169,12 +184,6 @@ class ChatController extends Controller
                 ->orderBy('created_at', 'asc')
                 ->with('sender:id,name,avatar_path')
                 ->get();
-
-            // Mark as read (Simple 1-on-1 logic)
-            ChatMessage::where('sender_id', $id)
-                ->where('receiver_id', $currentUserId)
-                ->where('is_read', false)
-                ->update(['is_read' => true]);
 
             return response()->json($messages);
         }
@@ -229,10 +238,16 @@ class ChatController extends Controller
 
         $message = ChatMessage::create($data);
 
+        // If it's a group message, we can automatically mark it as read by sender?
+        // Not really needed, as they don't count towards their own unread count.
+
         // Update sender's last active
         User::where('id', Auth::id())->update(['last_active_at' => now()]);
 
-        return response()->json($message->load('sender:id,name,avatar_path'));
+        $message->load('sender:id,name,avatar_path');
+        $message->read_count = 0; // Initial read count
+
+        return response()->json($message);
     }
 
     /**
@@ -254,13 +269,10 @@ class ChatController extends Controller
         $newDMs = $dmQuery->with('sender:id,name,avatar_path')->get();
 
         // 2. Group Messages (Community or Joined Groups)
-        // We fetch messages from groups the user has access to, created after last_check
-
         // Groups user is in
         $myGroupIds = DB::table('chat_group_members')->where('user_id', $currentUserId)->pluck('chat_group_id')->toArray();
         // Plus Community Groups
         $communityGroupIds = ChatGroup::where('type', 'community')->pluck('id')->toArray();
-
         $allGroupIds = array_unique(array_merge($myGroupIds, $communityGroupIds));
 
         $groupQuery = ChatMessage::whereIn('chat_group_id', $allGroupIds)
@@ -272,14 +284,98 @@ class ChatController extends Controller
              $groupQuery->where('created_at', '>', now()->subSeconds(10));
         }
 
-        $newGroupMsgs = $groupQuery->with('sender:id,name,avatar_path')->get();
+        $newGroupMsgs = $groupQuery->with('sender:id,name,avatar_path')
+            ->withCount('reads')
+            ->get();
+
+        // Add read_count to all new group messages
+        $newGroupMsgs->transform(function ($msg) {
+            $msg->read_count = $msg->reads_count;
+            return $msg;
+        });
 
         $allMessages = $newDMs->merge($newGroupMsgs);
 
+        // --- NEW: Fetch Read Updates for recent messages ---
+        // We need to know if "Read X" count updated for messages we see.
+        // For simplicity, let's fetch read counts for messages sent by ME or in my groups in the last 1 hour.
+        // Or better: Let the frontend handle calling 'fetchMessages' periodically? No, that's heavy.
+
+        // Let's just return a list of {id, read_count, is_read} for messages updated recently.
+        // This is getting complex for simple polling.
+        // Alternative: The user just asked for "Read X" label.
+        // If we only send new messages, the "Read X" on OLD messages won't update until refresh.
+        // Let's include a separate list of "read_updates".
+
+        $readUpdates = [];
+        if ($lastCheck) {
+             // Find messages where a read occurred since last_check
+             // For Groups:
+             $updatedGroupMessages = ChatMessage::whereIn('chat_group_id', $allGroupIds)
+                ->whereHas('reads', function($q) use ($lastCheck) {
+                    $q->where('read_at', '>', $lastCheck);
+                })
+                ->withCount('reads')
+                ->limit(50) // Limit to avoid massive payloads
+                ->get();
+
+             foreach($updatedGroupMessages as $msg) {
+                 $readUpdates[] = [
+                     'id' => $msg->id,
+                     'read_count' => $msg->reads_count,
+                     'is_read' => true // irrelevant for group usually, but consistent structure
+                 ];
+             }
+
+             // For DMs sent by ME:
+             $updatedDMs = ChatMessage::where('sender_id', $currentUserId)
+                ->where('is_read', true)
+                ->where('updated_at', '>', $lastCheck) // approximate
+                ->get();
+
+             foreach($updatedDMs as $msg) {
+                 $readUpdates[] = [
+                     'id' => $msg->id,
+                     'read_count' => 0,
+                     'is_read' => true
+                 ];
+             }
+        }
+
         return response()->json([
             'messages' => $allMessages,
+            'read_updates' => $readUpdates,
             'timestamp' => now()->toDateTimeString()
         ]);
+    }
+
+    /**
+     * Mark specific messages as read (e.g., when a new message arrives in an open window)
+     */
+    public function markAsRead(Request $request)
+    {
+        $currentUserId = Auth::id();
+        $messageIds = $request->input('message_ids', []);
+
+        if (empty($messageIds)) return response()->json(['success' => true]);
+
+        // Filter messages that are group messages vs DMs
+        $messages = ChatMessage::whereIn('id', $messageIds)->get();
+
+        foreach($messages as $msg) {
+            if ($msg->receiver_id == $currentUserId) {
+                // DM
+                $msg->update(['is_read' => true]);
+            } elseif ($msg->chat_group_id) {
+                // Group Message
+                ChatMessageRead::firstOrCreate([
+                    'chat_message_id' => $msg->id,
+                    'user_id' => $currentUserId
+                ]);
+            }
+        }
+
+        return response()->json(['success' => true]);
     }
 
     // ... existing updateProfile and uploadFile methods ...

--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class ChatMessage extends Model
 {
@@ -39,5 +41,16 @@ class ChatMessage extends Model
     public function group(): BelongsTo
     {
         return $this->belongsTo(ChatGroup::class, 'chat_group_id');
+    }
+
+    public function reads(): HasMany
+    {
+        return $this->hasMany(ChatMessageRead::class, 'chat_message_id');
+    }
+
+    public function readByUsers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'chat_message_reads', 'chat_message_id', 'user_id')
+            ->withPivot('read_at');
     }
 }

--- a/app/Models/ChatMessageRead.php
+++ b/app/Models/ChatMessageRead.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ChatMessageRead extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'chat_message_id',
+        'user_id',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'read_at' => 'datetime',
+    ];
+
+    public function message(): BelongsTo
+    {
+        return $this->belongsTo(ChatMessage::class, 'chat_message_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/migrations/2025_11_29_000000_create_chat_message_reads_table.php
+++ b/database/migrations/2025_11_29_000000_create_chat_message_reads_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('chat_message_reads', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_message_id')->constrained('chat_messages')->onDelete('cascade');
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->timestamp('read_at')->useCurrent();
+
+            $table->unique(['chat_message_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_message_reads');
+    }
+};

--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -7,7 +7,7 @@
 
     <!-- Notification Sound -->
     <audio id="chatNotificationSound" preload="auto">
-        <source src="data:audio/wav;base64,UklGRuQSAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YcASAAAAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQ=" type="audio/wav">
+        <source src="data:audio/wav;base64,UklGRuQSAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YcASAAAAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQAADtLu3m7eTtLAADFtEWGRYbFtAAAO0u7ebt5O0sAAMW0RYZFhsW0AAA7S7t5u3k7SwAAxbRFhkWGxbQ=" type="audio/wav">
     </audio>
 
     <!-- 1. Main Launcher Button (Floating & Draggable) -->
@@ -241,7 +241,20 @@
                             </template>
 
                             <div x-html="formatMessage(msg.message)"></div>
-                            <small class="d-block text-end opacity-50" style="font-size: 0.65rem;" x-text="formatTime(msg.created_at)"></small>
+                            <div class="d-flex justify-content-end align-items-center gap-1 mt-1">
+                                <small class="opacity-50" style="font-size: 0.65rem;" x-text="formatTime(msg.created_at)"></small>
+                                <!-- READ RECEIPT -->
+                                <template x-if="msg.sender_id == currentUserId">
+                                    <span class="opacity-75 ms-1" style="font-size: 0.65rem;">
+                                        <template x-if="chat.type === 'group'">
+                                            <span x-show="msg.read_count > 0" x-text="'{{ __('Read') }} ' + msg.read_count"></span>
+                                        </template>
+                                        <template x-if="chat.type !== 'group'">
+                                            <span x-show="msg.is_read">{{ __('Read') }}</span>
+                                        </template>
+                                    </span>
+                                </template>
+                            </div>
                         </div>
                     </div>
                 </template>
@@ -676,11 +689,24 @@
             },
 
             checkNewMessages() {
-                fetch('{{ route('chat.check_new') }}')
+                // Fetch new messages and read updates
+                // We need to pass the timestamp of the last message we have to optimize?
+                // The backend uses 'last_check'.
+                // Ideally, we should track last_check client side.
+                // But for simplicity, we just poll. The backend defaults to 10s if no param.
+
+                // We can't easily track a single 'last_check' if we want "read updates" for older messages.
+                // But the backend `checkNewMessages` now returns `read_updates`.
+
+                const now = new Date().toISOString();
+
+                fetch('{{ route('chat.check_new') }}?last_check=' + (this.lastCheckTime || ''))
                     .then(res => res.json())
                     .then(data => {
+                        this.lastCheckTime = data.timestamp;
+
+                        // 1. New Messages
                         if (data.messages && data.messages.length > 0) {
-                            // Handle new messages logic (similar to previous but adapted for groups)
                             data.messages.forEach(msg => {
                                 let uniqueKey;
                                 if (msg.chat_group_id) {
@@ -699,22 +725,55 @@
                                             chat.unreadCount = (chat.unreadCount || 0) + 1;
                                         }
                                     } else {
-                                        this.fetchMessages(uniqueKey);
+                                        // If open, just append if not exists
+                                         if (!chat.messages.find(m => m.id === msg.id)) {
+                                            chat.messages.push(msg);
+                                            this.$nextTick(() => this.scrollToBottom(uniqueKey));
+
+                                            // Mark as read immediately if window is open
+                                            this.markAsRead([msg.id]);
+                                        }
                                     }
                                 } else {
-                                    // Chat closed, refresh contacts to show badge
                                     this.fetchContacts();
                                 }
                             });
 
-                            // Simple sound logic (play if new msg ID > last)
+                            // Sound
                             const maxId = Math.max(...data.messages.map(m => m.id));
                             if (maxId > this.lastNotifiedMessageId) {
                                 this.playNotificationSound();
                                 this.lastNotifiedMessageId = maxId;
                             }
                         }
+
+                        // 2. Read Updates
+                        if (data.read_updates && data.read_updates.length > 0) {
+                            data.read_updates.forEach(update => {
+                                // Update read status in open chats
+                                this.openChats.forEach(chat => {
+                                    const msg = chat.messages.find(m => m.id === update.id);
+                                    if (msg) {
+                                        msg.is_read = update.is_read;
+                                        msg.read_count = update.read_count;
+                                    }
+                                });
+                            });
+                        }
                     });
+            },
+
+            markAsRead(messageIds) {
+                if (messageIds.length === 0) return;
+
+                fetch('{{ route('chat.mark_as_read') }}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                    },
+                    body: JSON.stringify({ message_ids: messageIds })
+                });
             },
 
             // --- Mentions Logic ---

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,7 @@ Route::middleware('auth')->group(function () {
         Route::get('/contacts', [ChatController::class, 'fetchContacts'])->name('contacts');
         Route::get('/messages/{id}', [ChatController::class, 'fetchMessages'])->name('messages'); // Changed {userId} to {id}
         Route::get('/check-new', [ChatController::class, 'checkNewMessages'])->name('check_new');
+        Route::post('/mark-as-read', [ChatController::class, 'markAsRead'])->name('mark_as_read');
         Route::post('/send', [ChatController::class, 'sendMessage'])->name('send');
         Route::post('/profile/update', [ChatController::class, 'updateProfile'])->name('profile.update_info');
         Route::post('/upload', [ChatController::class, 'uploadFile'])->name('upload');


### PR DESCRIPTION
- Added `chat_message_reads` table to track read status per user in group chats.
- Updated `ChatController` to mark messages as read and return read counts.
- Updated `chat-widget.blade.php` to display "Read" (Private) and "Read X" (Group) labels.
- Implemented real-time updates for read counts via polling.
- Fixed notification counters to correctly reflect unread messages per user in groups.