### PR TITLE
Fix Blade parser error in financial tab partial

### DIFF
--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -465,7 +465,7 @@ function financialManager() {
         // Custom Header Data
         showCustomHeaderModal: false,
         useCustomHeader: {{ isset($production->financial_data['custom_header']) ? 'true' : 'false' }},
-        customHeader: @json($production->financial_data['custom_header'] ?? ['name'=>'', 'address'=>'', 'tax_id'=>'', 'phone'=>'', 'logo'=>'']),
+        customHeader: {!! json_encode($production->financial_data['custom_header'] ?? ['name'=>'', 'address'=>'', 'tax_id'=>'', 'phone'=>'', 'logo'=>'']) !!},
         selectedProfileId: '{{ $production->financial_data['profile_id'] ?? '' }}',
 
         // Calculated values


### PR DESCRIPTION
Replaced `@json` directive with `{!! json_encode(...) !!}` in `resources/views/production/partials/financial-tab.blade.php` to resolve a PHP ParseError caused by complex array syntax within the directive arguments.