### PR TITLE
Implement automatic daily expiry check middleware

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -8,6 +8,7 @@ use App\Models\Employer;
 use App\Models\Notification;
 use App\Models\NotificationSetting;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 
 class CheckExpiries extends Command
 {
@@ -189,6 +190,12 @@ class CheckExpiries extends Command
 
         $this->info('Checking for missing Residence Notifications...');
         $this->checkResidencePermitMissing($today, $settings, $baseEmployeeQuery);
+
+        // If this is a full run (not targeted at a specific employee), update the cache
+        if (!$employeeId) {
+            Cache::put('last_expiry_check_date', now()->toDateString(), now()->addDay());
+            $this->info('Updated last_expiry_check_date cache.');
+        }
 
         $this->info('Expiry check process finished.');
         return 0;

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -32,6 +32,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\EnsureDailyExpiryCheck::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/EnsureDailyExpiryCheck.php
+++ b/app/Http/Middleware/EnsureDailyExpiryCheck.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
+
+class EnsureDailyExpiryCheck
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $today = now()->toDateString();
+        $lastCheck = Cache::get('last_expiry_check_date');
+
+        if ($lastCheck !== $today) {
+            // Attempt to acquire an atomic lock for 120 seconds to prevent race conditions
+            // and multiple concurrent executions.
+            $lock = Cache::lock('expiry_check_lock', 120);
+
+            if ($lock->get()) {
+                try {
+                    Log::info('EnsureDailyExpiryCheck: Triggering automatic expiry check.');
+
+                    // Run the command synchronously to ensure the user sees up-to-date data.
+                    // This might cause a slight delay for the first request of the day.
+                    Artisan::call('app:check-expiries');
+
+                    // Note: The command itself updates the 'last_expiry_check_date' cache key
+                    // upon successful completion. We rely on that to prevent future runs.
+
+                } catch (\Exception $e) {
+                    Log::error('EnsureDailyExpiryCheck: Failed to run expiry check. ' . $e->getMessage());
+                    // In case of failure, we might want to release the lock or let it expire.
+                    // Allowing it to expire prevents a "retry storm" if the command is broken.
+                } finally {
+                    $lock->release();
+                }
+            }
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This commit introduces a "self-healing" mechanism to ensure document expiry notifications are updated daily, even if the system's cron scheduler fails.

Changes:
1. Updated `app/Console/Commands/CheckExpiries.php`:
   - Upon successful completion of a full system check, it now stores the current date in the cache (`last_expiry_check_date`).

2. Created `app/Http/Middleware/EnsureDailyExpiryCheck.php`:
   - Checks the `last_expiry_check_date` cache key on every request.
   - If the key is stale (not today's date), it acquires an atomic lock and triggers the `app:check-expiries` command synchronously.
   - This ensures the first user visit of the day triggers the update.

3. Updated `app/Http/Kernel.php`:
   - Registered the new middleware in the `web` group.