### PR TITLE
Fix RouteNotFoundException for production.renewal.create

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -243,6 +243,8 @@ Route::middleware(['auth'])->group(function () {
     // Renewal Resolution Routes (NEW)
     Route::prefix('production/renewal')->name('production.renewal.')->group(function () {
         Route::get('/', [App\Http\Controllers\Production\RenewalController::class, 'index'])->name('index');
+        Route::get('/create', [App\Http\Controllers\Production\RenewalController::class, 'create'])->name('create');
+        Route::post('/store', [App\Http\Controllers\Production\RenewalController::class, 'store'])->name('store');
         Route::get('/employer/{employer}/employees', [App\Http\Controllers\Production\RenewalController::class, 'fetchEmployees'])->name('employer.employees');
         Route::get('/import', [App\Http\Controllers\Production\RenewalController::class, 'importView'])->name('import');
         Route::post('/configure-expiry', [App\Http\Controllers\Production\RenewalController::class, 'configureExpiry'])->name('configure_expiry');


### PR DESCRIPTION
Added the missing `create` and `store` routes to the `production/renewal` route group in `routes/web.php`. This resolves the `RouteNotFoundException` encountered when accessing the Renewal Resolution page, which references `production.renewal.create` in its view.