### PR TITLE
Fix PDF generation crash by ensuring standard fonts exist

### DIFF
--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -74,6 +74,18 @@ class ProcessDownload implements ShouldQueue
                 if (!file_exists($fontPath)) {
                     mkdir($fontPath, 0755, true);
                 }
+
+                // Ensure standard fonts exist in the custom font path
+                // This prevents "No such file or directory" errors when FPDF tries to load core fonts
+                $standardFonts = ['helvetica.php', 'helveticab.php', 'helveticai.php', 'helveticabi.php', 'courier.php', 'times.php'];
+                $vendorFontPath = base_path('vendor/setasign/fpdf/font/');
+
+                foreach ($standardFonts as $fontFile) {
+                    if (!file_exists($fontPath . $fontFile) && file_exists($vendorFontPath . $fontFile)) {
+                        @copy($vendorFontPath . $fontFile, $fontPath . $fontFile);
+                    }
+                }
+
                 define('FPDF_FONTPATH', $fontPath);
             }
 

--- a/verify_fix.php
+++ b/verify_fix.php
@@ -1,0 +1,47 @@
+<?php
+require 'vendor/autoload.php';
+use setasign\Fpdi\Fpdi;
+
+// Simulate the logic in ProcessDownload
+$fontPath = __DIR__ . '/storage/fonts_test_fixed/';
+if (file_exists($fontPath)) {
+    // clean up first
+    $files = glob($fontPath . '/*');
+    foreach($files as $file) unlink($file);
+    rmdir($fontPath);
+}
+mkdir($fontPath, 0755, true);
+
+$standardFonts = ['helvetica.php', 'helveticab.php', 'helveticai.php', 'helveticabi.php', 'courier.php', 'times.php'];
+$vendorFontPath = __DIR__ . '/vendor/setasign/fpdf/font/';
+
+foreach ($standardFonts as $fontFile) {
+    if (!file_exists($fontPath . $fontFile) && file_exists($vendorFontPath . $fontFile)) {
+        echo "Copying $fontFile...\n";
+        copy($vendorFontPath . $fontFile, $fontPath . $fontFile);
+    }
+}
+
+// Define the constant to force FPDF to look here
+if (!defined('FPDF_FONTPATH')) {
+    define('FPDF_FONTPATH', $fontPath);
+}
+
+echo "Testing with fixed font directory: $fontPath\n";
+
+try {
+    $pdf = new Fpdi();
+    $pdf->AddPage();
+    // This maps to helveticab.php
+    $pdf->SetFont('Arial', 'B', 20);
+    $pdf->Cell(40, 10, 'Hello World!');
+    echo "Success! The fix works.\n";
+
+    // cleanup
+    $files = glob($fontPath . '/*');
+    foreach($files as $file) unlink($file);
+    rmdir($fontPath);
+
+} catch (Throwable $e) {
+    echo "FAILED: " . $e->getMessage() . "\n";
+}


### PR DESCRIPTION
This commit resolves an issue where the `ProcessDownload` job would crash with a "No such file or directory" error when attempting to generate PDFs. The root cause was `FPDF_FONTPATH` pointing to an empty directory (`storage/fonts/`), causing FPDF to fail when loading standard fonts (Helvetica, Times, Courier).

Changes:
- Modified `app/Jobs/ProcessDownload.php` to automatically copy standard font files from `vendor/setasign/fpdf/font/` to `storage/fonts/` if they are missing.
- This ensures that the PDF generation process can initialize correctly and proceed to merge employee documents and images.