### PR TITLE
Update employee preview with PDF export and description text

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -782,6 +782,122 @@ public function create(Request $request) // เพิ่ม Request $request เ
     }
 
     /**
+     * Download a document as PDF (converting images if necessary).
+     */
+    public function downloadDocumentAsPdf(Employee $employee, $field)
+    {
+        // Allowed fields (same as serveDocument, plus 'insurance_document_path')
+        $allowedFields = [
+            'employee_doc_1', 'employee_doc_2', 'employee_doc_3', 'employee_doc_4',
+            'employee_doc_5', 'employee_doc_6', 'employee_doc_7', 'employee_doc_8',
+            'employee_doc_9', 'employee_doc_10', 'employee_doc_11', 'employee_doc_12',
+            'employee_doc_13', 'employee_doc_14', 'employee_doc_15', 'employee_doc_16',
+            'employee_doc_17', 'employee_doc_18',
+            'insurance_document_path',
+            'insurance_document_path_private',
+            // Legacy fields
+            'passport_file_path', 'visa_file_path', 'work_permit_file_path',
+            'pink_card_file_path', 'insurance_attachment_path'
+        ];
+
+        if (!in_array($field, $allowedFields)) {
+            abort(404, 'Document type not found.');
+        }
+
+        $this->authorize('view', $employee);
+
+        $filePath = $employee->{$field};
+
+        // Check public disk first (standard for newer uploads)
+        $disk = 'public';
+        if (!$filePath || !Storage::disk($disk)->exists($filePath)) {
+            // Check private disk (legacy)
+            $disk = 'private';
+            if (!$filePath || !Storage::disk($disk)->exists($filePath)) {
+                abort(404, 'File not found.');
+            }
+        }
+
+        $mimeType = Storage::disk($disk)->mimeType($filePath);
+
+        // If it's already a PDF, download it directly
+        if ($mimeType === 'application/pdf') {
+            return Storage::disk($disk)->download($filePath);
+        }
+
+        // If it's an image, convert to PDF
+        if (str_starts_with($mimeType, 'image/')) {
+            $fullPath = Storage::disk($disk)->path($filePath);
+
+            // Create PDF using FPDF (assuming it's available via service container or global class)
+            // Note: Since 'setasign/fpdf' is in composer, FPDF class should be available.
+            $pdf = new \FPDF();
+            $pdf->AddPage();
+
+            // Get image dimensions
+            list($width, $height) = getimagesize($fullPath);
+
+            // Calculate dimensions to fit in A4 (210mm x 297mm)
+            // A4 size in mm
+            $pdfWidth = 210;
+            $pdfHeight = 297;
+
+            // Margins (10mm)
+            $margin = 10;
+            $maxWidth = $pdfWidth - (2 * $margin);
+            $maxHeight = $pdfHeight - (2 * $margin);
+
+            // Calculate scale factor
+            $widthScale = $maxWidth / $width;
+            $heightScale = $maxHeight / $height;
+            $scale = min($widthScale, $heightScale);
+
+            // Convert pixels to mm roughly (approximate since getimagesize returns pixels)
+            // However, FPDF Image() takes width/height in user units (mm by default).
+            // So we need to ensure we pass the correct scaled width/height.
+            // But wait, FPDF's Image() method logic:
+            // If we provide width (and 0 height), it scales proportionally.
+            // Let's just fit it to width unless it exceeds height.
+
+            // Logic: Calculate new dimensions in mm based on pixels is tricky without DPI.
+            // Better approach: Let FPDF handle scaling by restricting width/height.
+
+            // Convert pixels to mm? No, just use the ratio.
+            // FPDF AddPage defaults to A4 portrait.
+            // We want to fit the image into the page area.
+
+            $finalW = 0;
+            $finalH = 0;
+
+            // Simple logic:
+            // 1. Convert px to mm assuming 72dpi? Or just use ratio.
+            // Actually, we can just say: "Fit this image into this box ($maxWidth x $maxHeight)".
+            // FPDF doesn't have a "fit" helper, we calculate it.
+            // We need the aspect ratio.
+            $aspectRatio = $width / $height;
+
+            if ($maxWidth / $maxHeight > $aspectRatio) {
+                // Limited by height
+                $finalH = $maxHeight;
+                $finalW = $maxHeight * $aspectRatio;
+            } else {
+                // Limited by width
+                $finalW = $maxWidth;
+                $finalH = $maxWidth / $aspectRatio;
+            }
+
+            $pdf->Image($fullPath, $margin, $margin, $finalW, $finalH);
+
+            return response($pdf->Output('S', basename($filePath) . '.pdf'))
+                ->header('Content-Type', 'application/pdf')
+                ->header('Content-Disposition', 'attachment; filename="' . basename($filePath) . '.pdf"');
+        }
+
+        // If unsupported type, just download original
+        return Storage::disk($disk)->download($filePath);
+    }
+
+    /**
      * Serve a private document for a given employee.
      *
      * @param  \App\Models\Employee  $employee

--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -183,6 +183,9 @@
                     <a href="{{ Storage::disk('public')->url($employee->insurance_document_path_private) }}" target="_blank" class="btn btn-success btn-sm text-white">
                         <i class="bi bi-eye-fill"></i> ดูเอกสาร
                     </a>
+                    <a href="{{ route('employees.documents.pdf', ['employee' => $employee->id, 'field' => 'insurance_document_path_private']) }}" target="_blank" class="btn btn-danger btn-sm text-white ms-1">
+                        <i class="bi bi-file-earmark-pdf-fill"></i> PDF
+                    </a>
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
@@ -225,6 +228,7 @@
                 $label = $file['label'];
                 $desc_field = $file['desc_field'] ?? null;
                 $url = $employee->{$field} ? Storage::disk('public')->url($employee->{$field}) : '#';
+                $pdfUrl = $employee->{$field} ? route('employees.documents.pdf', ['employee' => $employee->id, 'field' => $field]) : '#';
             @endphp
             <div class="col-md-4">
                 <label class="form-label fw-bold">{{ $label }}</label>
@@ -233,10 +237,15 @@
                         <a href="{{ $url }}" target="_blank" class="btn btn-success btn-sm text-white">
                             <i class="bi bi-eye-fill"></i> ดูเอกสาร
                         </a>
+                        <a href="{{ $pdfUrl }}" target="_blank" class="btn btn-danger btn-sm text-white ms-1">
+                            <i class="bi bi-file-earmark-pdf-fill"></i> PDF
+                        </a>
                          @if($desc_field && $employee->{$desc_field})
                             <span class="text-muted d-block" style="font-size: 0.875em;">({{ $employee->{$desc_field} }})</span>
                         @endif
                     </p>
+                @elseif($desc_field && $employee->{$desc_field})
+                    <p class="form-control-plaintext text-muted" style="color: #6c757d !important;">{{ $employee->{$desc_field} }}</p>
                 @else
                     <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/employees/advanced-export', [EmployeeController::class, 'advancedExport'])->name('employees.advanced_export');
     Route::get('/employees/history', [EmployeeController::class, 'historyIndex'])->name('employees.history');
     Route::get('/employees/{employee}/documents/{field}', [EmployeeController::class, 'serveDocument'])->name('employees.documents.serve');
+    Route::get('/employees/{employee}/documents/{field}/pdf', [EmployeeController::class, 'downloadDocumentAsPdf'])->name('employees.documents.pdf');
 
     // Import Routes
     Route::get('employees/import', [App\Http\Controllers\ImportEmployeeController::class, 'index'])->name('employees.import_view');


### PR DESCRIPTION
- Added a new `downloadDocumentAsPdf` method in `EmployeeController` to handle PDF generation from image attachments using FPDF, or direct download for existing PDFs.
- Updated `resources/views/previews/_employee_data.blade.php` to include a Red "PDF" export button next to every file attachment.
- Updated the "Other Documents" loop in the preview view to display description text in muted gray when no file is attached, fulfilling the user requirement.
- Registered the new route `/employees/{employee}/documents/{field}/pdf`.