### PR TITLE
Fix: Add missing Cropper modal to Registration Resolution

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -537,6 +537,37 @@
 @include('employees.modals.advanced_export')
 @include('employees.modals.select_target_employer_modal')
 
+{{-- Cropper Modal (Required for Employee Edit) --}}
+<div class="modal fade" id="cropperModal" tabindex="-1" aria-labelledby="cropperModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="cropperModalLabel">ครอบตัดรูปภาพ</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <style>
+                    .img-container {
+                        max-height: 500px;
+                        display: block;
+                    }
+                    .img-container img {
+                        max-width: 100%;
+                        display: block;
+                    }
+                </style>
+                <div class="img-container">
+                    <img id="imageToCrop" src="" alt="Picture" style="display: block; max-width: 100%;">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                <button type="button" class="btn btn-primary" id="cropImageBtn">ครอบตัดและบันทึก</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 {{-- View Selected Items Modal --}}
 <div class="modal fade" id="viewSelectedModal" tabindex="-1" aria-labelledby="viewSelectedModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered">


### PR DESCRIPTION
Added the `cropperModal` HTML structure to `resources/views/production/registration/index.blade.php`. This modal is required for the image cropping functionality (powered by `cropper.js`) to work when editing employee photos, ensuring consistency with other parts of the application.

- Added `#cropperModal` div with localized title "ครอบตัดรูปภาพ" and control buttons.
- Cleaned up redundant `cropper.min.js/css` files that were temporarily created but not needed (CDN used).