### PR TITLE
Fix: Exclude registration_cancelled employees from main employee lists

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -84,11 +84,11 @@ public function reinstate(Employee $employee)
 
     public function index(Request $request)
 {
-    // Filter out 'registration_pending' status so they don't appear until finalized
+    // Filter out 'registration_pending' and 'registration_cancelled' statuses so they don't appear until finalized
     $query = Employee::query()
         ->whereNull('terminated_at')
         ->where(function($q) {
-            $q->where('status', '!=', 'registration_pending')
+            $q->whereNotIn('status', ['registration_pending', 'registration_cancelled'])
               ->orWhereNull('status');
         });
 
@@ -588,7 +588,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
             $query = Employee::query()
                 ->whereNull('terminated_at')
                 ->where(function($q) {
-                    $q->where('status', '!=', 'registration_pending')
+                    $q->whereNotIn('status', ['registration_pending', 'registration_cancelled'])
                       ->orWhereNull('status');
                 });
         }

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -123,7 +123,12 @@ public function edit(Request $request, Employer $employer)
     $jobOwners = JobOwner::orderBy('name')->get();
     $staffUsers = User::role(['admin', 'staff', 'caretaker'])->orderBy('name')->get();
 
-    $employeeQuery = $employer->employees()->whereNull('terminated_at');
+    $employeeQuery = $employer->employees()
+        ->whereNull('terminated_at')
+        ->where(function($q) {
+            $q->whereNotIn('status', ['registration_pending', 'registration_cancelled'])
+              ->orWhereNull('status');
+        });
 
     // --- START: ADDED FILTERING LOGIC ---
     if ($request->filled('search')) {
@@ -323,7 +328,12 @@ public function edit(Request $request, Employer $employer)
         if ($isHistoryExport) {
             $query = $employer->employees()->whereNotNull('terminated_at');
         } else {
-            $query = $employer->employees()->whereNull('terminated_at');
+            $query = $employer->employees()
+                ->whereNull('terminated_at')
+                ->where(function($q) {
+                    $q->whereNotIn('status', ['registration_pending', 'registration_cancelled'])
+                      ->orWhereNull('status');
+                });
         }
 
         // Reuse the same filtering logic from the edit/history methods


### PR DESCRIPTION
Refactored filtering logic in EmployeeController and EmployerController to ensure that employees with 'registration_cancelled' status do not appear in the active employee lists or exports. This addresses the issue where cancelled registration workflows were incorrectly showing up as valid employees in the database view. Only finalized ('registration_completed') or standard employees (null status) are now shown.