### PR TITLE
Fix undefined constant error in registration view

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -281,7 +281,10 @@
             const ids = Array.from(checked).map(cb => cb.value);
 
             if(ids.length === 0) return;
-            if(!confirm(`{{ __("Save ${ids.length} employees to the main database?") }}`)) return;
+            let message = '{{ __("Save :count employees to the main database?") }}';
+            message = message.replace(':count', ids.length);
+
+            if(!confirm(message)) return;
 
             fetch('{{ route("production.registration.bulk_finalize") }}', {
                 method: 'POST',


### PR DESCRIPTION
Separated server-side Blade translation from client-side JavaScript variable interpolation to prevent 'Undefined constant "ids"' error. Used a placeholder in the translation string and replaced it in JS.