### PR TITLE
feat: update employer password fields to plain text and fix layout

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -73,6 +73,8 @@ class EmployerController extends Controller
             'employerEmail' => 'nullable|email|max:255|unique:employers,employerEmail',
             'employerPassword' => 'nullable|string|max:255',
             'employerPhone' => 'nullable|string|max:255',
+            'outsource_re_code' => 'nullable|string|max:255',
+            'outsource_password' => 'nullable|string|max:255',
             'socialSecurityHospital' => 'nullable|string|max:255',
             'businessType' => 'required|string|max:255',
             'signerNameTh' => 'nullable|string|max:255',
@@ -110,9 +112,10 @@ class EmployerController extends Controller
             }
         }
 
-        if (!empty($validated['employerPassword'])) {
-            $validated['employerPassword'] = Hash::make($validated['employerPassword']);
-        }
+        // Password is now stored as plain text per user requirement
+        // if (!empty($validated['employerPassword'])) {
+        //     $validated['employerPassword'] = Hash::make($validated['employerPassword']);
+        // }
 
         Employer::create($validated);
         return redirect()->route('employers.index')->with('success', 'Employer created successfully.');
@@ -216,6 +219,8 @@ public function edit(Request $request, Employer $employer)
             'employerEmail' => ['nullable', 'email', 'max:255', Rule::unique('employers', 'employerEmail')->ignore($employer->id)],
             'employerPassword' => 'nullable|string|max:255',
             'employerPhone' => 'nullable|string|max:255',
+            'outsource_re_code' => 'nullable|string|max:255',
+            'outsource_password' => 'nullable|string|max:255',
             'socialSecurityHospital' => 'nullable|string|max:255',
             'businessType' => 'required|string|max:255',
             'signerNameTh' => 'nullable|string|max:255',
@@ -251,11 +256,10 @@ public function edit(Request $request, Employer $employer)
             }
         }
 
-        if (!empty($validated['employerPassword'])) {
-            $validated['employerPassword'] = Hash::make($validated['employerPassword']);
-        } else {
-            unset($validated['employerPassword']);
-        }
+        // Password is now stored as plain text per user requirement
+        // if (!empty($validated['employerPassword'])) {
+        //     $validated['employerPassword'] = Hash::make($validated['employerPassword']);
+        // }
 
         $employer->update($validated);
         return redirect()->route('employers.index')->with('success', 'Employer updated successfully.');

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -40,6 +40,8 @@ class Employer extends Model
         'employerEmail',
         'employerPassword',
         'employerPhone',
+        'outsource_re_code',
+        'outsource_password',
         'socialSecurityHospital',
         'businessType',
         'signerNameTh',

--- a/database/migrations/2025_11_15_110000_add_outsource_fields_to_employers_table.php
+++ b/database/migrations/2025_11_15_110000_add_outsource_fields_to_employers_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->string('outsource_re_code')->nullable()->after('employerPhone');
+            $table->string('outsource_password')->nullable()->after('outsource_re_code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->dropColumn(['outsource_re_code', 'outsource_password']);
+        });
+    }
+};

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -147,8 +147,7 @@
  </div>
  <div class="col-md-6">
  <label for="employerPassword" class="form-label">{{ __('Email Password (รหัสสำหรับอีเมล)') }}</label>
- <input type="text" class="form-control @error('employerPassword') is-invalid @enderror" id="employerPassword" name="employerPassword" value="">
- <small class="text-muted d-block">{{ __('Leave blank to keep current password') }}</small>
+ <input type="text" class="form-control @error('employerPassword') is-invalid @enderror" id="employerPassword" name="employerPassword" value="{{ old('employerPassword', $employer->employerPassword) }}">
  @error('employerPassword')
  <div class="invalid-feedback">{{ $message }}</div>
  @enderror
@@ -178,6 +177,22 @@
             <div class="col-md-6">
                 <label for="signerNameEn" class="form-label">{{ __('Authorized Signatory (English)') }}</label>
                 <input type="text" class="form-control" id="signerNameEn" name="signerNameEn" value="{{ old('signerNameEn', $employer->signerNameEn) }}">
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="signerNameTh2" class="form-label">{{ __('Authorized Signatory 2 (Thai)') }}</label>
+                <input type="text" class="form-control @error('signerNameTh2') is-invalid @enderror" id="signerNameTh2" name="signerNameTh2" value="{{ old('signerNameTh2', $employer->signerNameTh2 ?? '') }}">
+                @error('signerNameTh2')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+            <div class="col-md-6">
+                <label for="signerNameEn2" class="form-label">{{ __('Authorized Signatory 2 (English)') }}</label>
+                <input type="text" class="form-control @error('signerNameEn2') is-invalid @enderror" id="signerNameEn2" name="signerNameEn2" value="{{ old('signerNameEn2', $employer->signerNameEn2 ?? '') }}">
+                @error('signerNameEn2')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
             </div>
         </div>
         <div class="row mb-3">
@@ -222,22 +237,6 @@
                 <label for="employer_doc_company_expiry" class="form-label">{{ __('Expiry Date') }}</label>
                 <input type="date" class="form-control form-control-sm @error('employer_doc_company_expiry') is-invalid @enderror" id="employer_doc_company_expiry" name="employer_doc_company_expiry" value="{{ old('employer_doc_company_expiry', $employer->employer_doc_company_expiry) }}">
                 @error('employer_doc_company_expiry')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
-            </div>
-        </div>
-        <div class="row mb-3">
-            <div class="col-md-6">
-                <label for="signerNameTh2" class="form-label">{{ __('Authorized Signatory 2 (Thai)') }}</label>
-                <input type="text" class="form-control @error('signerNameTh2') is-invalid @enderror" id="signerNameTh2" name="signerNameTh2" value="{{ old('signerNameTh2', $employer->signerNameTh2 ?? '') }}">
-                @error('signerNameTh2')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
-            </div>
-            <div class="col-md-6">
-                <label for="signerNameEn2" class="form-label">{{ __('Authorized Signatory 2 (English)') }}</label>
-                <input type="text" class="form-control @error('signerNameEn2') is-invalid @enderror" id="signerNameEn2" name="signerNameEn2" value="{{ old('signerNameEn2', $employer->signerNameEn2 ?? '') }}">
-                @error('signerNameEn2')
                     <div class="invalid-feedback">{{ $message }}</div>
                 @enderror
             </div>

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -60,7 +60,7 @@
         </div>
         <div class="col-md-6">
             <label class="form-label fw-bold">รหัสสำหรับอีเมล</label>
-            <p class="form-control-plaintext">{{ $employer->employerPassword ?? 'N/A' }}</p>
+            <p class="form-control-plaintext text-break">{{ $employer->employerPassword ?? 'N/A' }}</p>
         </div>
     </div>
     <div class="row mb-3">
@@ -70,7 +70,7 @@
         </div>
         <div class="col-md-6">
             <label class="form-label fw-bold">รหัสสำหรับเข้าระบบ Outsource</label>
-            <p class="form-control-plaintext">{{ $employer->outsource_password ?? 'N/A' }}</p>
+            <p class="form-control-plaintext text-break">{{ $employer->outsource_password ?? 'N/A' }}</p>
         </div>
     </div>
     <div class="row mb-3">


### PR DESCRIPTION
- Add `outsource_re_code` and `outsource_password` to employers table via migration
- Update `Employer` model to include new fields in `$fillable`
- Update `EmployerController` to stop hashing `employerPassword` and validate new fields
- Update `edit.blade.php` to move Signer 2 fields below Signer 1
- Update `_employer_data.blade.php` preview to show passwords in plain text
- Ensure password inputs in edit view display the current stored value