### PR TITLE
Fix migration failure by making schema changes idempotent

### DIFF
--- a/database/migrations/2025_08_29_134135_add_signature_support_tables.php
+++ b/database/migrations/2025_08_29_134135_add_signature_support_tables.php
@@ -13,26 +13,74 @@ return new class extends Migration
     {
         // 1. Update Employers Table
         Schema::table('employers', function (Blueprint $table) {
-            $table->string('signer_2_name_th')->nullable()->after('signerNameEn');
-            $table->string('signer_2_name_en')->nullable()->after('signer_2_name_th');
-            $table->string('signature_1_path')->nullable()->after('signer_2_name_en');
-            $table->string('signature_2_path')->nullable()->after('signature_1_path');
+            $signerNameEnExists = Schema::hasColumn('employers', 'signerNameEn');
+
+            // Track availability to handle both existing columns and columns added in this transaction
+            // for the 'after' clause chaining.
+            $signer_2_name_th_available = Schema::hasColumn('employers', 'signer_2_name_th');
+
+            if (!$signer_2_name_th_available) {
+                if ($signerNameEnExists) {
+                    $table->string('signer_2_name_th')->nullable()->after('signerNameEn');
+                } else {
+                    $table->string('signer_2_name_th')->nullable();
+                }
+                $signer_2_name_th_available = true;
+            }
+
+            $signer_2_name_en_available = Schema::hasColumn('employers', 'signer_2_name_en');
+
+            if (!$signer_2_name_en_available) {
+                if ($signer_2_name_th_available) {
+                    $table->string('signer_2_name_en')->nullable()->after('signer_2_name_th');
+                } else {
+                    $table->string('signer_2_name_en')->nullable();
+                }
+                $signer_2_name_en_available = true;
+            }
+
+            $signature_1_path_available = Schema::hasColumn('employers', 'signature_1_path');
+
+            if (!$signature_1_path_available) {
+                if ($signer_2_name_en_available) {
+                    $table->string('signature_1_path')->nullable()->after('signer_2_name_en');
+                } else {
+                    $table->string('signature_1_path')->nullable();
+                }
+                $signature_1_path_available = true;
+            }
+
+            if (!Schema::hasColumn('employers', 'signature_2_path')) {
+                if ($signature_1_path_available) {
+                    $table->string('signature_2_path')->nullable()->after('signature_1_path');
+                } else {
+                    $table->string('signature_2_path')->nullable();
+                }
+            }
         });
 
         // 2. Update Employees Table
         Schema::table('employees', function (Blueprint $table) {
-            $table->string('signature_path')->nullable()->after('status');
+            if (!Schema::hasColumn('employees', 'signature_path')) {
+                if (Schema::hasColumn('employees', 'status')) {
+                    $table->string('signature_path')->nullable()->after('status');
+                } else {
+                    $table->string('signature_path')->nullable();
+                }
+            }
         });
 
         // 3. Create Global Witnesses Table
-        Schema::create('global_witnesses', function (Blueprint $table) {
-            $table->id();
-            $table->string('alias')->unique(); // 'witness_1', 'witness_2', etc.
-            $table->string('name_th')->nullable();
-            $table->string('name_en')->nullable();
-            $table->string('signature_path')->nullable();
-            $table->timestamps();
-        });
+        if (!Schema::hasTable('global_witnesses')) {
+            Schema::create('global_witnesses', function (Blueprint $table) {
+                $table->id();
+                $table->string('alias')->unique(); // 'witness_1', 'witness_2', etc.
+                $table->string('name_th')->nullable();
+                $table->string('name_en')->nullable();
+                $table->string('signature_path')->nullable();
+                $table->timestamps();
+            });
+        }
     }
 
     /**
@@ -43,16 +91,29 @@ return new class extends Migration
         Schema::dropIfExists('global_witnesses');
 
         Schema::table('employees', function (Blueprint $table) {
-            $table->dropColumn(['signature_path']);
+            if (Schema::hasColumn('employees', 'signature_path')) {
+                $table->dropColumn(['signature_path']);
+            }
         });
 
         Schema::table('employers', function (Blueprint $table) {
-            $table->dropColumn([
+            $columns = [
                 'signer_2_name_th',
                 'signer_2_name_en',
                 'signature_1_path',
                 'signature_2_path'
-            ]);
+            ];
+
+            $toDrop = [];
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('employers', $column)) {
+                    $toDrop[] = $column;
+                }
+            }
+
+            if (!empty($toDrop)) {
+                $table->dropColumn($toDrop);
+            }
         });
     }
 };


### PR DESCRIPTION
The migration `2025_08_29_134135_add_signature_support_tables.php` was failing with "Duplicate column name" errors, likely due to a partial previous run or mixed database state. This change wraps table creations and column additions in existence checks (`Schema::hasTable`, `Schema::hasColumn`) to ensure the migration can run successfully on databases that already have some of the schema elements. It also defensively handles `after()` clauses to avoid errors if the target column is missing.