### PR TITLE
feat: allow employers to soft-delete tickets and manage in central trash

### DIFF
--- a/app/Http/Controllers/Admin/TrashController.php
+++ b/app/Http/Controllers/Admin/TrashController.php
@@ -14,6 +14,7 @@ use App\Models\Agent;
 use App\Models\Importer;
 use App\Models\Delegate;
 use App\Models\Address;
+use App\Models\JobTicket;
 use App\Models\SystemConfig;
 
 class TrashController extends Controller
@@ -67,6 +68,9 @@ class TrashController extends Controller
                         case 'delegates':
                             $q->where('delegateNameTh', 'like', "%{$searchTerm}%")
                                 ->orWhere('delegateNameEn', 'like', "%{$searchTerm}%");
+                            break;
+                        case 'tickets':
+                            $q->where('subject', 'like', "%{$searchTerm}%");
                             break;
                         // No default case: if a model has no specific search, we don't apply a search filter.
                         // This prevents errors on models like 'Address' that don't have a standard searchable name field.
@@ -175,6 +179,9 @@ class TrashController extends Controller
                         $q->where('delegateNameTh', 'like', "%{$searchTerm}%")
                             ->orWhere('delegateNameEn', 'like', "%{$searchTerm}%");
                         break;
+                    case 'tickets':
+                        $q->where('subject', 'like', "%{$searchTerm}%");
+                        break;
                 }
             });
         }
@@ -220,6 +227,10 @@ class TrashController extends Controller
                         $identifierTh = "Address ID: " . $item->id;
                         $identifierEn = $item->addressLine1;
                         break;
+                    case 'tickets':
+                        $identifierTh = "Ticket ID: " . $item->id;
+                        $identifierEn = $item->subject;
+                        break;
                 }
 
                 fputcsv($handle, [
@@ -245,7 +256,13 @@ class TrashController extends Controller
         // Correctly generate permission name, e.g., 'restore-employees'
         $permission = 'restore-' . Str::plural(strtolower(class_basename($modelClass)));
 
-        if (Gate::denies($permission)) {
+        // V2.5.4: Fallback for Tickets - Allow 'manage-tickets' permission
+        $authorized = Gate::allows($permission);
+        if ($model === 'tickets' && Gate::allows('manage-tickets')) {
+            $authorized = true;
+        }
+
+        if (!$authorized) {
             return response()->json(['error' => 'You do not have permission to restore this item.'], 403);
         }
 
@@ -264,7 +281,13 @@ class TrashController extends Controller
         // Correctly generate permission name, e.g., 'force-delete-employees'
         $permission = 'force-delete-' . Str::plural(strtolower(class_basename($modelClass)));
 
-        if (Gate::denies($permission)) {
+        // V2.5.4: Fallback for Tickets - Allow 'manage-tickets' permission
+        $authorized = Gate::allows($permission);
+        if ($model === 'tickets' && Gate::allows('manage-tickets')) {
+            $authorized = true;
+        }
+
+        if (!$authorized) {
             return response()->json(['error' => 'You do not have permission to permanently delete this item.'], 403);
         }
 
@@ -287,6 +310,7 @@ class TrashController extends Controller
             'importers' => Importer::class,
             'delegates' => Delegate::class,
             'addresses' => Address::class,
+            'tickets'   => JobTicket::class,
         ];
     }
 

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -255,4 +255,23 @@ class TicketController extends Controller
         // The categorized_attachments accessor will handle the rest of the data loading.
         return view('tickets.show', compact('ticket'));
     }
+
+    /**
+     * Remove the specified ticket from storage (Soft Delete).
+     *
+     * @param  \App\Models\JobTicket  $ticket
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(JobTicket $ticket): RedirectResponse
+    {
+        // Enforce Tenancy: Only the owner (employer) can delete their ticket.
+        if ($ticket->employer_user_id !== Auth::id()) {
+            abort(403, 'Unauthorized action. You do not own this ticket.');
+        }
+
+        // Perform Soft Delete
+        $ticket->delete();
+
+        return redirect()->route('tickets.index')->with('success', 'Ticket deleted successfully.');
+    }
 }

--- a/app/Models/JobTicket.php
+++ b/app/Models/JobTicket.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 // Import Attribute for Accessors
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Facades\Storage;
@@ -15,7 +16,7 @@ use App\Traits\LogActivity;
 
 class JobTicket extends Model
 {
-    use HasFactory, LogActivity;
+    use HasFactory, LogActivity, SoftDeletes;
 
     // Corrected $fillable
     protected $fillable = [

--- a/database/migrations/2025_12_02_000002_add_soft_deletes_to_job_tickets_table.php
+++ b/database/migrations/2025_12_02_000002_add_soft_deletes_to_job_tickets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('job_tickets', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('job_tickets', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/resources/views/admin/trash/index.blade.php
+++ b/resources/views/admin/trash/index.blade.php
@@ -121,6 +121,9 @@
                                                         @elseif($modelName === 'delegates')
                                                             {{ $item->delegateNameTh }}
                                                             <small class="d-block text-muted">{{ $item->delegateNameEn }}</small>
+                                                        @elseif($modelName === 'tickets')
+                                                            {{ $item->subject }}
+                                                            <small class="d-block text-muted">Ticket ID: {{ $item->id }}</small>
                                                         @else
                                                             {{ $item->employerNameTh ?? $item->name ?? $item->address_line_1 ?? 'Item ID: ' . $item->id }}
                                                             <small class="d-block text-muted">ID: {{ $item->id }}</small>
@@ -147,16 +150,16 @@
                                                                  <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employer" data-model-id="{{ $item->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
                                                             @endif
                                                             {{-- RESTORE BUTTON (Permission-Protected) --}}
-                                                            @can('restore-' . $modelName)
+                                                            @if(($modelName === 'tickets' && auth()->user()->can('manage-tickets')) || auth()->user()->can('restore-' . $modelName))
                                                                 {{-- FIX: Added method="POST" to prevent 405 error from Brief 17 --}}
                                                                 <form action="{{ route('admin.trash.restore', ['model' => $modelName, 'id' => $item->id]) }}" method="POST" class="d-grid d-md-inline restore-form">
                                                                     @csrf
                                                                     <button type="submit" class="btn btn-sm btn-outline-success">Restore</button>
                                                                 </form>
-                                                            @endcan
+                                                            @endif
 
                                                             {{-- FORCE DELETE BUTTON (Permission-Protected) --}}
-                                                            @can('force-delete-' . $modelName)
+                                                            @if(($modelName === 'tickets' && auth()->user()->can('manage-tickets')) || auth()->user()->can('force-delete-' . $modelName))
                                                                 <form action="{{ route('admin.trash.forceDelete', ['model' => $modelName, 'id' => $item->id]) }}" method="POST" class="d-grid d-md-inline delete-form">
                                                                     @csrf
                                                                     @method('DELETE')
@@ -164,7 +167,7 @@
                                                                         Force Delete
                                                                     </button>
                                                                 </form>
-                                                            @endcan
+                                                            @endif
                                                         </div>
                                                     </td>
                                                 </tr>

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -64,14 +64,27 @@
                     {{-- Format date consistently --}}
                     <td>{{ $ticket->created_at->format('d M Y H:i') }}</td>
                     <td class="text-center">
-                        <a href="{{ route('tickets.show', $ticket) }}" class="btn btn-sm btn-outline-primary position-relative">
-                            <i class="bi bi-eye"></i> {{ __('View Details') }}
-                            @if($ticket->employer_unread_count > 0)
-                                <span class="position-absolute top-0 start-100 translate-middle p-2 bg-danger border border-light rounded-circle">
-                                    <span class="visually-hidden">Unread</span>
-                                </span>
-                            @endif
-                        </a>
+                        <div class="d-flex justify-content-center gap-2">
+                            <a href="{{ route('tickets.show', $ticket) }}" class="btn btn-sm btn-outline-primary position-relative">
+                                <i class="bi bi-eye"></i> {{ __('View Details') }}
+                                @if($ticket->employer_unread_count > 0)
+                                    <span class="position-absolute top-0 start-100 translate-middle p-2 bg-danger border border-light rounded-circle">
+                                        <span class="visually-hidden">Unread</span>
+                                    </span>
+                                @endif
+                            </a>
+                            <form action="{{ route('tickets.destroy', $ticket) }}" method="POST" class="d-inline">
+                                @csrf
+                                @method('DELETE')
+                                <button type="button" class="btn btn-sm btn-outline-danger btn-submit-swal"
+                                    data-swal-title="{{ __('Confirm Delete') }}"
+                                    data-swal-text="{{ __('Are you sure you want to delete this ticket?') }}"
+                                    data-swal-icon="warning"
+                                    data-swal-confirm-text="{{ __('Yes, delete it') }}">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </form>
+                        </div>
                     </td>
                 </tr>
                 @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -117,7 +117,7 @@ Route::middleware('auth')->group(function () {
 
     // --- V2.4: Employer Ticket Routes ---
     Route::resource('tickets', TicketController::class)->only([
-        'index', 'create', 'store', 'show'
+        'index', 'create', 'store', 'show', 'destroy'
     ]);
 
     Route::post('tickets/{ticket}/replies', [TicketReplyController::class, 'store'])->name('tickets.replies.store');

--- a/verification/verify_ticket_delete.py
+++ b/verification/verify_ticket_delete.py
@@ -1,0 +1,123 @@
+
+import os
+import sys
+from playwright.sync_api import sync_playwright
+
+def verify_ticket_delete(page):
+    # 1. Define the HTML content directly
+    html_content = """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Verify Ticket Delete</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
+        <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    </head>
+    <body>
+        <div class="container mt-5">
+            <h2>My Request List</h2>
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Subject</th>
+                            <th>Status</th>
+                            <th>Created Date</th>
+                            <th class="text-center">Manage</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>101</td>
+                            <td>Test Ticket Subject</td>
+                            <td><span class="badge bg-warning">Pending Staff</span></td>
+                            <td>02 Dec 2025 10:00</td>
+                            <td class="text-center">
+                                <div class="d-flex justify-content-center gap-2">
+                                    <a href="#" class="btn btn-sm btn-outline-primary">View Details</a>
+
+                                    <!-- The Delete Button & Form (Mocked) -->
+                                    <form action="/tickets/101" method="POST" class="d-inline">
+                                        <input type="hidden" name="_token" value="mock_token">
+                                        <input type="hidden" name="_method" value="DELETE">
+                                        <button type="button" class="btn btn-sm btn-outline-danger btn-submit-swal"
+                                            data-swal-title="Confirm Delete"
+                                            data-swal-text="Are you sure you want to delete this ticket?"
+                                            data-swal-icon="warning"
+                                            data-swal-confirm-text="Yes, delete it">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <script>
+        // Mock the SweetAlert logic (copied from the intended implementation)
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('.btn-submit-swal').forEach(button => {
+                button.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    const form = this.closest('form');
+                    if (!form) return;
+
+                    const title = this.dataset.swalTitle;
+                    const text = this.dataset.swalText;
+                    const icon = this.dataset.swalIcon;
+                    const confirmText = this.dataset.swalConfirmText;
+
+                    Swal.fire({
+                        title: title,
+                        text: text,
+                        icon: icon,
+                        showCancelButton: true,
+                        confirmButtonColor: (icon === 'danger' || icon === 'warning') ? '#d33' : '#3085d6',
+                        cancelButtonColor: '#6c757d',
+                        confirmButtonText: confirmText,
+                        cancelButtonText: 'Cancel'
+                    }).then((result) => {
+                        if (result.isConfirmed) {
+                            // Mock submission for verification
+                            console.log('Form submitted!');
+                            document.body.innerHTML += '<div id="submitted-msg" class="alert alert-success mt-3">Form submitted!</div>';
+                        }
+                    });
+                });
+            });
+        });
+        </script>
+    </body>
+    </html>
+    """
+
+    # 2. Set the content
+    page.set_content(html_content)
+
+    # 3. Verify the button exists and click it
+    delete_btn = page.locator('.btn-submit-swal')
+    if delete_btn.is_visible():
+        print("Delete button found.")
+        delete_btn.click()
+    else:
+        print("Delete button NOT found.")
+
+    # 4. Take a screenshot of the SweetAlert
+    page.wait_for_selector('.swal2-container')
+    page.screenshot(path="/home/jules/verification/ticket_delete_swal.png")
+    print("Screenshot taken: ticket_delete_swal.png")
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        verify_ticket_delete(page)
+        browser.close()


### PR DESCRIPTION
- Add `deleted_at` column to `job_tickets` via migration.
- Add `SoftDeletes` trait to `JobTicket` model.
- Implement `destroy` method in `TicketController` with strict ownership check.
- Update `tickets.index` view with a delete button and SweetAlert confirmation.
- Update `Admin/TrashController` to include `tickets` in central trash management.
- Update `TrashController` and view to use `manage-tickets` permission fallback for ticket operations.