### PR TITLE
Fix Registration Resolution import flow and workflow step UI

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -176,6 +176,44 @@ class RegistrationController extends Controller
      * Show the form for creating a new registration employee.
      * Reuses the standard employee form view but we might need to inject context.
      */
+    /**
+     * Display the Import View for Registration Resolution.
+     * Reuses the standard 'employees.import' view but with specific context.
+     */
+    public function importView(Request $request)
+    {
+        // Reuse logic from ImportEmployeeController@index but simplified
+        $employers = collect();
+        if (auth()->user()->can('view-employers')) {
+             $employers = Employer::orderBy('employerNameTh')->get(['id', 'employerNameTh', 'employerNameEn']);
+        } else {
+             $user = auth()->user();
+             if ($user->employer) {
+                 $employers = collect([$user->employer]);
+             }
+        }
+
+        // We pass 'target_status' via the URL query string to the view's form action
+        // Actually, the view 'employees.import' has a hidden input logic for 'target_status' if it's in the request.
+        // So we just need to ensure the form posts to the standard import route but carries the payload.
+
+        // However, the standard import route (ImportEmployeeController@store) redirects 'back()'.
+        // If we serve the view from THIS route, 'back()' will return here. Perfect.
+
+        // We inject the 'target_status' into the request or view so the view renders the hidden input.
+        $request->merge(['target_status' => 'registration_pending']);
+
+        // Set session for finish_route because store() redirects back() which is this view,
+        // but session helps persist the intent for the Success Modal buttons.
+        session()->flash('finish_route', route('production.registration.index'));
+
+        return view('employees.import', [
+            'employers' => $employers,
+            'production' => null, // No specific production order context needed, just status
+            'back_route' => route('production.registration.index'),
+        ]);
+    }
+
     public function create(Request $request)
     {
         // We can reuse the standard view, or create a specific one.

--- a/resources/views/employees/import.blade.php
+++ b/resources/views/employees/import.blade.php
@@ -97,7 +97,9 @@
                         </div>
 
                         <div class="d-flex justify-content-between">
-                            @if(isset($production))
+                            @if(isset($back_route))
+                                <a href="{{ $back_route }}" class="btn btn-light">{{ __('Back') }}</a>
+                            @elseif(isset($production))
                                 <a href="{{ route('production.edit', $production->id) }}" class="btn btn-light">{{ __('Back to Project') }}</a>
                             @else
                                 <a href="{{ route('employees.index') }}" class="btn btn-light">{{ __('Cancel') }}</a>
@@ -170,7 +172,11 @@
                 <button type="button" class="btn btn-danger me-auto" id="btn-cancel-import">
                     <i class="bi bi-x-circle me-1"></i> {{ __('Cancel Import') }}
                 </button>
-                @if(session('production_id'))
+                @if(session('finish_route'))
+                    <a href="{{ session('finish_route') }}" class="btn btn-primary px-4">{{ __('Finish Import') }}</a>
+                @elseif(isset($back_route)) {{-- Fallback if passed directly --}}
+                    <a href="{{ $back_route }}" class="btn btn-primary px-4">{{ __('Finish Import') }}</a>
+                @elseif(session('production_id'))
                     <a href="{{ route('production.edit', session('production_id')) }}" class="btn btn-primary px-4">{{ __('Finish & Return to Project') }}</a>
                 @else
                     <a href="{{ route('employees.index') }}" class="btn btn-primary px-4">{{ __('Finish Import') }}</a>

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -64,9 +64,10 @@
             <a href="{{ route('production.registration.create') }}" class="btn btn-warning text-white">
                 <i class="bi bi-plus-lg"></i> Add New Employee
             </a>
-            <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#importModal">
+            {{-- UPDATED: Link to dedicated import page --}}
+            <a href="{{ route('production.registration.import') }}" class="btn btn-success">
                 <i class="bi bi-file-earmark-spreadsheet"></i> Import
-            </button>
+            </a>
         </div>
     </div>
 
@@ -180,40 +181,7 @@
     </div>
 </div>
 
-{{-- Import Modal --}}
-<div class="modal fade" id="importModal" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Import Employees from Excel</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-            </div>
-            <div class="modal-body">
-                <form action="{{ route('employees.import') }}" method="POST" enctype="multipart/form-data">
-                    @csrf
-                    <input type="hidden" name="redirect_route" value="{{ route('production.registration.index') }}">
-
-                    <div class="mb-3">
-                        <label class="form-label">Select Employer</label>
-                        <select class="form-select" name="employer_id" required>
-                            <option value="">-- Choose Employer --</option>
-                            @foreach($employers as $emp)
-                                <option value="{{ $emp->id }}">{{ $emp->employerNameTh }}</option>
-                            @endforeach
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Excel File</label>
-                        <input type="file" class="form-control" name="file" required accept=".xlsx, .xls, .csv">
-                    </div>
-                    <div class="d-grid">
-                        <button type="submit" class="btn btn-success">Import</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-</div>
+{{-- REMOVED: Import Modal (Replaced by direct page link) --}}
 
 @endsection
 
@@ -297,17 +265,36 @@
         });
     }
 
-    // --- New AJAX Toggle Step with Real-time Updates ---
+    // --- Fixed AJAX Toggle Step with Real-time Updates ---
     function toggleStep(employeeId, stepId, completed) {
-        // Find the specific button instance
-        // We use querySelectorAll because an employee ID might be unique, but let's be safe
-        // Construct the selector to find the exact button
+        // Find the card and button
         const card = document.getElementById(`employee-card-${employeeId}`);
-        // We look for a button that has the onclick matching our target
-        // Note: The previous logic relied on `querySelector` with a specific attribute value which might be flaky if spacing differs
-        // Let's use a more robust way: attributes
-        // Actually, we can just find buttons in the card and check their onclick or text
-        // Or simpler: Add a unique ID to each step button: step-btn-{emp}-{step}
+        if (!card) return;
+
+        // Use more specific selector to find the button
+        const btn = card.querySelector(`button[data-step-id="${stepId}"]`);
+
+        // Optimistic UI Update (Instant Feedback)
+        const originalClass = btn.className;
+        const originalHtml = btn.innerHTML;
+        const originalOnClick = btn.getAttribute('onclick');
+
+        if (btn) {
+            if (completed) {
+                // Determine it is becoming complete
+                btn.classList.remove('btn-outline-secondary');
+                btn.classList.add('btn-success');
+                if(!btn.querySelector('i.bi-check')) {
+                    btn.innerHTML = btn.innerText + ' <i class="bi bi-check"></i>';
+                }
+            } else {
+                // Becoming incomplete
+                btn.classList.remove('btn-success');
+                btn.classList.add('btn-outline-secondary');
+                const icon = btn.querySelector('i.bi-check');
+                if(icon) icon.remove();
+            }
+        }
 
         fetch(`/production/registration/${employeeId}/progress`, {
             method: 'POST',
@@ -317,44 +304,25 @@
         .then(res => res.json())
         .then(data => {
             if(data.success) {
-                // 1. Update Button State
-                // We need to find the button. Since we don't have a direct reference, let's rely on the DOM structure.
-                // It's inside #employee-card-{id} -> .d-flex.gap-1.flex-wrap -> button
-                // We can iterate buttons to find the one for this stepId.
-                // To do this cleanly, I'll update _employee_card.blade.php to add data-step-id to buttons.
-                // But since I can't edit _employee_card in this block, I'll use a selector based on onclick text or order?
-                // Actually, I am editing index.blade.php, so I can't change _employee_card here easily without a separate tool call.
-                // But I *can* overwrite _employee_card in the next step.
-                // For now, let's assume I will add `data-step-id` to the buttons in the next step.
-
-                const card = document.getElementById(`employee-card-${employeeId}`);
-                if (card) {
-                    // Try to find button with data attribute (which I will add)
-                    const btn = card.querySelector(`button[data-step-id="${stepId}"]`);
-                    if (btn) {
-                        if (completed) {
-                            btn.classList.remove('btn-outline-secondary');
-                            btn.classList.add('btn-success');
-                            if(!btn.querySelector('i.bi-check')) {
-                                btn.innerHTML = btn.innerText + ' <i class="bi bi-check"></i>';
-                            }
-                            btn.setAttribute('onclick', `toggleStep(${employeeId}, ${stepId}, false)`);
-                        } else {
-                            btn.classList.remove('btn-success');
-                            btn.classList.add('btn-outline-secondary');
-                            const icon = btn.querySelector('i.bi-check');
-                            if(icon) icon.remove();
-                            btn.setAttribute('onclick', `toggleStep(${employeeId}, ${stepId}, true)`);
-                        }
+                // 1. Update Button State (Confirm & Update OnClick)
+                if (btn) {
+                    if (completed) {
+                         // Set next action to un-complete (false)
+                        btn.setAttribute('onclick', `toggleStep(${employeeId}, ${stepId}, false)`);
+                    } else {
+                         // Set next action to complete (true)
+                        btn.setAttribute('onclick', `toggleStep(${employeeId}, ${stepId}, true)`);
                     }
                 }
 
                 // 2. Update Global Stats
                 if (data.globalStats) {
                     const globalContainer = document.getElementById('global-stats-container');
-                    for (const [sId, count] of Object.entries(data.globalStats)) {
-                        const badge = globalContainer.querySelector(`.global-stat-badge[data-step-id="${sId}"]`);
-                        if (badge) badge.textContent = count;
+                    if (globalContainer) {
+                        for (const [sId, count] of Object.entries(data.globalStats)) {
+                            const badge = globalContainer.querySelector(`.global-stat-badge[data-step-id="${sId}"]`);
+                            if (badge) badge.textContent = count;
+                        }
                     }
                 }
 
@@ -368,9 +336,24 @@
                         }
                     }
                 }
+            } else {
+                // Revert on failure
+                if (btn) {
+                    btn.className = originalClass;
+                    btn.innerHTML = originalHtml;
+                    btn.setAttribute('onclick', originalOnClick);
+                }
             }
         })
-        .catch(error => console.error('Error:', error));
+        .catch(error => {
+            console.error('Error:', error);
+            // Revert on failure
+            if (btn) {
+                btn.className = originalClass;
+                btn.innerHTML = originalHtml;
+                btn.setAttribute('onclick', originalOnClick);
+            }
+        });
     }
 </script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -192,6 +192,7 @@ Route::middleware(['auth'])->group(function () {
     // MOVED ABOVE 'production' resource to prevent route masking
     Route::prefix('production/registration')->name('production.registration.')->group(function () {
         Route::get('/', [App\Http\Controllers\Production\RegistrationController::class, 'index'])->name('index');
+        Route::get('/import', [App\Http\Controllers\Production\RegistrationController::class, 'importView'])->name('import');
         Route::get('/create', [App\Http\Controllers\Production\RegistrationController::class, 'create'])->name('create');
         Route::post('/store', [App\Http\Controllers\Production\RegistrationController::class, 'store'])->name('store');
 


### PR DESCRIPTION
- Updated `production/registration/index` to link to a dedicated import page instead of using a modal.
- Refactored `toggleStep` JS to ensure optimistic UI updates (turning buttons green instantly).
- Added `importView` to `RegistrationController` to reuse the `employees.import` view with `registration_pending` context.
- Enhanced `employees/import` view to support `back_route` and `finish_route` for better navigation flow in sub-modules.