### PR TITLE
Increase file upload limit for employer custom fields to 100MB

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -768,7 +768,7 @@ class RegistrationController extends Controller
             'field_name' => 'required|string|max:255',
             'field_type' => 'required|in:text,date,file',
             'field_value' => 'nullable|string',
-            'field_file' => 'nullable|file|max:10240', // 10MB
+            'field_file' => 'nullable|file|max:102400', // 100MB
         ]);
 
         $data = [


### PR DESCRIPTION
Updated the validation rule in RegistrationController::storeEmployerCustomField to allow file uploads up to 100MB (102400 KB), matching the limit used for employee custom fields. This resolves an issue where users were unable to upload larger documents to employer records in the Registration Resolution menu.