### PR TITLE
Fix inaccurate step counters in Renewal and Registration workflows

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -77,12 +77,12 @@ class RegistrationController extends Controller
                 }
 
                 // Not Started Logic
-                if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                if ($stepOneId && !$emp->registrationSteps->where('type', 'registration')->contains('id', $stepOneId)) {
                     $notStartedCount++;
                 }
 
                 // Step Stats (Highest Step)
-                $highestStep = $emp->registrationSteps->sortByDesc('order')->first();
+                $highestStep = $emp->registrationSteps->where('type', 'registration')->sortByDesc('order')->first();
                 if ($highestStep && isset($stepStats[$highestStep->id])) {
                     $stepStats[$highestStep->id]++;
                 }
@@ -188,11 +188,11 @@ class RegistrationController extends Controller
                     $empSavedCount++;
                 }
 
-                if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                if ($stepOneId && !$emp->registrationSteps->where('type', 'registration')->contains('id', $stepOneId)) {
                     $empNotStarted++;
                 }
 
-                $highestStep = $emp->registrationSteps->sortByDesc('order')->first();
+                $highestStep = $emp->registrationSteps->where('type', 'registration')->sortByDesc('order')->first();
                 if ($highestStep && isset($empStats[$highestStep->id])) {
                     $empStats[$highestStep->id]++;
                 }
@@ -280,7 +280,7 @@ class RegistrationController extends Controller
             $filterStepId = $request->filter;
             $employees = $employees->filter(function($emp) use ($filterStepId) {
                 if ($emp->status === 'registration_cancelled') return false;
-                $highest = $emp->registrationSteps->sortByDesc('order')->first();
+                $highest = $emp->registrationSteps->where('type', 'registration')->sortByDesc('order')->first();
                 return $highest && $highest->id == $filterStepId;
             });
         }
@@ -778,11 +778,11 @@ class RegistrationController extends Controller
 
             foreach ($allEmployees as $emp) {
                 // Count Not Started
-                if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                if ($stepOneId && !$emp->registrationSteps->where('type', 'registration')->contains('id', $stepOneId)) {
                     $globalNotStarted++;
                 }
 
-                $highest = $emp->registrationSteps->sortByDesc('order')->first();
+                $highest = $emp->registrationSteps->where('type', 'registration')->sortByDesc('order')->first();
                 if ($highest && isset($globalStats[$highest->id])) {
                     $globalStats[$highest->id]++;
                 }
@@ -816,11 +816,11 @@ class RegistrationController extends Controller
 
             foreach ($employerEmployees as $emp) {
                  // Count Not Started
-                 if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                 if ($stepOneId && !$emp->registrationSteps->where('type', 'registration')->contains('id', $stepOneId)) {
                      $employerNotStarted++;
                  }
 
-                 $highest = $emp->registrationSteps->sortByDesc('order')->first();
+                 $highest = $emp->registrationSteps->where('type', 'registration')->sortByDesc('order')->first();
                  if ($highest && isset($employerStats[$highest->id])) {
                      $employerStats[$highest->id]++;
                  }

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -66,12 +66,14 @@ class RenewalController extends Controller
                 }
 
                 // Not Started Logic
-                if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                // IMPORTANT: Filter by 'renewal' type steps
+                if ($stepOneId && !$emp->registrationSteps->where('type', 'renewal')->contains('id', $stepOneId)) {
                     $notStartedCount++;
                 }
 
                 // Step Stats (Highest Step)
-                $highestStep = $emp->registrationSteps->sortByDesc('order')->first();
+                // IMPORTANT: Filter by 'renewal' type steps
+                $highestStep = $emp->registrationSteps->where('type', 'renewal')->sortByDesc('order')->first();
                 if ($highestStep && isset($stepStats[$highestStep->id])) {
                     $stepStats[$highestStep->id]++;
                 }
@@ -161,11 +163,11 @@ class RenewalController extends Controller
                     $empSavedCount++;
                 }
 
-                if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                if ($stepOneId && !$emp->registrationSteps->where('type', 'renewal')->contains('id', $stepOneId)) {
                     $empNotStarted++;
                 }
 
-                $highestStep = $emp->registrationSteps->sortByDesc('order')->first();
+                $highestStep = $emp->registrationSteps->where('type', 'renewal')->sortByDesc('order')->first();
                 if ($highestStep && isset($empStats[$highestStep->id])) {
                     $empStats[$highestStep->id]++;
                 }
@@ -241,7 +243,7 @@ class RenewalController extends Controller
             $filterStepId = $request->filter;
             $employees = $employees->filter(function($emp) use ($filterStepId) {
                 if ($emp->status === 'renewal_cancelled') return false;
-                $highest = $emp->registrationSteps->sortByDesc('order')->first();
+                $highest = $emp->registrationSteps->where('type', 'renewal')->sortByDesc('order')->first();
                 return $highest && $highest->id == $filterStepId;
             });
         }
@@ -616,10 +618,10 @@ class RenewalController extends Controller
             $globalNotStarted = 0;
 
             foreach ($allEmployees as $emp) {
-                if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                if ($stepOneId && !$emp->registrationSteps->where('type', 'renewal')->contains('id', $stepOneId)) {
                     $globalNotStarted++;
                 }
-                $highest = $emp->registrationSteps->sortByDesc('order')->first();
+                $highest = $emp->registrationSteps->where('type', 'renewal')->sortByDesc('order')->first();
                 if ($highest && isset($globalStats[$highest->id])) {
                     $globalStats[$highest->id]++;
                 }
@@ -645,10 +647,10 @@ class RenewalController extends Controller
             $employerNotStarted = 0;
 
             foreach ($employerEmployees as $emp) {
-                 if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                 if ($stepOneId && !$emp->registrationSteps->where('type', 'renewal')->contains('id', $stepOneId)) {
                      $employerNotStarted++;
                  }
-                 $highest = $emp->registrationSteps->sortByDesc('order')->first();
+                 $highest = $emp->registrationSteps->where('type', 'renewal')->sortByDesc('order')->first();
                  if ($highest && isset($employerStats[$highest->id])) {
                      $employerStats[$highest->id]++;
                  }

--- a/mock_renewal_dashboard.html
+++ b/mock_renewal_dashboard.html
@@ -1,0 +1,117 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Renewal Resolution</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+    <style>
+        .filter-active { border: 2px solid #3b82f6 !important; }
+        .grayscale-mode { filter: grayscale(100%); opacity: 0.8; }
+        .employee-sequence-number::before { content: counter(employee-counter); }
+        .employee-list { counter-reset: employee-counter; }
+        .employee-card-wrapper { counter-increment: employee-counter; }
+    </style>
+</head>
+<body class="bg-light">
+<div class="container-fluid p-4">
+    <!-- Top Stats -->
+    <div class="row row-cols-1 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
+        <div class="col"><div class="card text-white h-100 shadow-sm" style="background-color: #FBBF24;"><div class="card-body text-center py-4"><h1 class="display-4 fw-bold">10</h1><p class="fs-5">Total Employees</p></div></div></div>
+        <div class="col"><div class="card text-white h-100 shadow-sm" style="background-color: #EF4444;"><div class="card-body text-center py-4"><h1 class="display-4 fw-bold">5</h1><p class="fs-5">Not Started</p></div></div></div>
+        <div class="col"><div class="card text-white h-100 shadow-sm" style="background-color: #6B7280;"><div class="card-body text-center py-4"><h1 class="display-4 fw-bold">0</h1><p class="fs-5">Total Cancelled</p></div></div></div>
+        <div class="col"><div class="card text-white h-100 shadow-sm" style="background-color: #10B981;"><div class="card-body text-center py-4"><h1 class="display-4 fw-bold">2</h1><p class="fs-5">Saved to Database</p></div></div></div>
+        <div class="col"><div class="card bg-dark text-white h-100 shadow-sm"><div class="card-body text-center py-4"><h1 class="display-4 fw-bold">3</h1><p class="fs-5">Total Employers</p></div></div></div>
+    </div>
+
+    <!-- Workflow Progress -->
+    <div class="card shadow-sm border-0 mb-4">
+        <div class="card-body p-4">
+            <h5 class="card-title fw-bold text-secondary mb-3">Workflow Progress (Global)</h5>
+            <div class="d-flex gap-2">
+                <div class="d-inline-flex align-items-center bg-white border rounded-pill py-2 px-3 shadow-sm gap-2">
+                    <span class="badge rounded-circle fs-6 p-2 bg-success" style="width: 32px; height: 32px;">3</span>
+                    <span class="fw-bold">Step 1: Check Docs</span>
+                </div>
+                <div class="d-inline-flex align-items-center bg-white border rounded-pill py-2 px-3 shadow-sm gap-2">
+                    <span class="badge rounded-circle fs-6 p-2 bg-secondary bg-opacity-50 text-white" style="width: 32px; height: 32px;">0</span>
+                    <span class="fw-bold">Step 2: Submit</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Employee List (Mocking the Accordion Content) -->
+    <div class="card border-primary border-2 shadow-sm mb-4">
+        <div class="card-header bg-white py-3 px-4">
+            <h4 class="fw-bold mb-0 text-primary">Mock Employer Co., Ltd.</h4>
+        </div>
+        <div class="card-body bg-light p-4">
+            <div class="employee-list">
+
+                <!-- Card 1: Not Started (Simulating filtered logic) -->
+                <!-- Because our backend fix filters out old steps, this employee has NO renewal steps completed. -->
+                <div class="d-flex align-items-center mb-3 employee-card-wrapper">
+                    <div class="employee-sequence-number me-2 fs-5 fw-bold text-muted opacity-50 text-end" style="min-width: 30px;">1</div>
+                    <div class="card bg-white border shadow-sm w-100">
+                        <div class="card-body p-3">
+                            <div class="d-flex justify-content-between align-items-start gap-3">
+                                <div class="d-flex align-items-center gap-3">
+                                    <div class="rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center shadow-sm" style="width: 50px; height: 50px;">A</div>
+                                    <div>
+                                        <div class="fw-bold">Mr. Arthur Dent</div>
+                                        <div class="text-muted small">ID: 123456</div>
+                                    </div>
+                                </div>
+                                <span class="badge bg-secondary">Pending</span>
+                            </div>
+
+                            <!-- Steps Container -->
+                            <div class="mt-3">
+                                <div class="d-flex gap-2">
+                                    <!-- Both steps gray because user has not started RENEWAL (even if they did Registration before) -->
+                                    <button class="btn btn-sm btn-light border text-secondary rounded-pill px-3">Step 1: Check Docs</button>
+                                    <button class="btn btn-sm btn-light border text-secondary rounded-pill px-3">Step 2: Submit</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Card 2: In Progress -->
+                <div class="d-flex align-items-center mb-3 employee-card-wrapper">
+                    <div class="employee-sequence-number me-2 fs-5 fw-bold text-muted opacity-50 text-end" style="min-width: 30px;">2</div>
+                    <div class="card bg-white border shadow-sm w-100">
+                        <div class="card-body p-3">
+                            <div class="d-flex justify-content-between align-items-start gap-3">
+                                <div class="d-flex align-items-center gap-3">
+                                    <div class="rounded-circle bg-primary text-white d-flex align-items-center justify-content-center shadow-sm" style="width: 50px; height: 50px;">F</div>
+                                    <div>
+                                        <div class="fw-bold">Ms. Ford Prefect</div>
+                                        <div class="text-muted small">ID: 987654</div>
+                                    </div>
+                                </div>
+                                <span class="badge bg-primary">Active</span>
+                            </div>
+
+                            <!-- Steps Container -->
+                            <div class="mt-3">
+                                <div class="d-flex gap-2">
+                                    <!-- Step 1 Completed -->
+                                    <button class="btn btn-sm btn-success text-white rounded-pill px-3">Step 1: Check Docs <i class="bi bi-check-circle-fill ms-1"></i></button>
+                                    <!-- Step 2 Incomplete -->
+                                    <button class="btn btn-sm btn-light border text-secondary rounded-pill px-3">Step 2: Submit</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -18,7 +18,9 @@
     }
 
     // Determine Highest Completed Step for Filtering
-    $highestStep = $employee->registrationSteps->sortByDesc('order')->first();
+    // Filter steps to only include those relevant to the current view (passed via $steps)
+    $validStepIds = $steps->pluck('id');
+    $highestStep = $employee->registrationSteps->whereIn('id', $validStepIds)->sortByDesc('order')->first();
     $highestStepId = $highestStep ? $highestStep->id : '';
     // Determine if "Not Started" (only if active status and no steps)
     $isNotStarted = (!$isCompleted && !$isCancelled && !$highestStep);


### PR DESCRIPTION
- Modify `RenewalController` to filter employee steps by 'renewal' type when calculating stats and progress.
- Modify `RegistrationController` to filter employee steps by 'registration' type for robustness.
- Update `_employee_card.blade.php` to calculate the highest step based only on steps relevant to the current view context.
- Ensure 'Not Started' and step-specific counters accurately reflect the specific workflow state.