### PR TITLE
Fix: Ensure notification days remaining updates automatically

### DIFF
--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Carbon\Carbon;
 
 class Notification extends Model
 {
@@ -25,6 +26,31 @@ class Notification extends Model
         'cancellation_reason',
         'cancelled_at',
     ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'due_date' => 'date',
+        'cancelled_at' => 'datetime',
+    ];
+
+    /**
+     * Get the days remaining dynamically.
+     * Overrides the database column value.
+     *
+     * @param mixed $value
+     * @return int
+     */
+    public function getDaysRemainingAttribute($value)
+    {
+        if ($this->due_date) {
+            return (int) Carbon::now()->startOfDay()->diffInDays($this->due_date, false);
+        }
+        return $value;
+    }
 
     /**
      * Get the employee that the notification belongs to.


### PR DESCRIPTION
Implemented a dynamic accessor `getDaysRemainingAttribute` on the Notification model. This calculates the remaining days in real-time based on the due_date and current date, ensuring the display is always accurate without relying on the background scheduler to update the static database column.