### PR TITLE
Standardize date inputs to DD/MM/YYYY format globally

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,6 +19,9 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
 
+    <!-- Flatpickr CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.1/cropper.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <!-- Alpine.js -->
@@ -801,6 +804,64 @@
     </script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.1/cropper.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+    <!-- Flatpickr JS -->
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script src="https://npmcdn.com/flatpickr/dist/l10n/th.js"></script>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        // Function to initialize Flatpickr on a given element
+        function initFlatpickr(element) {
+            if (element._flatpickr) return; // Already initialized
+
+            // Check if element is readonly or disabled, if so, we might want to respect that
+            // Flatpickr handles this automatically usually.
+
+            flatpickr(element, {
+                locale: 'th',
+                dateFormat: 'Y-m-d',
+                altInput: true,
+                altFormat: 'd/m/Y',
+                allowInput: true,
+                disableMobile: true, // Force Flatpickr UI on mobile for consistency
+                onChange: function(selectedDates, dateStr, instance) {
+                    // Dispatch native input event for frameworks like Alpine.js or Vue
+                    // and 'change' event for standard listeners
+                    instance.element.dispatchEvent(new Event('input', {bubbles: true}));
+                    instance.element.dispatchEvent(new Event('change', {bubbles: true}));
+                }
+            });
+        }
+
+        // 1. Initialize on existing elements
+        const dateInputs = document.querySelectorAll('input[type="date"]');
+        dateInputs.forEach(input => initFlatpickr(input));
+
+        // 2. Observe for new elements (e.g. via Alpine or AJAX)
+        const observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(mutation) {
+                mutation.addedNodes.forEach(function(node) {
+                    if (node.nodeType === 1) { // Element node
+                        if (node.tagName === 'INPUT' && node.type === 'date') {
+                            initFlatpickr(node);
+                        } else if (node.querySelectorAll) {
+                             // Check children
+                            const inputs = node.querySelectorAll('input[type="date"]');
+                            inputs.forEach(input => initFlatpickr(input));
+                        }
+                    }
+                });
+            });
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    });
+    </script>
+
     @include('components.download-modals')
     @stack('scripts')
 

--- a/verification/verify_flatpickr.py
+++ b/verification/verify_flatpickr.py
@@ -1,0 +1,71 @@
+from playwright.sync_api import sync_playwright, expect
+import os
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    file_path = os.path.abspath("verification/test_flatpickr.html")
+    page.goto(f"file://{file_path}")
+
+    # 1. Verify Static Input
+    print("Verifying Static Input...")
+
+    # Check siblings of #static-date
+    # The alt input should be immediately after
+    static_wrapper = page.locator("div").first
+    # Print inner HTML of the wrapper
+    print(f"Wrapper HTML: {static_wrapper.inner_html()}")
+
+    # Find the visible input
+    # It should have value 01/01/2024
+    visible_input = page.locator("input[type='text']").first
+    if visible_input.count() > 0:
+        print(f"Visible input found. Value: {visible_input.input_value()}")
+        expect(visible_input).to_have_value("01/01/2024")
+    else:
+        print("No visible text input found!")
+
+    # 2. Verify Dynamic Input
+    print("Verifying Dynamic Input...")
+    page.click("#add-btn")
+    page.wait_for_timeout(500)
+
+    # Check container HTML
+    container = page.locator("#dynamic-container")
+    print(f"Dynamic container HTML: {container.inner_html()}")
+
+    dynamic_visible = container.locator("input[type='text']")
+    if dynamic_visible.count() > 0:
+        print(f"Dynamic visible input found. Value: {dynamic_visible.input_value()}")
+        expect(dynamic_visible).to_have_value("01/03/2024")
+
+    # 3. Verify Alpine Sync
+    print("Verifying Alpine Sync...")
+    alpine_visible = page.locator("input[type='text']").nth(2) # 0=static, 1=dynamic, 2=alpine?
+    # Alpine visible input
+    # Depending on order.
+    # We have static (1), dynamic (1), alpine (1).
+
+    # Let's target by proximity to label
+    alpine_label = page.locator("text=Alpine Date:")
+    # The input should be near
+
+    # Just find all text inputs
+    all_text = page.locator("input[type='text']")
+    print(f"Total text inputs: {all_text.count()}")
+    for i in range(all_text.count()):
+        print(f"Input {i}: {all_text.nth(i).input_value()}")
+
+    # Assume last one is Alpine
+    alpine_inp = all_text.last
+    alpine_inp.fill("15/02/2024")
+    alpine_inp.press("Enter")
+
+    expect(page.locator("#alpine-value")).to_have_text("2024-02-15")
+
+    page.screenshot(path="verification/verification.png")
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
- Added Flatpickr library via CDN in layouts/app.blade.php
- Implemented global script to initialize Flatpickr on all input[type="date"]
- Configured Flatpickr to display dates as d/m/Y (DD/MM/YYYY)
- Enabled disableMobile: true to enforce consistent UI on mobile devices
- Added logic to sync input/change events for compatibility with JS frameworks like Alpine.js
- Implemented MutationObserver to handle dynamically added date inputs