### PR TITLE
Fix ParseError in employee create and import views

### DIFF
--- a/resources/views/employees/import.blade.php
+++ b/resources/views/employees/import.blade.php
@@ -118,6 +118,15 @@
                                     </div>
                                 </div>
 
+                                @php
+                                    $employerOptions = $employers->map(fn($e) => [
+                                        'id' => $e->id,
+                                        'name_th' => $e->employerNameTh,
+                                        'name_en' => $e->employerNameEn,
+                                        'search_str' => strtolower($e->employerNameTh . ' ' . $e->employerNameEn)
+                                    ]);
+                                @endphp
+
                                 <script>
                                     function importEmployerSelector() {
                                         return {
@@ -126,12 +135,7 @@
                                             selectedId: '{{ $selectedEmployerId }}',
                                             selectedName: '',
                                             touched: false,
-                                            employers: @json($employers->map(fn($e) => [
-                                                'id' => $e->id,
-                                                'name_th' => $e->employerNameTh,
-                                                'name_en' => $e->employerNameEn,
-                                                'search_str' => strtolower($e->employerNameTh . ' ' . $e->employerNameEn)
-                                            ])),
+                                            employers: @json($employerOptions),
 
                                             init() {
                                                 if (this.selectedId) {

--- a/resources/views/employees/partials/create_form_partial_content.blade.php
+++ b/resources/views/employees/partials/create_form_partial_content.blade.php
@@ -57,6 +57,14 @@
         </div>
     </div>
 
+    @php
+        $employerOptions = $employers->map(fn($e) => [
+            'id' => $e->id,
+            'name_th' => $e->employerNameTh,
+            'name_en' => $e->employerNameEn,
+            'search_str' => strtolower($e->employerNameTh . ' ' . $e->employerNameEn)
+        ]);
+    @endphp
     <script>
         function employerSelector() {
             return {
@@ -65,12 +73,7 @@
                 selectedId: '{{ old('employer_id') }}',
                 selectedName: '',
                 touched: false,
-                employers: @json($employers->map(fn($e) => [
-                    'id' => $e->id,
-                    'name_th' => $e->employerNameTh,
-                    'name_en' => $e->employerNameEn,
-                    'search_str' => strtolower($e->employerNameTh . ' ' . $e->employerNameEn)
-                ])),
+                employers: @json($employerOptions),
 
                 init() {
                     // Pre-select if old value exists


### PR DESCRIPTION
Refactored the Blade templates for employee creation and import to fix a `ParseError` caused by using complex closures inside the `@json` directive.
- Extracted the employer list mapping logic into a `@php` block.
- Passed the pre-calculated variable to the `@json` directive to ensure compatibility with the Blade parser.

This resolves the issue where the "Create Employee" and "Import Employee" pages were failing to load.