### PR TITLE
Fix empty chat contact list by allowing group fetching

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -43,7 +43,8 @@ class ChatController extends Controller
                 });
             });
         } else {
-            return response()->json([]);
+            // Allow fetching groups even if no user contacts are visible
+            $userQuery->whereRaw('1 = 0');
         }
 
         $contacts = $userQuery->select('id', 'name', 'avatar_path', 'position_title', 'last_active_at')


### PR DESCRIPTION
The chat contact list was returning completely empty for users who did not match the strict role check (admin, staff, caretaker, delegate), preventing them from seeing even the community groups they were members of.

This change modifies `ChatController@fetchContacts` to remove the early return. Instead, it forces the user query to return no results for unauthorized roles but allows the execution to proceed to the group fetching logic. This restores the visibility of Chat Groups for all authorized chat users.