### PR TITLE
Update Registration Resolution with Cancel/Restore Employer workflow …

### DIFF
--- a/app/Http/Controllers/Admin/TrashController.php
+++ b/app/Http/Controllers/Admin/TrashController.php
@@ -26,7 +26,7 @@ class TrashController extends Controller
     }
 
     /**
-     * Display a list of all soft-deleted items, with search and view state.
+     * Display the list of all soft-deleted items, with search and view state.
      */
     public function index(Request $request)
     {
@@ -37,6 +37,11 @@ class TrashController extends Controller
 
         foreach ($models as $modelName => $modelClass) {
             $query = $modelClass::onlyTrashed();
+
+            // V2.5.5 Fix: Ensure Admin sees all trashed items by ignoring global scopes (tenancy)
+            if ($modelName === 'employees' || $modelName === 'employers') {
+                $query->withoutGlobalScopes();
+            }
 
             // --- Eager Loading ---
             // Eager load relationships to prevent N+1 query problems in the view.
@@ -156,6 +161,11 @@ class TrashController extends Controller
         // 1. Fetch the specific model's data, applying the same filters as the index page
         $query = $modelClass::onlyTrashed();
 
+        // V2.5.5 Fix: Ensure Admin sees all trashed items by ignoring global scopes (tenancy)
+        if ($modelName === 'employees' || $modelName === 'employers') {
+            $query->withoutGlobalScopes();
+        }
+
         if ($searchTerm) {
             $query->where(function ($q) use ($searchTerm, $modelName) {
                 // This switch MUST be kept in sync with the index method's search logic
@@ -268,7 +278,13 @@ class TrashController extends Controller
             return response()->json(['error' => 'You do not have permission to restore this item.'], 403);
         }
 
-        $item = $modelClass::onlyTrashed()->findOrFail($id);
+        // V2.5.5 Fix: Ensure we can find the item even if out of scope
+        $query = $modelClass::onlyTrashed();
+        if ($model === 'employees' || $model === 'employers') {
+            $query->withoutGlobalScopes();
+        }
+        $item = $query->findOrFail($id);
+
         $item->restore();
 
         return response()->json(['success' => class_basename($modelClass) . ' restored successfully.']);
@@ -293,7 +309,12 @@ class TrashController extends Controller
             return response()->json(['error' => 'You do not have permission to permanently delete this item.'], 403);
         }
 
-        $item = $modelClass::onlyTrashed()->findOrFail($id);
+        // V2.5.5 Fix: Ensure we can find the item even if out of scope
+        $query = $modelClass::onlyTrashed();
+        if ($model === 'employees' || $model === 'employers') {
+            $query->withoutGlobalScopes();
+        }
+        $item = $query->findOrFail($id);
         // Note: Logic for deleting associated files (like photos) should be in an observer or the model's forceDeleting event.
         $item->forceDelete();
 

--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -107,24 +107,29 @@ class RegistrationController extends Controller
             }])->get();
 
         foreach ($employers as $employer) {
-            $financeOrder = ProductionOrder::with('financialGroups.transactions')->firstOrCreate(
-                [
+            // Find existing order regardless of active/cancelled status to preserve state
+            $financeOrder = ProductionOrder::with('financialGroups.transactions')
+                ->where('employer_id', $employer->id)
+                ->whereIn('status', ['registration_resolution', 'registration_resolution_cancelled'])
+                ->first();
+
+            if (!$financeOrder) {
+                $financeOrder = ProductionOrder::create([
                     'employer_id' => $employer->id,
-                    'status'      => 'registration_resolution'
-                ],
-                [
+                    'status'      => 'registration_resolution',
                     'type'         => 'employer',
                     'project_name' => 'Registration Resolution - ' . $employer->employerNameTh,
                     'financial_data' => []
-                ]
-            );
+                ]);
+            }
+
             $employer->financeOrder = $financeOrder;
 
             // Ensure at least one default financial group exists
             if ($financeOrder->financialGroups->isEmpty()) {
                 $financeOrder->financialGroups()->create([
                     'name' => 'General',
-                    'financial_data' => $financeOrder->financial_data
+                    'financial_data' => $financeOrder->financial_data ?? []
                 ]);
                 $financeOrder->load('financialGroups.transactions');
             }
@@ -161,17 +166,87 @@ class RegistrationController extends Controller
             $employer->savedCount = $employer->employees->where('status', 'registration_completed')->count();
         }
 
+        // Sort Employers: Active first, Cancelled last
+        $employers = $employers->sortBy(function($emp) {
+            return $emp->financeOrder->status === 'registration_resolution_cancelled' ? 1 : 0;
+        });
+
+        $cancelledEmployersCount = $employers->where('financeOrder.status', 'registration_resolution_cancelled')->count();
+
         return view('production.registration.index', compact(
             'totalEmployees',
             'totalCancelled',
             'totalSaved',
             'totalEmployers',
+            'cancelledEmployersCount',
             'notStartedCount',
             'steps',
             'stepStats',
             'employers',
             'lastStepId'
         ));
+    }
+
+    /**
+     * Cancel an Employer.
+     */
+    public function cancelEmployer(Request $request, Employer $employer)
+    {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
+        DB::transaction(function () use ($employer) {
+            // 1. Update Order Status
+            $order = ProductionOrder::where('employer_id', $employer->id)
+                ->whereIn('status', ['registration_resolution', 'registration_resolution_cancelled'])
+                ->first();
+
+            if ($order) {
+                $order->update(['status' => 'registration_resolution_cancelled']);
+            }
+
+            // 2. Update Employees (Only Pending ones get cancelled)
+            $employer->employees()
+                ->where('status', 'registration_pending')
+                ->update(['status' => 'registration_cancelled']);
+        });
+
+        if ($request->ajax()) {
+            return response()->json(['success' => true]);
+        }
+        return back()->with('success', 'Employer registration cancelled.');
+    }
+
+    /**
+     * Restore an Employer.
+     */
+    public function restoreEmployer(Request $request, Employer $employer)
+    {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
+        DB::transaction(function () use ($employer) {
+            // 1. Update Order Status
+            $order = ProductionOrder::where('employer_id', $employer->id)
+                ->whereIn('status', ['registration_resolution', 'registration_resolution_cancelled'])
+                ->first();
+
+            if ($order) {
+                $order->update(['status' => 'registration_resolution']);
+            }
+
+            // 2. Update Employees (Cancelled -> Pending)
+            $employer->employees()
+                ->where('status', 'registration_cancelled')
+                ->update(['status' => 'registration_pending']);
+        });
+
+        if ($request->ajax()) {
+            return response()->json(['success' => true]);
+        }
+        return back()->with('success', 'Employer registration restored.');
     }
 
     /**

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -15,6 +15,10 @@
     .filter-active .badge {
         box-shadow: 0 0 10px rgba(59, 130, 246, 0.5) !important;
     }
+    .grayscale-mode {
+        filter: grayscale(100%);
+        opacity: 0.8;
+    }
 </style>
 
 <div class="container-fluid">
@@ -43,7 +47,7 @@
             </div>
         </div>
 
-        {{-- Cancelled (New) --}}
+        {{-- Total Cancelled Employees --}}
         <div class="col">
             <div class="card text-white h-100 shadow-sm" style="background-color: #6B7280; border: none;"> {{-- Gray --}}
                 <div class="card-body text-center d-flex flex-column justify-content-center py-4">
@@ -69,6 +73,16 @@
                 <div class="card-body text-center d-flex flex-column justify-content-center py-4">
                     <h1 class="display-4 fw-bold mb-0" id="global-employers-count">{{ $totalEmployers }}</h1>
                     <p class="fs-5 fw-light mb-0">{{ __('Total Employers') }}</p>
+                </div>
+            </div>
+        </div>
+
+        {{-- Cancelled Employers --}}
+        <div class="col">
+            <div class="card text-white h-100 shadow-sm" style="background-color: #4B5563; border: none;"> {{-- Dark Gray --}}
+                <div class="card-body text-center d-flex flex-column justify-content-center py-4">
+                    <h1 class="display-4 fw-bold mb-0" id="global-cancelled-employers-count">{{ $cancelledEmployersCount }}</h1>
+                    <p class="fs-5 fw-light mb-0">{{ __('Cancelled Employers') }}</p>
                 </div>
             </div>
         </div>
@@ -211,8 +225,13 @@
     {{-- Employers List --}}
     <div class="accordion" id="employersAccordion">
         @foreach($employers as $employer)
-            <div class="card mb-4 border border-primary border-2 shadow-sm overflow-hidden" id="employer-card-{{ $employer->id }}">
-                <div class="card-header bg-white py-3 px-4 border-bottom" id="heading{{ $employer->id }}">
+            @php
+                $isEmployerCancelled = $employer->financeOrder && $employer->financeOrder->status === 'registration_resolution_cancelled';
+                $employerCardClass = $isEmployerCancelled ? 'border-secondary grayscale-mode' : 'border-primary border-2';
+                $employerHeaderClass = $isEmployerCancelled ? 'bg-light' : 'bg-white';
+            @endphp
+            <div class="card mb-4 shadow-sm overflow-hidden {{ $employerCardClass }}" id="employer-card-{{ $employer->id }}">
+                <div class="card-header py-3 px-4 border-bottom {{ $employerHeaderClass }}" id="heading{{ $employer->id }}">
 
                     {{-- Top Row: Identity + Stats + Actions --}}
                     <div class="d-flex flex-column flex-xl-row justify-content-between align-items-xl-center gap-3 mb-3">
@@ -283,7 +302,7 @@
 
                              @can('manage-own-workflow')
                              {{-- Add Employee Button --}}
-                             <a href="{{ route('production.registration.create', ['employer_id' => $employer->id]) }}" class="btn btn-outline-warning btn-sm fw-bold">
+                             <a href="{{ route('production.registration.create', ['employer_id' => $employer->id]) }}" class="btn btn-outline-warning btn-sm fw-bold {{ $isEmployerCancelled ? 'd-none' : '' }}">
                                 <i class="bi bi-plus-lg"></i> {{ __('Add Employee') }}
                              </a>
                              @endcan
@@ -293,6 +312,19 @@
                              <button class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#financeModal-{{ $employer->id }}" onclick="event.stopPropagation()">
                                 <i class="bi bi-currency-dollar"></i> {{ __('Finance') }}
                             </button>
+                            @endcan
+
+                            {{-- Cancel/Restore Employer Actions --}}
+                            @can('manage-own-workflow')
+                                @if($isEmployerCancelled)
+                                    <button class="btn btn-outline-warning btn-sm" onclick="restoreEmployer({{ $employer->id }})">
+                                        <i class="bi bi-arrow-counterclockwise"></i> {{ __('Restore Employer') }}
+                                    </button>
+                                @else
+                                    <button class="btn btn-outline-secondary btn-sm" onclick="cancelEmployer({{ $employer->id }})">
+                                        <i class="bi bi-x-circle"></i> {{ __('Cancel Employer') }}
+                                    </button>
+                                @endif
                             @endcan
 
                             {{-- Collapse Chevron --}}
@@ -999,6 +1031,55 @@
                             applyFilters();
                             recalculateVisibleStats();
                         }
+                    }
+                });
+             }
+        });
+    }
+
+    function cancelEmployer(id) {
+        Swal.fire({
+            title: '{{ __("Cancel Employer?") }}',
+            text: "{{ __('This will seal the card and move it to the end. Active employees will also be cancelled.') }}",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            confirmButtonText: '{{ __("Yes, Cancel Employer") }}'
+        }).then((result) => {
+             if (result.isConfirmed) {
+                fetch(`/production/registration/employer/${id}/cancel`, {
+                    method: 'POST',
+                    headers: { 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' }
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if(data.success) {
+                        Swal.fire('{{ __("Cancelled") }}', '{{ __("Employer registration cancelled.") }}', 'success')
+                        .then(() => location.reload()); // Reload to handle sorting and complex UI changes
+                    }
+                });
+             }
+        });
+    }
+
+    function restoreEmployer(id) {
+        Swal.fire({
+            title: '{{ __("Restore Employer?") }}',
+            text: "{{ __('This will restore the employer card and active employees.') }}",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: '{{ __("Yes, Restore") }}'
+        }).then((result) => {
+             if (result.isConfirmed) {
+                fetch(`/production/registration/employer/${id}/restore`, {
+                    method: 'POST',
+                    headers: { 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' }
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if(data.success) {
+                        Swal.fire('{{ __("Restored") }}', '{{ __("Employer restored.") }}', 'success')
+                        .then(() => location.reload());
                     }
                 });
              }

--- a/routes/web.php
+++ b/routes/web.php
@@ -218,6 +218,10 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/{employee}/cancel', [App\Http\Controllers\Production\RegistrationController::class, 'cancel'])->name('cancel');
         Route::post('/{employee}/restore', [App\Http\Controllers\Production\RegistrationController::class, 'restore'])->name('restore');
         Route::delete('/{employee}/destroy', [App\Http\Controllers\Production\RegistrationController::class, 'destroy'])->name('destroy');
+
+        // Employer Actions (NEW)
+        Route::post('/employer/{employer}/cancel', [App\Http\Controllers\Production\RegistrationController::class, 'cancelEmployer'])->name('cancel_employer');
+        Route::post('/employer/{employer}/restore', [App\Http\Controllers\Production\RegistrationController::class, 'restoreEmployer'])->name('restore_employer');
     });
 
     Route::resource('production', \App\Http\Controllers\ProductionController::class);
@@ -225,6 +229,7 @@ Route::middleware(['auth'])->group(function () {
     // Additional Production Routes
     Route::post('production/{id}/add-employee', [\App\Http\Controllers\ProductionController::class, 'addEmployee'])->name('production.add_employee');
     Route::post('production/{id}/add-new-employee', [\App\Http\Controllers\ProductionController::class, 'addNewEmployee'])->name('production.add_new_employee');
+
     Route::post('production/{id}/toggle-status', [\App\Http\Controllers\ProductionController::class, 'toggleStatus'])->name('production.toggle_status');
     Route::post('production/{id}/upload-logo', [\App\Http\Controllers\ProductionController::class, 'uploadLogo'])->name('production.upload_logo');
     Route::post('production/{id}/financial-groups', [\App\Http\Controllers\ProductionController::class, 'storeFinancialGroup'])->name('production.financial_groups.store');


### PR DESCRIPTION
…and fix Trash visibility

- Added `cancelEmployer` and `restoreEmployer` methods to `RegistrationController` to handle status updates for employers and their pending employees.
- Updated `RegistrationController@index` to sort employers (active first, cancelled last) and calculate cancelled employer stats.
- Added `cancel_employer` and `restore_employer` routes in `web.php`.
- Updated `production/registration/index.blade.php` to include a "Cancelled Employers" stats card and UI controls for cancelling/restoring employers.
- Modified `TrashController` to use `withoutGlobalScopes()` for Employees and Employers, ensuring soft-deleted items from tenant-scoped models are visible to Admins in the Central Trash.
- Verified route names to prevent regressions in `production.add_new_employee`.