### PR TITLE
Fix: Decouple finance UI saving states and add error handling

### DIFF
--- a/resources/js/financial-manager.js
+++ b/resources/js/financial-manager.js
@@ -44,7 +44,11 @@ if (typeof window.financialManager === 'undefined') {
             newTransaction: { type: 'installment', amount: '', due_date: '', notes: '' },
             editingTransaction: {},
             selectedFile: null,
-            isSaving: false,
+
+            // Separate Saving States
+            isSavingSettings: false,
+            isSavingTransaction: false,
+
             selectedTransactionIds: [],
             documentTypeToGenerate: '',
 
@@ -265,7 +269,7 @@ if (typeof window.financialManager === 'undefined') {
             saveFinancialData() {
                 if (!this.activeGroupId) return;
 
-                this.isSaving = true;
+                this.isSavingSettings = true;
 
                 const payload = {
                     financial: {
@@ -299,7 +303,7 @@ if (typeof window.financialManager === 'undefined') {
                 })
                 .then(res => res.json())
                 .then(data => {
-                    this.isSaving = false;
+                    this.isSavingSettings = false;
                     const group = this.financialGroups.find(g => g.id === this.activeGroupId);
                     if (group) {
                         group.financial_data = payload.financial;
@@ -314,7 +318,7 @@ if (typeof window.financialManager === 'undefined') {
                     });
                 })
                 .catch(err => {
-                    this.isSaving = false;
+                    this.isSavingSettings = false;
                     Swal.fire('Error', 'Error saving data', 'error');
                 });
             },
@@ -382,8 +386,7 @@ if (typeof window.financialManager === 'undefined') {
                 // Better: use x-ref="logoInput" and access via this.$refs.logoInput
                 // But $refs might be tricky if inside a loop.
                 // Let's assume standard behavior.
-                // Actually, inside the loop, refs are scoped to the component instance root?
-                // Yes, in Alpine, $refs are scoped to the `x-data` root.
+                // Actually, inside the loop, refs are scoped to the `x-data` root.
 
                 const file = this.$refs.logoInput ? this.$refs.logoInput.files[0] : null;
                 if (!file) return;
@@ -416,7 +419,7 @@ if (typeof window.financialManager === 'undefined') {
             },
             addTransaction() {
                 if (!this.activeGroupId) return;
-                this.isSaving = true;
+                this.isSavingTransaction = true;
                 const payload = { ...this.newTransaction, financial_group_id: this.activeGroupId };
 
                 fetch(`/admin/production/production/${this.productionId}/transactions`, {
@@ -424,15 +427,43 @@ if (typeof window.financialManager === 'undefined') {
                     headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
                     body: JSON.stringify(payload)
                 })
-                .then(res => res.json())
+                .then(res => {
+                    if (!res.ok) {
+                         // Check if response is JSON, else throw text
+                         const contentType = res.headers.get("content-type");
+                         if (contentType && contentType.indexOf("application/json") !== -1) {
+                             return res.json().then(err => { throw new Error(err.message || 'Server Error'); });
+                         } else {
+                             return res.text().then(text => { throw new Error(text || 'Server Error'); });
+                         }
+                    }
+                    return res.json();
+                })
                 .then(data => {
                     if(data.success) {
                         this.transactions.push(data.transaction);
                         bootstrap.Modal.getOrCreateInstance(this.$refs.addModal).hide();
                         this.newTransaction = { type: 'installment', amount: '', due_date: '', notes: '' };
+                        Swal.fire({
+                            icon: 'success',
+                            title: 'Success',
+                            text: 'Transaction added successfully',
+                            timer: 1500,
+                            showConfirmButton: false
+                        });
+                    } else {
+                         throw new Error(data.message || 'Unknown error');
                     }
                 })
-                .finally(() => this.isSaving = false);
+                .catch(err => {
+                    console.error(err);
+                    Swal.fire({
+                        icon: 'error',
+                        title: 'Error',
+                        text: err.message || 'Failed to add transaction. Please check your inputs.',
+                    });
+                })
+                .finally(() => this.isSavingTransaction = false);
             },
             openPayModal(t) {
                 this.editingTransaction = { ...t };
@@ -452,13 +483,40 @@ if (typeof window.financialManager === 'undefined') {
                     headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
                     body: formData
                 })
-                .then(res => res.json())
+                .then(res => {
+                     if (!res.ok) {
+                         const contentType = res.headers.get("content-type");
+                         if (contentType && contentType.indexOf("application/json") !== -1) {
+                             return res.json().then(err => { throw new Error(err.message || 'Server Error'); });
+                         } else {
+                             return res.text().then(text => { throw new Error(text || 'Server Error'); });
+                         }
+                    }
+                    return res.json();
+                })
                 .then(data => {
                     if(data.success) {
                         const idx = this.transactions.findIndex(t => t.id === data.transaction.id);
                         if(idx !== -1) this.transactions[idx] = data.transaction;
                         bootstrap.Modal.getInstance(this.$refs.payModal).hide();
+                        Swal.fire({
+                            icon: 'success',
+                            title: 'Success',
+                            text: 'Payment updated successfully',
+                            timer: 1500,
+                            showConfirmButton: false
+                        });
+                    } else {
+                        throw new Error(data.message || 'Unknown error');
                     }
+                })
+                .catch(err => {
+                    console.error(err);
+                    Swal.fire({
+                        icon: 'error',
+                        title: 'Update Failed',
+                        text: err.message || 'Could not update transaction.',
+                    });
                 });
             },
             deleteTransaction(id) {

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -162,7 +162,7 @@
                 </div>
 
                 <!-- Save Pricing Button -->
-                <button class="btn btn-primary btn-sm w-100" @click="saveFinancialData()" :disabled="isSaving || (pricingMode === 'per_head' && tierCountSum !== employeeCount)">
+                <button class="btn btn-primary btn-sm w-100" @click="saveFinancialData()" :disabled="isSavingSettings || (pricingMode === 'per_head' && tierCountSum !== employeeCount)">
                     <i class="bi bi-save me-1"></i> {{ __('Save Pricing Settings') }}
                 </button>
             </div>
@@ -509,7 +509,7 @@
                             <label class="form-label small">Notes</label>
                             <textarea class="form-control form-control-sm" x-model="newTransaction.notes" rows="2"></textarea>
                         </div>
-                        <button type="submit" class="btn btn-primary btn-sm w-100" :disabled="isSaving">Save</button>
+                        <button type="submit" class="btn btn-primary btn-sm w-100" :disabled="isSavingTransaction">Save</button>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
- Separated `isSaving` into `isSavingSettings` and `isSavingTransaction` in `financial-manager.js` to prevent the "Save Pricing Settings" button from flashing/disabling when adding a transaction.
- Added explicit error handling (Swal.fire) to `addTransaction` and `updateTransaction` to provide feedback on failures instead of failing silently.
- Updated `financial-tab.blade.php` to use the new state variables.