### PR TITLE
Fix layout of employer cards in Registration and Renewal Resolution v…

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -272,7 +272,7 @@
     </div>
 
     {{-- Employers List --}}
-    <div class="accordion d-flex flex-column" id="employersAccordion">
+    <div class="accordion" id="employersAccordion">
         @foreach($employers as $employer)
             @php
                 $isEmployerCancelled = $employer->financeOrder && $employer->financeOrder->status === 'registration_resolution_cancelled';

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -278,7 +278,7 @@
     </div>
 
     {{-- Employers List --}}
-    <div class="accordion d-flex flex-column" id="employersAccordion">
+    <div class="accordion" id="employersAccordion">
         @foreach($employers as $employer)
             @php
                 $isEmployerCancelled = $employer->financeOrder && $employer->financeOrder->status === 'registration_resolution_cancelled';


### PR DESCRIPTION
…iews

- Removed `d-flex` and `flex-column` classes from `#employersAccordion` in both `resources/views/production/registration/index.blade.php` and `resources/views/production/renewal/index.blade.php`.
- This restores the default vertical stacking behavior for employer cards, correcting the issue where they were displaying horizontally and shrunk.