### PR TITLE
Refactor PDF generation to use background queues for high-volume support

### DIFF
--- a/app/Http/Controllers/Admin/PdfGenerationController.php
+++ b/app/Http/Controllers/Admin/PdfGenerationController.php
@@ -3,14 +3,16 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Jobs\FinalizePdfBatch;
+use App\Jobs\ProcessPdfGenerationBatch;
 use App\Models\Employee;
 use App\Models\PdfTemplate;
 use App\Models\Employer;
 use App\Services\PdfGeneratorService;
+use Illuminate\Bus\Batch;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use ZipArchive;
-use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Str;
 
 class PdfGenerationController extends Controller
@@ -24,7 +26,7 @@ class PdfGenerationController extends Controller
 
     public function showGenerateModal(Request $request)
     {
-        $this->authorize('view-pdf-templates'); // Or a generic permission
+        $this->authorize('view-pdf-templates');
 
         $employeeIds = $request->input('employees', []);
 
@@ -43,7 +45,7 @@ class PdfGenerationController extends Controller
              $employers = $query->orderBy('employerNameTh')->get();
         }
 
-        // Fetch Initial Templates (Global by default or user specific)
+        // Fetch Initial Templates
         $query = PdfTemplate::query();
         if ($user->hasRole('employer')) {
              $query->where(function($q) use ($user) {
@@ -51,14 +53,11 @@ class PdfGenerationController extends Controller
                    ->orWhere('employer_id', $user->employer->id);
              });
         } elseif ($user->hasRole('caretaker')) {
-             // By default show global + their employers
              $query->where(function($q) use ($user) {
                  $q->where('type', 'global')
                    ->orWhereIn('employer_id', Employer::where('assigned_staff_id', $user->id)->pluck('id'));
              });
         } else {
-            // Admin/Staff: Default to Global only to avoid clutter, or all?
-            // Let's default to global to match the "filter" UX.
             $query->where('type', 'global');
         }
         $templates = $query->latest()->get();
@@ -82,135 +81,51 @@ class PdfGenerationController extends Controller
             'slot_name' => 'required_if:output_type,save_to_slot',
         ]);
 
-        $employees = Employee::with('employer')->whereIn('id', $request->employees)->get();
-        $template = PdfTemplate::findOrFail($request->template_id);
+        // Pre-flight check for Zip extension if download mode is selected
+        if ($request->output_type === 'download' && !extension_loaded('zip')) {
+             return redirect()->back()->with('danger', 'PHP Zip extension is not loaded. Cannot generate ZIP file.');
+        }
+
+        $employeeIds = $request->employees;
+        $templateId = $request->template_id;
+        $outputType = $request->output_type;
+        $slotName = $request->slot_name;
+        $userId = Auth::id();
+        $batchId = (string) Str::uuid(); // Unique ID for this operation
+
+        // Chunk size for batch processing
+        $chunkSize = 50;
+        $chunks = array_chunk($employeeIds, $chunkSize);
+        $totalCount = count($employeeIds);
+
+        $jobs = [];
+        foreach ($chunks as $chunk) {
+            $jobs[] = new ProcessPdfGenerationBatch(
+                $chunk,
+                $templateId,
+                $outputType,
+                $slotName,
+                $userId,
+                $batchId
+            );
+        }
 
         try {
-            // Check if Zip extension is loaded before proceeding (only for download/zip mode, but good to check generally)
-            if (!extension_loaded('zip') && $request->output_type === 'download' && count($employees) > 1) {
-                throw new \Exception('PHP Zip extension is not loaded. Cannot generate ZIP file.');
-            }
+            Bus::batch($jobs)
+                ->name('PDF Generation - ' . $batchId)
+                ->then(function (Batch $batch) use ($batchId, $userId, $outputType, $totalCount) {
+                    dispatch(new FinalizePdfBatch($batchId, $userId, $outputType, $totalCount));
+                })
+                ->dispatch();
 
-            // Generate content only (don't save via service)
-            $results = $this->pdfService->generateForEmployees($template, $employees, [
-                'output_type' => 'raw_content', // Change to get raw content
-            ]);
+            $message = $outputType === 'download'
+                ? 'Processing started. You will receive a notification with the download link shortly.'
+                : 'Processing started. Documents will be attached to employee records in the background.';
 
-            if (empty($results)) {
-                throw new \Exception('No documents were generated. Please check the template mapping and employee data.');
-            }
-
-            if ($request->output_type === 'save_to_slot') {
-                $count = 0;
-                $slotName = $request->slot_name;
-
-                foreach ($results as $result) {
-                    $employee = Employee::find($result['employee_id']);
-                    if (!$employee) continue;
-
-                    // Determine target model and file path
-                    if (str_starts_with($slotName, 'employee_doc_')) {
-                        // Save to Employee
-                        $filename = 'employee_files/' . $employee->id . '/' . $slotName . '_' . time() . '.pdf';
-                        Storage::disk('public')->put($filename, $result['content']);
-
-                        // Update Employee Record
-                        $updated = $employee->update([
-                            $slotName => $filename,
-                        ]);
-
-                        // Handle Description Update:
-                        // Mapping:
-                        // employee_doc_9  -> other_doc_1_desc
-                        // ...
-                        // employee_doc_18 -> other_doc_10_desc
-
-                        if (preg_match('/employee_doc_(\d+)/', $slotName, $matches)) {
-                            $index = (int)$matches[1];
-                            // Check if it falls in the "Other Document" range (9-18)
-                            if ($index >= 9 && $index <= 18) {
-                                $descIndex = $index - 8; // 9->1, 10->2...
-                                $descCol = "other_doc_{$descIndex}_desc";
-
-                                // Check if description exists in fillable is not easily possible here without loading model details
-                                // But based on code review, other_doc_1_desc to other_doc_10_desc exist.
-                                $employee->update([
-                                    $descCol => $template->name // Use Template Name as description
-                                ]);
-                            }
-                        }
-
-                        $count++;
-
-                    } elseif (str_starts_with($slotName, 'employer_doc_other_')) {
-                        // Save to Employer
-                        if ($employee->employer) {
-                            $employer = $employee->employer;
-                            $filename = 'employer_documents/' . $employer->id . '/' . $slotName . '_' . $employee->id . '_' . time() . '.pdf';
-                            Storage::disk('public')->put($filename, $result['content']);
-
-                            $employer->update([
-                                $slotName => $filename,
-                            ]);
-                             // Try to update description
-                             if (preg_match('/employer_doc_other_(\d+)/', $slotName, $matches)) {
-                                $index = $matches[1];
-                                $descCol = "employer_doc_other_{$index}_desc";
-                                $employer->update([
-                                    $descCol => "Auto-generated for " . $employee->employeeNameEn . ": " . $template->name
-                                ]);
-                            }
-                            $count++;
-                        }
-                    }
-                }
-
-                if ($count === 0) {
-                     return redirect()->route('employees.index')->with('warning', 'No documents were saved. Please check if the selected slot matches the target (Employee vs Employer).');
-                }
-
-                return redirect()->route('employees.index')
-                    ->with('success', 'Documents generated and saved for ' . $count . ' employees.');
-
-            } else {
-                // Handle Download
-                if (count($results) === 1) {
-                    // Single File
-                    $file = $results[0];
-                    return response($file['content'])
-                        ->header('Content-Type', 'application/pdf')
-                        ->header('Content-Disposition', 'attachment; filename="' . $file['filename'] . '"');
-                } else {
-                    // Zip Multiple Files
-                    $zipName = 'generated_docs_' . time() . '.zip';
-                    $zipPath = storage_path('app/public/temp/' . $zipName);
-
-                    // Ensure temp dir exists
-                    if (!file_exists(dirname($zipPath))) {
-                        mkdir(dirname($zipPath), 0755, true);
-                    }
-
-                    $zip = new ZipArchive;
-                    $openResult = $zip->open($zipPath, ZipArchive::CREATE);
-                    if ($openResult === TRUE) {
-                        foreach ($results as $file) {
-                            $zip->addFromString($file['filename'], $file['content']);
-                        }
-                        $zip->close();
-                    } else {
-                        throw new \Exception('Failed to create ZIP archive. Error Code: ' . $openResult);
-                    }
-
-                    if (!file_exists($zipPath)) {
-                        throw new \Exception('ZIP file was not created successfully.');
-                    }
-
-                    return response()->download($zipPath)->deleteFileAfterSend(true);
-                }
-            }
+            return redirect()->route('employees.index')->with('success', $message);
 
         } catch (\Throwable $e) {
-            return redirect()->route('employees.index')->with('danger', 'Error generating documents: ' . $e->getMessage());
+            return redirect()->route('employees.index')->with('danger', 'Error starting batch process: ' . $e->getMessage());
         }
     }
 }

--- a/app/Jobs/FinalizePdfBatch.php
+++ b/app/Jobs/FinalizePdfBatch.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\DownloadTask;
+use App\Models\User;
+use App\Notifications\PdfBatchCompleted;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use ZipArchive;
+
+class FinalizePdfBatch implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $batchId;
+    protected $userId;
+    protected $outputType;
+    protected $totalEmployees;
+
+    public function __construct($batchId, $userId, $outputType, $totalEmployees)
+    {
+        $this->batchId = $batchId;
+        $this->userId = $userId;
+        $this->outputType = $outputType;
+        $this->totalEmployees = $totalEmployees;
+    }
+
+    public function handle()
+    {
+        $user = User::find($this->userId);
+        if (!$user) return;
+
+        if ($this->outputType === 'save_to_slot') {
+            // Just notify
+            $user->notify(new PdfBatchCompleted('save_to_slot', $this->totalEmployees));
+        } else {
+            // Download Mode: Zip and Create Task
+            $this->finalizeDownload($user);
+        }
+    }
+
+    protected function finalizeDownload($user)
+    {
+        $tempDir = 'temp/batches/' . $this->batchId;
+        $fullTempPath = storage_path('app/public/' . $tempDir);
+
+        if (!File::exists($fullTempPath) || File::isEmptyDirectory($fullTempPath)) {
+            // Nothing generated?
+             \Log::warning("FinalizePdfBatch: No files found in $fullTempPath");
+             return;
+        }
+
+        $zipName = 'export_' . date('Ymd_His') . '.zip';
+        $zipRelativePath = 'downloads/' . $zipName;
+        $zipFullPath = storage_path('app/public/' . $zipRelativePath);
+
+        // Ensure downloads dir exists
+        if (!File::exists(dirname($zipFullPath))) {
+            File::makeDirectory(dirname($zipFullPath), 0755, true);
+        }
+
+        $zip = new ZipArchive;
+        if ($zip->open($zipFullPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) === TRUE) {
+            $files = File::files($fullTempPath);
+            foreach ($files as $file) {
+                $zip->addFile($file->getRealPath(), $file->getFilename());
+            }
+            $zip->close();
+        } else {
+             \Log::error("FinalizePdfBatch: Failed to create zip at $zipFullPath");
+             return;
+        }
+
+        // Create Download Task
+        $task = DownloadTask::create([
+            'user_id' => $user->id,
+            'type' => 'zip', // Generic zip type
+            'status' => 'completed',
+            'file_path' => $zipRelativePath // DownloadController expects relative to storage/app/public
+        ]);
+
+        // Clean up temp batch folder
+        File::deleteDirectory($fullTempPath);
+
+        // Notify
+        $user->notify(new PdfBatchCompleted('download', $this->totalEmployees, $task->id));
+    }
+}

--- a/app/Jobs/ProcessPdfGenerationBatch.php
+++ b/app/Jobs/ProcessPdfGenerationBatch.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Employee;
+use App\Models\PdfTemplate;
+use App\Services\PdfGeneratorService;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ProcessPdfGenerationBatch implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $employeeIds;
+    protected $templateId;
+    protected $outputType; // 'download' or 'save_to_slot'
+    protected $slotName;
+    protected $userId;
+    protected $batchId; // Custom UUID for temp folder organization
+
+    public function __construct($employeeIds, $templateId, $outputType, $slotName, $userId, $batchId)
+    {
+        $this->employeeIds = $employeeIds;
+        $this->templateId = $templateId;
+        $this->outputType = $outputType;
+        $this->slotName = $slotName;
+        $this->userId = $userId;
+        $this->batchId = $batchId;
+    }
+
+    public function handle(PdfGeneratorService $pdfService)
+    {
+        if ($this->batch() && $this->batch()->cancelled()) {
+            return;
+        }
+
+        $employees = Employee::with('employer')->whereIn('id', $this->employeeIds)->get();
+        $template = PdfTemplate::findOrFail($this->templateId);
+
+        foreach ($employees as $employee) {
+            try {
+                // Generate Content (Using Raw Content Mode)
+                $result = $pdfService->generateForEmployees($template, collect([$employee]), [
+                    'output_type' => 'raw_content'
+                ]);
+
+                if (empty($result)) continue;
+
+                $fileData = $result[0];
+                $content = $fileData['content'];
+
+                // Fix: Ensure filename is unique by appending Employee ID
+                // Original: TemplateName-EmployeeName.pdf
+                // New: TemplateName-EmployeeName-ID.pdf
+                $baseFilename = Str::slug($template->name . '-' . $employee->employeeNameEn . '-' . $employee->id) . '.pdf';
+
+                if ($this->outputType === 'save_to_slot') {
+                    $this->handleSaveToSlot($employee, $content, $template);
+                } else {
+                    $this->handleDownloadStorage($content, $baseFilename);
+                }
+
+            } catch (\Exception $e) {
+                // Log error but continue batch
+                \Log::error("PDF Batch Error (Emp ID: {$employee->id}): " . $e->getMessage());
+            }
+        }
+    }
+
+    protected function handleSaveToSlot($employee, $content, $template)
+    {
+        $slotName = $this->slotName;
+
+        // Determine path and model
+        if (str_starts_with($slotName, 'employee_doc_')) {
+            $filename = 'employee_files/' . $employee->id . '/' . $slotName . '_' . time() . '.pdf';
+            Storage::disk('public')->put($filename, $content);
+
+            $employee->update([$slotName => $filename]);
+
+            // Update Description if applicable
+            if (preg_match('/employee_doc_(\d+)/', $slotName, $matches)) {
+                $index = (int)$matches[1];
+                if ($index >= 9 && $index <= 18) {
+                    $descIndex = $index - 8;
+                    $employee->update(["other_doc_{$descIndex}_desc" => $template->name]);
+                }
+            }
+
+        } elseif (str_starts_with($slotName, 'employer_doc_other_')) {
+            if ($employee->employer) {
+                $employer = $employee->employer;
+                $filename = 'employer_documents/' . $employer->id . '/' . $slotName . '_' . $employee->id . '_' . time() . '.pdf';
+                Storage::disk('public')->put($filename, $content);
+
+                $employer->update([$slotName => $filename]);
+
+                if (preg_match('/employer_doc_other_(\d+)/', $slotName, $matches)) {
+                    $index = $matches[1];
+                    $employer->update(["employer_doc_other_{$index}_desc" => "Auto: " . $employee->employeeNameEn . " - " . $template->name]);
+                }
+            }
+        }
+    }
+
+    protected function handleDownloadStorage($content, $filename)
+    {
+        // Store in a temp folder dedicated to this batch UUID
+        // storage/app/public/temp/batches/{batchId}/{filename}
+        $path = 'temp/batches/' . $this->batchId . '/' . $filename;
+        Storage::disk('public')->put($path, $content);
+    }
+}

--- a/app/Notifications/PdfBatchCompleted.php
+++ b/app/Notifications/PdfBatchCompleted.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PdfBatchCompleted extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected $mode; // 'download' or 'save_to_slot'
+    protected $count;
+    protected $downloadTaskId;
+
+    public function __construct($mode, $count, $downloadTaskId = null)
+    {
+        $this->mode = $mode;
+        $this->count = $count;
+        $this->downloadTaskId = $downloadTaskId;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database']; // Keeping it simple for now, can add 'mail' if requested
+    }
+
+    public function toArray($notifiable)
+    {
+        $message = $this->mode === 'save_to_slot'
+            ? "Successfully saved documents for {$this->count} employees."
+            : "Your PDF export for {$this->count} employees is ready.";
+
+        $actionUrl = $this->downloadTaskId
+            ? route('admin.downloads.download', $this->downloadTaskId)
+            : null;
+
+        return [
+            'title' => 'PDF Generation Completed',
+            'message' => $message,
+            'action_url' => $actionUrl,
+            'type' => 'success'
+        ];
+    }
+}


### PR DESCRIPTION
- Implement `App\Jobs\ProcessPdfGenerationBatch` to handle PDF generation in chunks (50 employees/job).
- Implement `App\Jobs\FinalizePdfBatch` to handle post-processing (zipping, cleanup, notifications).
- Add `App\Notifications\PdfBatchCompleted` for user feedback.
- Refactor `PdfGenerationController` to dispatch `Bus::batch`.
- Append Employee ID to filenames to prevent collisions with duplicate names.
- Support both 'Download' (Zip) and 'Save to Slot' (Attachment) modes asynchronously.