### PR TITLE
Fix syntax error in registration resolution view

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -1377,7 +1377,7 @@
                 .then(res => res.json())
                 .then(data => {
                     if(data.success) {
-                        Swal.fire('{{ __('Restored') }}', '{{ __('Employer restored.") }}', 'success')
+                        Swal.fire('{{ __('Restored') }}', '{{ __('Employer restored.') }}', 'success')
                         .then(() => location.reload());
                     }
                 });


### PR DESCRIPTION
Corrected a mismatched quote in `resources/views/production/registration/index.blade.php` that was causing a PHP ParseError. Changed `__('Employer restored.")` to `__('Employer restored.')`.