### PR TITLE
Fix incorrect document headers by enabling specific views

### DIFF
--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -126,12 +126,13 @@ class ProductionDocumentController extends Controller
 
         // Determine View
         $view = 'documents.generic'; // Default
-        if (in_array($type, ['tax_invoice', 'invoice', 'receipt', 'quotation'])) {
-            // Re-use tax_invoice template for most structured docs, or specific ones if they exist
-            // I'll update tax_invoice to be the master template
-            $view = 'documents.tax_invoice';
-        } elseif ($type === 'advance_receipt') {
-            $view = 'documents.advance_receipt';
+
+        // Check if a specific view exists for this type
+        if (view()->exists('documents.' . $type)) {
+            $view = 'documents.' . $type;
+        } elseif (in_array($type, ['tax_invoice', 'invoice', 'receipt', 'quotation'])) {
+             // Fallback to tax_invoice if specific file missing (legacy safety)
+             $view = 'documents.tax_invoice';
         }
 
         return view($view, $data);

--- a/resources/views/documents/credit_note.blade.php
+++ b/resources/views/documents/credit_note.blade.php
@@ -1,1 +1,6 @@
-@include('documents.layout', ['type' => 'Credit Note', 'title' => 'ใบลดหนี้ / Credit Note'])
+@include('documents.layout', [
+    'type' => $type ?? 'Credit Note',
+    'title' => $title ?? 'ใบลดหนี้ / Credit Note',
+    'mode' => $mode ?? 'combined',
+    'advanceItems' => $advanceItems ?? collect()
+])

--- a/resources/views/documents/invoice.blade.php
+++ b/resources/views/documents/invoice.blade.php
@@ -1,1 +1,6 @@
-@include('documents.layout', ['type' => 'Invoice', 'title' => 'ใบแจ้งหนี้ / Invoice'])
+@include('documents.layout', [
+    'type' => $type ?? 'Invoice',
+    'title' => $title ?? 'ใบแจ้งหนี้ / Invoice',
+    'mode' => $mode ?? 'combined',
+    'advanceItems' => $advanceItems ?? collect()
+])

--- a/resources/views/documents/quotation.blade.php
+++ b/resources/views/documents/quotation.blade.php
@@ -1,1 +1,6 @@
-@include('documents.layout', ['type' => 'Quotation', 'title' => 'ใบเสนอราคา / Quotation'])
+@include('documents.layout', [
+    'type' => $type ?? 'Quotation',
+    'title' => $title ?? 'ใบเสนอราคา / Quotation',
+    'mode' => $mode ?? 'combined',
+    'advanceItems' => $advanceItems ?? collect()
+])

--- a/resources/views/documents/receipt.blade.php
+++ b/resources/views/documents/receipt.blade.php
@@ -1,1 +1,6 @@
-@include('documents.layout', ['type' => 'Receipt', 'title' => 'ใบเสร็จรับเงิน / Receipt'])
+@include('documents.layout', [
+    'type' => $type ?? 'Receipt',
+    'title' => $title ?? 'ใบเสร็จรับเงิน / Receipt',
+    'mode' => $mode ?? 'combined',
+    'advanceItems' => $advanceItems ?? collect()
+])

--- a/resources/views/documents/tax_invoice.blade.php
+++ b/resources/views/documents/tax_invoice.blade.php
@@ -1,6 +1,6 @@
 @include('documents.layout', [
-    'type' => 'Tax Invoice',
-    'title' => 'ใบกำกับภาษี / Tax Invoice',
+    'type' => $type ?? 'Tax Invoice',
+    'title' => $title ?? 'ใบกำกับภาษี / Tax Invoice',
     'mode' => $mode ?? 'combined',
     'advanceItems' => $advanceItems ?? collect()
 ])


### PR DESCRIPTION
- Updated `ProductionDocumentController` to dynamically load specific views (quotation, invoice, receipt) based on the requested document type instead of forcing `tax_invoice`.
- Updated `quotation.blade.php`, `invoice.blade.php`, `receipt.blade.php`, and `credit_note.blade.php` to accept dynamic `title` and `type` variables and pass `mode` and `advanceItems` to the layout, ensuring feature parity with the tax invoice template.
- Updated `tax_invoice.blade.php` to use the dynamic title from the controller.

This change ensures that generating a Quotation correctly displays "Quotation" in the header, and likewise for Invoices and Receipts, fulfilling the requirement to separate document types correctly.