### PR TITLE
Update employee import template layout and logic

### DIFF
--- a/app/Http/Controllers/ImportEmployeeController.php
+++ b/app/Http/Controllers/ImportEmployeeController.php
@@ -16,6 +16,8 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
 
 class ImportEmployeeController extends Controller
 {
@@ -61,72 +63,149 @@ class ImportEmployeeController extends Controller
         $sheet = new \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet($spreadsheet, 'Employees');
         $spreadsheet->addSheet($sheet, 0);
 
+        // --- EMPLOYER INFO HEADER SECTION (Rows 1-11) ---
+        // We will create a layout mimicking the provided image roughly.
+        // We'll use columns A-L, merging as needed.
+
+        // Default Font
+        $sheet->getParent()->getDefaultStyle()->getFont()->setName('Angsana New')->setSize(16);
+
+        // Row 1: Employer Name & ID Card
+        $sheet->setCellValue('A1', 'ชื่อนายจ้าง');
+        $sheet->mergeCells('B1:F1'); // Name Input
+        $sheet->setCellValue('G1', 'เลขประจำตัวประชาชน');
+        $sheet->setCellValue('G2', '/ทะเบียนนิติบุคคล');
+        $sheet->mergeCells('H1:L1'); // ID Input
+        $sheet->mergeCells('H2:L2'); // ID Input continuation if needed or just align
+
+        // Row 3: Business Type & Request No
+        $sheet->setCellValue('A3', 'ประเภทธุรกิจ');
+        $sheet->mergeCells('B3:F3'); // Business Input
+        $sheet->setCellValue('G3', 'เลขคำขอ');
+        $sheet->mergeCells('H3:L3'); // Request Input
+
+        // Row 4: Address
+        $sheet->setCellValue('A4', 'ที่อยู่');
+        $sheet->mergeCells('B4:L4');
+
+        // Row 5: Moo, Soi, Road
+        $sheet->setCellValue('A5', 'หมู่ที่/อาคาร');
+        $sheet->mergeCells('B5:D5');
+        $sheet->setCellValue('E5', 'ซอย');
+        $sheet->mergeCells('F5:H5');
+        $sheet->setCellValue('I5', 'ถนน');
+        $sheet->mergeCells('J5:L5');
+
+        // Row 6: Subdistrict, District
+        $sheet->setCellValue('A6', 'ตำบล/แขวง');
+        $sheet->mergeCells('B6:E6');
+        $sheet->setCellValue('F6', 'อำเภอ/เขต');
+        $sheet->mergeCells('G6:L6');
+
+        // Row 7: Province, Zip
+        $sheet->setCellValue('A7', 'จังหวัด');
+        $sheet->mergeCells('B7:E7');
+        $sheet->setCellValue('F7', 'รหัสไปรษณีย์');
+        $sheet->mergeCells('G7:L7');
+
+        // Row 8: Tel, Email
+        $sheet->setCellValue('A8', 'โทรศัพท์');
+        $sheet->mergeCells('B8:E8');
+        $sheet->setCellValue('F8', 'e-Mail');
+        $sheet->mergeCells('G8:L8');
+
+        // Row 9-10: Requirement Block
+        // "มีความต้องการจ้างแรงงานต่างด้าว"
+        $sheet->mergeCells('I9:L9');
+        $sheet->setCellValue('I9', 'มีความต้องการจ้างแรงงานต่างด้าว');
+        $sheet->getStyle('I9')->getFill()->setFillType(\PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID)->getStartColor()->setARGB('FFF0F0F0');
+        $sheet->getStyle('I9')->getAlignment()->setHorizontal(Alignment::HORIZONTAL_CENTER);
+
+        $sheet->mergeCells('I10:L10');
+        $sheet->setCellValue('I10', 'สัญชาติ _________ จำนวน ____ คน');
+        $sheet->getStyle('I10')->getFill()->setFillType(\PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID)->getStartColor()->setARGB('FFF0F0F0');
+        $sheet->getStyle('I10')->getAlignment()->setHorizontal(Alignment::HORIZONTAL_CENTER);
+
+        $sheet->setCellValue('I11', 'ตามรายชื่อดังต่อไปนี้');
+
+
+        // Add Underlines (Bottom Border) to input cells for form look
+        $inputCells = [
+            'B1:F1', 'H1:L2',
+            'B3:F3', 'H3:L3',
+            'B4:L4',
+            'B5:D5', 'F5:H5', 'J5:L5',
+            'B6:E6', 'G6:L6',
+            'B7:E7', 'G7:L7',
+            'B8:E8', 'G8:L8'
+        ];
+        foreach ($inputCells as $range) {
+             $sheet->getStyle($range)->getBorders()->getBottom()->setBorderStyle(Border::BORDER_THIN);
+        }
+
+        // --- DATA TABLE HEADERS (Row 12) ---
+        $headerRow = 12;
         $columns = [
-            'Title (TH)',
-            'Name (TH)',
-            'Name (EN)',
-            'Gender',
-            'Date of Birth (YYYY-MM-DD)',
-            'Nationality',
-            'Passport Number',
-            'Work Permit Number',
-            'Work Permit Type',
-            'Pink Card Number',
-            'CI/PJ/TD/Inter',
-            'Photo (Insert Image in Cell)'
+            'Photo (Insert Image)', // A
+            'Title (TH)',           // B
+            'Name (TH)',            // C
+            'Name (EN)',            // D
+            'Gender',               // E
+            'Date of Birth (YYYY-MM-DD)', // F
+            'Nationality',          // G
+            'Passport Number',      // H
+            'Work Permit Number',   // I
+            'Work Permit Type',     // J
+            'Pink Card Number',     // K
+            'CI/PJ/TD/Inter'        // L
         ];
 
-        // Set Headers
         foreach ($columns as $index => $header) {
             $columnLetter = Coordinate::stringFromColumnIndex($index + 1);
-            $sheet->setCellValue($columnLetter . '1', $header);
+            $cell = $columnLetter . $headerRow;
+            $sheet->setCellValue($cell, $header);
+
             // Style header
-            $sheet->getStyle($columnLetter . '1')->getFont()->setBold(true);
-            $sheet->getStyle($columnLetter . '1')->getFill()
+            $sheet->getStyle($cell)->getFont()->setBold(true);
+            $sheet->getStyle($cell)->getFill()
                 ->setFillType(\PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID)
                 ->getStartColor()->setARGB('FFF0F0F0');
+            $sheet->getStyle($cell)->getAlignment()->setVertical(Alignment::VERTICAL_CENTER);
+            $sheet->getStyle($cell)->getAlignment()->setHorizontal(Alignment::HORIZONTAL_CENTER);
+            // Add border
+            $sheet->getStyle($cell)->getBorders()->getAllBorders()->setBorderStyle(Border::BORDER_THIN);
         }
 
-        // Add instructions in a comment or separate row?
-        // Let's add a note above headers (Row 1) and headers at Row 2?
-        // No, let's keep headers at Row 1 for simplicity, but add a comment to the Photo header.
-        $sheet->getComment('L1')->getText()->createTextRun('Insert your employee photos into this column. Ensure the image fits within the cell boundaries.');
+        // Add instructions as a comment on Photo header
+        $sheet->getComment('A'.$headerRow)->getText()->createTextRun('Insert employee photo here. Image should fit within the cell.');
 
-        // Sample Data
-        $sample = [
-            'นาย',
-            'สมชาย ใจดี',
-            'Somchai Jaidee',
-            'Male',
-            '1990-01-31',
-            'เมียนมา',
-            'PP123456',
-            'WP987654',
-            'MOU',
-            '-',
-            'CI'
-        ];
+        // --- PRE-FORMAT DATA ROWS (13 to 112) ---
+        $startDataRow = 13;
+        $endDataRow = 112; // 100 rows
 
-        foreach ($sample as $index => $value) {
-            $sheet->setCellValue(Coordinate::stringFromColumnIndex($index + 1) . '2', $value);
-        }
+        // Set dimensions
+        // Column A (Photo) Width ~ 20 (approx 140px width)
+        $sheet->getColumnDimension('A')->setWidth(20);
 
-        // Auto-size columns
-        foreach (range('A', 'K') as $col) {
+        // Auto-size other columns (B to L)
+        foreach (range('B', 'L') as $col) {
             $sheet->getColumnDimension($col)->setAutoSize(true);
         }
 
-        // Set Photo column width larger to encourage image placement
-        $sheet->getColumnDimension('L')->setAutoSize(false);
-        $sheet->getColumnDimension('L')->setWidth(30);
-        $sheet->getRowDimension(2)->setRowHeight(80); // Make the sample row taller for image space
+        // Set Row Height for data rows to accommodate photos (e.g., 60-80 points)
+        for ($r = $startDataRow; $r <= $endDataRow; $r++) {
+            $sheet->getRowDimension($r)->setRowHeight(80);
+
+            // Apply borders to all cells in the grid
+            $rowRange = "A{$r}:L{$r}";
+            $sheet->getStyle($rowRange)->getBorders()->getAllBorders()->setBorderStyle(Border::BORDER_THIN);
+            $sheet->getStyle($rowRange)->getAlignment()->setVertical(Alignment::VERTICAL_CENTER);
+        }
 
         $writer = new Xlsx($spreadsheet);
-
         $filename = 'employee_import_template.xlsx';
 
         return response()->streamDownload(function() use ($writer) {
-             // Ensure clean buffer again inside the callback
              if (ob_get_length()) ob_end_clean();
              $writer->save('php://output');
         }, $filename);
@@ -167,72 +246,90 @@ class ImportEmployeeController extends Controller
             $spreadsheet = IOFactory::load($path);
 
             // Robustly get the first sheet.
-            // This fixes "Sheet not found" if 'getActiveSheet' relies on internal state that might be empty or invalid.
             try {
                 $sheet = $spreadsheet->getSheet(0);
             } catch (\Exception $e) {
-                // Fallback to active sheet if getSheet(0) somehow fails (unlikely)
                 $sheet = $spreadsheet->getActiveSheet();
             }
+
+            // Define Header Row
+            // We assume headers are on Row 12, so Data starts at Row 13
+            $START_ROW = 13;
 
             // Extract Images first to map them to rows
             $images = [];
             foreach ($sheet->getDrawingCollection() as $drawing) {
-                // Get coordinates (e.g. "L2")
+                // Get coordinates (e.g. "A13")
                 $coords = $drawing->getCoordinates();
 
-                // Parse column and row
-                // The regex captures the column letter(s) and the row number
                 if (preg_match('/^([A-Z]+)(\d+)$/', $coords, $matches)) {
                     $column = $matches[1];
                     $row = (int)$matches[2];
 
-                    // We strictly look for images anchored in Column L (Photo column)
-                    if ($column === 'L') {
+                    // Look for images in Column A
+                    if ($column === 'A' && $row >= $START_ROW) {
                         $images[$row] = $drawing;
                     }
                 }
             }
 
             if (!empty($images)) {
-                Log::info("Found " . count($images) . " images in import file.");
+                Log::info("Found " . count($images) . " images in import file starting from row $START_ROW.");
             }
 
-            // Iterate rows starting from 2
+            // Iterate rows starting from START_ROW
             $highestRow = $sheet->getHighestRow();
 
-            for ($rowIdx = 2; $rowIdx <= $highestRow; $rowIdx++) {
+            for ($rowIdx = $START_ROW; $rowIdx <= $highestRow; $rowIdx++) {
                 // Get cell values
+                // Mapped Columns:
+                // A (1) = Photo
+                // B (2) = Title (TH)
+                // C (3) = Name (TH)
+                // D (4) = Name (EN)
+                // E (5) = Gender
+                // F (6) = DOB
+                // G (7) = Nationality
+                // H (8) = Passport
+                // I (9) = WP
+                // J (10) = WP Type
+                // K (11) = Pink Card
+                // L (12) = Book Type
+
                 $row = [];
-                for ($colIdx = 1; $colIdx <= 11; $colIdx++) {
-                    // Use format value or raw value? GetValue is raw.
+                // We read columns 2 (B) through 12 (L) for text data
+                for ($colIdx = 2; $colIdx <= 12; $colIdx++) {
                     $colLetter = Coordinate::stringFromColumnIndex($colIdx);
                     $val = $sheet->getCell($colLetter . $rowIdx)->getValue();
                     $row[] = trim((string)$val);
                 }
 
-                // Check if empty row (skip if NameTH and NameEN are empty)
-                if (empty($row[1]) && empty($row[2])) {
+                // Check if empty row (Title, NameTH, NameEN are in indices 0, 1, 2 of $row array)
+                // $row array is 0-indexed relative to the loop.
+                // Loop starts at col 2 (B), so $row[0] is Col B, $row[1] is Col C.
+                if (empty($row[0]) && empty($row[1])) {
+                    // It might be one of the pre-formatted empty rows.
                     continue;
                 }
 
                 // Parse Data
-                $titleTh = $row[0];
-                $nameTh = $row[1];
-                $nameEn = $row[2];
-                // $gender = $row[3];
-                $dobRaw = $row[4];
-                $nationality = $row[5];
-                $passport = $row[6];
-                $wp = $row[7];
-                $wpType = $row[8];
-                $pinkCard = $row[9];
-                $bookType = $row[10];
+                $titleTh = $row[0]; // B
+                $nameTh = $row[1];  // C
+                $nameEn = $row[2];  // D
+                // $gender = $row[3]; // E
+                $dobRaw = $row[4];  // F
+                $nationality = $row[5]; // G
+                $passport = $row[6];    // H
+                $wp = $row[7];          // I
+                $wpType = $row[8];      // J
+                $pinkCard = $row[9];    // K
+                $bookType = $row[10];   // L
 
                  // Format Date
                 $dob = null;
                 if (!empty($dobRaw)) {
-                    $dobColLetter = Coordinate::stringFromColumnIndex(5);
+                    // DOB is at Col 6 (F)
+                    $dobColLetter = 'F';
                     if (Date::isDateTime($sheet->getCell($dobColLetter . $rowIdx))) {
                          $dob = Carbon::instance(Date::excelToDateTimeObject($dobRaw))->format('Y-m-d');
                     } else {
@@ -244,7 +341,7 @@ class ImportEmployeeController extends Controller
                     }
                 }
 
-                // Process Image
+                // Process Image from Column A
                 $photoPath = null;
                 if (isset($images[$rowIdx])) {
                     $drawing = $images[$rowIdx];
@@ -253,7 +350,6 @@ class ImportEmployeeController extends Controller
 
                     try {
                         if ($drawing instanceof MemoryDrawing) {
-                            // Ensure buffer is clean before starting specific image capture
                             if (ob_get_length()) ob_end_clean();
 
                             ob_start();
@@ -273,7 +369,6 @@ class ImportEmployeeController extends Controller
                                     $extension = 'jpg'; break;
                             }
                         } elseif ($drawing instanceof Drawing) {
-                            // Helper to get image contents safely
                             $imagePath = $drawing->getPath();
                             if ($imagePath && file_exists($imagePath)) {
                                  $imageContent = file_get_contents($imagePath);
@@ -286,7 +381,6 @@ class ImportEmployeeController extends Controller
                             $filename = 'import_' . uniqid() . '.' . $extension;
                             $storagePath = 'employee_photos/' . $filename;
 
-                            // Ensure directory exists
                             if (!Storage::disk('public')->exists('employee_photos')) {
                                 Storage::disk('public')->makeDirectory('employee_photos');
                             }


### PR DESCRIPTION
- Move Photo column to the first position (Column A).
- Add an 'Employer Information' header section (Rows 1-11) for manual use.
- Pre-format 100 rows with adjusted height for photos.
- Update import logic to skip the new header and read from the new column layout.