### PR TITLE
Fix AJAX headers for Registration Resolution action buttons

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -356,7 +356,7 @@
 
         fetch('{{ route("production.registration.steps.store") }}', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken },
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' },
             body: JSON.stringify({ name: name })
         })
         .then(res => res.json())
@@ -386,7 +386,7 @@
             if (result.isConfirmed) {
                 fetch(`/production/registration/steps/${id}`, {
                     method: 'DELETE',
-                    headers: { 'X-CSRF-TOKEN': csrfToken }
+                    headers: { 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' }
                 })
                 .then(res => res.json())
                 .then(data => {
@@ -413,7 +413,7 @@
 
         fetch(`/production/registration/steps/${id}`, {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken },
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' },
             body: JSON.stringify({ name: newName })
         })
         .then(res => res.json())
@@ -442,7 +442,7 @@
              if (result.isConfirmed) {
                 fetch(`/production/registration/${id}/finalize`, {
                     method: 'POST',
-                    headers: { 'X-CSRF-TOKEN': csrfToken }
+                    headers: { 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' }
                 })
                 .then(res => res.json())
                 .then(data => {
@@ -490,7 +490,7 @@
              if (result.isConfirmed) {
                 fetch(`/production/registration/${id}/restore`, {
                     method: 'POST',
-                    headers: { 'X-CSRF-TOKEN': csrfToken }
+                    headers: { 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' }
                 })
                 .then(res => res.json())
                 .then(data => {
@@ -544,7 +544,7 @@
              if (result.isConfirmed) {
                 fetch(`/production/registration/${id}/cancel`, {
                     method: 'POST',
-                    headers: { 'X-CSRF-TOKEN': csrfToken }
+                    headers: { 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' }
                 })
                 .then(res => res.json())
                 .then(data => {
@@ -594,7 +594,7 @@
              if (result.isConfirmed) {
                 fetch(`/production/registration/${id}/destroy`, {
                     method: 'DELETE',
-                    headers: { 'X-CSRF-TOKEN': csrfToken }
+                    headers: { 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' }
                 })
                 .then(res => {
                      if(!res.ok) throw new Error(res.statusText);
@@ -672,7 +672,7 @@
 
         fetch(`/production/registration/progress/${employeeId}`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken },
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' },
             body: JSON.stringify({ step_id: stepId, completed: completed })
         })
         .then(res => {


### PR DESCRIPTION
Added `X-Requested-With: XMLHttpRequest` header to all fetch requests in `production/registration/index.blade.php`. This ensures the backend returns JSON responses instead of HTML redirects, fixing issues where the UI failed to update or showed error popups for actions like Delete, Cancel, Save, and Restore.