### PR TITLE
Restrict employer workflow editing and enable read-only preview

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -179,6 +179,10 @@ class RegistrationController extends Controller
      */
     public function finalize(Request $request, Employee $employee)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         // Change status to 'registration_completed'
         $employee->update(['status' => 'registration_completed']);
 
@@ -196,6 +200,10 @@ class RegistrationController extends Controller
      */
     public function cancel(Request $request, Employee $employee)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         $employee->update(['status' => 'registration_cancelled']);
 
         if ($request->ajax()) {
@@ -212,6 +220,10 @@ class RegistrationController extends Controller
      */
     public function restore(Request $request, Employee $employee)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         $employee->update(['status' => 'registration_pending']);
 
         if ($request->ajax()) {
@@ -228,6 +240,10 @@ class RegistrationController extends Controller
      */
     public function destroy(Request $request, Employee $employee)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         $employerId = $employee->employer_id; // Capture ID before deletion
         $employee->delete(); // Soft delete
 
@@ -245,6 +261,10 @@ class RegistrationController extends Controller
      */
     public function bulkFinalize(Request $request)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         $request->validate([
             'employee_ids' => 'required|array',
             'employee_ids.*' => 'exists:employees,id',
@@ -298,6 +318,10 @@ class RegistrationController extends Controller
 
     public function create(Request $request)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         $employers = \App\Models\Employer::orderBy('employerNameTh')->get();
         $selectedEmployer = null;
 
@@ -317,6 +341,10 @@ class RegistrationController extends Controller
      */
     public function store(Request $request)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         // Copy of validation from EmployeeController@store
         $validated = $request->validate([
             'employer_id' => 'required|exists:employers,id',
@@ -493,6 +521,10 @@ class RegistrationController extends Controller
      */
     public function updateProgress(Request $request, Employee $employee)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         try {
             $validated = $request->validate([
                 'step_id' => 'required|exists:registration_steps,id',
@@ -601,6 +633,10 @@ class RegistrationController extends Controller
      */
     public function storeCustomField(Request $request, Employee $employee)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         $validated = $request->validate([
             'field_name' => 'required|string|max:255',
             'field_type' => 'required|in:text,date,file',
@@ -645,6 +681,10 @@ class RegistrationController extends Controller
 
     public function destroyCustomField(EmployeeCustomField $field)
     {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
         if ($field->field_type === 'file' && $field->file_path) {
             Storage::disk('public')->delete($field->file_path);
         }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -29,6 +29,7 @@ class DatabaseSeeder extends Seeder
             NotificationSettingSeeder::class,
             ApproveProductionPermissionSeeder::class,
             WorkflowBarrierSeeder::class,
+            WorkflowPermissionSeeder::class,
         ]);
     }
 }

--- a/database/seeders/WorkflowPermissionSeeder.php
+++ b/database/seeders/WorkflowPermissionSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class WorkflowPermissionSeeder extends Seeder
+{
+    public function run()
+    {
+        // Create the permission
+        $permission = Permission::firstOrCreate(['name' => 'manage-own-workflow']);
+
+        // Assign to Admin and Staff
+        $admin = Role::where('name', 'admin')->first();
+        if ($admin) {
+            $admin->givePermissionTo($permission);
+        }
+
+        $staff = Role::where('name', 'staff')->first();
+        if ($staff) {
+            $staff->givePermissionTo($permission);
+        }
+
+        // Ensure Employer does NOT have it by default
+        // (No action needed as we are not assigning it)
+    }
+}

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -36,6 +36,7 @@
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-3">
             {{-- Checkbox & Basic Info --}}
             <div class="d-flex align-items-center gap-3 w-100">
+                @can('manage-own-workflow')
                 {{-- Only show checkbox if Active (Pending) --}}
                 <div class="form-check {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}" id="checkbox-container-{{ $employee->id }}">
                     <input class="form-check-input employee-checkbox"
@@ -50,6 +51,7 @@
                            data-photo="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}"
                            data-employer-name="{{ $employee->employer->employerNameTh ?? 'N/A' }}">
                 </div>
+                @endcan
 
                 <div class="d-flex align-items-center gap-3 {{ $overlayClass }}" id="info-container-{{ $employee->id }}">
                     {{-- Avatar --}}
@@ -95,6 +97,7 @@
                     <i class="bi bi-eye-fill"></i>
                 </button>
 
+                 @can('manage-own-workflow')
                  {{-- Inline Drawer Toggle --}}
                  <button class="btn btn-sm btn-outline-primary rounded-pill px-3" title="Custom Fields"
                     onclick="toggleInlineDrawer({{ $employee->id }}, {{ json_encode($employee) }})">
@@ -141,6 +144,7 @@
                 <button class="btn btn-sm btn-outline-danger rounded-pill px-3" title="Delete" onclick="deleteEmployee({{ $employee->id }})">
                     <i class="bi bi-trash-fill"></i>
                 </button>
+                @endcan
             </div>
         </div>
 
@@ -177,14 +181,20 @@
                             }
                         }
                     @endphp
+                        @php
+                            $canManage = auth()->user()->can('manage-own-workflow');
+                            $disabled = ($isCompleted || $isCancelled || !$canManage) ? 'disabled' : '';
+                            $pointerEvents = !$canManage ? 'pointer-events: none;' : '';
+                            $onclick = $canManage ? "onclick=\"toggleStep({$employee->id}, {$step->id}, " . ($isStepCompleted ? 'false' : 'true') . ")\"" : '';
+                        @endphp
                     <button
                         class="btn btn-sm {{ $btnClass }} rounded-pill px-3"
-                        style="font-size: 0.8rem; {{ $btnStyle }}"
-                        onclick="toggleStep({{ $employee->id }}, {{ $step->id }}, {{ $isStepCompleted ? 'false' : 'true' }})"
+                            style="font-size: 0.8rem; {{ $btnStyle }} {{ $pointerEvents }}"
+                            {!! $onclick !!}
                         data-step-id="{{ $step->id }}"
                         data-color="{{ $step->color }}"
                         data-hex-color="{{ $hexColor }}"
-                        {{ ($isCompleted || $isCancelled) ? 'disabled' : '' }}
+                            {{ $disabled }}
                     >
                         {{ $step->name }}
                         @if($isStepCompleted) <i class="bi bi-check-circle-fill ms-1"></i> @endif

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -79,9 +79,11 @@
         <div class="card-body p-4">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h5 class="card-title fw-bold text-secondary mb-0"><i class="bi bi-bar-chart-fill me-2"></i>{{ __('Workflow Progress (Global)') }}</h5>
+                @can('manage-own-workflow')
                 <button class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#manageStepsModal">
                     <i class="bi bi-gear-fill me-1"></i> {{ __('Settings') }}
                 </button>
+                @endcan
             </div>
 
             <div class="d-flex gap-2 flex-wrap justify-content-start align-items-center" id="global-stats-container">
@@ -150,6 +152,7 @@
                 </form>
 
                 <div class="d-flex gap-2 flex-wrap justify-content-end">
+                    @can('manage-own-workflow')
                     <a href="{{ route('production.registration.create') }}" class="btn btn-warning text-white fw-bold">
                         <i class="bi bi-plus-lg me-1"></i> {{ __('New Employee') }}
                     </a>
@@ -159,9 +162,11 @@
                     <a href="{{ route('admin.trash.index', ['tab' => 'employees']) }}" class="btn btn-secondary fw-bold">
                         <i class="bi bi-trash-fill me-1"></i> {{ __('Trash') }}
                     </a>
+                    @endcan
                 </div>
             </div>
 
+            @can('manage-own-workflow')
             {{-- Bulk Action Bar --}}
             <div class="bulk-action-bar mt-3 align-items-center gap-2 p-2 bg-light border rounded"
                  style="display: none;"
@@ -199,6 +204,7 @@
                     <i class="bi bi-arrows-move me-1"></i> {{ __('Drag to Chat') }}
                 </div>
             </div>
+            @endcan
         </div>
     </div>
 
@@ -213,10 +219,12 @@
 
                         {{-- Left: Identity --}}
                         <div class="d-flex align-items-center flex-wrap gap-3">
+                            @can('manage-own-workflow')
                             {{-- Select All for Employer --}}
                             <div class="form-check mb-0">
                                 <input class="form-check-input employer-select-all" type="checkbox" data-employer-id="{{ $employer->id }}" title="Select All for this Employer">
                             </div>
+                            @endcan
 
                             {{-- Name & Collapse Trigger --}}
                             <button class="btn btn-link text-decoration-none text-dark p-0 text-start d-flex align-items-center gap-2" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ $employer->id }}">
@@ -273,10 +281,12 @@
 
                              <div class="vr d-none d-xl-block"></div>
 
+                             @can('manage-own-workflow')
                              {{-- Add Employee Button --}}
                              <a href="{{ route('production.registration.create', ['employer_id' => $employer->id]) }}" class="btn btn-outline-warning btn-sm fw-bold">
                                 <i class="bi bi-plus-lg"></i> {{ __('Add Employee') }}
                              </a>
+                             @endcan
 
                              {{-- Finance Button --}}
                              @can('view-finance')


### PR DESCRIPTION
Created a 'manage-own-workflow' permission to control editing access to the registration resolution workflow.
- Added `WorkflowPermissionSeeder` to create the permission and assign it to Admin/Staff.
- Updated `RegistrationController` to enforce authorization on state-changing actions (create, store, finalize, cancel, restore, destroy).
- Updated `index.blade.php` to hide Admin/Staff-only actions (settings, bulk actions, add employee) from employers.
- Updated `_employee_card.blade.php` to hide/disable edit buttons (tick steps, save, delete, etc.) for users without permission, while keeping the preview function accessible.