### PR TITLE
Fix PWA startup stability by changing start_url to dashboard and enfo…

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectIfAuthenticated
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, string ...$guards): Response
+    {
+        $guards = empty($guards) ? [null] : $guards;
+
+        foreach ($guards as $guard) {
+            if (Auth::guard($guard)->check()) {
+                // Explicitly redirect to dashboard to fix PWA/Mobile session loop issues
+                return redirect('/dashboard');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -21,5 +21,6 @@ return Application::configure(basePath: dirname(__DIR__))
             'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
             'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
             'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+            'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         ]);
     })->create();

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "PWL System",
     "short_name": "PWL System",
-    "start_url": "/login",
+    "start_url": "/dashboard",
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#F97316",


### PR DESCRIPTION
…rcing auth redirect

- Updated `public/manifest.json` `start_url` from `/login` to `/dashboard` to ensure the PWA attempts to load the authenticated state first.
- Created `app/Http/Middleware/RedirectIfAuthenticated.php` to explicitly redirect authenticated users to `/dashboard` instead of the default `/home` (which does not exist).
- Registered the new middleware as the `guest` alias in `bootstrap/app.php` to override default behavior.

These changes resolve the issue where users were forced to re-login or encountered errors when reopening the PWA on mobile devices.