### PR TITLE
feat: add 'View Selected' modal for managing bulk selection

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -115,6 +115,9 @@
         </ul>
     </div>
     <button class="btn btn-sm btn-outline-danger" onclick="window.clearGlobalSelection();">{{ __('Clear Selection') }}</button>
+    <button class="btn btn-sm btn-info text-white" id="btn-view-selected">
+        <i class="bi bi-eye me-1"></i> {{ __('View Selected') }}
+    </button>
     <div class="ms-auto text-muted small d-none d-md-block">
         <i class="bi bi-arrows-move me-1"></i> {{ __('Drag to Chat') }}
     </div>
@@ -163,7 +166,7 @@
                             url: '{{ route('employees.show', $employee->id) }}'
                         })"
                         style="cursor: grab;">
-                        <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}" data-employer-id="{{ $employee->employer_id }}"></td>
+                        <td><input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}" data-employer-id="{{ $employee->employer_id }}" data-name-th="{{ $employee->employeeNameTh }}" data-name-en="{{ $employee->employeeNameEn }}" data-photo="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}" data-employer-name="{{ $employee->employer->employerNameTh ?? 'N/A' }}"></td>
                         <td>
                             <div class="d-flex align-items-center">
                                 <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}" alt="Photo" class="employee-photo-thumb" style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; margin-right: 0.75rem;">
@@ -214,7 +217,155 @@
 @include('employees.modals.advanced_export')
 @include('employees.modals.select_target_employer_modal')
 
+<!-- View Selected Items Modal -->
+<div class="modal fade" id="viewSelectedModal" tabindex="-1" aria-labelledby="viewSelectedModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="viewSelectedModalLabel">{{ __('Selected Employees') }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body p-0">
+                <div id="selected-list-container" class="list-group list-group-flush">
+                    <!-- Items will be populated here -->
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Close') }}</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 @push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const viewSelectedBtn = document.getElementById('btn-view-selected');
+    const container = document.getElementById('selected-list-container');
+    const modalEl = document.getElementById('viewSelectedModal');
+    const modal = new bootstrap.Modal(modalEl);
+
+    if (viewSelectedBtn) {
+        viewSelectedBtn.addEventListener('click', function() {
+            const data = window.getGlobalSelectedData();
+            if (data.length === 0) {
+                showToast('{{ __('No employees selected') }}', 'danger');
+                return;
+            }
+
+            container.innerHTML = '';
+            data.forEach(item => {
+                const li = document.createElement('div');
+                li.className = 'list-group-item d-flex align-items-center justify-content-between';
+                li.id = `selected-item-${item.id}`;
+
+                const photoUrl = item.photo || 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC';
+                const nameTh = item.name_th || 'N/A';
+                const nameEn = item.name_en || 'N/A';
+                const employerName = item.employer_name || 'N/A';
+
+                // --- Safe DOM Creation ---
+                const leftDiv = document.createElement('div');
+                leftDiv.className = 'd-flex align-items-center';
+
+                const img = document.createElement('img');
+                img.src = photoUrl;
+                img.alt = 'Photo';
+                img.className = 'rounded-circle me-3';
+                img.style.width = '40px';
+                img.style.height = '40px';
+                img.style.objectFit = 'cover';
+                leftDiv.appendChild(img);
+
+                const infoDiv = document.createElement('div');
+
+                const nameEnDiv = document.createElement('div');
+                nameEnDiv.className = 'fw-bold';
+                nameEnDiv.textContent = nameEn;
+                infoDiv.appendChild(nameEnDiv);
+
+                const nameThDiv = document.createElement('div');
+                nameThDiv.className = 'text-muted small';
+                nameThDiv.textContent = nameTh;
+                infoDiv.appendChild(nameThDiv);
+
+                const employerDiv = document.createElement('div');
+                employerDiv.className = 'text-muted small';
+                const buildingIcon = document.createElement('i');
+                buildingIcon.className = 'bi bi-building me-1';
+                employerDiv.appendChild(buildingIcon);
+                employerDiv.appendChild(document.createTextNode(employerName));
+                infoDiv.appendChild(employerDiv);
+
+                leftDiv.appendChild(infoDiv);
+                li.appendChild(leftDiv);
+
+                const rightDiv = document.createElement('div');
+                rightDiv.className = 'd-flex align-items-center gap-2';
+
+                // Employee Preview Button
+                const empPreviewBtn = document.createElement('button');
+                empPreviewBtn.type = 'button';
+                empPreviewBtn.className = 'btn btn-sm btn-outline-info btn-preview';
+                empPreviewBtn.dataset.modelType = 'employee';
+                empPreviewBtn.dataset.modelId = item.id;
+                empPreviewBtn.title = '{{ __('Preview Employee') }}';
+                empPreviewBtn.innerHTML = '<i class="bi bi-person-lines-fill"></i>';
+                rightDiv.appendChild(empPreviewBtn);
+
+                // Employer Preview Button (Conditional)
+                if (item.employer_id) {
+                    const emrPreviewBtn = document.createElement('button');
+                    emrPreviewBtn.type = 'button';
+                    emrPreviewBtn.className = 'btn btn-sm btn-outline-primary btn-preview';
+                    emrPreviewBtn.dataset.modelType = 'employer';
+                    emrPreviewBtn.dataset.modelId = item.employer_id;
+                    emrPreviewBtn.title = '{{ __('Preview Employer') }}';
+                    emrPreviewBtn.innerHTML = '<i class="bi bi-building"></i>';
+                    rightDiv.appendChild(emrPreviewBtn);
+                }
+
+                // Remove Button
+                const removeBtn = document.createElement('button');
+                removeBtn.type = 'button';
+                removeBtn.className = 'btn btn-sm btn-outline-danger btn-remove-selected';
+                removeBtn.dataset.id = item.id;
+                removeBtn.title = '{{ __('Remove from selection') }}';
+                removeBtn.innerHTML = '<i class="bi bi-trash"></i>';
+                rightDiv.appendChild(removeBtn);
+
+                li.appendChild(rightDiv);
+                container.appendChild(li);
+            });
+
+            modal.show();
+        });
+    }
+
+    // Handle removal from within the modal
+    if (container) {
+        container.addEventListener('click', function(e) {
+            const removeBtn = e.target.closest('.btn-remove-selected');
+            if (removeBtn) {
+                const id = removeBtn.dataset.id;
+                // Remove from global storage
+                window.removeItemsByIds([id]);
+                // Remove from UI
+                const itemEl = document.getElementById(`selected-item-${id}`);
+                if (itemEl) itemEl.remove();
+
+                // Check if empty
+                if (container.children.length === 0) {
+                    modal.hide();
+                    // Also update the UI on the page is automatic via window.removeItemsByIds
+                    // but we might want to trigger a toast
+                    showToast('{{ __('Selection cleared') }}', 'info');
+                }
+            }
+        });
+    }
+});
+</script>
 <script>
     // Special handler for bulk drag
     window.startDragBulk = function(e) {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1280,7 +1280,10 @@ document.addEventListener('DOMContentLoaded', function () {
     // Helper: Add items (accepts array of {id, employer_id})
     function addItems(newItems) {
         const current = window.getGlobalSelectedData();
-        const combined = [...current, ...newItems];
+        // Filter out existing items that are being re-added (to update them with potentially newer data)
+        const newIds = newItems.map(i => String(i.id));
+        const currentFiltered = current.filter(i => !newIds.includes(String(i.id)));
+        const combined = [...currentFiltered, ...newItems];
         window.setGlobalSelectedData(combined);
     }
 
@@ -1331,6 +1334,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (!selectAllCheckbox && employeeCheckboxes.length === 0) return;
 
+    // Helper to extract rich data
+    function getEmployeeData(cb) {
+        return {
+            id: cb.value,
+            employer_id: cb.dataset.employerId || '',
+            name_th: cb.dataset.nameTh || '',
+            name_en: cb.dataset.nameEn || '',
+            photo: cb.dataset.photo || '',
+            employer_name: cb.dataset.employerName || ''
+        };
+    }
+
     // 1. Restore state from storage on load
     const savedIds = window.getGlobalSelectedIds();
     employeeCheckboxes.forEach(cb => {
@@ -1343,12 +1358,11 @@ document.addEventListener('DOMContentLoaded', function () {
     // 2. Handle Individual Checkbox Changes
     employeeCheckboxes.forEach(checkbox => {
         checkbox.addEventListener('change', function () {
-            const id = this.value;
-            const employerId = this.dataset.employerId || '';
+            const data = getEmployeeData(this);
             if (this.checked) {
-                addItems([{ id: id, employer_id: employerId }]);
+                addItems([data]);
             } else {
-                removeItemsByIds([id]);
+                removeItemsByIds([data.id]);
             }
         });
     });
@@ -1356,10 +1370,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // 3. Handle "Select All" Checkbox
     if (selectAllCheckbox) {
         selectAllCheckbox.addEventListener('change', function () {
-            const visibleItems = Array.from(employeeCheckboxes).map(cb => ({
-                id: cb.value,
-                employer_id: cb.dataset.employerId || ''
-            }));
+            const visibleItems = Array.from(employeeCheckboxes).map(cb => getEmployeeData(cb));
             const visibleIds = visibleItems.map(item => item.id);
 
             if (this.checked) {

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -25,7 +25,7 @@
      })">
     <div class="card-body d-flex align-items-center">
         <div class="me-3">
-            <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}" data-employer-id="{{ $employee->employer_id }}">
+            <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}" data-employer-id="{{ $employee->employer_id }}" data-name-th="{{ $employee->employeeNameTh }}" data-name-en="{{ $employee->employeeNameEn }}" data-photo="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : asset('images/default-profile.png') }}" data-employer-name="{{ $employee->employer->employerNameTh ?? 'N/A' }}">
         </div>
 
         <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : asset('images/default-profile.png') }}"


### PR DESCRIPTION
- Added a 'View Selected' button to the employee bulk action bar.
- Implemented a modal to view selected employees with their photo, names, and employer.
- Added 'Preview' buttons for both Employee and Employer in the modal list.
- Added a 'Remove' button to deselect items directly from the list.
- Enhanced `layouts/app.blade.php` to store rich employee data (names, photo) in `sessionStorage` alongside IDs.
- Updated `_employee_card` and `employees/index` to provide this data via attributes.
- Ensured XSS safety by using DOM creation instead of innerHTML.