### PR TITLE
Add Job Owner display and filtering to Registration Resolution page

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -41,7 +41,10 @@ class RegistrationController extends Controller
                   ->orWhere('employeePassport', 'like', "%{$search}%")
                   ->orWhereHas('employer', function($q2) use ($search) {
                       $q2->where('employerNameTh', 'like', "%{$search}%")
-                         ->orWhere('employerNameEn', 'like', "%{$search}%");
+                         ->orWhere('employerNameEn', 'like', "%{$search}%")
+                         ->orWhereHas('jobOwner', function($q3) use ($search) {
+                             $q3->where('name', 'like', "%{$search}%");
+                         });
                   });
             });
         }
@@ -96,7 +99,7 @@ class RegistrationController extends Controller
         $filteredEmployerIds = $registrationEmployees->pluck('employer_id')->unique();
 
         $employers = Employer::whereIn('id', $filteredEmployerIds)
-            ->with(['employees' => function($q) use ($registrationEmployees) {
+            ->with(['jobOwner', 'employees' => function($q) use ($registrationEmployees) {
                 // Only load the employees that match our main filter
                 // We can use whereIn('id', ...)
                 $q->whereIn('id', $registrationEmployees->pluck('id'))

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -225,10 +225,24 @@
                             </div>
 
                             {{-- Row 2: Employer Name --}}
-                            <button class="btn btn-link text-decoration-none text-dark p-0 text-start" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ $employer->id }}">
-                                <h4 class="fw-bold mb-0 text-truncate" title="{{ $employer->employerNameTh }}">{{ $employer->employerNameTh }}</h4>
-                                <div class="text-muted small text-truncate" title="{{ $employer->employerNameEn }}">{{ $employer->employerNameEn }}</div>
-                            </button>
+                            <div class="d-flex align-items-center gap-2">
+                                <button class="btn btn-link text-decoration-none text-dark p-0 text-start flex-grow-1" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ $employer->id }}">
+                                    <h4 class="fw-bold mb-0 text-truncate" title="{{ $employer->employerNameTh }}">{{ $employer->employerNameTh }}</h4>
+                                    <div class="text-muted small text-truncate" title="{{ $employer->employerNameEn }}">{{ $employer->employerNameEn }}</div>
+                                </button>
+                                <button class="btn btn-sm btn-outline-info btn-preview flex-shrink-0" data-model-type="employer" data-model-id="{{ $employer->id }}" title="Preview Employer Data">
+                                    <i class="bi bi-search"></i>
+                                </button>
+                            </div>
+
+                            @if($employer->jobOwner)
+                                <div class="mt-1">
+                                    <i class="bi bi-person-badge text-muted me-1"></i>
+                                    <a href="{{ route('production.registration.index', ['search' => $employer->jobOwner->name]) }}" class="text-decoration-none text-secondary small" title="Filter by Job Owner">
+                                        {{ $employer->jobOwner->name }}
+                                    </a>
+                                </div>
+                            @endif
                         </div>
 
                         {{-- Middle: Workflow Steps (Col-7) - Single Row, Scrollable --}}


### PR DESCRIPTION
- Update RegistrationController to support searching/filtering by Job Owner name.
- Eager load 'jobOwner' relationship for efficiency.
- Update index view to display Job Owner name as a clickable filter link below the employer name.
- Add a 'Preview' button (magnifying glass) next to the employer name for quick data access.