### PR TITLE
Improve PDF generation error reporting and confirm dependency require…

### DIFF
--- a/app/Http/Controllers/Admin/PdfGenerationController.php
+++ b/app/Http/Controllers/Admin/PdfGenerationController.php
@@ -172,7 +172,10 @@ class PdfGenerationController extends Controller
                 }
 
                 if ($generatedCount === 0 && !empty($errorLog)) {
-                     return redirect()->route('employees.index')->with('danger', 'Generation Failed. See error log in next attempt or check system logs.');
+                     // Expose the error log in the flash message so the user knows WHY it failed.
+                     // Truncate if too long (though session flash can handle reasonably large strings)
+                     $errorMessage = "Generation Failed. Details:\n" . $errorLog;
+                     return redirect()->route('employees.index')->with('danger', $errorMessage);
                 }
 
                 return response()->download($zipPath)->deleteFileAfterSend(true);


### PR DESCRIPTION
…ments

- Modified PdfGenerationController to expose the actual error log in the flash message instead of a generic error.
- Verified that the root cause of the crash was missing `node_modules`.
- Confirmed `package.json` correctly lists `pdf-lib` as a dependency.
- Note: Environment must run `npm install` for the PDF normalization to function.