### PR TITLE
Align Registration and Renewal menu functionality

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -712,11 +712,33 @@ class RegistrationController extends Controller
         $request->validate([
             'order' => 'required|array',
             'order.*' => 'exists:registration_steps,id',
+            'handle_step_one_behavior' => 'nullable|string|in:auto_tick,none',
         ]);
 
         $order = $request->input('order');
+        $behavior = $request->input('handle_step_one_behavior', 'none');
 
-        DB::transaction(function () use ($order) {
+        DB::transaction(function () use ($order, $behavior) {
+            // Handle Step 1 Change Logic
+            if ($behavior === 'auto_tick') {
+                $oldStepOne = RegistrationStep::registration()->orderBy('order')->first();
+                $newStepOneId = $order[0] ?? null;
+
+                if ($oldStepOne && $newStepOneId && $oldStepOne->id != $newStepOneId) {
+                    // Find active employees (those who have the OLD Step 1 completed)
+                    $employeesToUpdate = Employee::whereHas('registrationSteps', function($q) use ($oldStepOne) {
+                        $q->where('registration_steps.id', $oldStepOne->id);
+                    })->get();
+
+                    // Sync the NEW Step 1 for them
+                    foreach ($employeesToUpdate as $emp) {
+                        $emp->registrationSteps()->syncWithoutDetaching([
+                            $newStepOneId => ['completed_at' => now()]
+                        ]);
+                    }
+                }
+            }
+
             foreach ($order as $index => $id) {
                 RegistrationStep::where('id', $id)->update(['order' => $index + 1]);
             }

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -1142,9 +1142,40 @@
         });
     }
 
+    // Helper for submitting step reorder
+    function submitReorder(order, behavior) {
+        fetch('{{ route("production.registration.steps.reorder") }}', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' },
+            body: JSON.stringify({
+                order: order,
+                handle_step_one_behavior: behavior
+            })
+        })
+        .then(res => res.json())
+        .then(data => {
+            if(data.success) {
+               if (behavior === 'auto_tick') {
+                   Swal.fire({
+                        icon: 'success',
+                        title: '{{ __('Updated!') }}',
+                        text: '{{ __('Order updated and employees processed.') }}',
+                        timer: 1500,
+                        showConfirmButton: false
+                   }).then(() => location.reload());
+               }
+               // For 'none', silent success or toast
+            }
+        });
+    }
+
     window.moveStep = function(id, direction) {
         const stepsList = document.getElementById('stepsList');
         const currentItem = document.getElementById(`step-item-${id}`);
+
+        // Capture current first item ID before move
+        const firstLi = stepsList.querySelector('li');
+        const currentFirstId = firstLi ? firstLi.id.replace('step-item-', '') : null;
 
         if (direction === 'up') {
             const prevItem = currentItem.previousElementSibling;
@@ -1164,18 +1195,39 @@
             newOrder.push(li.id.replace('step-item-', ''));
         });
 
-        // Save new order
-        fetch('{{ route("production.registration.steps.reorder") }}', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken, 'X-Requested-With': 'XMLHttpRequest' },
-            body: JSON.stringify({ order: newOrder })
-        })
-        .then(res => res.json())
-        .then(data => {
-            if(data.success) {
-               // Optional: Show toast
-            }
-        });
+        // Capture new first item ID
+        const newFirstId = newOrder[0];
+
+        // Check if Step 1 has changed
+        if (currentFirstId && newFirstId && currentFirstId !== newFirstId) {
+            Swal.fire({
+                title: '{{ __('Change First Step?') }}',
+                text: '{{ __('You are changing the first step. Select how to handle existing active employees:') }}',
+                icon: 'warning',
+                showCancelButton: true,
+                showDenyButton: true,
+                confirmButtonText: '{{ __('Auto-tick New Step 1') }}', // Choice 1
+                denyButtonText: '{{ __('Just Move (No Data Change)') }}', // Choice 2
+                cancelButtonText: '{{ __('Cancel') }}',
+                confirmButtonColor: '#3085d6',
+                denyButtonColor: '#6c757d',
+                allowOutsideClick: false
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    // Choice 1: Auto-tick
+                    submitReorder(newOrder, 'auto_tick');
+                } else if (result.isDenied) {
+                    // Choice 2: Just Move
+                    submitReorder(newOrder, 'none');
+                } else {
+                    // Cancel: Revert DOM change by reloading
+                    location.reload();
+                }
+            });
+        } else {
+            // Standard move (Step 1 didn't change)
+            submitReorder(newOrder, 'none');
+        }
     }
 
     // --- Employee Actions (Updated for Immediate DOM Feedback & Stats) ---

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -225,6 +225,9 @@
                     <a href="{{ route('admin.trash.index', ['tab' => 'employees']) }}" class="btn btn-secondary fw-bold">
                         <i class="bi bi-trash-fill me-1"></i> {{ __('Trash') }}
                     </a>
+                    <button class="btn btn-outline-secondary fw-bold ms-2" id="btn-global-toggle-cancelled" onclick="toggleGlobalCancelled()">
+                        <i class="bi bi-eye-slash-fill me-1"></i> {{ __('Hide Cancelled') }}
+                    </button>
                     @endcan
                 </div>
             </div>
@@ -280,7 +283,7 @@
                 $employerHeaderClass = $isEmployerCancelled ? 'bg-light' : 'bg-white';
             @endphp
 
-            <div class="d-flex align-items-start employer-card-container mb-4" id="employer-card-{{ $employer->id }}">
+            <div class="d-flex align-items-start employer-card-container mb-4" id="employer-card-{{ $employer->id }}" data-is-cancelled="{{ $isEmployerCancelled ? 'true' : 'false' }}">
                 {{-- Sequence Number (CSS Counter will handle number) --}}
                 <div class="employer-sequence-number me-3 pt-2"></div>
 
@@ -429,6 +432,10 @@
                                         </button>
                                     @endif
                                 @endcan
+
+                                <button class="btn btn-outline-secondary btn-sm ms-1" id="btn-employer-toggle-cancelled-{{ $employer->id }}" onclick="toggleEmployerCancelled({{ $employer->id }}); event.stopPropagation();" title="{{ __('Hide Cancelled Items') }}">
+                                    <i class="bi bi-eye-slash"></i>
+                                </button>
 
                                 {{-- Collapse Chevron --}}
                                 <button class="btn btn-light btn-sm rounded-circle ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ $employer->id }}">
@@ -845,6 +852,57 @@
             }
         })
         .catch(err => Swal.fire('{{ __('Error') }}', '{{ __('Network error') }}', 'error'));
+    }
+
+    // --- Global & Employer Cancelled Toggle ---
+    window.globalCancelledHidden = false; // Default: show cancelled
+    window.employerCancelledHidden = {}; // Per employer state
+
+    window.toggleGlobalCancelled = function() {
+        window.globalCancelledHidden = !window.globalCancelledHidden;
+        const btn = document.getElementById('btn-global-toggle-cancelled');
+
+        if (window.globalCancelledHidden) {
+            btn.innerHTML = '<i class="bi bi-eye-fill me-1"></i> {{ __('Show Cancelled') }}';
+            // Hide all cancelled employers
+            document.querySelectorAll('.employer-card-container[data-is-cancelled="true"]').forEach(el => el.classList.add('d-none'));
+            // Hide all cancelled employees globally
+            document.querySelectorAll('.employee-card-wrapper[data-status="renewal_cancelled"]').forEach(el => el.classList.add('d-none'));
+        } else {
+            btn.innerHTML = '<i class="bi bi-eye-slash-fill me-1"></i> {{ __('Hide Cancelled') }}';
+            // Show all cancelled employers
+            document.querySelectorAll('.employer-card-container[data-is-cancelled="true"]').forEach(el => el.classList.remove('d-none'));
+            // Show all cancelled employees globally
+            document.querySelectorAll('.employee-card-wrapper[data-status="renewal_cancelled"]').forEach(el => el.classList.remove('d-none'));
+        }
+    }
+
+    window.toggleEmployerCancelled = function(employerId) {
+        if (typeof window.employerCancelledHidden[employerId] === 'undefined') {
+            window.employerCancelledHidden[employerId] = false;
+        }
+
+        window.employerCancelledHidden[employerId] = !window.employerCancelledHidden[employerId];
+        const btn = document.getElementById(`btn-employer-toggle-cancelled-${employerId}`);
+        const listContainer = document.getElementById(`employee-list-${employerId}`);
+
+        if (window.employerCancelledHidden[employerId]) {
+            btn.innerHTML = '<i class="bi bi-eye"></i>';
+            btn.title = '{{ __('Show Cancelled Items') }}';
+            btn.classList.add('active', 'bg-secondary', 'text-white');
+            // Hide cancelled employees in this employer container
+            if (listContainer) {
+                listContainer.querySelectorAll('.employee-card-wrapper[data-status="renewal_cancelled"]').forEach(el => el.classList.add('d-none'));
+            }
+        } else {
+            btn.innerHTML = '<i class="bi bi-eye-slash"></i>';
+            btn.title = '{{ __('Hide Cancelled Items') }}';
+            btn.classList.remove('active', 'bg-secondary', 'text-white');
+            // Show cancelled employees in this employer container
+            if (listContainer) {
+                listContainer.querySelectorAll('.employee-card-wrapper[data-status="renewal_cancelled"]').forEach(el => el.classList.remove('d-none'));
+            }
+        }
     }
 
     // Modal variable init inside DOMContentLoaded to ensure Bootstrap is loaded


### PR DESCRIPTION
- Added 'Hide Cancelled Items' toggle to Renewal Resolution menu (global and per-employer).
- Added 'Step 1 Change Alert' with auto-tick logic to Registration Resolution menu.
- Updated `RegistrationController` to handle `auto_tick` behavior for step reordering.
- ensured all new UI text is localizable.