### PR TITLE
Fix automatic PDF generation errors by validating PDF version

### DIFF
--- a/app/Helpers/PdfHelper.php
+++ b/app/Helpers/PdfHelper.php
@@ -3,6 +3,7 @@
 namespace App\Helpers;
 
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\File;
 
 class PdfHelper
 {
@@ -67,5 +68,46 @@ class PdfHelper
 
         // Fallback
         return Storage::disk($disk)->download($filePath);
+    }
+
+    /**
+     * Get the PDF version from the file header.
+     *
+     * @param string $filePath
+     * @return float|null
+     */
+    public static function getVersion(string $filePath): ?float
+    {
+        if (!File::exists($filePath)) {
+            return null;
+        }
+
+        // Read the first line (or first few bytes)
+        $handle = fopen($filePath, 'rb');
+        if (!$handle) {
+            return null;
+        }
+
+        $header = fgets($handle); // e.g., %PDF-1.4
+        fclose($handle);
+
+        if (preg_match('/%PDF-(\d\.\d)/', $header, $matches)) {
+            return (float) $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if the PDF version is compatible.
+     *
+     * @param string $filePath
+     * @param float $maxVersion
+     * @return bool
+     */
+    public static function isCompatible(string $filePath, float $maxVersion = 1.4): bool
+    {
+        $version = self::getVersion($filePath);
+        return $version !== null && $version <= $maxVersion;
     }
 }

--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -8,6 +8,7 @@ use App\Models\PdfTemplate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use App\Helpers\PdfHelper;
 
 class PdfTemplateController extends Controller
 {
@@ -60,7 +61,19 @@ class PdfTemplateController extends Controller
             'employer_id' => 'required_if:type,employer|nullable|exists:employers,id',
         ]);
 
-        $path = $request->file('file')->store('pdf_templates', 'public');
+        $file = $request->file('file');
+
+        // Validate PDF Version (Must be <= 1.4 for FPDI compatibility)
+        // We do this before storing to avoid saving bad files.
+        // Since we need to read the file, valid upload is assumed by validation rules.
+        if (!PdfHelper::isCompatible($file->getRealPath(), 1.4)) {
+            $version = PdfHelper::getVersion($file->getRealPath()) ?? 'Unknown';
+            return back()->withErrors([
+                'file' => "The uploaded PDF is version {$version}. The system requires PDF Version 1.4 or lower. Please open your PDF in a PDF editor (like Acrobat) and 'Save As' -> 'PDF 1.4'."
+            ])->withInput();
+        }
+
+        $path = $file->store('pdf_templates', 'public');
 
         $template = PdfTemplate::create([
             'name' => $request->name,

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -7,6 +7,7 @@ use App\Models\PdfTemplate;
 use setasign\Fpdi\Fpdi;
 use setasign\Fpdi\PdfParser\StreamReader;
 use Illuminate\Support\Facades\Storage;
+use App\Helpers\PdfHelper;
 use Illuminate\Support\Str;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -85,6 +86,13 @@ class PdfGeneratorService
             try {
                 $pageCount = $pdf->setSourceFile($templatePath);
             } catch (\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException $e) {
+
+                // Immediate check for version incompatibility to provide a clean error
+                $version = PdfHelper::getVersion($templatePath);
+                if ($version && $version > 1.4) {
+                     throw new \Exception("The PDF template '{$template->name}' is version {$version}, but the system requires version 1.4 or lower. Please open this template in a PDF editor and save it as 'PDF 1.4' (Acrobat 5.x compatible).");
+                }
+
                 // Try to normalize the PDF using Ghostscript or Python
                 try {
                     $normalizedPath = $this->tryNormalizePdf($templatePath);
@@ -93,7 +101,9 @@ class PdfGeneratorService
                         $this->tempFiles[] = $normalizedPath; // Mark for deletion
                     }
                 } catch (\Exception $ex) {
-                     throw new \Exception('Automatic PDF repair failed. ' . $ex->getMessage());
+                     // If normalization failed, assume it's because of the version mismatch and missing tools
+                     $verString = $version ?? 'Unknown';
+                     throw new \Exception("PDF Incompatible: The template '{$template->name}' is too new (Version {$verString}). " . $ex->getMessage());
                 }
             } catch (\Exception $e) {
                 throw new \Exception('Failed to process PDF template: ' . $e->getMessage());
@@ -268,11 +278,12 @@ class PdfGeneratorService
         }
 
         // If we reach here, all strategies failed
-        $errorMsg = "Could not repair PDF. Attempts:\n" . implode("\n", $errors);
+        $errorMsg = "Automatic PDF repair failed. The system attempted to convert the PDF to version 1.4 but could not find the necessary tools (Ghostscript or Python).\n\n" .
+                    "SOLUTION: Please open your PDF template in a PDF editor and save it specifically as 'PDF Version 1.4' (Acrobat 5.x compatible).";
 
         Log::error('PDF Normalization Failed', ['errors' => $errors]);
 
-        throw new \Exception($errorMsg . "\n\nSuggestion: Install Ghostscript or Python (with pypdf), or save your PDF template as 'PDF Version 1.4' using a PDF editor.");
+        throw new \Exception($errorMsg);
     }
 
     protected function resolveValue(Employee $employee, $key)


### PR DESCRIPTION
- Add `PdfHelper` class with methods to check PDF version.
- Validate PDF uploads in `PdfTemplateController` to ensure version <= 1.4.
- Improve error handling in `PdfGeneratorService` to provide clear instructions when incompatible PDFs are encountered.
- Restore `streamFile` method in `PdfHelper` to avoid regressions.