### PR TITLE
Add missing BusinessType model

### DIFF
--- a/app/Models/BusinessType.php
+++ b/app/Models/BusinessType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BusinessType extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name_th',
+        'name_en',
+    ];
+}


### PR DESCRIPTION
This commit adds the missing `App\Models\BusinessType` class, which is required for the "Manage Business Types" feature to function. Without this model, the `Admin\BusinessTypeController` was failing to save new records. This also restores the ability to delete business types, as the controller relies on this model for deletion as well.