### PR TITLE
Fix Registration Resolution UI bugs: step colors, button visibility, …

### DIFF
--- a/app/Models/RegistrationStep.php
+++ b/app/Models/RegistrationStep.php
@@ -9,7 +9,7 @@ class RegistrationStep extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'order'];
+    protected $fillable = ['name', 'order', 'color'];
 
     public function employees()
     {

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -136,8 +136,8 @@
                         // Determine styles based on hex or class
                         $hexColor = str_starts_with($step->color, '#') ? $step->color : null;
 
-                        // Default State: Incomplete -> Gray outline
-                        $btnClass = 'btn-outline-secondary';
+                        // Default State: Incomplete -> Solid Gray (visible "To Do" state)
+                        $btnClass = 'btn-light border text-secondary';
                         $btnStyle = '';
 
                         // Completed State: Colored background

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -52,14 +52,15 @@
                     @php
                         $count = $stepStats[$step->id] ?? 0;
                         $isZero = $count === 0;
-
-                        // Check if color is hex or class
-                        $bgStyle = (!$isZero && str_starts_with($step->color, '#')) ? "background-color: {$step->color} !important;" : "";
-                        $bgClass = (!$isZero && !str_starts_with($step->color, '#')) ? "bg-{$step->color}" : "";
+                        $color = $step->color ?? 'primary';
 
                         if ($isZero) {
                             $bgClass = "bg-secondary bg-opacity-50 text-white"; // Gray for zero
                             $bgStyle = "";
+                        } else {
+                            // Check if color is hex or class
+                            $bgStyle = str_starts_with($color, '#') ? "background-color: {$color} !important;" : "";
+                            $bgClass = !str_starts_with($color, '#') ? "bg-{$color}" : "";
                         }
                     @endphp
                     <div class="d-flex flex-column align-items-center" style="min-width: 80px;">
@@ -176,13 +177,14 @@
                                     @php
                                         $count = $employer->stepStats[$step->id] ?? 0;
                                         $isZero = $count === 0;
-
-                                        $bgStyle = (!$isZero && str_starts_with($step->color, '#')) ? "background-color: {$step->color} !important;" : "";
-                                        $bgClass = (!$isZero && !str_starts_with($step->color, '#')) ? "bg-{$step->color}" : "";
+                                        $color = $step->color ?? 'primary';
 
                                         if ($isZero) {
                                             $bgClass = "bg-secondary bg-opacity-25 text-muted"; // Lighter gray for zero
                                             $bgStyle = "";
+                                        } else {
+                                             $bgStyle = str_starts_with($color, '#') ? "background-color: {$color} !important;" : "";
+                                             $bgClass = !str_starts_with($color, '#') ? "bg-{$color}" : "";
                                         }
                                     @endphp
                                     <div class="text-center" style="min-width: 50px;">


### PR DESCRIPTION
…and badge display

- Add `color` to `RegistrationStep` fillable array to allow saving colors.
- Update `index.blade.php` to render zero-count steps as gray badges and ensure non-zero steps display their assigned color correctly.
- Update `_employee_card.blade.php` to style incomplete step buttons as solid gray (`btn-light`) instead of outline, improving visibility.