### PR TITLE
feat: enhance production create and prepare pages with grouped tables…

### DIFF
--- a/resources/views/production/create.blade.php
+++ b/resources/views/production/create.blade.php
@@ -15,7 +15,7 @@
                 {{-- Hidden Inputs for Selected Employees --}}
                 @if($preSelectedEmployees->isNotEmpty())
                     @foreach($preSelectedEmployees as $emp)
-                        <input type="hidden" name="selected_employees[]" value="{{ $emp->id }}">
+                        <input type="hidden" name="selected_employees[]" value="{{ $emp->id }}" id="hidden-input-{{ $emp->id }}">
                     @endforeach
                 @endif
 
@@ -53,7 +53,7 @@
                         <option value="">-- Choose Employer --</option>
                         @if($preSelectedEmployees->isNotEmpty() && $employerId)
                              <option value="{{ $employerId }}" selected>
-                                 {{ $preSelectedEmployees->first()->employer->name_th ?? 'Selected Employer' }}
+                                 {{ $preSelectedEmployees->first()->employer->employerNameTh ?? 'Selected Employer' }}
                              </option>
                         @elseif(isset($employers) && $employers->isNotEmpty())
                             @foreach($employers as $emp)
@@ -73,26 +73,82 @@
 
                 <hr>
 
-                <h5 class="fw-bold mb-3">Selected Employees ({{ $preSelectedEmployees->count() }})</h5>
+                <h5 class="fw-bold mb-3">Selected Employees (<span id="selected-count">{{ $preSelectedEmployees->count() }}</span>)</h5>
                 @if($preSelectedEmployees->isNotEmpty())
-                    <div class="table-responsive" style="max-height: 300px; overflow-y: auto;">
-                        <table class="table table-sm table-bordered">
-                            <thead class="table-light sticky-top">
-                                <tr>
-                                    <th>Name</th>
-                                    <th>Passport</th>
-                                    <th>Employer</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach($preSelectedEmployees as $emp)
-                                    <tr>
-                                        <td>{{ $emp->fullname_th ?? $emp->name_th }}</td>
-                                        <td>{{ $emp->passport_number ?? $emp->passport_no }}</td>
-                                        <td>{{ $emp->employer->name_th ?? 'N/A' }}</td>
+                    <div class="table-responsive">
+                        <table class="table table-bordered align-middle">
+                            @php
+                                $groupedEmployees = $preSelectedEmployees->groupBy('employer_id');
+                            @endphp
+
+                            @foreach($groupedEmployees as $employerId => $employees)
+                                @php
+                                    $firstEmp = $employees->first();
+                                    $employer = $firstEmp->employer;
+                                    $employerName = $employer ? ($employer->employerNameTh . ' (' . $employer->employerNameEn . ')') : 'Unknown Employer';
+                                @endphp
+                                <tbody class="group-tbody">
+                                    <tr class="table-light">
+                                        <td colspan="4" class="fw-bold py-2">
+                                            <div class="d-flex justify-content-between align-items-center">
+                                                <span>
+                                                    <i class="bi bi-building me-2"></i> {{ $employerName }}
+                                                    <span class="badge bg-secondary ms-2">{{ $employees->count() }} Employees</span>
+                                                </span>
+                                                @if($employer)
+                                                    <button type="button" class="btn btn-sm btn-outline-info btn-preview"
+                                                            data-model-type="employer"
+                                                            data-model-id="{{ $employer->id }}"
+                                                            title="Preview Employer">
+                                                        <i class="bi bi-search"></i> Preview
+                                                    </button>
+                                                @endif
+                                            </div>
+                                        </td>
                                     </tr>
-                                @endforeach
-                            </tbody>
+                                    @foreach($employees as $emp)
+                                        <tr id="row-{{ $emp->id }}">
+                                            <td style="width: 60px;" class="text-center">
+                                                <img src="{{ $emp->employeePhoto ? asset('storage/' . $emp->employeePhoto) : asset('images/default-profile.png') }}"
+                                                     alt="Photo" class="rounded-circle border" width="40" height="40" style="object-fit: cover;">
+                                            </td>
+                                            <td>
+                                                <div class="fw-bold">{{ $emp->employeeNameTh }}</div>
+                                                <div class="text-muted small">{{ $emp->employeeNameEn }}</div>
+                                            </td>
+                                            <td>
+                                                <div class="d-flex flex-column small">
+                                                    <span><i class="bi bi-passport me-1"></i> {{ $emp->employeePassport ?? '-' }}</span>
+                                                    @if($emp->employeeNationality)
+                                                        @php
+                                                            $countryCode = \App\Helpers\CountryHelper::getCountryCode($emp->employeeNationality);
+                                                        @endphp
+                                                        <span class="text-muted mt-1">
+                                                            @if($countryCode)
+                                                                <img src="{{ asset('images/flags/' . strtolower($countryCode) . '.png') }}" alt="{{ $countryCode }}" style="width: 16px; height: 12px;" class="me-1">
+                                                            @endif
+                                                            {{ $emp->employeeNationality }}
+                                                        </span>
+                                                    @endif
+                                                </div>
+                                            </td>
+                                            <td class="text-center" style="width: 120px;">
+                                                <button type="button" class="btn btn-sm btn-outline-info btn-preview me-1"
+                                                        data-model-type="employee"
+                                                        data-model-id="{{ $emp->id }}"
+                                                        title="Preview Employee">
+                                                    <i class="bi bi-search"></i>
+                                                </button>
+                                                <button type="button" class="btn btn-sm btn-outline-danger"
+                                                        onclick="removeEmployee({{ $emp->id }})"
+                                                        title="Remove">
+                                                    <i class="bi bi-trash"></i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            @endforeach
                         </table>
                     </div>
                 @else
@@ -125,5 +181,27 @@
             });
         });
     });
+
+    function removeEmployee(id) {
+        if (confirm('Are you sure you want to remove this employee from the list?')) {
+            // Remove the row
+            const row = document.getElementById('row-' + id);
+            if (row) row.remove();
+
+            // Remove the hidden input
+            const input = document.getElementById('hidden-input-' + id);
+            if (input) input.remove();
+
+            // Update count
+            const countSpan = document.getElementById('selected-count');
+            let count = parseInt(countSpan.innerText);
+            if (count > 0) {
+                countSpan.innerText = count - 1;
+            }
+
+            // Optional: Hide empty groups
+            // (If complex logic needed, we can implement it, but simple row removal is usually enough)
+        }
+    }
 </script>
 @endsection

--- a/resources/views/production/prepare.blade.php
+++ b/resources/views/production/prepare.blade.php
@@ -6,7 +6,9 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
             <div class="text-uppercase text-muted small fw-bold">Pre-Production Stage</div>
-            <h2 class="fw-bold mb-0">{{ $production->project_name ?? 'Untitled Project' }}</h2>
+            <!-- Editable Header Title -->
+            <input type="text" x-model="projectName" class="display-6 fw-bold border-0 bg-transparent p-0 w-100" placeholder="Project Name" aria-label="Project Name">
+
             <div class="text-muted">{{ $production->employer->name_en ?? $production->employer->name_th ?? 'Independent Project' }}</div>
         </div>
         <div class="d-flex gap-2">
@@ -92,7 +94,7 @@
                                 @method('PUT')
                                 <div class="mb-3">
                                     <label class="form-label">Project Name</label>
-                                    <input type="text" name="project_name" class="form-control" value="{{ $production->project_name }}">
+                                    <input type="text" name="project_name" x-model="projectName" class="form-control">
                                 </div>
                                 <div class="mb-3">
                                     <label class="form-label">Description</label>
@@ -185,6 +187,14 @@
 
                                                         <div class="small text-muted mb-2">
                                                             <i class="bi bi-building me-1"></i> {{ $employerName }}
+                                                            @if($emp->employer)
+                                                                <button type="button" class="btn btn-link p-0 text-info btn-preview ms-1"
+                                                                        data-model-type="employer"
+                                                                        data-model-id="{{ $emp->employer->id }}"
+                                                                        title="Preview Employer">
+                                                                    <i class="bi bi-search"></i>
+                                                                </button>
+                                                            @endif
                                                         </div>
 
                                                         <div>
@@ -305,6 +315,7 @@
 <script>
     function preparationManager() {
         return {
+            projectName: '{{ $production->project_name ?? "" }}',
             documentReady: {{ $production->document_ready_at ? 'true' : 'false' }},
             financialApproved: {{ $production->financial_approved_at ? 'true' : 'false' }},
 


### PR DESCRIPTION
… and editable headers

- Refactor `production/create` view to use a table layout grouped by employer.
- Add employee photos, preview buttons, and removal functionality to the creation list.
- Update `production/prepare` view to make the project name header editable.
- Add employer preview button to employee cards in the preparation view.