### PR TITLE
Fix: Redirect to employee index after PDF generation attempt

### DIFF
--- a/app/Http/Controllers/Admin/PdfGenerationController.php
+++ b/app/Http/Controllers/Admin/PdfGenerationController.php
@@ -149,7 +149,7 @@ class PdfGenerationController extends Controller
                 }
 
                 if ($count === 0) {
-                     return redirect()->back()->with('warning', 'No documents were saved. Please check if the selected slot matches the target (Employee vs Employer).');
+                     return redirect()->route('employees.index')->with('warning', 'No documents were saved. Please check if the selected slot matches the target (Employee vs Employer).');
                 }
 
                 return redirect()->route('employees.index')
@@ -193,7 +193,7 @@ class PdfGenerationController extends Controller
             }
 
         } catch (\Throwable $e) {
-            return redirect()->back()->with('danger', 'Error generating documents: ' . $e->getMessage());
+            return redirect()->route('employees.index')->with('danger', 'Error generating documents: ' . $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
- Replaced `redirect()->back()` with `redirect()->route('employees.index')` in `PdfGenerationController`.
- This prevents a redirect loop or fallback to a generic error message when an error occurs during the POST request.
- Ensures that the actual error message (e.g., missing extension, validation failure) is displayed to the user.