### PR TITLE
feat: Add 6 more other document slots to employee forms

### DIFF
--- a/database/migrations/2025_12_12_120902_add_more_document_fields_to_employees_table.php
+++ b/database/migrations/2025_12_12_120902_add_more_document_fields_to_employees_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->string('employee_doc_13')->nullable();
+            $table->string('employee_doc_14')->nullable();
+            $table->string('employee_doc_15')->nullable();
+            $table->string('employee_doc_16')->nullable();
+            $table->string('employee_doc_17')->nullable();
+            $table->string('employee_doc_18')->nullable();
+            $table->string('other_doc_5_desc')->nullable();
+            $table->string('other_doc_6_desc')->nullable();
+            $table->string('other_doc_7_desc')->nullable();
+            $table->string('other_doc_8_desc')->nullable();
+            $table->string('other_doc_9_desc')->nullable();
+            $table->string('other_doc_10_desc')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn([
+                'employee_doc_13',
+                'employee_doc_14',
+                'employee_doc_15',
+                'employee_doc_16',
+                'employee_doc_17',
+                'employee_doc_18',
+                'other_doc_5_desc',
+                'other_doc_6_desc',
+                'other_doc_7_desc',
+                'other_doc_8_desc',
+                'other_doc_9_desc',
+                'other_doc_10_desc',
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
- Added `employee_doc_13` to `employee_doc_18` and corresponding `other_doc_X_desc` columns to `employees` table.
- Updated `Employee` model to include new fields.
- Updated `create` and `edit` views to include new document fields.
- Updated Ticket System "New Employee" modal and scripts.
- Updated Employee Preview modal to display new documents.
- Updated `EmployeeController` validation, bulk edit, and export logic.
- Updated `AdminJobTicketController` and validation request.
- Added Thai translation for "Employees" menu item.