### PR TITLE
Fix PWA start URL and update service worker version

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "PWL System",
     "short_name": "PWL System",
-    "start_url": "/dashboard",
+    "start_url": "/login",
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#F97316",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pwl-system-v1';
+const CACHE_NAME = 'pwl-system-v2';
 const urlsToCache = [
     '/images/icons/icon-192x192.png',
     '/images/icons/icon-512x512.png'


### PR DESCRIPTION
- Changed PWA `start_url` in `public/manifest.json` from `/dashboard` to `/login` to prevent unauthenticated access errors on app launch.
- Bumped cache version in `public/sw.js` to `pwl-system-v2` to force client-side updates.