### PR TITLE
Fix PDF normalization script ES module compatibility

### DIFF
--- a/scripts/normalize_pdf.js
+++ b/scripts/normalize_pdf.js
@@ -1,5 +1,5 @@
-const { PDFDocument } = require('pdf-lib');
-const fs = require('fs').promises;
+import { PDFDocument } from 'pdf-lib';
+import { promises as fs } from 'fs';
 
 async function normalizePdf() {
     const args = process.argv.slice(2);


### PR DESCRIPTION
The `scripts/normalize_pdf.js` script was failing with a `ReferenceError` because it used CommonJS `require` syntax while the project is configured as an ES module (`"type": "module"` in package.json).

This change updates the script to use ES module `import` syntax, allowing the automatic PDF repair mechanism to function correctly when incompatible PDF versions (e.g., 1.7) are encountered. This resolves the "PDF Incompatible" error reported during document generation.