### PR TITLE
Fix PDF generation route error and implement slot-based saving

### DIFF
--- a/app/Http/Controllers/Admin/PdfGenerationController.php
+++ b/app/Http/Controllers/Admin/PdfGenerationController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use ZipArchive;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class PdfGenerationController extends Controller
 {
@@ -47,9 +48,8 @@ class PdfGenerationController extends Controller
         }
         $templates = $query->latest()->get();
 
-        // Fetch existing slot names for autocomplete
-        // We can look at EmployeeGeneratedDocument for distinct names
-        $existingSlots = \App\Models\EmployeeGeneratedDocument::distinct()->pluck('document_name');
+        // existingSlots no longer needed with hardcoded select
+        $existingSlots = [];
 
         return view('pdf_templates.generate_modal', [
             'employees' => $employeeIds,
@@ -74,45 +74,102 @@ class PdfGenerationController extends Controller
         $template = PdfTemplate::findOrFail($request->template_id);
 
         try {
+            // Generate content only (don't save via service)
             $results = $this->pdfService->generateForEmployees($template, $employees, [
-                'output_type' => $request->output_type,
-                'slot_name' => $request->slot_name ?? null,
+                'output_type' => 'raw_content', // Change to get raw content
             ]);
+
+            if ($request->output_type === 'save_to_slot') {
+                $count = 0;
+                $slotName = $request->slot_name;
+
+                foreach ($results as $result) {
+                    $employee = Employee::find($result['employee_id']);
+                    if (!$employee) continue;
+
+                    // Determine target model and file path
+                    if (str_starts_with($slotName, 'employee_doc_')) {
+                        // Save to Employee
+                        $filename = 'employee_files/' . $employee->id . '/' . $slotName . '_' . time() . '.pdf';
+                        Storage::disk('public')->put($filename, $result['content']);
+
+                        // Update Employee Record
+                        $employee->update([
+                            $slotName => $filename,
+                        ]);
+
+                        // Try to update description if possible (e.g. employee_doc_1 -> other_doc_1_desc)
+                        if (preg_match('/employee_doc_(\d+)/', $slotName, $matches)) {
+                            $index = $matches[1];
+                            // Check if description column exists (1-10)
+                            if ($index >= 1 && $index <= 10) {
+                                $descCol = "other_doc_{$index}_desc";
+                                $employee->update([
+                                    $descCol => "Auto-generated: " . $template->name
+                                ]);
+                            }
+                        }
+
+                        $count++;
+
+                    } elseif (str_starts_with($slotName, 'employer_doc_other_')) {
+                        // Save to Employer
+                        if ($employee->employer) {
+                            $employer = $employee->employer;
+                            $filename = 'employer_documents/' . $employer->id . '/' . $slotName . '_' . $employee->id . '_' . time() . '.pdf';
+                            Storage::disk('public')->put($filename, $result['content']);
+
+                            $employer->update([
+                                $slotName => $filename,
+                            ]);
+                             // Try to update description
+                             if (preg_match('/employer_doc_other_(\d+)/', $slotName, $matches)) {
+                                $index = $matches[1];
+                                $descCol = "employer_doc_other_{$index}_desc";
+                                $employer->update([
+                                    $descCol => "Auto-generated for " . $employee->employeeNameEn . ": " . $template->name
+                                ]);
+                            }
+                            $count++;
+                        }
+                    }
+                }
+
+                return redirect()->route('employees.index')
+                    ->with('success', 'Documents generated and saved for ' . $count . ' employees.');
+
+            } else {
+                // Handle Download
+                if (count($results) === 1) {
+                    // Single File
+                    $file = $results[0];
+                    return response($file['content'])
+                        ->header('Content-Type', 'application/pdf')
+                        ->header('Content-Disposition', 'attachment; filename="' . $file['filename'] . '"');
+                } else {
+                    // Zip Multiple Files
+                    $zipName = 'generated_docs_' . time() . '.zip';
+                    $zipPath = storage_path('app/public/temp/' . $zipName);
+
+                    // Ensure temp dir exists
+                    if (!file_exists(dirname($zipPath))) {
+                        mkdir(dirname($zipPath), 0755, true);
+                    }
+
+                    $zip = new ZipArchive;
+                    if ($zip->open($zipPath, ZipArchive::CREATE) === TRUE) {
+                        foreach ($results as $file) {
+                            $zip->addFromString($file['filename'], $file['content']);
+                        }
+                        $zip->close();
+                    }
+
+                    return response()->download($zipPath)->deleteFileAfterSend(true);
+                }
+            }
+
         } catch (\Exception $e) {
             return redirect()->back()->with('danger', $e->getMessage());
-        }
-
-        if ($request->output_type === 'save_to_slot') {
-            return redirect()->route('employees.index')
-                ->with('success', 'Documents generated and saved to ' . count($results) . ' employees.');
-        } else {
-            // Handle Download
-            if (count($results) === 1) {
-                // Single File
-                $file = $results[0];
-                return response($file['content'])
-                    ->header('Content-Type', 'application/pdf')
-                    ->header('Content-Disposition', 'attachment; filename="' . $file['filename'] . '"');
-            } else {
-                // Zip Multiple Files
-                $zipName = 'generated_docs_' . time() . '.zip';
-                $zipPath = storage_path('app/public/temp/' . $zipName);
-
-                // Ensure temp dir exists
-                if (!file_exists(dirname($zipPath))) {
-                    mkdir(dirname($zipPath), 0755, true);
-                }
-
-                $zip = new ZipArchive;
-                if ($zip->open($zipPath, ZipArchive::CREATE) === TRUE) {
-                    foreach ($results as $file) {
-                        $zip->addFromString($file['filename'], $file['content']);
-                    }
-                    $zip->close();
-                }
-
-                return response()->download($zipPath)->deleteFileAfterSend(true);
-            }
         }
     }
 }

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -25,7 +25,7 @@ class PdfGeneratorService
 
     public function generateForEmployees(PdfTemplate $template, Collection $employees, $options = [])
     {
-        // Options: 'output_type' => 'download' | 'save_to_slot'
+        // Options: 'output_type' => 'download' | 'save_to_slot' | 'raw_content'
         //          'slot_name' => string (required if save_to_slot)
 
         $outputType = $options['output_type'] ?? 'download';
@@ -33,12 +33,20 @@ class PdfGeneratorService
 
         foreach ($employees as $employee) {
             $pdfContent = $this->generateSinglePdf($template, $employee);
+            $filename = $this->generateFilename($template, $employee);
 
             if ($outputType === 'save_to_slot') {
+                // Legacy support (though controller now handles saving directly)
                 $this->saveToSlot($employee, $pdfContent, $options['slot_name']);
                 $results[] = ['employee' => $employee->id, 'status' => 'saved'];
+            } elseif ($outputType === 'raw_content') {
+                $results[] = [
+                    'employee_id' => $employee->id,
+                    'filename' => $filename,
+                    'content' => $pdfContent
+                ];
             } else {
-                $filename = $this->generateFilename($template, $employee);
+                // Download
                 $results[] = ['filename' => $filename, 'content' => $pdfContent];
             }
         }
@@ -207,12 +215,11 @@ class PdfGeneratorService
 
     protected function saveToSlot(Employee $employee, $content, $slotName)
     {
+        // This is kept for legacy compatibility but is largely bypassed by 'raw_content' option
         $filename = 'generated/' . $employee->id . '/' . Str::slug($slotName) . '_' . time() . '.pdf';
 
         Storage::disk('public')->put($filename, $content);
 
-        // Ensure we check if relation exists or model exists
-        // Assuming EmployeeGeneratedDocument model exists based on trace
         $doc = \App\Models\EmployeeGeneratedDocument::updateOrCreate(
             [
                 'employee_id' => $employee->id,

--- a/resources/views/pdf_templates/generate_modal.blade.php
+++ b/resources/views/pdf_templates/generate_modal.blade.php
@@ -58,23 +58,25 @@
 
                         <!-- Slot Name Configuration -->
                         <div class="mb-4 p-3 bg-light rounded border" x-show="outputType === 'save_to_slot'" x-transition>
-                            <label class="form-label fw-bold">Slot Name</label>
+                            <label class="form-label fw-bold">Select Attachment Slot</label>
                             <p class="text-sm text-gray-500 mb-2">
-                                Enter a name for this document slot (e.g., "Work Permit 2024").
-                                If a slot with this name exists, it will be overwritten.
+                                Choose where to attach this document on the record.
+                                Note: This will overwrite any existing file in the selected slot.
                             </p>
 
-                            <!-- Autocomplete / Suggestions could go here -->
-                            <input type="text" name="slot_name" class="form-control"
-                                   :required="outputType === 'save_to_slot'"
-                                   placeholder="e.g. Visa Application Form"
-                                   list="slotSuggestions">
-
-                            <datalist id="slotSuggestions">
-                                @foreach($existingSlots as $slot)
-                                    <option value="{{ $slot }}">
-                                @endforeach
-                            </datalist>
+                            <select name="slot_name" class="form-select" :required="outputType === 'save_to_slot'">
+                                <option value="">-- Select Slot --</option>
+                                <optgroup label="Employee Documents">
+                                    @for($i = 1; $i <= 10; $i++)
+                                        <option value="employee_doc_{{ $i }}">Employee Other Document {{ $i }}</option>
+                                    @endfor
+                                </optgroup>
+                                <optgroup label="Employer Documents">
+                                    @for($i = 1; $i <= 3; $i++)
+                                        <option value="employer_doc_other_{{ $i }}">Employer Other Document {{ $i }}</option>
+                                    @endfor
+                                </optgroup>
+                            </select>
                         </div>
 
                         <div class="d-flex justify-content-end gap-2 pt-3 border-top">

--- a/routes/web.php
+++ b/routes/web.php
@@ -169,11 +169,14 @@ Route::middleware(['auth', 'permission:manage-tickets'])->prefix('admin')->name(
 
     // PDF Generation
     Route::post('pdf-templates/generate', [\App\Http\Controllers\Admin\PdfGenerationController::class, 'showGenerateModal'])->name('pdf-templates.generate.modal');
+    Route::get('pdf-templates/generate', function () {
+        return redirect()->route('employees.index')->with('error', 'Please select employees to generate PDF.');
+    });
     Route::post('pdf-templates/generate/process', [\App\Http\Controllers\Admin\PdfGenerationController::class, 'process'])->name('pdf-templates.generate.process');
 
     // PDF Templates
     Route::get('pdf-templates/{pdf_template}/file', [\App\Http\Controllers\Admin\PdfTemplateController::class, 'file'])->name('pdf-templates.file');
-    Route::resource('pdf-templates', \App\Http\Controllers\Admin\PdfTemplateController::class);
+    Route::resource('pdf-templates', \App\Http\Controllers\Admin\PdfTemplateController::class)->except(['show']);
     Route::get('pdf-templates/{pdf_template}/builder', [\App\Http\Controllers\Admin\PdfTemplateController::class, 'builder'])->name('pdf-templates.builder');
 
     Route::post('tickets/{ticket}/resolve', [TicketStatusController::class, 'resolve'])->name('tickets.resolve');


### PR DESCRIPTION
- Fix BadMethodCallException by excluding 'show' from pdf-templates resource and adding a fallback GET route.
- Update PDF generation modal to use a structured select dropdown for Employee (1-10) and Employer (1-3) document slots.
- Refactor PdfGenerationController to save generated PDFs directly to the selected `employee_doc_X` or `employer_doc_other_X` columns on the models.
- Update PdfGeneratorService to support returning raw content for controller-level handling.