### PR TITLE
Fix: Add automatic PDF normalization fallback for unsupported compres…

### DIFF
--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -15,6 +15,7 @@ class PdfGeneratorService
 {
     protected $fontPath;
     protected $signatureService;
+    protected $tempFiles = [];
 
     public function __construct(SignatureGeneratorService $signatureService)
     {
@@ -69,14 +70,6 @@ class PdfGeneratorService
         // Load the template file
         $templatePath = Storage::disk('public')->path($template->file_path);
 
-        try {
-            $pageCount = $pdf->setSourceFile($templatePath);
-        } catch (\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException $e) {
-            throw new \Exception('This PDF file uses an unsupported compression format (likely PDF 1.5+). Please open the file in a PDF viewer, choose "Print to PDF", and try uploading the new file.');
-        } catch (\Exception $e) {
-            throw new \Exception('Failed to process PDF template: ' . $e->getMessage());
-        }
-
         // Font Handling
         $fontLoaded = false;
         if (file_exists($this->fontPath)) {
@@ -87,22 +80,39 @@ class PdfGeneratorService
              $pdf->SetFont('Arial', '', 12);
         }
 
-        // Generate Signatures for this session (Consistent per person)
-        $employeeSignature = $this->signatureService->generate('EMP-' . $employee->id);
-
-        // Employer Signature: Use Employer ID.
-        // Note: In real app, we might check if employer has a REAL uploaded signature first.
-        // For now, we generate one procedurally for consistency.
-        $employerSignature = $this->signatureService->generate('EMPR-' . $employee->employer_id);
-
-        // Save temp files for FPDF to read
-        $tempEmpSigPath = tempnam(sys_get_temp_dir(), 'sig_emp_');
-        file_put_contents($tempEmpSigPath, $employeeSignature);
-
-        $tempEmprSigPath = tempnam(sys_get_temp_dir(), 'sig_empr_');
-        file_put_contents($tempEmprSigPath, $employerSignature);
-
         try {
+            try {
+                $pageCount = $pdf->setSourceFile($templatePath);
+            } catch (\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException $e) {
+                // Try to normalize the PDF using Python script
+                $normalizedPath = $this->tryNormalizePdf($templatePath);
+                if ($normalizedPath) {
+                    try {
+                        $pageCount = $pdf->setSourceFile($normalizedPath);
+                        $this->tempFiles[] = $normalizedPath; // Mark for deletion
+                    } catch (\Exception $ex) {
+                        throw new \Exception('Automatic PDF repair failed. Please use "Print to PDF". Original error: ' . $e->getMessage());
+                    }
+                } else {
+                    throw new \Exception('This PDF file uses an unsupported compression format (likely PDF 1.5+). Please open the file in a PDF viewer, choose "Print to PDF", and try uploading the new file.');
+                }
+            } catch (\Exception $e) {
+                throw new \Exception('Failed to process PDF template: ' . $e->getMessage());
+            }
+
+            // Generate Signatures for this session (Consistent per person)
+            $employeeSignature = $this->signatureService->generate('EMP-' . $employee->id);
+
+            // Employer Signature: Use Employer ID.
+            $employerSignature = $this->signatureService->generate('EMPR-' . $employee->employer_id);
+
+            // Save temp files for FPDF to read
+            $tempEmpSigPath = tempnam(sys_get_temp_dir(), 'sig_emp_');
+            file_put_contents($tempEmpSigPath, $employeeSignature);
+
+            $tempEmprSigPath = tempnam(sys_get_temp_dir(), 'sig_empr_');
+            file_put_contents($tempEmprSigPath, $employerSignature);
+
             // Iterate Pages
             for ($pageNo = 1; $pageNo <= $pageCount; $pageNo++) {
                 $templateId = $pdf->importPage($pageNo);
@@ -160,13 +170,45 @@ class PdfGeneratorService
                     }
                 }
             }
+
+            // Output PDF content
+            $content = $pdf->Output('S');
+
         } finally {
-            // Cleanup temp files
-            if (file_exists($tempEmpSigPath)) unlink($tempEmpSigPath);
-            if (file_exists($tempEmprSigPath)) unlink($tempEmprSigPath);
+            // Cleanup temp files (Signatures)
+            if (isset($tempEmpSigPath) && file_exists($tempEmpSigPath)) @unlink($tempEmpSigPath);
+            if (isset($tempEmprSigPath) && file_exists($tempEmprSigPath)) @unlink($tempEmprSigPath);
+
+            // Cleanup normalized PDF files
+            foreach ($this->tempFiles as $tempFile) {
+                if (file_exists($tempFile)) @unlink($tempFile);
+            }
+            $this->tempFiles = []; // Reset for next call
         }
 
-        return $pdf->Output('S');
+        return $content;
+    }
+
+    protected function tryNormalizePdf($inputPath)
+    {
+        $outputPath = tempnam(sys_get_temp_dir(), 'norm_') . '.pdf';
+        $scriptPath = base_path('scripts/normalize_pdf.py');
+
+        // Check if script exists
+        if (!file_exists($scriptPath)) {
+            return false;
+        }
+
+        // Construct command
+        $cmd = "python3 " . escapeshellarg($scriptPath) . " " . escapeshellarg($inputPath) . " " . escapeshellarg($outputPath) . " 2>&1";
+
+        exec($cmd, $output, $returnVar);
+
+        if ($returnVar === 0 && file_exists($outputPath) && filesize($outputPath) > 0) {
+            return $outputPath;
+        }
+
+        return false;
     }
 
     protected function resolveValue(Employee $employee, $key)

--- a/scripts/normalize_pdf.py
+++ b/scripts/normalize_pdf.py
@@ -1,0 +1,34 @@
+import sys
+import os
+from pypdf import PdfReader, PdfWriter
+
+def normalize(input_path, output_path):
+    try:
+        reader = PdfReader(input_path)
+        writer = PdfWriter()
+
+        for page in reader.pages:
+            writer.add_page(page)
+
+        # Write the normalized PDF
+        with open(output_path, "wb") as f:
+            writer.write(f)
+
+        # Verify file creation
+        if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+            print("Success")
+            sys.exit(0)
+        else:
+            print("Error: Output file not created or empty")
+            sys.exit(1)
+
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python normalize_pdf.py <input> <output>")
+        sys.exit(1)
+
+    normalize(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
…sion formats

- Added `scripts/normalize_pdf.py` to convert PDF 1.5+ files using `pypdf`.
- Updated `PdfGeneratorService` to catch `CrossReferenceException`.
- Implemented `tryNormalizePdf` method to invoke the Python script as a fallback.
- Added `try...finally` block to ensure temporary files are cleaned up.