### PR TITLE
Fix migration conflict by checking column existence

### DIFF
--- a/database/migrations/2025_11_28_000000_add_avatar_path_to_chat_groups_table.php
+++ b/database/migrations/2025_11_28_000000_add_avatar_path_to_chat_groups_table.php
@@ -8,15 +8,19 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('chat_groups', function (Blueprint $table) {
-            $table->string('avatar_path')->nullable()->after('name');
-        });
+        if (Schema::hasTable('chat_groups') && !Schema::hasColumn('chat_groups', 'avatar_path')) {
+            Schema::table('chat_groups', function (Blueprint $table) {
+                $table->string('avatar_path')->nullable()->after('name');
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('chat_groups', function (Blueprint $table) {
-            $table->dropColumn('avatar_path');
-        });
+        if (Schema::hasTable('chat_groups') && Schema::hasColumn('chat_groups', 'avatar_path')) {
+            Schema::table('chat_groups', function (Blueprint $table) {
+                $table->dropColumn('avatar_path');
+            });
+        }
     }
 };

--- a/database/migrations/2025_12_02_000002_add_soft_deletes_to_job_tickets_table.php
+++ b/database/migrations/2025_12_02_000002_add_soft_deletes_to_job_tickets_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('job_tickets', function (Blueprint $table) {
-            $table->softDeletes();
-        });
+        if (Schema::hasTable('job_tickets') && !Schema::hasColumn('job_tickets', 'deleted_at')) {
+            Schema::table('job_tickets', function (Blueprint $table) {
+                $table->softDeletes();
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('job_tickets', function (Blueprint $table) {
-            $table->dropSoftDeletes();
-        });
+        if (Schema::hasTable('job_tickets') && Schema::hasColumn('job_tickets', 'deleted_at')) {
+            Schema::table('job_tickets', function (Blueprint $table) {
+                $table->dropSoftDeletes();
+            });
+        }
     }
 };


### PR DESCRIPTION
Modified 'add_avatar_path_to_chat_groups_table' and 'add_soft_deletes_to_job_tickets_table' migrations to check for column existence using Schema::hasColumn before attempting to add them. This prevents 'Column already exists' errors during migration.