### PR TITLE
Fix undefined variable error in Registration Resolution view

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -309,12 +309,6 @@
         // Actually, we can just find buttons in the card and check their onclick or text
         // Or simpler: Add a unique ID to each step button: step-btn-{emp}-{step}
 
-        // However, I will stick to the provided code structure but improve robustness
-        // The original code passed 'completed' which is the *desired* state (true to complete, false to uncomplete)?
-        // No, 'completed' param in JS function call is usually "should be completed"
-        // Wait, the call is `toggleStep(id, stepId, true)` -> means "Make it true (completed)"
-        // The Blade renders: `onclick="toggleStep(..., {{ $isStepCompleted ? 'false' : 'true' }})"`
-
         fetch(`/production/registration/${employeeId}/progress`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken },


### PR DESCRIPTION
Removed commented-out code in `resources/views/production/registration/index.blade.php` that contained a Blade directive `{{ $isStepCompleted ... }}`. Even though it was inside a JavaScript comment, the Blade engine attempted to evaluate it, causing an "Undefined variable: $isStepCompleted" exception and preventing the page from loading. This variable is not defined in the global script scope.