### PR TITLE
feat: Auto-normalize incompatible PDFs using Node.js/pdf-lib

### DIFF
--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use App\Helpers\PdfHelper;
+use App\Services\PdfGeneratorService;
 
 class PdfTemplateController extends Controller
 {
@@ -50,7 +51,7 @@ class PdfTemplateController extends Controller
         return view('pdf_templates.create', compact('employers'));
     }
 
-    public function store(Request $request)
+    public function store(Request $request, PdfGeneratorService $pdfService)
     {
         $this->authorize('create-pdf-templates');
 
@@ -62,22 +63,50 @@ class PdfTemplateController extends Controller
         ]);
 
         $file = $request->file('file');
+        $filePath = $file->getRealPath();
 
         // Validate PDF Version (Must be <= 1.4 for FPDI compatibility)
-        // We do this before storing to avoid saving bad files.
-        // Since we need to read the file, valid upload is assumed by validation rules.
-        if (!PdfHelper::isCompatible($file->getRealPath(), 1.4)) {
-            $version = PdfHelper::getVersion($file->getRealPath()) ?? 'Unknown';
-            return back()->withErrors([
-                'file' => "The uploaded PDF is version {$version}. The system requires PDF Version 1.4 or lower. Please open your PDF in a PDF editor (like Acrobat) and 'Save As' -> 'PDF 1.4'."
-            ])->withInput();
-        }
+        // If not compatible, try to normalize immediately
+        if (!PdfHelper::isCompatible($filePath, 1.4)) {
+            try {
+                // Attempt to normalize the temp file directly
+                $normalizedPath = $pdfService->tryNormalizePdf($filePath);
 
-        $path = $file->store('pdf_templates', 'public');
+                // If normalization fails, tryNormalizePdf might return null depending on implementation
+                // (Though currently it throws Exception on failure, adding check for safety)
+                if (!$normalizedPath || !file_exists($normalizedPath)) {
+                     throw new \Exception("Normalization process failed to produce a valid file.");
+                }
+
+                // If normalization returned a path, we use that for storage
+                // Manual storage logic for normalized file
+                $filename = $file->hashName();
+                $storePath = 'pdf_templates/' . $filename;
+
+                // Move normalized file to public storage
+                Storage::disk('public')->put($storePath, file_get_contents($normalizedPath));
+
+                // Clean up temp normalized file
+                @unlink($normalizedPath);
+
+                // Use this path for the model creation
+                $finalPath = $storePath;
+
+            } catch (\Exception $e) {
+                // If normalization fails, fall back to the error message
+                $version = PdfHelper::getVersion($filePath) ?? 'Unknown';
+                return back()->withErrors([
+                    'file' => "The uploaded PDF is version {$version}. The system attempted to repair it but failed: " . $e->getMessage()
+                ])->withInput();
+            }
+        } else {
+            // Compatible, store normally
+            $finalPath = $file->store('pdf_templates', 'public');
+        }
 
         $template = PdfTemplate::create([
             'name' => $request->name,
-            'file_path' => $path,
+            'file_path' => $finalPath,
             'type' => $request->type,
             'employer_id' => $request->type === 'employer' ? $request->employer_id : null,
             'created_by' => Auth::id(),

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -86,14 +86,8 @@ class PdfGeneratorService
             try {
                 $pageCount = $pdf->setSourceFile($templatePath);
             } catch (\setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException $e) {
-
-                // Immediate check for version incompatibility to provide a clean error
-                $version = PdfHelper::getVersion($templatePath);
-                if ($version && $version > 1.4) {
-                     throw new \Exception("The PDF template '{$template->name}' is version {$version}, but the system requires version 1.4 or lower. Please open this template in a PDF editor and save it as 'PDF 1.4' (Acrobat 5.x compatible).");
-                }
-
-                // Try to normalize the PDF using Ghostscript or Python
+                // If FPDI fails, it's likely a version or structure issue.
+                // Try to normalize unconditionally.
                 try {
                     $normalizedPath = $this->tryNormalizePdf($templatePath);
                     if ($normalizedPath) {
@@ -101,12 +95,24 @@ class PdfGeneratorService
                         $this->tempFiles[] = $normalizedPath; // Mark for deletion
                     }
                 } catch (\Exception $ex) {
-                     // If normalization failed, assume it's because of the version mismatch and missing tools
+                     // If normalization failed
+                     $version = PdfHelper::getVersion($templatePath);
                      $verString = $version ?? 'Unknown';
-                     throw new \Exception("PDF Incompatible: The template '{$template->name}' is too new (Version {$verString}). " . $ex->getMessage());
+                     throw new \Exception("PDF Incompatible: The template '{$template->name}' is too new (Version {$verString}) and automatic repair failed. " . $ex->getMessage());
                 }
             } catch (\Exception $e) {
-                throw new \Exception('Failed to process PDF template: ' . $e->getMessage());
+                 // Other FPDI errors: try normalization as fallback too
+                 try {
+                    $normalizedPath = $this->tryNormalizePdf($templatePath);
+                    if ($normalizedPath) {
+                        $pageCount = $pdf->setSourceFile($normalizedPath);
+                        $this->tempFiles[] = $normalizedPath; // Mark for deletion
+                    } else {
+                        throw $e; // Rethrow original if normalization didn't return a path (shouldn't happen if no exception)
+                    }
+                 } catch (\Exception $ex) {
+                     throw new \Exception('Failed to process PDF template: ' . $e->getMessage() . ' | Repair attempt: ' . $ex->getMessage());
+                 }
             }
 
             // Generate Signatures for this session (Consistent per person)
@@ -198,12 +204,35 @@ class PdfGeneratorService
         return $content;
     }
 
-    protected function tryNormalizePdf($inputPath)
+    public function tryNormalizePdf($inputPath)
     {
         $outputPath = tempnam(sys_get_temp_dir(), 'norm_') . '.pdf';
-        $scriptPath = base_path('scripts/normalize_pdf.py');
 
-        // Check if script exists
+        // Strategy 0: Node.js (pdf-lib) - preferred strategy now
+        $nodeScriptPath = base_path('scripts/normalize_pdf.js');
+        if (file_exists($nodeScriptPath)) {
+            $cmd = sprintf(
+                'node %s %s %s 2>&1',
+                escapeshellarg($nodeScriptPath),
+                escapeshellarg($inputPath),
+                escapeshellarg($outputPath)
+            );
+
+            exec($cmd, $output, $returnVar);
+
+            if ($returnVar === 0 && file_exists($outputPath) && filesize($outputPath) > 0) {
+                return $outputPath;
+            }
+
+            Log::warning('Node.js PDF normalization failed', [
+                'cmd' => $cmd,
+                'return' => $returnVar,
+                'output' => $output
+            ]);
+        }
+
+        // Fallback strategies: Ghostscript or Python
+        $scriptPath = base_path('scripts/normalize_pdf.py');
         $scriptExists = file_exists($scriptPath);
 
         // Define strategies to try
@@ -278,8 +307,8 @@ class PdfGeneratorService
         }
 
         // If we reach here, all strategies failed
-        $errorMsg = "Automatic PDF repair failed. The system attempted to convert the PDF to version 1.4 but could not find the necessary tools (Ghostscript or Python).\n\n" .
-                    "SOLUTION: Please open your PDF template in a PDF editor and save it specifically as 'PDF Version 1.4' (Acrobat 5.x compatible).";
+        $errorMsg = "Automatic PDF repair failed. The system attempted to convert the PDF to version 1.4 but could not find the necessary tools (Node.js, Ghostscript, or Python).\n\n" .
+                    "SOLUTION: Please ensure 'node' is installed and 'pdf-lib' is added to package.json.";
 
         Log::error('PDF Normalization Failed', ['errors' => $errors]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
         "": {
             "name": "pro-worker-app",
             "dependencies": {
-                "bootstrap": "^5.3.8"
+                "bootstrap": "^5.3.8",
+                "pdf-lib": "^1.17.1"
             },
             "devDependencies": {
                 "@playwright/test": "^1.57.0",
@@ -594,6 +595,24 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@pdf-lib/standard-fonts": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+            "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^1.0.6"
+            }
+        },
+        "node_modules/@pdf-lib/upng": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+            "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^1.0.10"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -2854,6 +2873,12 @@
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2887,6 +2912,24 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/pdf-lib": {
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+            "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+            "license": "MIT",
+            "dependencies": {
+                "@pdf-lib/standard-fonts": "^1.0.0",
+                "@pdf-lib/upng": "^1.0.1",
+                "pako": "^1.0.11",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/pdf-lib/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "vite": "^7.0.4"
     },
     "dependencies": {
-        "bootstrap": "^5.3.8"
+        "bootstrap": "^5.3.8",
+        "pdf-lib": "^1.17.1"
     }
 }

--- a/scripts/normalize_pdf.js
+++ b/scripts/normalize_pdf.js
@@ -1,0 +1,33 @@
+const { PDFDocument } = require('pdf-lib');
+const fs = require('fs').promises;
+
+async function normalizePdf() {
+    const args = process.argv.slice(2);
+    if (args.length < 2) {
+        console.error('Usage: node normalize_pdf.js <input_path> <output_path>');
+        process.exit(1);
+    }
+
+    const inputPath = args[0];
+    const outputPath = args[1];
+
+    try {
+        const pdfBytes = await fs.readFile(inputPath);
+
+        // Load the PDF document
+        const pdfDoc = await PDFDocument.load(pdfBytes);
+
+        // Save the PDF with useObjectStreams: false to maximize compatibility (v1.4-like structure)
+        const pdfBytesNormalized = await pdfDoc.save({ useObjectStreams: false });
+
+        await fs.writeFile(outputPath, pdfBytesNormalized);
+
+        console.log('PDF normalized successfully');
+        process.exit(0);
+    } catch (error) {
+        console.error('Error normalizing PDF:', error);
+        process.exit(1);
+    }
+}
+
+normalizePdf();


### PR DESCRIPTION
- Added `pdf-lib` to `package.json`.
- Created `scripts/normalize_pdf.js` to downgrade/repair PDFs for FPDI 1.4 compatibility.
- Updated `PdfGeneratorService` to use the Node.js script as a normalization strategy.
- Updated `PdfTemplateController` to automatically attempt normalization on upload if version check fails.