### PR TITLE
feat: implement auto-scaling text for employee card fields

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -118,6 +118,31 @@
                 nameList: '{{ $employee->name_list_number }}',
                 reqNo: '{{ $employee->request_number }}',
                 refId: '{{ $employee->employee_reference_id }}',
+                fitText(el) {
+                    if (!el) return;
+                    el.style.fontSize = '';
+                    this.$nextTick(() => {
+                        if (el.offsetParent === null) return;
+                        if (el.scrollWidth > el.clientWidth) {
+                             let size = 87.5;
+                             while (el.scrollWidth > el.clientWidth && size > 50) {
+                                 size -= 5;
+                                 el.style.fontSize = size + '%';
+                             }
+                        }
+                    });
+                },
+                init() {
+                    this.$watch('isEditing', value => {
+                        if (!value) {
+                            this.$nextTick(() => {
+                                this.fitText(this.$refs.raDisplay);
+                                this.fitText(this.$refs.reqDisplay);
+                                this.fitText(this.$refs.refDisplay);
+                            });
+                        }
+                    });
+                },
                 saveFields() {
                     let formData = new FormData();
                     formData.append('name_list_number', this.nameList);
@@ -157,19 +182,19 @@
                     {{-- Field 1: Name List (Renamed to RA) --}}
                     <div style="width: 140px;">
                         <small class="text-muted d-block" style="font-size: 0.7rem;">เลข RA จากระบบ outsource</small>
-                        <div x-show="!isEditing" class="small text-dark border rounded px-2 py-1 bg-light text-break" style="min-height: 31px;" x-text="nameList || '-'"></div>
+                        <div x-show="!isEditing" x-ref="raDisplay" x-init="fitText($el)" class="small text-dark border rounded px-2 py-1 bg-light text-nowrap overflow-hidden" style="min-height: 31px;" x-text="nameList || '-'"></div>
                         <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="nameList" placeholder="RA No.">
                     </div>
                     {{-- Field 2: Request No --}}
                     <div style="width: 140px;">
                         <small class="text-muted d-block" style="font-size: 0.7rem;">เลขที่คำขอ</small>
-                        <div x-show="!isEditing" class="small text-dark border rounded px-2 py-1 bg-light text-break" style="min-height: 31px;" x-text="reqNo || '-'"></div>
+                        <div x-show="!isEditing" x-ref="reqDisplay" x-init="fitText($el)" class="small text-dark border rounded px-2 py-1 bg-light text-nowrap overflow-hidden" style="min-height: 31px;" x-text="reqNo || '-'"></div>
                         <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="reqNo" placeholder="Request No.">
                     </div>
                     {{-- Field 3: Ref ID --}}
                     <div style="width: 140px;">
                         <small class="text-muted d-block" style="font-size: 0.7rem;">เลขอ้างอิงคนงาน</small>
-                        <div x-show="!isEditing" class="small text-dark border rounded px-2 py-1 bg-light text-break" style="min-height: 31px;" x-text="refId || '-'"></div>
+                        <div x-show="!isEditing" x-ref="refDisplay" x-init="fitText($el)" class="small text-dark border rounded px-2 py-1 bg-light text-nowrap overflow-hidden" style="min-height: 31px;" x-text="refId || '-'"></div>
                         <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="refId" placeholder="Ref ID">
                     </div>
                 </div>


### PR DESCRIPTION
- Implement `fitText` Alpine.js helper to dynamically reduce font size for long text strings in employee card display fields.
- Update "RA Number", "Request Number", and "Reference ID" fields to use `text-nowrap` and `fitText`.
- Ensure text remains on a single line and is copyable, while shrinking to fit the container width.
- Add watcher to re-apply scaling after editing fields.