### PR TITLE
Fix PDF builder layout persistence and handle PDF parser crashes

### DIFF
--- a/app/Http/Controllers/Admin/PdfGenerationController.php
+++ b/app/Http/Controllers/Admin/PdfGenerationController.php
@@ -73,10 +73,14 @@ class PdfGenerationController extends Controller
         $employees = Employee::with('employer')->whereIn('id', $request->employees)->get();
         $template = PdfTemplate::findOrFail($request->template_id);
 
-        $results = $this->pdfService->generateForEmployees($template, $employees, [
-            'output_type' => $request->output_type,
-            'slot_name' => $request->slot_name ?? null,
-        ]);
+        try {
+            $results = $this->pdfService->generateForEmployees($template, $employees, [
+                'output_type' => $request->output_type,
+                'slot_name' => $request->slot_name ?? null,
+            ]);
+        } catch (\Exception $e) {
+            return redirect()->back()->with('danger', $e->getMessage());
+        }
 
         if ($request->output_type === 'save_to_slot') {
             return redirect()->route('employees.index')

--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -87,11 +87,11 @@ class PdfTemplateController extends Controller
         $this->authorize('edit-pdf-templates', $template);
 
         $request->validate([
-            'field_mapping' => 'required|array',
+            'field_mapping' => 'nullable|array',
         ]);
 
         $template->update([
-            'field_mapping' => $request->field_mapping,
+            'field_mapping' => $request->field_mapping ?? [],
         ]);
 
         return response()->json(['success' => true]);

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -55,8 +55,10 @@ class PdfGeneratorService
 
         try {
             $pageCount = $pdf->setSourceFile($templatePath);
+        } catch (\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException $e) {
+            throw new \Exception('This PDF file uses an unsupported compression format (likely PDF 1.5+). Please open the file in a PDF viewer, choose "Print to PDF", and try uploading the new file.');
         } catch (\Exception $e) {
-            throw $e;
+            throw new \Exception('Failed to process PDF template: ' . $e->getMessage());
         }
 
         // Font Handling

--- a/resources/views/pdf_templates/builder.blade.php
+++ b/resources/views/pdf_templates/builder.blade.php
@@ -293,6 +293,11 @@
             },
 
             async init() {
+                // Handle null or undefined items
+                if (!this.items) {
+                    this.items = [];
+                }
+
                 // Ensure page numbers are integers for correct comparison
                 // Also handle potential stringified JSON if DB returns string
                 if (typeof this.items === 'string') {
@@ -303,7 +308,11 @@
                     }
                 }
 
-                this.items = this.items.map(item => ({ ...item, page: parseInt(item.page) }));
+                // Defensive map: ensure item exists and has a page
+                this.items = this.items.map(item => ({
+                    ...item,
+                    page: item.page ? parseInt(item.page) : 1
+                }));
 
                 const url = '{{ route("admin.pdf-templates.file", $template) }}';
                 try {
@@ -487,22 +496,26 @@
             async saveMapping() {
                 this.isSaving = true;
                 try {
+                    // Ensure items is a clean array
+                    const itemsToSave = JSON.parse(JSON.stringify(this.items));
+
                     const response = await fetch('{{ route("admin.pdf-templates.update", $template) }}', {
                         method: 'PUT',
                         headers: {
                             'Content-Type': 'application/json',
                             'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
                         },
-                        body: JSON.stringify({ field_mapping: this.items })
+                        body: JSON.stringify({ field_mapping: itemsToSave })
                     });
 
                     if (response.ok) {
                         showToast('Template saved successfully!', 'success');
                     } else {
-                        throw new Error('Save failed');
+                        const errorData = await response.json();
+                        throw new Error(errorData.message || 'Save failed');
                     }
                 } catch (error) {
-                    showToast('Error saving template.', 'danger');
+                    showToast('Error saving template: ' + error.message, 'danger');
                     console.error(error);
                 } finally {
                     this.isSaving = false;


### PR DESCRIPTION
- Refactor `builder.blade.php` to robustly initialize items (default page to 1) and clean proxy objects before saving.
- Update `PdfTemplateController` validation to allow saving empty field mappings.
- Wrap `PdfGeneratorService` in try-catch to handle `CrossReferenceException` for compressed PDFs (PDF 1.5+) gracefully.
- Prevent 500 errors during generation by catching exceptions in `PdfGenerationController` and redirecting with a user-friendly error message.