### PR TITLE
Fix import session crash and enhance date parsing

### DIFF
--- a/app/Http/Controllers/ImportEmployeeController.php
+++ b/app/Http/Controllers/ImportEmployeeController.php
@@ -46,7 +46,13 @@ class ImportEmployeeController extends Controller
              }
         }
 
-        return view('employees.import', compact('employers', 'production'));
+        // Hydrate imported employees from session IDs if available (fix for max_packet crash)
+        $sessionImportedEmployees = collect();
+        if (session()->has('imported_employee_ids')) {
+            $sessionImportedEmployees = Employee::whereIn('id', session('imported_employee_ids'))->get();
+        }
+
+        return view('employees.import', compact('employers', 'production', 'sessionImportedEmployees'));
     }
 
     /**
@@ -590,7 +596,6 @@ class ImportEmployeeController extends Controller
 
             return back()->with('success', $msg)
                          ->with('import_errors', $errors)
-                         ->with('imported_employees', $importedEmployees)
                          ->with('imported_employee_ids', $importedEmployeeIds)
                          ->with('production_id', $productionId);
 
@@ -618,47 +623,46 @@ class ImportEmployeeController extends Controller
         }
 
         $value = trim((string)$value);
+        $day = null;
+        $month = null;
+        $year = null;
 
-        // 2. Strict D/M/Y Regex
-        // Supports 1/1/1999, 01/01/1999, 1-1-1999, 1.1.1999
+        // 2. Numeric Format: D/M/Y or D-M-Y or D.M.Y
         if (preg_match('/^(\d{1,2})[\/\-\.](\d{1,2})[\/\-\.](\d{4})$/', $value, $matches)) {
             $day = (int)$matches[1];
             $month = (int)$matches[2];
             $year = (int)$matches[3];
+        }
+        // 3. Text Month Format: D Mon Y (e.g., 1 Jan 1995, 14-Feb-2567)
+        elseif (preg_match('/^(\d{1,2})[\/\-\.\s]+([a-zA-Z]{3,})[\/\-\.\s]+(\d{4})$/', $value, $matches)) {
+            $day = (int)$matches[1];
+            $monthStr = strtolower($matches[2]);
+            $year = (int)$matches[3];
+
+            // Manual map to ensure accuracy and avoid Carbon guessing M/D vs D/M
+            $monthMap = [
+                'jan' => 1, 'feb' => 2, 'mar' => 3, 'apr' => 4, 'may' => 5, 'jun' => 6,
+                'jul' => 7, 'aug' => 8, 'sep' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
+            ];
+
+            // Check first 3 chars
+            $prefix = substr($monthStr, 0, 3);
+            if (isset($monthMap[$prefix])) {
+                $month = $monthMap[$prefix];
+            }
+        }
+
+        if ($day && $month && $year) {
+            // Smart Buddhist Year Conversion (if Year > 2400, assume BE and convert to CE)
+            if ($year > 2400) {
+                $year -= 543;
+            }
 
             if (checkdate($month, $day, $year)) {
                 return Carbon::create($year, $month, $day)->format('Y-m-d');
             }
         }
 
-        // 3. NEW: Handle English Month Formats (e.g., "1 jan 1995", "1 Jan 1995")
-        // Regex: Day (1-2 digits), Separator, Month (Text 3+ chars), Separator, Year (2 or 4 digits)
-        if (preg_match('/^(\d{1,2})[\/\-\.\s]+([a-zA-Z]{3,})[\/\-\.\s]+(\d{2,4})$/', $value, $matches)) {
-            try {
-                // Reconstruct to "Day Month Year" string for parsing
-                // Example: "1 jan 1995"
-                $day = $matches[1];
-                $monthStr = $matches[2];
-                $year = $matches[3];
-
-                $stringToParse = "$day $monthStr $year";
-
-                // Carbon parses standard formats like "1 jan 1995" very robustly
-                $date = Carbon::parse($stringToParse);
-
-                // Safety Check: Prevent logical overflows (e.g., "30 Feb" -> "2 Mar")
-                // We ensure the day we parsed matches the day in the input
-                if ($date->day !== (int)$day) {
-                    return null;
-                }
-
-                return $date->format('Y-m-d');
-            } catch (\Exception $e) {
-                // If parsing fails despite regex match, fall through to null
-            }
-        }
-
-        // 4. Reject other formats (Y-m-d, m/d/Y, etc.) as per user instruction
         return null;
     }
 

--- a/resources/views/employees/import.blade.php
+++ b/resources/views/employees/import.blade.php
@@ -117,9 +117,9 @@
 </div>
 
 {{-- Imported Employees Summary Modal --}}
-@if(session('imported_employees'))
+@if(isset($sessionImportedEmployees) && $sessionImportedEmployees->isNotEmpty())
 @php
-    $importedIds = session('imported_employee_ids', collect(session('imported_employees'))->pluck('id')->toArray());
+    $importedIds = $sessionImportedEmployees->pluck('id')->toArray();
 @endphp
 <div class="modal fade" id="importedEmployeesModal" tabindex="-1" aria-labelledby="importedEmployeesModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
     <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
@@ -132,7 +132,7 @@
             </div>
             <div class="modal-body">
                 <div class="alert alert-success">
-                    {{ __('Successfully imported') }} <strong>{{ count(session('imported_employees')) }}</strong> {{ __('employees.') }}
+                    {{ __('Successfully imported') }} <strong>{{ $sessionImportedEmployees->count() }}</strong> {{ __('employees.') }}
                     {{ __('Please review the list below. You can edit individual records or use Advanced Edit for bulk changes.') }}
                 </div>
 
@@ -161,7 +161,7 @@
                             </tr>
                         </thead>
                         <tbody id="import-table-body">
-                            @foreach(session('imported_employees') as $employee)
+                            @foreach($sessionImportedEmployees as $employee)
                                 @include('employees.partials._import_table_row', ['employee' => $employee])
                             @endforeach
                         </tbody>


### PR DESCRIPTION
- Modify ImportEmployeeController@store to flash only employee IDs to session instead of full objects, preventing 'max_allowed_packet' errors on large imports.
- Update ImportEmployeeController@index to re-hydrate employee models from session IDs.
- Update employees/import.blade.php to use the controller-passed employee collection.
- Enhance parseDateStrict to support 'Day Month Year' format with English month names (e.g., '1 Jan 1995').
- Add automatic Buddhist Era (BE) to Gregorian (CE) year conversion for years > 2400.