### PR TITLE
feat: enhance bulk edit and fix import functionality

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -818,6 +818,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
         // Define all available fields grouped by category
         $fieldGroups = [
             'Personal Information' => [
+                'employeePhoto' => 'Photo (Upload)',
                 'employeeTitleTh' => 'Title (TH)',
                 'employeeNameTh' => 'Name (TH)',
                 'employeeTitleEn' => 'Title (EN)',
@@ -896,6 +897,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
 
         // Define metadata for fields to render correct inputs
         $fileFields = [
+            'employeePhoto',
             'passport_file', 'visa_file', 'work_permit_file', 'pink_card_file', 'insurance_attachment',
             'employee_doc_5', 'employee_doc_6', 'employee_doc_7', 'employee_doc_8',
             'employee_doc_9', 'employee_doc_10', 'employee_doc_11', 'employee_doc_12'
@@ -923,6 +925,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
         // Map keys to labels (simplified version of what was in selectFields)
         // Ideally this should be a shared constant or helper.
         $fieldLabels = [
+            'employeePhoto' => 'Photo (Upload)',
             'employeeNameTh' => 'Name (TH)',
             'employeeNameEn' => 'Name (EN)',
             'employeeTitleTh' => 'Title (TH)',
@@ -992,6 +995,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
 
         // Define mapping for legacy file fields to actual database columns
         $fieldMapping = [
+            'employeePhoto'      => 'employeePhoto',
             'passport_file'      => 'employee_doc_1',
             'visa_file'          => 'employee_doc_2',
             'work_permit_file'   => 'employee_doc_3',

--- a/app/Http/Controllers/ImportEmployeeController.php
+++ b/app/Http/Controllers/ImportEmployeeController.php
@@ -293,7 +293,8 @@ class ImportEmployeeController extends Controller
 
                     // Look for images in Column A
                     // Use a looser check: if it's in Column A, and row >= START_ROW - 1 (to catch images slightly above first row)
-                    if ($column === 'A' && $row >= ($START_ROW - 1)) {
+                    // Also accept images anchored to B if the user slightly missed the cell
+                    if (($column === 'A' || $column === 'B') && $row >= ($START_ROW - 1)) {
                         $images[$row] = $drawing;
                     }
                 }

--- a/resources/views/employees/bulk_edit_form.blade.php
+++ b/resources/views/employees/bulk_edit_form.blade.php
@@ -173,6 +173,7 @@
                                             @php
                                                 // Define mapping for legacy file fields to actual database columns
                                                 $fieldMapping = [
+                                                    'employeePhoto'      => 'employeePhoto',
                                                     'passport_file'      => 'employee_doc_1',
                                                     'visa_file'          => 'employee_doc_2',
                                                     'work_permit_file'   => 'employee_doc_3',
@@ -192,6 +193,8 @@
 
                                                     @if($isSensitive)
                                                          <a href="{{ route('employees.documents.serve', ['employee' => $employee->id, 'field' => $dbColumn]) }}" target="_blank" class="text-decoration-none ms-1">({{ __('View') }})</a>
+                                                    @elseif($field === 'employeePhoto')
+                                                        <a href="{{ Storage::disk('public')->url($filePath) }}" target="_blank" class="text-decoration-none ms-1">({{ __('View') }})</a>
                                                     @else
                                                         <a href="{{ Storage::disk('public')->url($filePath) }}" target="_blank" class="text-decoration-none ms-1">({{ __('View') }})</a>
                                                     @endif

--- a/resources/views/employees/import.blade.php
+++ b/resources/views/employees/import.blade.php
@@ -316,6 +316,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
              actionModalBody.innerHTML = '';
              actionModalBody.appendChild(content);
+
+             // Re-run scripts from the fetched content to initialize event listeners (e.g., enable/disable Proceed button)
+             const scripts = content.querySelectorAll('script');
+             scripts.forEach(oldScript => {
+                const newScript = document.createElement('script');
+                Array.from(oldScript.attributes).forEach(attr => newScript.setAttribute(attr.name, attr.value));
+                newScript.appendChild(document.createTextNode(oldScript.innerHTML));
+                actionModalBody.appendChild(newScript);
+             });
         });
     });
 


### PR DESCRIPTION
- Added `employeePhoto` to the Advanced Edit (Bulk Update) field selection.
- Updated `bulkEditForm` to render file inputs for `employeePhoto` and provide "View" links for existing photos.
- Fixed a bug in `resources/views/employees/import.blade.php` where the "Advanced Edit" button inside the import modal was non-functional due to unexecuted JavaScript.
- Improved Excel import logic in `ImportEmployeeController.php` to robustly detect employee photos anchored to either Column A or B.