### PR TITLE
Fix horizontal layout of employer cards in Resolution menus

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -272,7 +272,7 @@
     </div>
 
     {{-- Employers List --}}
-    <div class="accordion" id="employersAccordion">
+    <div class="accordion d-flex flex-column" id="employersAccordion">
         @foreach($employers as $employer)
             @php
                 $isEmployerCancelled = $employer->financeOrder && $employer->financeOrder->status === 'registration_resolution_cancelled';

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -278,7 +278,7 @@
     </div>
 
     {{-- Employers List --}}
-    <div class="accordion" id="employersAccordion">
+    <div class="accordion d-flex flex-column" id="employersAccordion">
         @foreach($employers as $employer)
             @php
                 $isEmployerCancelled = $employer->financeOrder && $employer->financeOrder->status === 'registration_resolution_cancelled';


### PR DESCRIPTION
- Added `d-flex flex-column` to the accordion container in `resources/views/production/registration/index.blade.php` and `resources/views/production/renewal/index.blade.php` to force vertical stacking of employer cards.