### PR TITLE
Fix: Remove duplicate cropper modal from registration index

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -576,37 +576,6 @@
     </div>
 </div>
 
-{{-- Cropper Modal (Required for Employee Edit) --}}
-<div class="modal fade" id="cropperModal" tabindex="-1" aria-labelledby="cropperModalLabel" aria-hidden="true" style="z-index: 1060;">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="cropperModalLabel">ครอบตัดรูปภาพ</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <style>
-                    .img-container {
-                        max-height: 500px;
-                        display: block;
-                    }
-                    .img-container img {
-                        max-width: 100%;
-                        display: block;
-                    }
-                </style>
-                <div class="img-container">
-                    <img id="imageToCrop" src="" alt="Picture" style="display: block; max-width: 100%;">
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
-                <button type="button" class="btn btn-primary" id="cropImageBtn">ครอบตัดและบันทึก</button>
-            </div>
-        </div>
-    </div>
-</div>
-
 {{-- Manage Steps Modal --}}
 <div class="modal fade" id="manageStepsModal" tabindex="-1">
     <div class="modal-dialog modal-lg modal-dialog-centered">


### PR DESCRIPTION
This commit removes the redundant `cropperModal` HTML structure from `resources/views/production/registration/index.blade.php`. This modal was causing a DOM ID conflict with the identical modal loaded via AJAX in the employee edit form (`resources/views/employees/edit.blade.php`), preventing the "Crop and Save" button from functioning correctly. The edit form includes its own functional modal, making the one in the index file unnecessary and problematic.