### PR TITLE
feat: persist employee selection across search and pagination

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -114,6 +114,7 @@
             <li><a class="dropdown-item" href="#" id="bulk-send-production-btn"><i class="bi bi-clipboard-data me-2"></i>{{ __('Send to P Production') }}</a></li>
         </ul>
     </div>
+    <button class="btn btn-sm btn-outline-danger" onclick="window.clearGlobalSelection();">{{ __('Clear Selection') }}</button>
     <div class="ms-auto text-muted small d-none d-md-block">
         <i class="bi bi-arrows-move me-1"></i> {{ __('Drag to Chat') }}
     </div>
@@ -217,14 +218,14 @@
 <script>
     // Special handler for bulk drag
     window.startDragBulk = function(e) {
-        const checkboxes = document.querySelectorAll('.employee-checkbox:checked');
-        const count = checkboxes.length;
+        const ids = window.getGlobalSelectedIds();
+        const count = ids.length;
+
         if (count === 0) {
             e.preventDefault();
             return;
         }
 
-        const ids = Array.from(checkboxes).map(cb => cb.value);
         const payload = {
             type: 'employees_bulk',
             title: count + ' Employees',
@@ -246,7 +247,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (bulkExportBtn) {
         bulkExportBtn.addEventListener('click', function(e) {
             e.preventDefault();
-            const selected = Array.from(document.querySelectorAll('.employee-checkbox:checked')).map(cb => cb.value);
+            const selected = window.getGlobalSelectedIds();
 
             if (selected.length === 0) {
                 showToast('{{ __('Please select employees first.') }}', 'danger');
@@ -267,7 +268,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (bulkDownloadBtn) {
         bulkDownloadBtn.addEventListener('click', function(e) {
             e.preventDefault();
-            const selected = Array.from(document.querySelectorAll('.employee-checkbox:checked')).map(cb => cb.value);
+            const selected = window.getGlobalSelectedIds();
             if (selected.length === 0) {
                 showToast('{{ __('Please select employees first.') }}', 'danger');
                 return;
@@ -286,7 +287,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (bulkEditBtn) {
         bulkEditBtn.addEventListener('click', function(e) {
             e.preventDefault();
-            const selected = Array.from(document.querySelectorAll('.employee-checkbox:checked')).map(cb => cb.value);
+            const selected = window.getGlobalSelectedIds();
 
             if (selected.length === 0) {
                 showToast('{{ __('Please select employees first.') }}', 'danger');
@@ -329,23 +330,22 @@ document.addEventListener('DOMContentLoaded', function () {
     if (bulkSendDataBtn) {
         bulkSendDataBtn.addEventListener('click', function(e) {
             e.preventDefault();
-            const checkboxes = document.querySelectorAll('.employee-checkbox:checked');
-            const selected = Array.from(checkboxes).map(cb => cb.value);
+            const selectedData = window.getGlobalSelectedData();
+            const selectedIds = selectedData.map(item => item.id);
 
-            if (selected.length === 0) {
+            if (selectedIds.length === 0) {
                 showToast('{{ __('Please select employees first.') }}', 'danger');
                 return;
             }
 
-            // Step 1: Check if all selected employees belong to the same employer (based on current view context)
-            // Note: In table view, we added data-employer-id to the checkbox.
-            // If checking fails, we alert the user.
+            // Step 1: Check if all selected employees belong to the same employer
             let employerIds = new Set();
-            checkboxes.forEach(cb => {
-                const empId = cb.getAttribute('data-employer-id');
-                if (empId) employerIds.add(empId);
+            selectedData.forEach(item => {
+                if (item.employer_id) employerIds.add(item.employer_id);
             });
 
+            // Note: If we have items from previous pages that might NOT have captured employer_id (legacy data?), this check might be imperfect.
+            // But with the new logic, we capture employer_id on check.
             if (employerIds.size > 1) {
                  Swal.fire({
                     icon: 'warning',
@@ -356,7 +356,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
 
             // Step 2: Store selected IDs in a global variable
-            window.pendingTicketEmployeeIds = selected;
+            window.pendingTicketEmployeeIds = selectedIds;
 
             // Step 3: Open Modal to Select Target Employer
             const modalEl = document.getElementById('selectTargetEmployerModal');
@@ -370,19 +370,18 @@ document.addEventListener('DOMContentLoaded', function () {
     if (bulkSendProductionBtn) {
         bulkSendProductionBtn.addEventListener('click', function(e) {
             e.preventDefault();
-            const checkboxes = document.querySelectorAll('.employee-checkbox:checked');
-            const selected = Array.from(checkboxes).map(cb => cb.value);
+            const selectedData = window.getGlobalSelectedData();
+            const selectedIds = selectedData.map(item => item.id);
 
-            if (selected.length === 0) {
+            if (selectedIds.length === 0) {
                 showToast('{{ __('Please select employees first.') }}', 'danger');
                 return;
             }
 
             // Check employers
             let employerIds = new Set();
-            checkboxes.forEach(cb => {
-                const empId = cb.getAttribute('data-employer-id');
-                if (empId) employerIds.add(empId);
+            selectedData.forEach(item => {
+                if (item.employer_id) employerIds.add(item.employer_id);
             });
 
             if (employerIds.size > 1) {
@@ -396,7 +395,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             // Redirect to Production Create with IDs
             // Use JSON string for array of IDs
-            const idsJson = encodeURIComponent(JSON.stringify(selected));
+            const idsJson = encodeURIComponent(JSON.stringify(selectedIds));
             const employerId = employerIds.size === 1 ? employerIds.values().next().value : '';
 
             let url = '{{ route("production.create") }}?employee_ids_json=' + idsJson;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1237,41 +1237,142 @@ document.addEventListener('DOMContentLoaded', function () {
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+    // --- Global Selection Manager (Persists across pages/searches) ---
+    // Stores array of objects: { id: "1", employer_id: "5" }
+    const STORAGE_KEY = 'selectedEmployeeData';
     const selectAllCheckbox = document.getElementById('select-all-checkbox');
     const employeeCheckboxes = document.querySelectorAll('.employee-checkbox');
     const bulkActionBar = document.querySelector('.bulk-action-bar');
     const selectedCountSpan = document.getElementById('selected-count');
     const bulkActionButton = bulkActionBar ? bulkActionBar.querySelector('button') : null;
 
-    if (!selectAllCheckbox) return; // Exit if controls are not on this page
+    // Helper: Get all stored data
+    window.getGlobalSelectedData = function() {
+        const stored = sessionStorage.getItem(STORAGE_KEY);
+        try {
+            return stored ? JSON.parse(stored) : [];
+        } catch (e) {
+            console.error('Error parsing selectedEmployeeData', e);
+            return [];
+        }
+    };
 
-    function updateBulkActionBar() {
-        const selectedCheckboxes = document.querySelectorAll('.employee-checkbox:checked');
-        const count = selectedCheckboxes.length;
+    // Helper: Get just IDs (compatibility)
+    window.getGlobalSelectedIds = function() {
+        return window.getGlobalSelectedData().map(item => item.id);
+    };
 
-        if (count > 0) {
-            bulkActionBar.style.display = 'flex';
-            selectedCountSpan.textContent = count;
-            bulkActionButton.disabled = false;
-            // Sync select-all checkbox
-            selectAllCheckbox.checked = (count === employeeCheckboxes.length);
-        } else {
-            bulkActionBar.style.display = 'none';
-            bulkActionButton.disabled = true;
+    // Helper: Save data
+    window.setGlobalSelectedData = function(data) {
+        // Ensure uniqueness by ID
+        const unique = [];
+        const map = new Map();
+        for (const item of data) {
+            if(!map.has(String(item.id))) {
+                map.set(String(item.id), true);
+                unique.push(item);
+            }
+        }
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(unique));
+        updateUI();
+    };
+
+    // Helper: Add items (accepts array of {id, employer_id})
+    function addItems(newItems) {
+        const current = window.getGlobalSelectedData();
+        const combined = [...current, ...newItems];
+        window.setGlobalSelectedData(combined);
+    }
+
+    // Helper: Remove items by ID
+    function removeItemsByIds(idsToRemove) {
+        const current = window.getGlobalSelectedData();
+        const filtered = current.filter(item => !idsToRemove.includes(String(item.id)));
+        window.setGlobalSelectedData(filtered);
+    }
+
+    // Clear all selections
+    window.clearGlobalSelection = function() {
+        sessionStorage.removeItem(STORAGE_KEY);
+        // Uncheck all visible
+        document.querySelectorAll('.employee-checkbox').forEach(cb => cb.checked = false);
+        if(selectAllCheckbox) selectAllCheckbox.checked = false;
+        updateUI();
+    };
+
+    // UI Updater
+    function updateUI() {
+        const allData = window.getGlobalSelectedData();
+        const count = allData.length;
+        const allIds = allData.map(item => String(item.id));
+
+        if (bulkActionBar) {
+            if (count > 0) {
+                bulkActionBar.style.display = 'flex';
+                if (selectedCountSpan) selectedCountSpan.textContent = count;
+                if (bulkActionButton) bulkActionButton.disabled = false;
+            } else {
+                bulkActionBar.style.display = 'none';
+                if (bulkActionButton) bulkActionButton.disabled = true;
+            }
+        }
+
+        // Sync "Select All" checkbox state based on VISIBLE items
+        // If all visible items are in the selected set, check "Select All"
+        if (selectAllCheckbox && employeeCheckboxes.length > 0) {
+            const allVisibleSelected = Array.from(employeeCheckboxes).every(cb => allIds.includes(String(cb.value)));
+            selectAllCheckbox.checked = allVisibleSelected;
+        } else if (selectAllCheckbox) {
             selectAllCheckbox.checked = false;
         }
     }
 
-    selectAllCheckbox.addEventListener('change', function () {
-        employeeCheckboxes.forEach(checkbox => {
-            checkbox.checked = this.checked;
+    // --- Initialization ---
+
+    if (!selectAllCheckbox && employeeCheckboxes.length === 0) return;
+
+    // 1. Restore state from storage on load
+    const savedIds = window.getGlobalSelectedIds();
+    employeeCheckboxes.forEach(cb => {
+        if (savedIds.includes(String(cb.value))) {
+            cb.checked = true;
+        }
+    });
+    updateUI();
+
+    // 2. Handle Individual Checkbox Changes
+    employeeCheckboxes.forEach(checkbox => {
+        checkbox.addEventListener('change', function () {
+            const id = this.value;
+            const employerId = this.dataset.employerId || '';
+            if (this.checked) {
+                addItems([{ id: id, employer_id: employerId }]);
+            } else {
+                removeItemsByIds([id]);
+            }
         });
-        updateBulkActionBar();
     });
 
-    employeeCheckboxes.forEach(checkbox => {
-        checkbox.addEventListener('change', updateBulkActionBar);
-    });
+    // 3. Handle "Select All" Checkbox
+    if (selectAllCheckbox) {
+        selectAllCheckbox.addEventListener('change', function () {
+            const visibleItems = Array.from(employeeCheckboxes).map(cb => ({
+                id: cb.value,
+                employer_id: cb.dataset.employerId || ''
+            }));
+            const visibleIds = visibleItems.map(item => item.id);
+
+            if (this.checked) {
+                // Check all visible and add to storage
+                employeeCheckboxes.forEach(cb => cb.checked = true);
+                addItems(visibleItems);
+            } else {
+                // Uncheck all visible and remove from storage
+                employeeCheckboxes.forEach(cb => cb.checked = false);
+                removeItemsByIds(visibleIds);
+            }
+        });
+    }
 });
 </script>
 


### PR DESCRIPTION
- Implemented `sessionStorage` based persistence for `.employee-checkbox` selections in `layouts/app.blade.php`.
- Added logic to store both `id` and `employer_id` to allow validation of non-visible selected items.
- Added a "Clear Selection" button to the employee list bulk action bar.
- Updated bulk action handlers (Export, Download, Transfer, Ticket Creation) in `employees/index.blade.php` to use the globally persisted selection data instead of DOM-only queries.
- Ensured "Select All" behaves accumulatively, adding visible items to the stored selection.