### PR TITLE
Fix crash and import logic in Registration Resolution

### DIFF
--- a/app/Models/EmployeeCustomField.php
+++ b/app/Models/EmployeeCustomField.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EmployeeCustomField extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'employee_id',
+        'field_name',
+        'field_type',
+        'field_value',
+        'file_path',
+    ];
+
+    public function employee()
+    {
+        return $this->belongsTo(Employee::class);
+    }
+}

--- a/database/migrations/2025_12_10_070000_create_employee_registration_status_and_custom_fields_tables.php
+++ b/database/migrations/2025_12_10_070000_create_employee_registration_status_and_custom_fields_tables.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_registration_status', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employee_id')->constrained('employees')->onDelete('cascade');
+            $table->foreignId('registration_step_id')->constrained('registration_steps')->onDelete('cascade');
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('employee_custom_fields', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employee_id')->constrained('employees')->onDelete('cascade');
+            $table->string('field_name');
+            $table->enum('field_type', ['text', 'date', 'file']);
+            $table->text('field_value')->nullable();
+            $table->string('file_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_custom_fields');
+        Schema::dropIfExists('employee_registration_status');
+    }
+};

--- a/resources/views/employees/import.blade.php
+++ b/resources/views/employees/import.blade.php
@@ -51,6 +51,10 @@
                             <input type="hidden" name="production_id" value="{{ $production->id }}">
                         @endif
 
+                        @if(request('target_status'))
+                            <input type="hidden" name="target_status" value="{{ request('target_status') }}">
+                        @endif
+
                         <div class="mb-4">
                             <label for="employer_id" class="form-label fw-bold required">{{ __('Select Employer') }}</label>
 


### PR DESCRIPTION
- Create migration for missing `employee_registration_status` pivot table and `employee_custom_fields` table to resolve 500 Internal Server Error.
- Create `EmployeeCustomField` model.
- Update `import.blade.php` to pass `target_status` query parameter to the backend, ensuring employees are imported into the correct workflow state.