### PR TITLE
Restrict finance features access to Admin only

### DIFF
--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -47,7 +47,8 @@ class RoleAndPermissionSeeder extends Seeder
 
             'delete-addresses', 'restore-addresses', 'force-delete-addresses',
             'manage-tickets',
-            'use-chat'
+            'use-chat',
+            'view-finance'
             // END: Add new permissions
         ];
 

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -85,12 +85,14 @@
                                         </div>
 
                                         {{-- Ready to Process (Financial) Toggle --}}
+                                        @can('view-finance')
                                         <div class="form-check form-switch">
                                             <input class="form-check-input status-toggle" type="checkbox" id="finReady{{ $order->id }}"
                                                 data-id="{{ $order->id }}" data-type="financial_approved"
                                                 {{ $order->financial_approved_at ? 'checked' : '' }} disabled>
                                             <label class="form-check-label small" for="finReady{{ $order->id }}">{{ __('Ready to Process') }}</label>
                                         </div>
+                                        @endcan
 
                                         {{-- Waiting for Docs Button/Toggle --}}
                                         <button class="btn btn-sm btn-link text-decoration-none p-0 text-start text-danger"

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -1,3 +1,4 @@
+@can('view-finance')
 <div x-data="financialManager()" class="row">
 
     <!-- TAB NAVIGATION -->
@@ -1036,3 +1037,8 @@ function financialManager() {
     }
 }
 </script>
+@else
+    <div class="alert alert-danger">
+        <i class="bi bi-lock-fill me-2"></i> {{ __('Access Denied: You do not have permission to view financial data.') }}
+    </div>
+@endcan

--- a/resources/views/production/prepare.blade.php
+++ b/resources/views/production/prepare.blade.php
@@ -45,6 +45,7 @@
             </div>
         </div>
         <div class="col-md-6">
+            @can('view-finance')
             <div class="card shadow-sm border-0 h-100" :class="{'bg-success text-white': financialApproved, 'bg-light': !financialApproved}">
                 <div class="card-body d-flex align-items-center justify-content-between">
                     <div>
@@ -54,17 +55,14 @@
                         </div>
                     </div>
                     <div class="form-check form-switch">
-                        @can('approve-production')
                         <input class="form-check-input fs-4" type="checkbox" role="switch"
                             id="financialApprovedSwitch"
                             x-model="financialApproved"
                             @change="toggleStatus('financial_approved')">
-                        @else
-                        <input class="form-check-input fs-4" type="checkbox" disabled x-model="financialApproved">
-                        @endcan
                     </div>
                 </div>
             </div>
+            @endcan
         </div>
     </div>
 
@@ -73,9 +71,11 @@
         <li class="nav-item" role="presentation">
             <button class="nav-link active" id="details-tab" data-bs-toggle="tab" data-bs-target="#details" type="button" role="tab" aria-selected="true">Project Details & Employees</button>
         </li>
+        @can('view-finance')
         <li class="nav-item" role="presentation">
             <button class="nav-link" id="financial-tab" data-bs-toggle="tab" data-bs-target="#financial" type="button" role="tab" aria-selected="false">Financial Management</button>
         </li>
+        @endcan
     </ul>
 
     <div class="tab-content" id="productionTabsContent">
@@ -257,9 +257,11 @@
         </div>
 
         <!-- Tab 2: Financial Management -->
+        @can('view-finance')
         <div class="tab-pane fade" id="financial" role="tabpanel" tabindex="0">
             @include('production.partials.financial-tab')
         </div>
+        @endcan
     </div>
 </div>
 

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -247,9 +247,11 @@
                              <div class="vr d-none d-xl-block"></div>
 
                              {{-- Finance Button --}}
+                             @can('view-finance')
                              <button class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#financeModal-{{ $employer->id }}" onclick="event.stopPropagation()">
                                 <i class="bi bi-currency-dollar"></i> Finance
                             </button>
+                            @endcan
 
                             {{-- Collapse Chevron --}}
                             <button class="btn btn-light btn-sm rounded-circle" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ $employer->id }}">


### PR DESCRIPTION
- Added `view-finance` permission in `RoleAndPermissionSeeder`.
- Protected finance UI elements in Pre-Production index and Prepare page.
- Protected finance button in Registration Resolution page.
- Added defense-in-depth permission check to `financial-tab` partial.