### PR TITLE
fix(import): replace removed getImageResource method with Zip extraction

### DIFF
--- a/app/Http/Controllers/ImportEmployeeController.php
+++ b/app/Http/Controllers/ImportEmployeeController.php
@@ -459,33 +459,26 @@ class ImportEmployeeController extends Controller
                                  $info = pathinfo($imagePath);
                                  $extension = $info['extension'] ?? 'jpg';
                             } else {
-                                // Fallback: Try to use GD resource if path is invalid (common in imported Xlsx)
+                                // Fallback: Extract from Zip archive (XLSX is a zip)
                                 try {
-                                    $imageResource = $drawing->getImageResource();
-                                    if ($imageResource) {
-                                        $extension = $drawing->getExtension();
-                                        if (!$extension) $extension = 'jpg';
-
-                                        ob_start();
-                                        switch (strtolower($extension)) {
-                                            case 'png':
-                                                imagepng($imageResource);
+                                    $zip = new \ZipArchive();
+                                    if ($zip->open($path) === true) {
+                                        $drawingName = basename($imagePath);
+                                        // Images in Excel are usually in xl/media/
+                                        // We try to find the file in the zip that ends with the drawing name
+                                        for ($i = 0; $i < $zip->numFiles; $i++) {
+                                            $filename = $zip->getNameIndex($i);
+                                            if (basename($filename) === $drawingName) {
+                                                $imageContent = $zip->getFromIndex($i);
+                                                $info = pathinfo($filename);
+                                                $extension = $info['extension'] ?? 'jpg';
                                                 break;
-                                            case 'gif':
-                                                imagegif($imageResource);
-                                                break;
-                                            case 'jpeg':
-                                            case 'jpg':
-                                            default:
-                                                imagejpeg($imageResource);
-                                                $extension = 'jpg';
-                                                break;
+                                            }
                                         }
-                                        $imageContent = ob_get_contents();
-                                        ob_end_clean();
+                                        $zip->close();
                                     }
                                 } catch (\Exception $e) {
-                                    Log::warning("Fallback image extraction failed for row $rowIdx: " . $e->getMessage());
+                                    Log::warning("Zip extraction failed for row $rowIdx: " . $e->getMessage());
                                 }
                             }
                         }


### PR DESCRIPTION
The `PhpSpreadsheet` library removed the `getImageResource()` method in recent versions, causing a crash during employee import when fallback image extraction was needed.

This commit replaces the failing call with a `ZipArchive` implementation that extracts the image directly from the uploaded `.xlsx` file (which is a zip archive). This ensures robust image handling even when the library cannot resolve a local filesystem path for embedded images.