### PR TITLE
Fix broken HTML structure in Registration and Renewal views

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -511,7 +511,6 @@
                     </div>
                 </div>
             </div> {{-- End card --}}
-            </div> {{-- End d-flex wrapper --}}
 
             {{-- Finance Modal for this Employer --}}
             <div class="modal fade" id="financeModal-{{ $employer->id }}" tabindex="-1" aria-hidden="true" onclick="event.stopPropagation()">

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -517,7 +517,6 @@
                     </div>
                 </div>
             </div> {{-- End card --}}
-            </div> {{-- End d-flex wrapper --}}
 
             {{-- Finance Modal for this Employer --}}
             <div class="modal fade" id="financeModal-{{ $employer->id }}" tabindex="-1" aria-hidden="true" onclick="event.stopPropagation()">


### PR DESCRIPTION
Removed an extra closing `</div>` tag inside the employer loop in both `resources/views/production/registration/index.blade.php` and `resources/views/production/renewal/index.blade.php`. This extra tag was prematurely closing the main container, causing only the first employer card to render correctly and breaking subsequent DOM elements (including modal triggers).