### PR TITLE
Fix Admin visibility for Finance feature using Gate::before

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -22,6 +22,10 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // Implicitly grant "admin" role all permissions
+        // This works in the app by using Gate::before() interception
+        Gate::before(function ($user, $ability) {
+            return $user->hasRole('admin') ? true : null;
+        });
     }
 }


### PR DESCRIPTION
Implemented a Gate::before check in AuthServiceProvider to explicitly grant all permissions to users with the 'admin' role. This resolves the issue where Admins could not see the Finance button, while maintaining correct restrictions for Staff, Customer Care, and Employers.