### PR TITLE
Fix Production Registration 404 and Redesign Sidebar Menu

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -84,7 +84,13 @@ public function reinstate(Employee $employee)
 
     public function index(Request $request)
 {
-    $query = Employee::query()->whereNull('terminated_at');
+    // Filter out 'registration_pending' status so they don't appear until finalized
+    $query = Employee::query()
+        ->whereNull('terminated_at')
+        ->where(function($q) {
+            $q->where('status', '!=', 'registration_pending')
+              ->orWhereNull('status');
+        });
 
     // --- START: ADDED FILTERING LOGIC ---
     if ($request->filled('search')) {
@@ -544,7 +550,12 @@ public function create(Request $request) // เพิ่ม Request $request เ
         if ($isHistoryExport) {
             $query = Employee::query()->whereNotNull('terminated_at');
         } else {
-            $query = Employee::query()->whereNull('terminated_at');
+            $query = Employee::query()
+                ->whereNull('terminated_at')
+                ->where(function($q) {
+                    $q->where('status', '!=', 'registration_pending')
+                      ->orWhereNull('status');
+                });
         }
 
         // Reuse the same filtering logic from the index method

--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -26,8 +26,8 @@ class RegistrationController extends Controller
      */
     public function index(Request $request)
     {
-        // 1. Fetch Stats
-        $registrationEmployees = Employee::where('status', 'registration_pending')->get();
+        // 1. Fetch Stats (Both pending and completed/finalized)
+        $registrationEmployees = Employee::whereIn('status', ['registration_pending', 'registration_completed'])->get();
         $totalEmployees = $registrationEmployees->count();
         $totalEmployers = $registrationEmployees->pluck('employer_id')->unique()->count();
 
@@ -35,10 +35,6 @@ class RegistrationController extends Controller
         $steps = RegistrationStep::orderBy('order')->get();
         $stepStats = [];
 
-        // Count employees at each step (Cumulative or Specific?)
-        // User requested: "Who completed step 1... who finished step 2".
-        // And "who is stuck at step 1".
-        // Let's count how many have marked each step as completed.
         foreach ($steps as $step) {
             $count = DB::table('employee_registration_status')
                 ->where('registration_step_id', $step->id)
@@ -48,12 +44,11 @@ class RegistrationController extends Controller
         }
 
         // 3. Fetch Employees Grouped by Employer
-        // We want to display an employer list, and expand to see their registration employees.
         $employers = Employer::whereHas('employees', function($q) {
-            $q->where('status', 'registration_pending');
+            $q->whereIn('status', ['registration_pending', 'registration_completed']);
         })->with(['employees' => function($q) {
-            $q->where('status', 'registration_pending')
-              ->with(['registrationSteps', 'customFields']); // Eager load progress and fields
+            $q->whereIn('status', ['registration_pending', 'registration_completed'])
+              ->with(['registrationSteps', 'customFields']);
         }])->get();
 
         return view('production.registration.index', compact(
@@ -63,6 +58,54 @@ class RegistrationController extends Controller
             'stepStats',
             'employers'
         ));
+    }
+
+    /**
+     * Finalize an employee (Save to Database).
+     */
+    public function finalize(Request $request, Employee $employee)
+    {
+        // Change status to 'registration_completed'
+        // This makes them visible in the main Employee list (since we only filter out 'pending')
+        // AND keeps them visible here (since we include 'completed').
+        $employee->update(['status' => 'registration_completed']);
+
+        if ($request->ajax()) {
+            return response()->json(['success' => true]);
+        }
+        return back()->with('success', 'Employee saved to database.');
+    }
+
+    /**
+     * Bulk Finalize employees.
+     */
+    public function bulkFinalize(Request $request)
+    {
+        $request->validate([
+            'employee_ids' => 'required|array',
+            'employee_ids.*' => 'exists:employees,id',
+        ]);
+
+        Employee::whereIn('id', $request->input('employee_ids'))
+            ->update(['status' => 'registration_completed']);
+
+        if ($request->ajax()) {
+            return response()->json(['success' => true]);
+        }
+        return back()->with('success', 'Selected employees saved to database.');
+    }
+
+    /**
+     * Restore state (Undo Finalize).
+     */
+    public function restoreState(Request $request, Employee $employee)
+    {
+        $employee->update(['status' => 'registration_pending']);
+
+        if ($request->ajax()) {
+            return response()->json(['success' => true]);
+        }
+        return back()->with('success', 'Employee restored to pending state.');
     }
 
     /**

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -343,21 +343,15 @@
 
                 {{-- V2.4-S14: Production & Workflow Menus --}}
                 @if(Route::has('production.index'))
-                    <a href="#productionSubmenu" data-bs-toggle="collapse" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center {{ request()->routeIs('production.*') || request()->routeIs('workflow.*') ? 'active' : '' }}" aria-expanded="false">
-                        <span><i class="bi bi-clipboard-data-fill me-2"></i>{{ __('P Production') }}</span>
-                        <i class="bi bi-chevron-down small"></i>
+                    <a href="{{ route('production.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('production.*') ? 'active' : '' }}">
+                        <i class="bi bi-clipboard-data-fill me-2"></i>{{ __('P Production') }}
                     </a>
-                    <div class="collapse {{ request()->routeIs('production.*') || request()->routeIs('workflow.*') ? 'show' : '' }}" id="productionSubmenu">
-                        <a href="{{ route('production.index') }}" class="list-group-item list-group-item-action ps-4 border-0 {{ request()->routeIs('production.index') ? 'bg-light text-primary fw-bold' : '' }}">
-                            <i class="bi bi-circle-fill small me-2" style="font-size: 0.5rem;"></i>{{ __('Jobs') }}
-                        </a>
-                        <a href="{{ route('workflow.index') }}" class="list-group-item list-group-item-action ps-4 border-0 {{ request()->routeIs('workflow.*') ? 'bg-light text-primary fw-bold' : '' }}">
-                            <i class="bi bi-diagram-3-fill me-2"></i>{{ __('Workflow') }}
-                        </a>
-                        <a href="{{ route('production.registration.index') }}" class="list-group-item list-group-item-action ps-4 border-0 {{ request()->routeIs('production.registration.*') ? 'bg-light text-primary fw-bold' : '' }}">
-                            <i class="bi bi-person-lines-fill me-2"></i>{{ __('Registration Resolution') }}
-                        </a>
-                    </div>
+                    <a href="{{ route('workflow.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('workflow.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
+                        <i class="bi bi-diagram-3-fill me-2"></i>{{ __('Workflow') }}
+                    </a>
+                    <a href="{{ route('production.registration.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('production.registration.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
+                        <i class="bi bi-person-lines-fill me-2"></i>{{ __('Registration Resolution') }}
+                    </a>
                 @endif
 
                 @canany(['manage-roles', 'manage-settings'])

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -1,0 +1,87 @@
+@props(['employee', 'steps'])
+
+@php
+    $isCompleted = $employee->status === 'registration_completed';
+    // Style: if completed, flatten/grey out.
+    $cardClass = $isCompleted ? 'bg-secondary bg-opacity-10 border-0 text-muted' : 'bg-white border shadow-sm';
+    $overlayClass = $isCompleted ? 'opacity-50 pointer-events-none' : '';
+@endphp
+
+<div class="card {{ $cardClass }} mb-3" id="employee-card-{{ $employee->id }}" style="transition: all 0.3s ease;">
+    <div class="card-body p-3">
+        <div class="d-flex justify-content-between align-items-start">
+            {{-- Checkbox & Basic Info --}}
+            <div class="d-flex align-items-center gap-3 w-100">
+                {{-- Only show checkbox if NOT completed (or allow selecting completed for other actions? User said greyed out/sealed, usually implies no bulk actions unless restore) --}}
+                @if(!$isCompleted)
+                    <div class="form-check">
+                        <input class="form-check-input registration-checkbox" type="checkbox" value="{{ $employee->id }}" id="check_{{ $employee->id }}">
+                    </div>
+                @endif
+
+                <div class="d-flex align-items-center gap-3 {{ $overlayClass }}">
+                    {{-- Avatar --}}
+                    <div class="avatar-container">
+                        @if($employee->employeePhoto)
+                            <img src="{{ Storage::disk('public')->url($employee->employeePhoto) }}" class="rounded-circle" style="width: 50px; height: 50px; object-fit: cover;">
+                        @else
+                            <div class="rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center" style="width: 50px; height: 50px; font-size: 1.2rem;">
+                                {{ substr($employee->employeeNameEn ?? 'U', 0, 1) }}
+                            </div>
+                        @endif
+                    </div>
+
+                    {{-- Info --}}
+                    <div>
+                        <h6 class="mb-0 fw-bold">
+                            {{ $employee->employeeNameTh }}
+                            @if($employee->employeeNameEn) <span class="text-muted small">({{ $employee->employeeNameEn }})</span> @endif
+                        </h6>
+                        <div class="small text-muted">
+                            <i class="bi bi-passport me-1"></i> {{ $employee->employeePassport ?? '-' }} |
+                            <i class="bi bi-geo-alt me-1"></i> {{ $employee->employeeNationality ?? '-' }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {{-- Actions --}}
+            <div class="d-flex gap-2">
+                @if(!$isCompleted)
+                    {{-- Standard Actions --}}
+                    <button class="btn btn-sm btn-outline-success" title="Save to Database" onclick="finalizeEmployee({{ $employee->id }})">
+                        <i class="bi bi-check-lg"></i> <span class="d-none d-md-inline">{{ __('Save to DB') }}</span>
+                    </button>
+                    {{-- Add other actions like Edit/Delete here if needed --}}
+                @else
+                    {{-- Restore Action --}}
+                    <button class="btn btn-sm btn-outline-warning" title="Restore / Undo" onclick="restoreEmployeeState({{ $employee->id }})">
+                        <i class="bi bi-arrow-counterclockwise"></i> {{ __('Undo') }}
+                    </button>
+                    <span class="badge bg-success align-self-center"><i class="bi bi-database-check"></i> {{ __('Saved') }}</span>
+                @endif
+            </div>
+        </div>
+
+        {{-- Steps Progress Bar (Disable interaction if completed) --}}
+        <div class="mt-3 {{ $overlayClass }}">
+            <label class="small text-muted mb-1">{{ __('Workflow Progress') }}</label>
+            <div class="d-flex gap-1 flex-wrap">
+                @foreach($steps as $step)
+                    @php
+                        $isStepCompleted = $employee->registrationSteps->contains($step->id);
+                    @endphp
+                    <button
+                        class="btn btn-sm {{ $isStepCompleted ? 'btn-success' : 'btn-outline-secondary' }}"
+                        style="font-size: 0.75rem;"
+                        onclick="toggleStep({{ $employee->id }}, {{ $step->id }}, {{ $isStepCompleted ? 'false' : 'true' }})"
+                        {{ $isCompleted ? 'disabled' : '' }}
+                    >
+                        {{ $step->name }}
+                        @if($isStepCompleted) <i class="bi bi-check"></i> @endif
+                    </button>
+                @endforeach
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -39,6 +39,22 @@
             </div>
         </div>
 
+        {{-- Bulk Actions Bar --}}
+        <div class="col-12 mb-3" id="registration-bulk-bar" style="display: none;">
+            <div class="card border-primary bg-primary bg-opacity-10">
+                <div class="card-body d-flex justify-content-between align-items-center py-2">
+                    <div>
+                        <span class="fw-bold text-primary"><span id="reg-selected-count">0</span> {{ __('Selected') }}</span>
+                    </div>
+                    <div>
+                        <button class="btn btn-primary btn-sm" onclick="bulkFinalize()">
+                            <i class="bi bi-database-add me-1"></i> {{ __('Save All to Database') }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         {{-- Workflow Steps Summary --}}
         <div class="col-md-6 mb-3">
             <div class="card h-100 shadow-sm border-0">
@@ -188,5 +204,98 @@
             }
         }
     }
+
+    // Global Functions for Non-Alpine Actions (referenced in _employee_card)
+
+    function toggleStep(employeeId, stepId, completed) {
+        fetch(`/production/registration/progress/${employeeId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+            },
+            body: JSON.stringify({ step_id: stepId, completed: completed })
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data.success) {
+                // No reload needed for pure toggle if we want smooth UX,
+                // but simpler to reload to reflect stats unless we build full reactivity
+                location.reload();
+            }
+        });
+    }
+
+    function finalizeEmployee(id) {
+        if(!confirm('{{ __("Save this employee to the main database?") }}')) return;
+
+        fetch(`/production/registration/${id}/finalize`, {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+            }
+        })
+        .then(res => res.json())
+        .then(data => {
+            if(data.success) location.reload();
+        });
+    }
+
+    function restoreEmployeeState(id) {
+        if(!confirm('{{ __("Undo save? This will move employee back to pending state.") }}')) return;
+
+        fetch(`/production/registration/${id}/restore-state`, {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+            }
+        })
+        .then(res => res.json())
+        .then(data => {
+            if(data.success) location.reload();
+        });
+    }
+
+    // Bulk Selection Logic
+    document.addEventListener('DOMContentLoaded', function() {
+        const checkboxes = document.querySelectorAll('.registration-checkbox');
+        const bulkBar = document.getElementById('registration-bulk-bar');
+        const countSpan = document.getElementById('reg-selected-count');
+
+        function updateBulkUI() {
+            const checked = document.querySelectorAll('.registration-checkbox:checked');
+            if(checked.length > 0) {
+                bulkBar.style.display = 'block';
+                countSpan.textContent = checked.length;
+            } else {
+                bulkBar.style.display = 'none';
+            }
+        }
+
+        checkboxes.forEach(cb => {
+            cb.addEventListener('change', updateBulkUI);
+        });
+
+        window.bulkFinalize = function() {
+            const checked = document.querySelectorAll('.registration-checkbox:checked');
+            const ids = Array.from(checked).map(cb => cb.value);
+
+            if(ids.length === 0) return;
+            if(!confirm(`{{ __("Save ${ids.length} employees to the main database?") }}`)) return;
+
+            fetch('{{ route("production.registration.bulk_finalize") }}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ employee_ids: ids })
+            })
+            .then(res => res.json())
+            .then(data => {
+                if(data.success) location.reload();
+            });
+        }
+    });
 </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -185,6 +185,31 @@ Route::middleware(['auth', 'permission:manage-tickets'])->prefix('admin/producti
 
 // === Production & Workflow User Routes ===
 Route::middleware(['auth'])->group(function () {
+    // Registration Resolution Routes (P Production > Registration)
+    // MOVED ABOVE 'production' resource to prevent route masking
+    Route::prefix('production/registration')->name('production.registration.')->group(function () {
+        Route::get('/', [App\Http\Controllers\Production\RegistrationController::class, 'index'])->name('index');
+        Route::get('/create', [App\Http\Controllers\Production\RegistrationController::class, 'create'])->name('create');
+        Route::post('/store', [App\Http\Controllers\Production\RegistrationController::class, 'store'])->name('store');
+
+        // Step Management
+        Route::post('/steps', [App\Http\Controllers\Production\RegistrationController::class, 'storeStep'])->name('steps.store');
+        Route::put('/steps/{step}', [App\Http\Controllers\Production\RegistrationController::class, 'updateStep'])->name('steps.update');
+        Route::delete('/steps/{step}', [App\Http\Controllers\Production\RegistrationController::class, 'destroyStep'])->name('steps.destroy');
+
+        // Progress Updates
+        Route::post('/progress/{employee}', [App\Http\Controllers\Production\RegistrationController::class, 'updateProgress'])->name('progress.update');
+
+        // Custom Fields
+        Route::post('/custom-fields/{employee}', [App\Http\Controllers\Production\RegistrationController::class, 'storeCustomField'])->name('custom_fields.store');
+        Route::delete('/custom-fields/{field}', [App\Http\Controllers\Production\RegistrationController::class, 'destroyCustomField'])->name('custom_fields.destroy');
+
+        // Finalize & Restore (NEW)
+        Route::post('/{employee}/finalize', [App\Http\Controllers\Production\RegistrationController::class, 'finalize'])->name('finalize');
+        Route::post('/{employee}/restore-state', [App\Http\Controllers\Production\RegistrationController::class, 'restoreState'])->name('restore_state');
+        Route::post('/bulk-finalize', [App\Http\Controllers\Production\RegistrationController::class, 'bulkFinalize'])->name('bulk_finalize');
+    });
+
     Route::resource('production', \App\Http\Controllers\ProductionController::class);
 
     // Additional Production Routes
@@ -210,25 +235,6 @@ Route::middleware(['auth'])->group(function () {
     // Workflow API Routes
     Route::post('workflow/api/update-barrier', [\App\Http\Controllers\WorkflowController::class, 'updateItemBarrier'])->name('workflow.api.update_barrier');
     Route::post('workflow/api/bulk-step', [\App\Http\Controllers\WorkflowController::class, 'bulkStoreStep'])->name('workflow.api.bulk_step');
-
-    // Registration Resolution Routes (P Production > Registration)
-    Route::prefix('production/registration')->name('production.registration.')->group(function () {
-        Route::get('/', [App\Http\Controllers\Production\RegistrationController::class, 'index'])->name('index');
-        Route::get('/create', [App\Http\Controllers\Production\RegistrationController::class, 'create'])->name('create');
-        Route::post('/store', [App\Http\Controllers\Production\RegistrationController::class, 'store'])->name('store');
-
-        // Step Management
-        Route::post('/steps', [App\Http\Controllers\Production\RegistrationController::class, 'storeStep'])->name('steps.store');
-        Route::put('/steps/{step}', [App\Http\Controllers\Production\RegistrationController::class, 'updateStep'])->name('steps.update');
-        Route::delete('/steps/{step}', [App\Http\Controllers\Production\RegistrationController::class, 'destroyStep'])->name('steps.destroy');
-
-        // Progress Updates
-        Route::post('/progress/{employee}', [App\Http\Controllers\Production\RegistrationController::class, 'updateProgress'])->name('progress.update');
-
-        // Custom Fields
-        Route::post('/custom-fields/{employee}', [App\Http\Controllers\Production\RegistrationController::class, 'storeCustomField'])->name('custom_fields.store');
-        Route::delete('/custom-fields/{field}', [App\Http\Controllers\Production\RegistrationController::class, 'destroyCustomField'])->name('custom_fields.destroy');
-    });
 });
 
 use App\Http\Controllers\Admin\NotificationSettingController;


### PR DESCRIPTION
- Move `production/registration` route group above `production` resource route in `routes/web.php` to prevent route masking (Fixes 404).
- Redesign "P Production" sidebar menu in `resources/views/layouts/app.blade.php`: removed dropdown, now lists Jobs, Workflow, and Registration Resolution as static hierarchical links to match the "Employees" menu style.
- Update `EmployeeController.php` to filter out employees with `status = 'registration_pending'` from the main index and export lists.
- Update `RegistrationController.php` to handle `finalize` (save to database) and `restoreState` actions.
- Update `RegistrationController@index` to include both pending and finalized employees.
- Implement "Save to Database" and "Undo" UI in `resources/views/production/registration/index.blade.php` and the newly created `_employee_card.blade.php`.
- Add bulk "Save to Database" functionality.
- Apply visual distinction (greyed out/flattened) for finalized employees in the Registration view.