### PR TITLE
Fix finance save errors, profile creation, and improve delete UI

### DIFF
--- a/app/Http/Controllers/FinancialController.php
+++ b/app/Http/Controllers/FinancialController.php
@@ -156,18 +156,31 @@ class FinancialController extends Controller
 
     public function storeProfile(Request $request)
     {
-        $request->validate(['name' => 'required', 'logo' => 'nullable|image']);
+        // Allow logo to be a string (path) for JSON requests
+        $request->validate([
+            'name' => 'required',
+            'logo' => 'nullable',
+        ]);
+
         $data = $request->except('logo');
 
         if ($request->hasFile('logo')) {
             $data['logo_path'] = $request->file('logo')->store('company_logos', 'public');
+        } elseif ($request->filled('logo') && is_string($request->logo)) {
+            // If saving via JSON and logo is already a path
+            $data['logo_path'] = $request->logo;
         }
 
         if ($request->is_default) {
             CompanyProfile::where('is_default', true)->update(['is_default' => false]);
         }
 
-        CompanyProfile::create($data);
+        $profile = CompanyProfile::create($data);
+
+        if ($request->wantsJson()) {
+            return response()->json(['success' => true, 'profile' => $profile]);
+        }
+
         return back()->with('success', 'Profile created');
     }
 }

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -281,6 +281,10 @@ class ProductionController extends Controller
             'missing_documents' => $request->missing_documents,
         ]);
 
+        if ($request->wantsJson()) {
+            return response()->json(['success' => true, 'message' => 'Details updated.']);
+        }
+
         return back()->with('success', 'Details updated.');
     }
 

--- a/app/Models/CompanyProfile.php
+++ b/app/Models/CompanyProfile.php
@@ -13,6 +13,7 @@ class CompanyProfile extends Model
         'name',
         'address',
         'tax_id',
+        'phone',
         'logo_path',
         'is_default',
     ];

--- a/database/migrations/2025_05_15_000001_add_phone_to_company_profiles_table.php
+++ b/database/migrations/2025_05_15_000001_add_phone_to_company_profiles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('company_profiles', function (Blueprint $table) {
+            $table->string('phone')->nullable()->after('tax_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('company_profiles', function (Blueprint $table) {
+            $table->dropColumn('phone');
+        });
+    }
+};

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -843,15 +843,34 @@ function financialManager() {
             });
         },
         deleteTransaction(id) {
-            if(!confirm('Delete?')) return;
-            const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-            fetch('/production/transactions/' + id, {
-                method: 'DELETE',
-                headers: { 'X-CSRF-TOKEN': csrf, 'Accept': 'application/json' }
-            })
-            .then(res => res.json())
-            .then(data => {
-                if(data.success) this.transactions = this.transactions.filter(t => t.id !== id);
+            Swal.fire({
+                title: '{{ __('Are you sure?') }}',
+                text: '{{ __('This transaction will be permanently deleted.') }}',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                confirmButtonText: '{{ __('Yes, delete it!') }}'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+                    fetch('/production/transactions/' + id, {
+                        method: 'DELETE',
+                        headers: { 'X-CSRF-TOKEN': csrf, 'Accept': 'application/json' }
+                    })
+                    .then(res => res.json())
+                    .then(data => {
+                        if(data.success) {
+                            this.transactions = this.transactions.filter(t => t.id !== id);
+                            Swal.fire(
+                                '{{ __('Deleted!') }}',
+                                '{{ __('Transaction has been deleted.') }}',
+                                'success'
+                            );
+                        } else {
+                            Swal.fire('Error', data.message || 'Failed to delete', 'error');
+                        }
+                    });
+                }
             });
         },
         formatCurrency(val) {


### PR DESCRIPTION
- Fixed 'Error saving data' in Production Controller by returning JSON for AJAX requests instead of Redirect.
- Fixed 'Save as New System Profile' failure in Financial Controller:
    - Added support for JSON payloads where the logo is a path string instead of a file upload.
    - Added missing `phone` column to `company_profiles` via migration.
    - Added `phone` to `CompanyProfile` fillable attributes.
- Replaced native `confirm()` with SweetAlert2 (`Swal.fire`) for transaction deletion in `financial-tab.blade.php`.