### PR TITLE
Fix PDF batch generation fatal error by renaming conflicting property

### DIFF
--- a/app/Jobs/FinalizePdfBatch.php
+++ b/app/Jobs/FinalizePdfBatch.php
@@ -19,14 +19,14 @@ class FinalizePdfBatch implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    protected $batchId;
+    protected $customBatchId;
     protected $userId;
     protected $outputType;
     protected $totalEmployees;
 
-    public function __construct($batchId, $userId, $outputType, $totalEmployees)
+    public function __construct($customBatchId, $userId, $outputType, $totalEmployees)
     {
-        $this->batchId = $batchId;
+        $this->customBatchId = $customBatchId;
         $this->userId = $userId;
         $this->outputType = $outputType;
         $this->totalEmployees = $totalEmployees;
@@ -48,7 +48,7 @@ class FinalizePdfBatch implements ShouldQueue
 
     protected function finalizeDownload($user)
     {
-        $tempDir = 'temp/batches/' . $this->batchId;
+        $tempDir = 'temp/batches/' . $this->customBatchId;
         $fullTempPath = storage_path('app/public/' . $tempDir);
 
         if (!File::exists($fullTempPath) || File::isEmptyDirectory($fullTempPath)) {

--- a/app/Jobs/ProcessPdfGenerationBatch.php
+++ b/app/Jobs/ProcessPdfGenerationBatch.php
@@ -23,16 +23,16 @@ class ProcessPdfGenerationBatch implements ShouldQueue
     protected $outputType; // 'download' or 'save_to_slot'
     protected $slotName;
     protected $userId;
-    protected $batchId; // Custom UUID for temp folder organization
+    protected $customBatchId; // Custom UUID for temp folder organization
 
-    public function __construct($employeeIds, $templateId, $outputType, $slotName, $userId, $batchId)
+    public function __construct($employeeIds, $templateId, $outputType, $slotName, $userId, $customBatchId)
     {
         $this->employeeIds = $employeeIds;
         $this->templateId = $templateId;
         $this->outputType = $outputType;
         $this->slotName = $slotName;
         $this->userId = $userId;
-        $this->batchId = $batchId;
+        $this->customBatchId = $customBatchId;
     }
 
     public function handle(PdfGeneratorService $pdfService)
@@ -113,8 +113,8 @@ class ProcessPdfGenerationBatch implements ShouldQueue
     protected function handleDownloadStorage($content, $filename)
     {
         // Store in a temp folder dedicated to this batch UUID
-        // storage/app/public/temp/batches/{batchId}/{filename}
-        $path = 'temp/batches/' . $this->batchId . '/' . $filename;
+        // storage/app/public/temp/batches/{customBatchId}/{filename}
+        $path = 'temp/batches/' . $this->customBatchId . '/' . $filename;
         Storage::disk('public')->put($path, $content);
     }
 }


### PR DESCRIPTION
The custom `$batchId` property in `ProcessPdfGenerationBatch` and `FinalizePdfBatch` conflicted with the `$batchId` property reserved by the `Illuminate\Bus\Batchable` trait, causing a PHP Fatal Error.

This commit:
- Renames the custom property to `$customBatchId` in both Job classes.
- Updates constructors and methods to use the new property name.
- Ensures compatibility with the existing controller logic.
- Verifies that file generation logic correctly handles duplicate names by appending the employee ID to filenames.