### PR TITLE
Fix: Correct pivot table name in RegistrationController query

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -41,7 +41,7 @@ class RegistrationController extends Controller
             ->whereIn('status', ['registration_pending', 'registration_completed', 'registration_cancelled'])
             ->select('id', 'employer_id', 'status') // Lightweight Select
             ->with(['registrationSteps' => function($q) {
-                $q->select('registration_steps.id', 'registration_steps.order', 'employee_registration_step.employee_id'); // Lightweight Relation
+                $q->select('registration_steps.id', 'registration_steps.order', 'employee_registration_status.employee_id'); // Lightweight Relation
             }]);
 
         // Apply Search (Same logic as before)


### PR DESCRIPTION
The `RegistrationController` was incorrectly referencing `employee_registration_step` in a select clause, causing a SQL column not found error. This change updates it to `employee_registration_status`, matching the pivot table defined in the `Employee` model's `registrationSteps` relationship.