### PR TITLE
Fix "Error saving" bug in Resolution Registration edit form

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -132,7 +132,10 @@
 
                     fetch('{{ route('employees.update', $employee->id) }}', {
                         method: 'POST',
-                        headers: { 'Accept': 'application/json' },
+                        headers: {
+                            'Accept': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest'
+                        },
                         body: formData
                     })
                     .then(res => res.json())


### PR DESCRIPTION
- Add `X-Requested-With: XMLHttpRequest` header to fetch request in `_employee_card.blade.php`.
- This ensures the `EmployeeController@update` method returns a JSON response instead of a redirect, allowing the frontend to correctly interpret the success state.
- Resolves issue where data was saved but UI showed "Error" and remained in edit mode.