### PR TITLE
Fix selection sync and update preview icons in employee list

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -171,7 +171,12 @@
                             <div class="d-flex align-items-center">
                                 <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}" alt="Photo" class="employee-photo-thumb" style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; margin-right: 0.75rem;">
                                 <div>
-                                    <div class="fw-bold">{{ $employee->employeeNameEn ?? 'N/A' }}</div>
+                                    <div class="fw-bold">
+                                        {{ $employee->employeeNameEn ?? 'N/A' }}
+                                        <button type="button" class="btn btn-sm btn-outline-info btn-preview p-0 border-0 bg-transparent ms-2" data-model-type="employee" data-model-id="{{ $employee->id }}" title="{{ __('Preview Data') }}">
+                                            <i class="bi bi-search"></i>
+                                        </button>
+                                    </div>
                                     <div class="text-muted">{{ $employee->employeeNameTh ?? 'N/A' }}</div>
                                 </div>
                             </div>
@@ -189,7 +194,14 @@
                                 {{ $employee->employeeNationality ?? '-' }}
                             @endif
                         </td>
-                        <td class="text-muted">{{ $employee->employer->employerNameTh ?? 'N/A' }}</td>
+                        <td class="text-muted">
+                            {{ $employee->employer->employerNameTh ?? 'N/A' }}
+                            @if($employee->employer)
+                                <button type="button" class="btn btn-sm btn-outline-info btn-preview p-0 border-0 bg-transparent ms-2" data-model-type="employer" data-model-id="{{ $employee->employer->id }}" title="{{ __('Preview Data') }}">
+                                    <i class="bi bi-search"></i>
+                                </button>
+                            @endif
+                        </td>
                         <td>{{ $employee->employeePassport ?? '-' }}</td>
                         <td>{{ $employee->employeeWorkPermit ?? '-' }}</td>
                         <td>{{ $employee->ninetyDayReportDate ? $employee->ninetyDayReportDate->format('d/m/Y') : '-' }}</td>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1320,6 +1320,13 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }
 
+        // Sync individual checkboxes
+        if (employeeCheckboxes) {
+            employeeCheckboxes.forEach(cb => {
+                cb.checked = allIds.includes(String(cb.value));
+            });
+        }
+
         // Sync "Select All" checkbox state based on VISIBLE items
         // If all visible items are in the selected set, check "Select All"
         if (selectAllCheckbox && employeeCheckboxes.length > 0) {


### PR DESCRIPTION
- Updated `updateUI` in `layouts/app.blade.php` to synchronize individual checkbox states with the global selection store. This fixes the issue where removing an item from the "View Selected" modal did not uncheck the corresponding checkbox in the list.
- Updated `resources/views/employees/index.blade.php` to add "Magnifying Glass" preview buttons next to Employee and Employer names in the table view, replacing the previous action button and matching the card view style.