### PR TITLE
Fix Advanced Edit (Bulk) functionality in Import Employees flow

### DIFF
--- a/resources/views/employees/bulk_edit_form.blade.php
+++ b/resources/views/employees/bulk_edit_form.blade.php
@@ -365,14 +365,19 @@
             const container = document.getElementById('bulk-edit-wrapper');
             if (!container) return; // Should not happen
 
+            console.log('Bulk Edit Script Initialized');
+
             // --- 1. Master Field Sync (Event Delegation on Container) ---
             container.addEventListener('click', function(e) {
                 if (e.target.matches('.apply-master-btn') || e.target.closest('.apply-master-btn')) {
                     const btn = e.target.matches('.apply-master-btn') ? e.target : e.target.closest('.apply-master-btn');
                     const field = btn.dataset.field;
                     // Ensure we search within THIS container
-                    const formContainer = container.querySelector('#bulkEditForm');
-                    if (!formContainer) return;
+                    const formContainer = container.querySelector('#bulkEditForm') || container.querySelector('form');
+                    if (!formContainer) {
+                        console.error('Bulk Edit Form not found');
+                        return;
+                    }
 
                     const masterInput = formContainer.querySelector(`.master-input[data-field="${field}"]`);
                     const individualInputs = formContainer.querySelectorAll(`.individual-input[data-field="${field}"]`);

--- a/resources/views/employees/bulk_edit_selector.blade.php
+++ b/resources/views/employees/bulk_edit_selector.blade.php
@@ -3,7 +3,7 @@
 @section('title', __('Advanced Bulk Edit Selection'))
 
 @section('content')
-<div class="container-fluid p-4">
+<div class="container-fluid p-4" id="bulk-edit-selector-wrapper">
     <h2 class="mb-4">{{ __('Select Fields for Bulk Edit') }}</h2>
 
     <form action="{{ route('employees.bulk_edit.form') }}" method="POST">

--- a/resources/views/employees/import.blade.php
+++ b/resources/views/employees/import.blade.php
@@ -423,7 +423,7 @@ document.addEventListener('DOMContentLoaded', function() {
         .then(html => {
              const parser = new DOMParser();
              const doc = parser.parseFromString(html, 'text/html');
-             const content = doc.querySelector('.container-fluid') || doc.body;
+             const content = doc.getElementById('bulk-edit-selector-wrapper') || doc.querySelector('.container-fluid') || doc.body;
 
              // Hijack form submit
              const form = content.querySelector('form');
@@ -488,7 +488,7 @@ document.addEventListener('DOMContentLoaded', function() {
         .then(html => {
              const parser = new DOMParser();
              const doc = parser.parseFromString(html, 'text/html');
-             const content = doc.querySelector('.container-fluid') || doc.body;
+             const content = doc.getElementById('bulk-edit-wrapper') || doc.querySelector('.container-fluid') || doc.body;
 
              // Remove layout clutter (like Fixed Bottom bar wrapper if it causes issues in modal)
              // The view has `fixed-bottom`. In a modal, this might be weird.


### PR DESCRIPTION
- Updated `resources/views/employees/import.blade.php` to target specific wrapper IDs (`#bulk-edit-wrapper`) when loading modal content, ensuring scripts and wrappers are correctly preserved.
- Added `#bulk-edit-selector-wrapper` to `resources/views/employees/bulk_edit_selector.blade.php` for consistent targeting.
- Improved robustness of `resources/views/employees/bulk_edit_form.blade.php` script to fallback to generic form selection if ID lookup fails.