### PR TITLE
Append employee ID to bulk download filenames

### DIFF
--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -146,10 +146,10 @@ class ProcessDownload implements ShouldQueue
                 $prefix = !empty($employee->employeeTitleEn) ? $employee->employeeTitleEn . ' ' : '';
                 $rawName = $prefix . $employee->employeeNameEn;
             } else {
-                $rawName = $employee->employeeNameTh ?? 'Employee_' . $employee->id;
+                $rawName = $employee->employeeNameTh ?? 'Employee';
             }
 
-            $safeName = $this->sanitizeFileName($rawName);
+            $safeName = $this->sanitizeFileName($rawName) . '_' . $employee->id;
 
             // If singleFolder is true, we use an empty folder name (root),
             // but we might want to prefix the file with the employee name to avoid collisions.


### PR DESCRIPTION
- Updates `app/Jobs/ProcessDownload.php` to append the Employee ID to the generated folder/filename prefix in bulk ZIP downloads.
- Resolves issue where employees with identical names caused file overwrites.
- Standardizes fallback naming logic.