### PR TITLE
Fix migration error by referencing correct column insurance_document_…

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -815,7 +815,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
             'medical_certificate_path',
             // Legacy fields
             'passport_file_path', 'visa_file_path', 'work_permit_file_path',
-            'pink_card_file_path', 'insurance_attachment_path'
+            'pink_card_file_path'
         ];
 
         if (!in_array($field, $allowedFields)) {
@@ -864,9 +864,10 @@ public function create(Request $request) // เพิ่ม Request $request เ
             'employee_doc_17', 'employee_doc_18',
             'insurance_document_path_private',
             'medical_certificate_path',
+            'insurance_document_path',
             // Keep old fields for backward compatibility if needed
             'passport_file_path', 'visa_file_path', 'work_permit_file_path',
-            'pink_card_file_path', 'insurance_attachment_path'
+            'pink_card_file_path'
         ];
 
         if (!in_array($field, $allowedFields)) {

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -280,8 +280,7 @@ class NotificationController extends Controller
                     $fileField = 'insurance_document_path_private';
                 } else {
                     $fieldToUpdate = 'insurance_expiry_date';
-                    // Fix: Reverted to 'insurance_attachment_path' as 'insurance_document_path' column is missing in some environments
-                    $fileField = 'insurance_attachment_path';
+                    $fileField = 'insurance_document_path';
                 }
                 break;
             case 'employer_document_expiry':

--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -28,7 +28,7 @@ class ProcessDownload implements ShouldQueue
     // Map frontend checkbox values to model attributes
     protected $fileMap = [
         'photo' => 'employeePhoto',
-        'insurance' => ['insurance_attachment_path', 'insurance_document_path', 'insurance_document_path_private', 'social_security_file', 'insurance_file'],
+        'insurance' => ['insurance_document_path', 'insurance_document_path_private', 'social_security_file', 'insurance_file'],
         'passport' => ['passport_file_path', 'employee_doc_1'],
         'visa' => ['visa_file_path', 'employee_doc_2'],
         'work_permit' => ['work_permit_file_path', 'employee_doc_3'],

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -123,7 +123,6 @@ class Employee extends Model
         'visa_file_path',
         'work_permit_file_path',
         'pink_card_file_path',
-        'insurance_attachment_path',
         'medical_certificate_path',
         'medical_hospital_name',
     ];

--- a/database/migrations/2026_01_07_000000_add_medical_fields_to_employees_table.php
+++ b/database/migrations/2026_01_07_000000_add_medical_fields_to_employees_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('employees', function (Blueprint $table) {
-            $table->string('medical_certificate_path')->nullable()->after('insurance_attachment_path');
+            $table->string('medical_certificate_path')->nullable()->after('insurance_document_path');
             $table->string('medical_hospital_name')->nullable()->after('medical_certificate_path');
         });
     }


### PR DESCRIPTION
…path

- Update migration 2026_01_07_000000 to add medical fields after 'insurance_document_path' instead of the non-existent 'insurance_attachment_path'
- Standardize codebase to use 'insurance_document_path' in EmployeeController, NotificationController, and ProcessDownload job
- Remove references to 'insurance_attachment_path' from Employee model and allowed fields lists to prevent errors