### PR TITLE
Enhance drag-and-drop for employee data in chat

### DIFF
--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -106,12 +106,16 @@
                             @foreach($attachments->existing_employees as $item)
                                 @php $employee = $item->employee; @endphp
                                 <div class="list-group-item d-flex align-items-center gap-3 py-2"
+                                     id="employee-card-{{ $employee->id }}"
                                      draggable="true"
                                      @dragstart="startDragGlobal($event, 'employee', {
                                         id: {{ $employee->id }},
-                                        title: '{{ $employee->employeeNameTh }}',
-                                        subtitle: '{{ $employee->employeeNameEn }}',
-                                        url: '{{ route('employees.locate', $employee->id) }}'
+                                        title: @json($employee->employeeNameTh),
+                                        subtitle: @json($employee->employeeNameEn),
+                                        photo_url: '{{ $employee->photo_url }}',
+                                        url: window.location.href.split('#')[0] + '#employee-card-{{ $employee->id }}',
+                                        employer_name: @json(optional($employee->employer)->employerNameTh ?? 'N/A'),
+                                        nationality: '{{ $employee->employeeNationality }}'
                                      })">
                                     <div class="form-check mb-0">
                                         <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}">
@@ -155,12 +159,16 @@
                             @foreach($attachments->external_employees as $item)
                                 @php $employee = $item->employee; @endphp
                                 <div class="list-group-item d-flex align-items-center gap-3 py-2 bg-light"
+                                     id="employee-card-{{ $employee->id }}"
                                      draggable="true"
                                      @dragstart="startDragGlobal($event, 'employee', {
                                         id: {{ $employee->id }},
-                                        title: '{{ $employee->employeeNameTh }}',
-                                        subtitle: '{{ $employee->employeeNameEn }}',
-                                        url: '{{ route('employees.locate', $employee->id) }}'
+                                        title: @json($employee->employeeNameTh),
+                                        subtitle: @json($employee->employeeNameEn),
+                                        photo_url: '{{ $employee->photo_url }}',
+                                        url: window.location.href.split('#')[0] + '#employee-card-{{ $employee->id }}',
+                                        employer_name: @json(optional($employee->employer)->employerNameTh ?? 'N/A'),
+                                        nationality: '{{ $employee->employeeNationality }}'
                                      })">
                                     {{-- External employees don't have bulk actions for now --}}
                                     <div class="position-relative">

--- a/resources/views/employees/_employee_card.blade.php
+++ b/resources/views/employees/_employee_card.blade.php
@@ -1,6 +1,12 @@
 @php
     // Helper to prevent errors if employer relationship is not loaded
     $employerName = $employee->employer->employerNameTh ?? 'N/A';
+
+    // V2.5: Allow overriding the DOM ID and the Drag URL from parent views
+    // This is crucial for views like Groups/Teams where the same employee appears multiple times
+    // or where we need query parameters (active_tab) in the URL.
+    $elementId = $elementId ?? 'employee-card-' . $employee->id;
+    $dragUrl = $dragUrl ?? (request()->fullUrl() . '#' . $elementId);
 @endphp
 @php
     // V2.5: Check completeness for badge display (Only in Incomplete View)
@@ -10,7 +16,20 @@
     }
 @endphp
 
-<div id="employee-card-{{ $employee->id }}" class="list-group-item list-group-item-action position-relative">
+<div id="{{ $elementId }}"
+     class="list-group-item list-group-item-action position-relative"
+     draggable="true"
+     data-drag-payload="{{ json_encode([
+        'id' => $employee->id,
+        'title' => $employee->employeeNameTh,
+        'subtitle' => $employee->employeeNameEn,
+        'photo_url' => $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC',
+        'url' => $dragUrl,
+        'employer_name' => $employerName,
+        'nationality' => $employee->employeeNationality
+     ]) }}"
+     ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
+
     @if($missingCount > 0)
         <span class="position-absolute top-0 start-0 translate-middle badge rounded-pill bg-warning text-dark border border-light shadow-sm" style="z-index: 10; margin-left: 15px; margin-top: 15px; font-size: 0.8rem;">
             {{ $missingCount }}

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -27,7 +27,7 @@
         'id' => $employer->id,
         'title' => $employer->employerNameTh,
         'subtitle' => $employer->employerNameEn,
-        'url' => route('employers.edit', $employer->id)
+        'url' => request()->fullUrl()
      ]) }}"
      ondragstart="window.startDragGlobal(event, 'employer', JSON.parse(this.dataset.dragPayload))">
     <h2 class="mb-4">{{ __('Edit Employer') }}</h2>
@@ -420,16 +420,15 @@
         @if($currentView === 'card')
             <div class="list-group">
             @forelse($employees as $employee)
-                <div class="position-relative" draggable="true"
-                     data-drag-payload="{{ json_encode([
-                        'id' => $employee->id,
-                        'title' => $employee->employeeFullName,
-                        'subtitle' => $employer->employerNameTh,
-                        'url' => route('employees.show', $employee->id)
-                     ]) }}"
-                     ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
-                    {{-- DEFINITIVE FIX: Use the single, unified partial --}}
-                    @include('partials._employee_card', ['employee' => $employee, 'loop' => $loop, 'pagination' => $employees, 'showLocateButton' => false])
+                <div class="position-relative">
+                    @include('partials._employee_card', [
+                        'employee' => $employee,
+                        'loop' => $loop,
+                        'pagination' => $employees,
+                        'showLocateButton' => false,
+                        'elementId' => 'employee-card-' . $employee->id,
+                        'dragUrl' => request()->fullUrl() . '#employee-card-' . $employee->id
+                    ])
                 </div>
             @empty
                 <p class="text-center text-muted">{{ __('No employees found matching criteria') }}</p>
@@ -457,7 +456,10 @@
                                     'id' => $employee->id,
                                     'title' => $employee->employeeFullName,
                                     'subtitle' => $employer->employerNameTh,
-                                    'url' => route('employees.show', $employee->id)
+                                    'photo_url' => $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC',
+                                    'url' => request()->fullUrl() . '#employee-row-' . $employee->id,
+                                    'employer_name' => $employer->employerNameTh,
+                                    'nationality' => $employee->employeeNationality
                                 ]) }}"
                                 ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
                                 {{-- DEFINITIVE FIX: Add checkbox for bulk actions --}}

--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -257,23 +257,22 @@
                                                 </h5>
                                                 <div class="list-group">
                                                     @foreach($members as $member)
-                                                        <div draggable="true"
-                                                             data-drag-payload="{{ json_encode([
-                                                                'id' => $member->id,
-                                                                'title' => $member->employeeFullName,
-                                                                'subtitle' => $team->name,
-                                                                'url' => route('employees.show', $member->id)
-                                                             ]) }}"
-                                                             ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
-                                                            @include('partials._employee_card', [
-                                                                'employee' => $member,
-                                                                'loop' => $loop,
-                                                                'showLocateButton' => true,
-                                                                'hideTeamTags' => true,
-                                                                'currentTeamId' => $team->id,
-                                                                'idPrefix' => 'team-' . $team->id . '-'
-                                                            ])
-                                                        </div>
+                                                        @php
+                                                            $currentUrl = request()->fullUrlWithQuery([
+                                                                'active_group' => $activeGroup->id,
+                                                                'active_team' => $team->id,
+                                                                'highlight_employee' => $member->id
+                                                            ]);
+                                                        @endphp
+                                                        @include('partials._employee_card', [
+                                                            'employee' => $member,
+                                                            'loop' => $loop,
+                                                            'showLocateButton' => true,
+                                                            'hideTeamTags' => true,
+                                                            'currentTeamId' => $team->id,
+                                                            'elementId' => 'employee-card-team-' . $team->id . '-' . $member->id,
+                                                            'dragUrl' => $currentUrl . '#employee-card-team-' . $team->id . '-' . $member->id
+                                                        ])
                                                     @endforeach
                                                 </div>
                                             </div>
@@ -286,23 +285,22 @@
                                         {{-- No Grouping --}}
                                         <div class="list-group">
                                             @forelse($team->employees as $member)
-                                                <div draggable="true"
-                                                     data-drag-payload="{{ json_encode([
-                                                        'id' => $member->id,
-                                                        'title' => $member->employeeFullName,
-                                                        'subtitle' => $team->name,
-                                                        'url' => route('employees.show', $member->id)
-                                                     ]) }}"
-                                                     ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
-                                                    @include('partials._employee_card', [
-                                                        'employee' => $member,
-                                                        'loop' => $loop,
-                                                        'showLocateButton' => true,
-                                                        'hideTeamTags' => true,
-                                                        'currentTeamId' => $team->id,
-                                                        'idPrefix' => 'team-' . $team->id . '-'
-                                                    ])
-                                                </div>
+                                                @php
+                                                    $currentUrl = request()->fullUrlWithQuery([
+                                                        'active_group' => $activeGroup->id,
+                                                        'active_team' => $team->id,
+                                                        'highlight_employee' => $member->id
+                                                    ]);
+                                                @endphp
+                                                @include('partials._employee_card', [
+                                                    'employee' => $member,
+                                                    'loop' => $loop,
+                                                    'showLocateButton' => true,
+                                                    'hideTeamTags' => true,
+                                                    'currentTeamId' => $team->id,
+                                                    'elementId' => 'employee-card-team-' . $team->id . '-' . $member->id,
+                                                    'dragUrl' => $currentUrl . '#employee-card-team-' . $team->id . '-' . $member->id
+                                                ])
                                             @empty
                                                 <div class="text-center text-muted py-4 border rounded bg-light">
                                                     {{ __('No members in this team yet.') }}
@@ -466,6 +464,8 @@
                                     id: employee.id,
                                     title: employee.name,
                                     subtitle: employee.passport,
+                                    photo_url: employee.photo,
+                                    employer_name: employee.employer_name,
                                     url: '#'
                                  })">
                                 <div class="d-flex align-items-center">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1126,6 +1126,24 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         }
     });
+
+    // Global Highlight & Scroll Handler
+    document.addEventListener('DOMContentLoaded', function() {
+        if (window.location.hash) {
+            // Decouple from execution flow to ensure DOM is fully ready
+            setTimeout(() => {
+                const id = window.location.hash.substring(1);
+                const el = document.getElementById(id);
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    el.classList.add('highlight');
+                    setTimeout(() => {
+                        el.classList.remove('highlight');
+                    }, 5000);
+                }
+            }, 300);
+        }
+    });
 </script>
 
 </body>

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -51,7 +51,7 @@
         'employee_photo_url' => optional($employee)->photo_url,
         'employee_nationality' => optional($employee)->employeeNationality,
         'employer_name_th' => optional($employer)->employerNameTh,
-        'url' => route('notifications.index', ['highlight' => $notification->id, 'active_tab' => $notification->status]),
+        'url' => request()->fullUrl() . '#notification-item-' . $notification->id,
     ];
 @endphp
 


### PR DESCRIPTION
- Implement a rich notification card format for employee data dropped into the chat.
- Add drag-and-drop support to Employee Card, Notification items, Employer Edit list, and Group/Team lists.
- Ensure dragging an employee from a specific location (e.g., Team, Ticket) generates a URL that links back to that exact context and highlights the item.
- Resolve ID conflicts in draggable elements to support highlighting.
- Add global JavaScript to handle scrolling and highlighting of elements based on URL hashes.