### PR TITLE
Fix migration dependency order and repair chat tables

### DIFF
--- a/database/migrations/2024_05_22_000000_create_chat_groups_table.php
+++ b/database/migrations/2024_05_22_000000_create_chat_groups_table.php
@@ -25,22 +25,10 @@ return new class extends Migration
 
             $table->unique(['chat_group_id', 'user_id']);
         });
-
-        Schema::table('chat_messages', function (Blueprint $table) {
-            $table->foreignId('chat_group_id')->nullable()->after('receiver_id')->constrained('chat_groups')->onDelete('cascade');
-            $table->unsignedBigInteger('receiver_id')->nullable()->change();
-            $table->json('mentions')->nullable()->after('context_data');
-        });
     }
 
     public function down(): void
     {
-        Schema::table('chat_messages', function (Blueprint $table) {
-            $table->dropForeign(['chat_group_id']);
-            $table->dropColumn(['chat_group_id', 'mentions']);
-            $table->unsignedBigInteger('receiver_id')->nullable(false)->change();
-        });
-
         Schema::dropIfExists('chat_group_members');
         Schema::dropIfExists('chat_groups');
     }

--- a/database/migrations/2025_11_26_000001_create_chat_messages_table.php
+++ b/database/migrations/2025_11_26_000001_create_chat_messages_table.php
@@ -14,10 +14,14 @@ return new class extends Migration
         Schema::create('chat_messages', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('sender_id');
-            $table->unsignedBigInteger('receiver_id')->nullable(); // Nullable for group chats if needed later, or just direct
+            $table->unsignedBigInteger('receiver_id')->nullable(); // Nullable for group chats
+            // Added columns that were incorrectly placed in 2024 migration
+            $table->foreignId('chat_group_id')->nullable()->constrained('chat_groups')->onDelete('cascade');
+
             $table->text('message');
             $table->boolean('is_read')->default(false);
             $table->json('context_data')->nullable(); // For tags: { "type": "employee", "id": 123, "url": "..." }
+            $table->json('mentions')->nullable(); // Added
             $table->timestamps();
 
             $table->foreign('sender_id')->references('id')->on('users')->onDelete('cascade');

--- a/database/migrations/2025_12_02_000001_fix_chat_tables.php
+++ b/database/migrations/2025_12_02_000001_fix_chat_tables.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('chat_messages')) {
+            Schema::table('chat_messages', function (Blueprint $table) {
+                if (!Schema::hasColumn('chat_messages', 'chat_group_id')) {
+                    $table->foreignId('chat_group_id')->nullable()->after('receiver_id')->constrained('chat_groups')->onDelete('cascade');
+                }
+                if (!Schema::hasColumn('chat_messages', 'mentions')) {
+                    $table->json('mentions')->nullable()->after('context_data');
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('chat_messages')) {
+             Schema::table('chat_messages', function (Blueprint $table) {
+                if (Schema::hasColumn('chat_messages', 'chat_group_id')) {
+                     // Drop foreign key first if possible, but difficult to know name.
+                     // Usually chat_messages_chat_group_id_foreign
+                     try {
+                        $table->dropForeign(['chat_group_id']);
+                     } catch (\Exception $e) {}
+                     $table->dropColumn('chat_group_id');
+                }
+                if (Schema::hasColumn('chat_messages', 'mentions')) {
+                    $table->dropColumn('mentions');
+                }
+             });
+        }
+    }
+};


### PR DESCRIPTION
- Fixed `2024_05_22` migration to stop altering `chat_messages` table which didn't exist yet.
- Updated `2025_11_26` migration to include `chat_group_id` and `mentions` columns in the table creation.
- Added new `2025_12_02` migration to retroactive fix existing databases by adding missing columns if they don't exist.
- This resolves the issue where chat contacts/groups were not loading due to SQL errors from missing columns.