### PR TITLE
Add phpoffice/phpspreadsheet dependency to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": "^8.2",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
+        "phpoffice/phpspreadsheet": "^1.29",
         "setasign/fpdf": "^1.8",
         "setasign/fpdi": "^2.6",
         "spatie/laravel-permission": "^6.21"


### PR DESCRIPTION
This commit adds the `phpoffice/phpspreadsheet` package (version ^1.29) to the project's dependencies. This library is required by the `ImportEmployeeController` to generate and read Excel files, fixing the "Class 'PhpOffice\PhpSpreadsheet\Spreadsheet' not found" error during template download and import.

Note: Run `composer update` to install the new dependency.