### PR TITLE
feat: enhance employee drag-and-drop with rich chat cards and source …

### DIFF
--- a/resources/views/admin/incomplete_employees/index.blade.php
+++ b/resources/views/admin/incomplete_employees/index.blade.php
@@ -94,15 +94,12 @@
         @if($currentView === 'card')
             <div class="row g-3">
                 @foreach($employees as $employee)
-                    <div class="col-12 col-md-6 col-xl-4 position-relative" draggable="true"
-                         data-drag-payload="{{ json_encode([
-                            'id' => $employee->id,
-                            'title' => $employee->employeeNameEn,
-                            'subtitle' => optional($employee->employer)->employerNameTh,
-                            'url' => route('employers.edit', $employee->employer_id) . '?highlight_employee=' . $employee->id
-                         ]) }}"
-                         ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
-                        @include('employees._employee_card', ['employee' => $employee, 'is_incomplete_view' => true])
+                    <div class="col-12 col-md-6 col-xl-4 position-relative">
+                        @include('employees._employee_card', [
+                            'employee' => $employee,
+                            'is_incomplete_view' => true,
+                            'source_menu' => __('Incomplete Data')
+                        ])
                     </div>
                 @endforeach
             </div>
@@ -126,13 +123,18 @@
                         <tbody>
                             @foreach($employees as $employee)
                             <tr draggable="true"
-                                data-drag-payload="{{ json_encode([
-                                    'id' => $employee->id,
-                                    'title' => $employee->employeeNameEn,
-                                    'subtitle' => optional($employee->employer)->employerNameTh,
-                                    'url' => route('employers.edit', $employee->employer_id) . '?highlight_employee=' . $employee->id
-                                ]) }}"
-                                ondragstart="window.startDragGlobal(event, 'employee', JSON.parse(this.dataset.dragPayload))">
+                                ondragstart="window.startDragGlobal(event, 'employee', {
+                                    id: {{ $employee->id }},
+                                    title: '{{ $employee->employeeNameEn ?? $employee->employeeNameTh }}',
+                                    title_th: '{{ $employee->employeeNameTh }}',
+                                    title_en: '{{ $employee->employeeNameEn }}',
+                                    subtitle: '{{ $employee->job_title ?? 'N/A' }}',
+                                    photo_url: '{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : asset('images/default-profile.png') }}',
+                                    url: '{{ route('employers.edit', $employee->employer_id) . '?highlight_employee=' . $employee->id . '#employee-card-' . $employee->id }}',
+                                    source_menu: '{{ __('Incomplete Data') }}',
+                                    employer_name: '{{ optional($employee->employer)->employerNameTh }}',
+                                    nationality: '{{ $employee->employeeNationality }}'
+                                })">
                                 <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}"></td>
                                 <td>
                                     <div class="d-flex align-items-center">

--- a/resources/views/components/hybrid-attachment-scripts.blade.php
+++ b/resources/views/components/hybrid-attachment-scripts.blade.php
@@ -575,21 +575,46 @@ function hybridAttachmentManager(config = {}) {
                 return; // Done
             }
 
-            // 2. Handle Employee Drop (from anywhere) -> Add to Basket
+            // 2. Handle Employee Drop (from anywhere)
             if (data.type === 'employee') {
+                // PART A: Always add a Rich Card to the Chat Message Box
+                // This payload structure mimics the Notification Card structure which the PHP controller/view already knows how to render.
+                // We map our standard employee drag data to the expected notification format.
+                const richCardPayload = {
+                    notification_title_th: 'ข้อมูลจาก: ' + (data.source_menu || 'ระบบ'),
+                    employee_id: data.id,
+                    employee_name_th: data.title_th || data.title,
+                    employee_name_en: data.title_en || '',
+                    employee_nationality: data.nationality || '',
+                    employee_photo_url: data.photo_url || '',
+                    employer_name_th: data.employer_name || '',
+                    url: data.url // The source URL for highlighting
+                };
+
+                const textToAppend = `[[--NOTIFICATION_CARD--]]${JSON.stringify(richCardPayload)}[[--/NOTIFICATION_CARD--]]`;
+
+                // Append it to the message box if it exists
+                if (messageBox) {
+                    const currentVal = messageBox.value;
+                    messageBox.value = currentVal + (currentVal ? '\n' : '') + textToAppend;
+                    messageBox.dispatchEvent(new Event('input'));
+                }
+
+                // PART B: Add to Attachment Basket (Standard Logic)
                 const employeeId = data.id;
                 const sourceUrl = data.url || null;
 
                 const inExisting = this.basket.existing_employees.some(emp => emp.id == employeeId);
                 const inExternal = this.basket.external_employees.some(emp => emp.id == employeeId);
 
-                if (inExisting || inExternal) {
-                    Swal.fire({ toast: true, position: 'top-end', showConfirmButton: false, timer: 3000, icon: 'info', title: 'ลูกจ้างนี้ถูกเลือกแล้ว' });
-                    return;
+                if (!inExisting && !inExternal) {
+                     this.selectedEmployeeIds = [{ id: employeeId, url: sourceUrl }];
+                     this.fetchPreselectedEmployees();
+                } else {
+                    // Optional: Toast saying "Already attached" but we still allow the card paste above
+                    // Swal.fire({ toast: true, position: 'top-end', showConfirmButton: false, timer: 3000, icon: 'info', title: 'ลูกจ้างนี้ถูกเลือกแล้ว' });
                 }
 
-                this.selectedEmployeeIds = [{ id: employeeId, url: sourceUrl }];
-                this.fetchPreselectedEmployees();
                 return;
             }
 

--- a/resources/views/groups/manage.blade.php
+++ b/resources/views/groups/manage.blade.php
@@ -271,7 +271,8 @@
                                                             'hideTeamTags' => true,
                                                             'currentTeamId' => $team->id,
                                                             'elementId' => 'employee-card-team-' . $team->id . '-' . $member->id,
-                                                            'dragUrl' => $currentUrl . '#employee-card-team-' . $team->id . '-' . $member->id
+                                                            'dragUrl' => $currentUrl . '#employee-card-team-' . $team->id . '-' . $member->id,
+                                                            'source_menu' => __('Group & Team')
                                                         ])
                                                     @endforeach
                                                 </div>
@@ -299,7 +300,8 @@
                                                     'hideTeamTags' => true,
                                                     'currentTeamId' => $team->id,
                                                     'elementId' => 'employee-card-team-' . $team->id . '-' . $member->id,
-                                                    'dragUrl' => $currentUrl . '#employee-card-team-' . $team->id . '-' . $member->id
+                                                    'dragUrl' => $currentUrl . '#employee-card-team-' . $team->id . '-' . $member->id,
+                                                    'source_menu' => __('Group & Team')
                                                 ])
                                             @empty
                                                 <div class="text-center text-muted py-4 border rounded bg-light">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -113,10 +113,33 @@
             letter-spacing: 0.05em;
             font-weight: 600;
         }
+        /* Highlight Animation for Employee Card */
+        @keyframes highlightPulse {
+            0% {
+                box-shadow: 0 0 0 0 rgba(249, 115, 22, 0.7);
+                border-color: #f97316;
+                background-color: #fff7ed;
+                transform: scale(1.02);
+            }
+            50% {
+                box-shadow: 0 0 0 10px rgba(249, 115, 22, 0);
+                border-color: #f97316;
+                background-color: #fff7ed;
+                transform: scale(1.02);
+            }
+            100% {
+                box-shadow: 0 0 0 0 rgba(249, 115, 22, 0);
+                border-color: #f97316;
+                background-color: #fff7ed;
+                transform: scale(1.02);
+            }
+        }
+
         .employee-card.highlight {
-            border: 2px solid var(--bs-primary-dark);
-            box-shadow: 0 0 12px rgba(var(--bs-primary-rgb), 0.4);
-            background-color: #fffbeb;
+            animation: highlightPulse 2s ease-out infinite;
+            border: 2px solid #f97316 !important;
+            background-color: #fff7ed !important;
+            z-index: 10;
         }
         .modal-backdrop.fade.show{
             display: none;
@@ -485,6 +508,7 @@
             title: data.name || data.title || 'Item',
             subtitle: data.subtitle || data.code || '',
             url: data.url || window.location.href,
+            source_menu: data.source_menu || document.title, // Default to page title if not provided
             ...data
         };
         e.dataTransfer.effectAllowed = 'copy';

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -2,9 +2,27 @@
     $employerName = $employee->employer->employerNameTh ?? 'N/A';
     // Fix for duplicate IDs in list views
     $cardId = 'employee-card-' . ($idPrefix ?? '') . $employee->id;
+    // Determine the source menu name if passed, otherwise try to infer or default
+    $sourceMenu = $source_menu ?? __('Employee List');
+    // Generate the drag source URL. Use the 'dragUrl' prop if provided (for custom anchors like in Groups),
+    // otherwise fallback to a standard hash link on the current page.
+    $dragSourceUrl = $dragUrl ?? (request()->fullUrlWithQuery(['highlight_employee' => $employee->id]) . '#' . $cardId);
 @endphp
 
-<div id="{{ $cardId }}" class="employee-card card mb-3">
+<div id="{{ $cardId }}" class="employee-card card mb-3"
+     draggable="true"
+     ondragstart="startDragGlobal(event, 'employee', {
+        id: {{ $employee->id }},
+        title: '{{ $employee->employeeNameEn ?? $employee->employeeNameTh }}',
+        title_th: '{{ $employee->employeeNameTh }}',
+        title_en: '{{ $employee->employeeNameEn }}',
+        subtitle: '{{ $employee->job_title ?? 'N/A' }}',
+        photo_url: '{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : asset('images/default-profile.png') }}',
+        url: '{{ $dragSourceUrl }}',
+        source_menu: '{{ $sourceMenu }}',
+        employer_name: '{{ $employerName }}',
+        nationality: '{{ $employee->employeeNationality }}'
+     })">
     <div class="card-body d-flex align-items-center">
         <div class="me-3">
             <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}" data-employer-id="{{ $employee->employer_id }}">


### PR DESCRIPTION
…highlighting

- Standardize `startDragGlobal` to include `source_menu` and `source_url`.
- Update `_employee_card.blade.php` to be draggable and provide rich payload data.
- Update `groups/manage.blade.php` and `incomplete_employees/index.blade.php` to pass specific source context.
- Update `hybrid-attachment-scripts.blade.php` to handle employee drops by appending a rich card (`[[--NOTIFICATION_CARD--]]`) to the chat box.
- Implement global `.highlight` CSS with pulse animation in `layouts/app.blade.php` for visual feedback on navigation.