### PR TITLE
feat: make total employees card clickable to reset filters

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -63,7 +63,7 @@
     <div class="row row-cols-1 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
         {{-- Total Employees --}}
         <div class="col">
-            <div class="card text-white h-100 shadow-sm" style="background-color: #FBBF24; border: none;"> {{-- Yellow-ish --}}
+            <div class="card text-white h-100 shadow-sm cursor-pointer" onclick="window.location.href = window.location.pathname;" style="background-color: #FBBF24; border: none;"> {{-- Yellow-ish --}}
                 <div class="card-body text-center d-flex flex-column justify-content-center py-4">
                     <h1 class="display-4 fw-bold mb-0" id="global-total-count">{{ $totalEmployees }}</h1>
                     <p class="fs-5 fw-light mb-0">{{ __('Total Employees') }}</p>

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -63,7 +63,7 @@
     <div class="row row-cols-1 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
         {{-- Total Employees --}}
         <div class="col">
-            <div class="card text-white h-100 shadow-sm" style="background-color: #FBBF24; border: none;"> {{-- Yellow-ish --}}
+            <div class="card text-white h-100 shadow-sm cursor-pointer" onclick="window.location.href = window.location.pathname;" style="background-color: #FBBF24; border: none;"> {{-- Yellow-ish --}}
                 <div class="card-body text-center d-flex flex-column justify-content-center py-4">
                     <h1 class="display-4 fw-bold mb-0" id="global-total-count">{{ $totalEmployees }}</h1>
                     <p class="fs-5 fw-light mb-0">{{ __('Total Employees') }}</p>


### PR DESCRIPTION
- Updated `resources/views/production/registration/index.blade.php` to add `cursor-pointer` and `onclick` event to the Total Employees card.
- Updated `resources/views/production/renewal/index.blade.php` to add `cursor-pointer` and `onclick` event to the Total Employees card.
- The `onclick` event redirects to `window.location.pathname`, effectively clearing all query parameters and resetting the view.