### PR TITLE
Fix Admin/Staff permission access in Registration Workflow

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -192,7 +192,7 @@ class RegistrationController extends Controller
      */
     public function cancelEmployer(Request $request, Employer $employer)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employers')) {
             abort(403);
         }
 
@@ -223,7 +223,7 @@ class RegistrationController extends Controller
      */
     public function restoreEmployer(Request $request, Employer $employer)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employers')) {
             abort(403);
         }
 
@@ -254,7 +254,7 @@ class RegistrationController extends Controller
      */
     public function finalize(Request $request, Employee $employee)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -275,7 +275,7 @@ class RegistrationController extends Controller
      */
     public function cancel(Request $request, Employee $employee)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -295,7 +295,7 @@ class RegistrationController extends Controller
      */
     public function restore(Request $request, Employee $employee)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -315,7 +315,7 @@ class RegistrationController extends Controller
      */
     public function destroy(Request $request, Employee $employee)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -336,7 +336,7 @@ class RegistrationController extends Controller
      */
     public function bulkFinalize(Request $request)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -393,7 +393,7 @@ class RegistrationController extends Controller
 
     public function create(Request $request)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -416,7 +416,7 @@ class RegistrationController extends Controller
      */
     public function store(Request $request)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -596,7 +596,7 @@ class RegistrationController extends Controller
      */
     public function updateProgress(Request $request, Employee $employee)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -708,7 +708,7 @@ class RegistrationController extends Controller
      */
     public function storeCustomField(Request $request, Employee $employee)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 
@@ -756,7 +756,7 @@ class RegistrationController extends Controller
 
     public function destroyCustomField(EmployeeCustomField $field)
     {
-        if (!auth()->user()->can('manage-own-workflow')) {
+        if (!auth()->user()->can('edit-employees')) {
             abort(403);
         }
 

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -36,7 +36,7 @@
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-3">
             {{-- Checkbox & Basic Info --}}
             <div class="d-flex align-items-center gap-3 w-100">
-                @can('manage-own-workflow')
+                @can('edit-employees')
                 {{-- Only show checkbox if Active (Pending) --}}
                 <div class="form-check {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}" id="checkbox-container-{{ $employee->id }}">
                     <input class="form-check-input employee-checkbox"
@@ -97,7 +97,7 @@
                     <i class="bi bi-eye-fill"></i>
                 </button>
 
-                 @can('manage-own-workflow')
+                 @can('edit-employees')
                  {{-- Inline Drawer Toggle --}}
                  <button class="btn btn-sm btn-outline-primary rounded-pill px-3" title="Custom Fields"
                     onclick="toggleInlineDrawer({{ $employee->id }}, {{ json_encode($employee) }})">
@@ -183,7 +183,7 @@
                         }
                     @endphp
                         @php
-                            $canManage = auth()->user()->can('manage-own-workflow');
+                            $canManage = auth()->user()->can('edit-employees');
                             $disabled = ($isCompleted || $isCancelled || !$canManage) ? 'disabled' : '';
                             $pointerEvents = !$canManage ? 'pointer-events: none;' : '';
                             $onclick = $canManage ? "onclick=\"toggleStep({$employee->id}, {$step->id}, " . ($isStepCompleted ? 'false' : 'true') . ")\"" : '';

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -93,7 +93,7 @@
         <div class="card-body p-4">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h5 class="card-title fw-bold text-secondary mb-0"><i class="bi bi-bar-chart-fill me-2"></i>{{ __('Workflow Progress (Global)') }}</h5>
-                @can('manage-own-workflow')
+                @can('edit-employees')
                 <button class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#manageStepsModal">
                     <i class="bi bi-gear-fill me-1"></i> {{ __('Settings') }}
                 </button>
@@ -166,7 +166,7 @@
                 </form>
 
                 <div class="d-flex gap-2 flex-wrap justify-content-end">
-                    @can('manage-own-workflow')
+                    @can('edit-employees')
                     <a href="{{ route('production.registration.create') }}" class="btn btn-warning text-white fw-bold">
                         <i class="bi bi-plus-lg me-1"></i> {{ __('New Employee') }}
                     </a>
@@ -180,7 +180,7 @@
                 </div>
             </div>
 
-            @can('manage-own-workflow')
+            @can('edit-employees')
             {{-- Bulk Action Bar --}}
             <div class="bulk-action-bar mt-3 align-items-center gap-2 p-2 bg-light border rounded"
                  style="display: none;"
@@ -238,7 +238,7 @@
 
                         {{-- Left: Identity --}}
                         <div class="d-flex align-items-center flex-wrap gap-3">
-                            @can('manage-own-workflow')
+                            @can('edit-employees')
                             {{-- Select All for Employer --}}
                             <div class="form-check mb-0">
                                 <input class="form-check-input employer-select-all" type="checkbox" data-employer-id="{{ $employer->id }}" title="Select All for this Employer">
@@ -300,7 +300,7 @@
 
                              <div class="vr d-none d-xl-block"></div>
 
-                             @can('manage-own-workflow')
+                             @can('edit-employees')
                              {{-- Add Employee Button --}}
                              <a href="{{ route('production.registration.create', ['employer_id' => $employer->id]) }}" class="btn btn-outline-warning btn-sm fw-bold {{ $isEmployerCancelled ? 'd-none' : '' }}">
                                 <i class="bi bi-plus-lg"></i> {{ __('Add Employee') }}
@@ -315,7 +315,7 @@
                             @endcan
 
                             {{-- Cancel/Restore Employer Actions --}}
-                            @can('manage-own-workflow')
+                            @can('edit-employers')
                                 @if($isEmployerCancelled)
                                     <button class="btn btn-outline-warning btn-sm" onclick="restoreEmployer({{ $employer->id }})">
                                         <i class="bi bi-arrow-counterclockwise"></i> {{ __('Restore Employer') }}


### PR DESCRIPTION
Replaced the incorrect `manage-own-workflow` permission check with standard `edit-employees` and `edit-employers` permissions in the Registration Controller and associated views. This ensures that Admin, Staff, and Caretaker roles can correctly interact with the workflow board (tick steps, restore, cancel) while keeping the Employer role in a read-only state.