### PR TITLE
Fix missing import preview modal in Registration Resolution

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -489,10 +489,17 @@ class RegistrationController extends Controller
 
         session()->flash('finish_route', route('production.registration.index'));
 
+        // Hydrate imported employees from session IDs if available (Restoring Preview Feature)
+        $sessionImportedEmployees = collect();
+        if (session()->has('imported_employee_ids')) {
+            $sessionImportedEmployees = Employee::whereIn('id', session('imported_employee_ids'))->get();
+        }
+
         return view('employees.import', [
             'employers' => $employers,
             'production' => null,
             'back_route' => route('production.registration.index'),
+            'sessionImportedEmployees' => $sessionImportedEmployees,
         ]);
     }
 


### PR DESCRIPTION
The `importView` method in `RegistrationController` was failing to pass the `$sessionImportedEmployees` variable to the view, which prevented the post-import preview modal (containing verification and advanced edit features) from appearing.

This change adds logic to hydrate imported employees from the session IDs, mirroring the standard import controller's behavior, ensuring the modal is displayed correctly.