### PR TITLE
Refactor Business Type fields in Employer forms and preview

### DIFF
--- a/app/Http/Controllers/Admin/BusinessTypeController.php
+++ b/app/Http/Controllers/Admin/BusinessTypeController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\BusinessType;
+use Illuminate\Http\Request;
+
+class BusinessTypeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return response()->json(BusinessType::latest()->get());
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name_th' => 'required|string|max:255',
+            'name_en' => 'required|string|max:255',
+        ]);
+
+        $businessType = BusinessType::create($request->only('name_th', 'name_en'));
+
+        return response()->json([
+            'success' => true,
+            'data' => $businessType,
+            'message' => 'Business Type created successfully.'
+        ]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(BusinessType $businessType)
+    {
+        $businessType->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Business Type deleted successfully.'
+        ]);
+    }
+}

--- a/database/migrations/2026_01_02_000000_create_business_types_table.php
+++ b/database/migrations/2026_01_02_000000_create_business_types_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('business_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name_th');
+            $table->string('name_en');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('business_types');
+    }
+};

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -76,13 +76,37 @@
                 @enderror
             </div>
             <div class="col-md-6">
-                <label for="businessType" class="form-label">{{ __('Business Type') }}</label>
+                <label class="form-label">{{ __('Select Business Type') }}</label>
+                <div class="input-group">
+                    <select class="form-select" id="business_type_select">
+                        <option value="">{{ __('Select...') }}</option>
+                    </select>
+                    @if(auth()->user()->hasRole('admin'))
+                    <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#manageBusinessTypeModal">
+                        <i class="bi bi-gear"></i> {{ __('Manage') }}
+                    </button>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="businessType" class="form-label">{{ __('Business Type (Thai)') }}</label>
                 <input type="text" class="form-control @error('businessType') is-invalid @enderror" id="businessType" name="businessType" value="{{ old('businessType') }}">
                 @error('businessType')
                     <div class="invalid-feedback">{{ $message }}</div>
                 @enderror
             </div>
+             <div class="col-md-6">
+                <label for="businessTypeEn" class="form-label">{{ __('Business Type (English)') }}</label>
+                <input type="text" class="form-control @error('businessTypeEn') is-invalid @enderror" id="businessTypeEn" name="businessTypeEn" value="{{ old('businessTypeEn') }}">
+                @error('businessTypeEn')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
         </div>
+
 <div class="row mb-3">
  <div class="col-md-6">
  <label for="employerEmail" class="form-label">{{ __('Employer Email') }}</label>
@@ -132,13 +156,6 @@
             </div>
         </div>
         <div class="row mb-3">
-            <div class="col-md-6">
-                <label for="businessTypeEn" class="form-label">{{ __('Type of Business') }}</label>
-                <input type="text" class="form-control @error('businessTypeEn') is-invalid @enderror" id="businessTypeEn" name="businessTypeEn" value="{{ old('businessTypeEn') }}">
-                @error('businessTypeEn')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
-            </div>
             <div class="col-md-6">
                 <label for="regCapital" class="form-label">{{ __('Registered Capital') }}</label>
                 <input type="text" class="form-control @error('regCapital') is-invalid @enderror" id="regCapital" name="regCapital" value="{{ old('regCapital') }}">
@@ -273,11 +290,148 @@
 </div>
 
 @include('partials._address_management')
+
+<!-- Business Type Management Modal -->
+<div class="modal fade" id="manageBusinessTypeModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{ __('Manage Business Types') }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addBusinessTypeForm" class="mb-4">
+                    <div class="mb-2">
+                        <label class="form-label">{{ __('Thai Name') }}</label>
+                        <input type="text" class="form-control form-control-sm" name="name_th" required>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">{{ __('English Name') }}</label>
+                        <input type="text" class="form-control form-control-sm" name="name_en" required>
+                    </div>
+                    <button type="submit" class="btn btn-sm btn-success w-100">{{ __('Add Type') }}</button>
+                </form>
+                <hr>
+                <h6>{{ __('Existing Types') }}</h6>
+                <ul class="list-group" id="businessTypeList">
+                    <!-- Loaded via JS -->
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
 @endsection
 
 @push('scripts')
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+    // --- Business Type Logic ---
+    const businessTypeSelect = document.getElementById('business_type_select');
+    const businessTypeThInput = document.getElementById('businessType');
+    const businessTypeEnInput = document.getElementById('businessTypeEn');
+    const businessTypeList = document.getElementById('businessTypeList');
+
+    function fetchBusinessTypes() {
+        fetch('{{ route('admin.business-types.index') }}')
+            .then(response => response.json())
+            .then(data => {
+                // Populate Select
+                businessTypeSelect.innerHTML = '<option value="">{{ __('Select...') }}</option>';
+                data.forEach(item => {
+                    const option = document.createElement('option');
+                    option.value = item.id;
+                    option.textContent = `${item.name_th} / ${item.name_en}`;
+                    option.dataset.th = item.name_th;
+                    option.dataset.en = item.name_en;
+                    businessTypeSelect.appendChild(option);
+                });
+
+                // Populate List in Modal (if exists)
+                if (businessTypeList) {
+                    businessTypeList.innerHTML = '';
+                    data.forEach(item => {
+                        const li = document.createElement('li');
+                        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+                        li.innerHTML = `
+                            <span>${item.name_th} / ${item.name_en}</span>
+                            <button class="btn btn-sm btn-outline-danger delete-business-type" data-id="${item.id}"><i class="bi bi-trash"></i></button>
+                        `;
+                        businessTypeList.appendChild(li);
+                    });
+                }
+            });
+    }
+
+    // Initial Fetch
+    fetchBusinessTypes();
+
+    // Handle Select Change
+    if (businessTypeSelect) {
+        businessTypeSelect.addEventListener('change', function() {
+            const selectedOption = this.options[this.selectedIndex];
+            if (selectedOption.value) {
+                businessTypeThInput.value = selectedOption.dataset.th;
+                businessTypeEnInput.value = selectedOption.dataset.en;
+            }
+        });
+    }
+
+    // Handle Add New Type
+    const addBusinessTypeForm = document.getElementById('addBusinessTypeForm');
+    if (addBusinessTypeForm) {
+        addBusinessTypeForm.addEventListener('submit', function(e) {
+            e.preventDefault();
+            const formData = new FormData(this);
+            const data = {
+                name_th: formData.get('name_th'),
+                name_en: formData.get('name_en')
+            };
+
+            fetch('{{ route('admin.business-types.store') }}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify(data)
+            })
+            .then(response => response.json())
+            .then(result => {
+                if (result.success) {
+                    fetchBusinessTypes();
+                    this.reset();
+                    showToast('Business Type added', 'success');
+                }
+            });
+        });
+    }
+
+    // Handle Delete Type
+    if (businessTypeList) {
+        businessTypeList.addEventListener('click', function(e) {
+            if (e.target.closest('.delete-business-type')) {
+                const btn = e.target.closest('.delete-business-type');
+                const id = btn.dataset.id;
+                if (confirm('Delete this type?')) {
+                    fetch(`{{ url('admin/business-types') }}/${id}`, {
+                        method: 'DELETE',
+                        headers: {
+                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                        }
+                    })
+                    .then(response => response.json())
+                    .then(result => {
+                        if (result.success) {
+                            fetchBusinessTypes();
+                        }
+                    });
+                }
+            }
+        });
+    }
+
+    // --- End Business Type Logic ---
     // --- Temporary Address Storage ---
     let tempRegisteredAddresses = [];
     let tempWorkplaceAddresses = [];

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -93,10 +93,31 @@
                 <input type="text" class="form-control" id="employerTaxId" name="employerTaxId" value="{{ old('employerTaxId', $employer->employerTaxId) }}">
             </div>
             <div class="col-md-6">
-                <label for="businessType" class="form-label">{{ __('Business Type') }}</label>
-                <input type="text" class="form-control" id="businessType" name="businessType" value="{{ old('businessType', $employer->businessType) }}">
+                <label class="form-label">{{ __('Select Business Type') }}</label>
+                <div class="input-group">
+                    <select class="form-select" id="business_type_select">
+                        <option value="">{{ __('Select...') }}</option>
+                    </select>
+                    @if(auth()->user()->hasRole('admin'))
+                    <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#manageBusinessTypeModal">
+                        <i class="bi bi-gear"></i> {{ __('Manage') }}
+                    </button>
+                    @endif
+                </div>
             </div>
         </div>
+
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="businessType" class="form-label">{{ __('Business Type (Thai)') }}</label>
+                <input type="text" class="form-control" id="businessType" name="businessType" value="{{ old('businessType', $employer->businessType) }}">
+            </div>
+            <div class="col-md-6">
+                <label for="businessTypeEn" class="form-label">{{ __('Business Type (English)') }}</label>
+                <input type="text" class="form-control" id="businessTypeEn" name="businessTypeEn" value="{{ old('businessTypeEn', $employer->businessTypeEn) }}">
+            </div>
+        </div>
+
         <div class="row mb-3">
  <div class="col-md-6">
  <label for="employerEmail" class="form-label">{{ __('Employer Email') }}</label>
@@ -140,10 +161,6 @@
             </div>
         </div>
         <div class="row mb-3">
-            <div class="col-md-6">
-                <label for="businessTypeEn" class="form-label">{{ __('Type of Business') }}</label>
-                <input type="text" class="form-control" id="businessTypeEn" name="businessTypeEn" value="{{ old('businessTypeEn', $employer->businessTypeEn) }}">
-            </div>
             <div class="col-md-6">
                 <label for="regCapital" class="form-label">{{ __('Registered Capital') }}</label>
                 <input type="text" class="form-control" id="regCapital" name="regCapital" value="{{ old('regCapital', $employer->regCapital) }}">
@@ -539,11 +556,148 @@
     @include('partials._employee_action_modals')
     @include('employees.modals.advanced_export')
     @include('employees.modals.select_target_employer_modal')
+
+<!-- Business Type Management Modal -->
+<div class="modal fade" id="manageBusinessTypeModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{ __('Manage Business Types') }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addBusinessTypeForm" class="mb-4">
+                    <div class="mb-2">
+                        <label class="form-label">{{ __('Thai Name') }}</label>
+                        <input type="text" class="form-control form-control-sm" name="name_th" required>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">{{ __('English Name') }}</label>
+                        <input type="text" class="form-control form-control-sm" name="name_en" required>
+                    </div>
+                    <button type="submit" class="btn btn-sm btn-success w-100">{{ __('Add Type') }}</button>
+                </form>
+                <hr>
+                <h6>{{ __('Existing Types') }}</h6>
+                <ul class="list-group" id="businessTypeList">
+                    <!-- Loaded via JS -->
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
 @endsection
 
 @push('scripts')
 <script>
     document.addEventListener('DOMContentLoaded', function () {
+        // --- Business Type Logic ---
+        const businessTypeSelect = document.getElementById('business_type_select');
+        const businessTypeThInput = document.getElementById('businessType');
+        const businessTypeEnInput = document.getElementById('businessTypeEn');
+        const businessTypeList = document.getElementById('businessTypeList');
+
+        function fetchBusinessTypes() {
+            fetch('{{ route('admin.business-types.index') }}')
+                .then(response => response.json())
+                .then(data => {
+                    // Populate Select
+                    businessTypeSelect.innerHTML = '<option value="">{{ __('Select...') }}</option>';
+                    data.forEach(item => {
+                        const option = document.createElement('option');
+                        option.value = item.id;
+                        option.textContent = `${item.name_th} / ${item.name_en}`;
+                        option.dataset.th = item.name_th;
+                        option.dataset.en = item.name_en;
+                        businessTypeSelect.appendChild(option);
+                    });
+
+                    // Populate List in Modal (if exists)
+                    if (businessTypeList) {
+                        businessTypeList.innerHTML = '';
+                        data.forEach(item => {
+                            const li = document.createElement('li');
+                            li.className = 'list-group-item d-flex justify-content-between align-items-center';
+                            li.innerHTML = `
+                                <span>${item.name_th} / ${item.name_en}</span>
+                                <button class="btn btn-sm btn-outline-danger delete-business-type" data-id="${item.id}"><i class="bi bi-trash"></i></button>
+                            `;
+                            businessTypeList.appendChild(li);
+                        });
+                    }
+                });
+        }
+
+        // Initial Fetch
+        fetchBusinessTypes();
+
+        // Handle Select Change
+        if (businessTypeSelect) {
+            businessTypeSelect.addEventListener('change', function() {
+                const selectedOption = this.options[this.selectedIndex];
+                if (selectedOption.value) {
+                    businessTypeThInput.value = selectedOption.dataset.th;
+                    businessTypeEnInput.value = selectedOption.dataset.en;
+                }
+            });
+        }
+
+        // Handle Add New Type
+        const addBusinessTypeForm = document.getElementById('addBusinessTypeForm');
+        if (addBusinessTypeForm) {
+            addBusinessTypeForm.addEventListener('submit', function(e) {
+                e.preventDefault();
+                const formData = new FormData(this);
+                const data = {
+                    name_th: formData.get('name_th'),
+                    name_en: formData.get('name_en')
+                };
+
+                fetch('{{ route('admin.business-types.store') }}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                    },
+                    body: JSON.stringify(data)
+                })
+                .then(response => response.json())
+                .then(result => {
+                    if (result.success) {
+                        fetchBusinessTypes();
+                        this.reset();
+                        showToast('Business Type added', 'success');
+                    }
+                });
+            });
+        }
+
+        // Handle Delete Type
+        if (businessTypeList) {
+            businessTypeList.addEventListener('click', function(e) {
+                if (e.target.closest('.delete-business-type')) {
+                    const btn = e.target.closest('.delete-business-type');
+                    const id = btn.dataset.id;
+                    if (confirm('Delete this type?')) {
+                        fetch(`{{ url('admin/business-types') }}/${id}`, {
+                            method: 'DELETE',
+                            headers: {
+                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                            }
+                        })
+                        .then(response => response.json())
+                        .then(result => {
+                            if (result.success) {
+                                fetchBusinessTypes();
+                            }
+                        });
+                    }
+                }
+            });
+        }
+
+        // --- End Business Type Logic ---
         // Handle Advanced Edit
         const bulkEditBtn = document.getElementById('employer-bulk-advanced-edit-btn');
         if (bulkEditBtn) {

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -39,9 +39,16 @@
             <label class="form-label fw-bold">เลขประจำตัวนายจ้าง</label>
             <p class="form-control-plaintext">{{ $employer->employerTaxId ?? 'N/A' }}</p>
         </div>
+    </div>
+
+    <div class="row mb-3">
         <div class="col-md-6">
-            <label class="form-label fw-bold">ประเภทกิจการ</label>
+            <label class="form-label fw-bold">ประเภทกิจการ (ไทย)</label>
             <p class="form-control-plaintext">{{ $employer->businessType ?? 'N/A' }}</p>
+        </div>
+        <div class="col-md-6">
+            <label class="form-label fw-bold">ประเภทกิจการ (อังกฤษ)</label>
+            <p class="form-control-plaintext">{{ $employer->businessTypeEn ?? 'N/A' }}</p>
         </div>
     </div>
 
@@ -54,6 +61,12 @@
         <div class="col-md-6">
             <label class="form-label fw-bold">เบอร์โทรศัพท์</label>
             <p class="form-control-plaintext">{{ $employer->employerPhone ?? 'N/A' }}</p>
+        </div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-md-6">
+            <label class="form-label fw-bold">รหัสผ่านสำหรับนายจ้าง</label>
+            <p class="form-control-plaintext">{{ $employer->employerPassword ?? 'N/A' }}</p>
         </div>
     </div>
     <div class="row mb-3">
@@ -75,10 +88,6 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-md-6">
-            <label class="form-label fw-bold">Type of Business</label>
-            <p class="form-control-plaintext">{{ $employer->businessTypeEn ?? 'N/A' }}</p>
-        </div>
         <div class="col-md-6">
             <label class="form-label fw-bold">ทุนจดทะเบียน</label>
             <p class="form-control-plaintext">{{ $employer->regCapital ? number_format($employer->regCapital, 2) : 'N/A' }}</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -176,6 +176,9 @@ Route::middleware(['auth', 'permission:manage-tickets'])->prefix('admin')->name(
     Route::post('tickets/employers/{user}/unhide', [AdminTicketController::class, 'unhideEmployer'])->name('tickets.unhideEmployer'); // V2.5.2 Unhide Employer Box
 
     Route::delete('tickets/messages/{message}', [\App\Http\Controllers\TicketMessageController::class, 'destroy'])->name('tickets.messages.destroy');
+
+    // Business Types
+    Route::resource('business-types', \App\Http\Controllers\Admin\BusinessTypeController::class)->only(['index', 'store', 'destroy']);
 });
 
 // === Production & Workflow Admin Routes ===


### PR DESCRIPTION
- Created BusinessType model and migration for standardized business type selection.
- Created Admin\BusinessTypeController to manage business types via AJAX.
- Updated Employer create and edit forms:
  - Moved Business Type (Thai) and Business Type (English) to be side-by-side.
  - Added a dropdown to select from standardized Business Types.
  - Added a "Manage" button (for admins) to add/delete types via a modal.
- Updated Employer Preview modal:
  - Displayed Business Type fields side-by-side.
  - Added display for Employer Password.
- Registered new admin routes for business types.