### PR TITLE
Fix migration duplicate column errors and improve robustness

### DIFF
--- a/database/migrations/2025_08_29_134136_add_assigned_staff_id_to_employers_table.php
+++ b/database/migrations/2025_08_29_134136_add_assigned_staff_id_to_employers_table.php
@@ -11,13 +11,19 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('employers', function (Blueprint $table) {
-            $table->foreignId('assigned_staff_id')
-                  ->nullable()
-                  ->after('job_owner_id')
-                  ->constrained('users')
-                  ->nullOnDelete();
-        });
+        if (!Schema::hasColumn('employers', 'assigned_staff_id')) {
+            Schema::table('employers', function (Blueprint $table) {
+                $column = $table->foreignId('assigned_staff_id')
+                    ->nullable();
+
+                if (Schema::hasColumn('employers', 'job_owner_id')) {
+                    $column->after('job_owner_id');
+                }
+
+                $column->constrained('users')
+                    ->nullOnDelete();
+            });
+        }
     }
 
     /**
@@ -25,9 +31,11 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('employers', function (Blueprint $table) {
-            $table->dropForeign(['assigned_staff_id']);
-            $table->dropColumn('assigned_staff_id');
-        });
+        if (Schema::hasColumn('employers', 'assigned_staff_id')) {
+            Schema::table('employers', function (Blueprint $table) {
+                $table->dropForeign(['assigned_staff_id']);
+                $table->dropColumn('assigned_staff_id');
+            });
+        }
     }
 };

--- a/database/migrations/2025_08_30_095700_add_full_fields_to_employees_table.php
+++ b/database/migrations/2025_08_30_095700_add_full_fields_to_employees_table.php
@@ -12,28 +12,72 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('employees', function (Blueprint $table) {
-            $table->string('employeeTitleTh')->nullable()->after('employeeNameEn');
-            $table->string('employeeTitleEn')->nullable()->after('employeeTitleTh');
-            $table->date('employeeDob')->nullable()->after('employeeTitleEn');
-            $table->string('passportType')->nullable()->after('employeePassport');
-            $table->string('namelistNo')->nullable()->after('passportType');
-            $table->string('requestNo')->nullable()->after('namelistNo');
-            $table->string('workerRefNo')->nullable()->after('requestNo');
-            $table->string('personalId')->nullable()->after('workerRefNo');
-            $table->string('companyWorkerId')->nullable()->after('personalId');
-            $table->string('pinkCardNo')->nullable()->after('companyWorkerId');
-            $table->string('socialSecurityNo')->nullable()->after('pinkCardNo');
-            $table->string('taxIdNo')->nullable()->after('socialSecurityNo');
-            $table->string('designatedHospital')->nullable()->after('taxIdNo');
-            $table->date('startDate')->nullable()->after('ninetyDayReportDate');
-            $table->string('employeePhone')->nullable()->after('startDate');
-            $table->string('employeePosition')->nullable()->after('employeePhone');
-            $table->string('employeePassportFile')->nullable()->after('employeePosition');
-            $table->string('employeeWorkPermitFile')->nullable()->after('employeePassportFile');
-            $table->string('pinkCardFile')->nullable()->after('employeeWorkPermitFile');
-            $table->string('workPermitMOUGroup')->nullable()->after('workPermitExpiryDate');
-            $table->string('workPermitMOUGroupOther')->nullable()->after('workPermitMOUGroup');
-            $table->string('employeePhoto')->nullable()->after('employeePosition');
+            if (!Schema::hasColumn('employees', 'employeeTitleTh')) {
+                $table->string('employeeTitleTh')->nullable()->after('employeeNameEn');
+            }
+            if (!Schema::hasColumn('employees', 'employeeTitleEn')) {
+                $table->string('employeeTitleEn')->nullable()->after('employeeTitleTh');
+            }
+            if (!Schema::hasColumn('employees', 'employeeDob')) {
+                $table->date('employeeDob')->nullable()->after('employeeTitleEn');
+            }
+            if (!Schema::hasColumn('employees', 'passportType')) {
+                $table->string('passportType')->nullable()->after('employeePassport');
+            }
+            if (!Schema::hasColumn('employees', 'namelistNo')) {
+                $table->string('namelistNo')->nullable()->after('passportType');
+            }
+            if (!Schema::hasColumn('employees', 'requestNo')) {
+                $table->string('requestNo')->nullable()->after('namelistNo');
+            }
+            if (!Schema::hasColumn('employees', 'workerRefNo')) {
+                $table->string('workerRefNo')->nullable()->after('requestNo');
+            }
+            if (!Schema::hasColumn('employees', 'personalId')) {
+                $table->string('personalId')->nullable()->after('workerRefNo');
+            }
+            if (!Schema::hasColumn('employees', 'companyWorkerId')) {
+                $table->string('companyWorkerId')->nullable()->after('personalId');
+            }
+            if (!Schema::hasColumn('employees', 'pinkCardNo')) {
+                $table->string('pinkCardNo')->nullable()->after('companyWorkerId');
+            }
+            if (!Schema::hasColumn('employees', 'socialSecurityNo')) {
+                $table->string('socialSecurityNo')->nullable()->after('pinkCardNo');
+            }
+            if (!Schema::hasColumn('employees', 'taxIdNo')) {
+                $table->string('taxIdNo')->nullable()->after('socialSecurityNo');
+            }
+            if (!Schema::hasColumn('employees', 'designatedHospital')) {
+                $table->string('designatedHospital')->nullable()->after('taxIdNo');
+            }
+            if (!Schema::hasColumn('employees', 'startDate')) {
+                $table->date('startDate')->nullable()->after('ninetyDayReportDate');
+            }
+            if (!Schema::hasColumn('employees', 'employeePhone')) {
+                $table->string('employeePhone')->nullable()->after('startDate');
+            }
+            if (!Schema::hasColumn('employees', 'employeePosition')) {
+                $table->string('employeePosition')->nullable()->after('employeePhone');
+            }
+            if (!Schema::hasColumn('employees', 'employeePassportFile')) {
+                $table->string('employeePassportFile')->nullable()->after('employeePosition');
+            }
+            if (!Schema::hasColumn('employees', 'employeeWorkPermitFile')) {
+                $table->string('employeeWorkPermitFile')->nullable()->after('employeePassportFile');
+            }
+            if (!Schema::hasColumn('employees', 'pinkCardFile')) {
+                $table->string('pinkCardFile')->nullable()->after('employeeWorkPermitFile');
+            }
+            if (!Schema::hasColumn('employees', 'workPermitMOUGroup')) {
+                $table->string('workPermitMOUGroup')->nullable()->after('workPermitExpiryDate');
+            }
+            if (!Schema::hasColumn('employees', 'workPermitMOUGroupOther')) {
+                $table->string('workPermitMOUGroupOther')->nullable()->after('workPermitMOUGroup');
+            }
+            if (!Schema::hasColumn('employees', 'employeePhoto')) {
+                $table->string('employeePhoto')->nullable()->after('employeePosition');
+            }
         });
     }
 
@@ -43,7 +87,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('employees', function (Blueprint $table) {
-            $table->dropColumn([
+            $columns = [
                 'employeeTitleTh',
                 'employeeTitleEn',
                 'employeeDob',
@@ -66,7 +110,18 @@ return new class extends Migration
                 'workPermitMOUGroup',
                 'workPermitMOUGroupOther',
                 'employeePhoto',
-            ]);
+            ];
+
+            $toDrop = [];
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('employees', $column)) {
+                    $toDrop[] = $column;
+                }
+            }
+
+            if (!empty($toDrop)) {
+                $table->dropColumn($toDrop);
+            }
         });
     }
 };

--- a/database/migrations/2025_08_30_103800_add_document_fields_to_employees_table.php
+++ b/database/migrations/2025_08_30_103800_add_document_fields_to_employees_table.php
@@ -12,15 +12,33 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('employees', function (Blueprint $table) {
-            $table->string('document_1')->nullable()->after('employeePhoto');
-            $table->string('document_2')->nullable()->after('document_1');
-            $table->string('document_3')->nullable()->after('document_2');
-            $table->string('document_4')->nullable()->after('document_3');
-            $table->string('document_description_4')->nullable()->after('document_4');
-            $table->string('document_5')->nullable()->after('document_description_4');
-            $table->string('document_description_5')->nullable()->after('document_5');
-            $table->string('document_6')->nullable()->after('document_description_5');
-            $table->string('document_description_6')->nullable()->after('document_6');
+            if (!Schema::hasColumn('employees', 'document_1')) {
+                $table->string('document_1')->nullable()->after('employeePhoto');
+            }
+            if (!Schema::hasColumn('employees', 'document_2')) {
+                $table->string('document_2')->nullable()->after('document_1');
+            }
+            if (!Schema::hasColumn('employees', 'document_3')) {
+                $table->string('document_3')->nullable()->after('document_2');
+            }
+            if (!Schema::hasColumn('employees', 'document_4')) {
+                $table->string('document_4')->nullable()->after('document_3');
+            }
+            if (!Schema::hasColumn('employees', 'document_description_4')) {
+                $table->string('document_description_4')->nullable()->after('document_4');
+            }
+            if (!Schema::hasColumn('employees', 'document_5')) {
+                $table->string('document_5')->nullable()->after('document_description_4');
+            }
+            if (!Schema::hasColumn('employees', 'document_description_5')) {
+                $table->string('document_description_5')->nullable()->after('document_5');
+            }
+            if (!Schema::hasColumn('employees', 'document_6')) {
+                $table->string('document_6')->nullable()->after('document_description_5');
+            }
+            if (!Schema::hasColumn('employees', 'document_description_6')) {
+                $table->string('document_description_6')->nullable()->after('document_6');
+            }
         });
     }
 
@@ -30,7 +48,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('employees', function (Blueprint $table) {
-            $table->dropColumn([
+            $columns = [
                 'document_1',
                 'document_2',
                 'document_3',
@@ -40,7 +58,18 @@ return new class extends Migration
                 'document_description_5',
                 'document_6',
                 'document_description_6',
-            ]);
+            ];
+
+            $toDrop = [];
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('employees', $column)) {
+                    $toDrop[] = $column;
+                }
+            }
+
+            if (!empty($toDrop)) {
+                $table->dropColumn($toDrop);
+            }
         });
     }
 };

--- a/database/migrations/2025_08_30_112500_add_full_fields_to_employers_table.php
+++ b/database/migrations/2025_08_30_112500_add_full_fields_to_employers_table.php
@@ -12,11 +12,21 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('employers', function (Blueprint $table) {
-            $table->string('signerNameTh')->nullable()->after('businessType');
-            $table->string('signerNameEn')->nullable()->after('signerNameTh');
-            $table->string('businessTypeEn')->nullable()->after('signerNameEn');
-            $table->string('regCapital')->nullable()->after('businessTypeEn');
-            $table->date('regDate')->nullable()->after('regCapital');
+            if (!Schema::hasColumn('employers', 'signerNameTh')) {
+                $table->string('signerNameTh')->nullable()->after('businessType');
+            }
+            if (!Schema::hasColumn('employers', 'signerNameEn')) {
+                $table->string('signerNameEn')->nullable()->after('signerNameTh');
+            }
+            if (!Schema::hasColumn('employers', 'businessTypeEn')) {
+                $table->string('businessTypeEn')->nullable()->after('signerNameEn');
+            }
+            if (!Schema::hasColumn('employers', 'regCapital')) {
+                $table->string('regCapital')->nullable()->after('businessTypeEn');
+            }
+            if (!Schema::hasColumn('employers', 'regDate')) {
+                $table->date('regDate')->nullable()->after('regCapital');
+            }
         });
     }
 
@@ -26,13 +36,24 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('employers', function (Blueprint $table) {
-            $table->dropColumn([
+            $columns = [
                 'signerNameTh',
                 'signerNameEn',
                 'businessTypeEn',
                 'regCapital',
                 'regDate',
-            ]);
+            ];
+
+            $toDrop = [];
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('employers', $column)) {
+                    $toDrop[] = $column;
+                }
+            }
+
+            if (!empty($toDrop)) {
+                $table->dropColumn($toDrop);
+            }
         });
     }
 };

--- a/database/migrations/2025_08_30_114100_add_final_fields_to_employers_table.php
+++ b/database/migrations/2025_08_30_114100_add_final_fields_to_employers_table.php
@@ -12,11 +12,21 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('employers', function (Blueprint $table) {
-            $table->string('employerNameEn')->nullable()->after('employerNameTh');
-            $table->string('minimum_wage')->nullable()->after('regDate');
-            $table->string('document_company_registration')->nullable()->after('minimum_wage');
-            $table->string('document_vat_registration')->nullable()->after('document_company_registration');
-            $table->string('document_map')->nullable()->after('document_vat_registration');
+            if (!Schema::hasColumn('employers', 'employerNameEn')) {
+                $table->string('employerNameEn')->nullable()->after('employerNameTh');
+            }
+            if (!Schema::hasColumn('employers', 'minimum_wage')) {
+                $table->string('minimum_wage')->nullable()->after('regDate');
+            }
+            if (!Schema::hasColumn('employers', 'document_company_registration')) {
+                $table->string('document_company_registration')->nullable()->after('minimum_wage');
+            }
+            if (!Schema::hasColumn('employers', 'document_vat_registration')) {
+                $table->string('document_vat_registration')->nullable()->after('document_company_registration');
+            }
+            if (!Schema::hasColumn('employers', 'document_map')) {
+                $table->string('document_map')->nullable()->after('document_vat_registration');
+            }
         });
     }
 
@@ -26,13 +36,24 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('employers', function (Blueprint $table) {
-            $table->dropColumn([
+            $columns = [
                 'employerNameEn',
                 'minimum_wage',
                 'document_company_registration',
                 'document_vat_registration',
                 'document_map',
-            ]);
+            ];
+
+            $toDrop = [];
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('employers', $column)) {
+                    $toDrop[] = $column;
+                }
+            }
+
+            if (!empty($toDrop)) {
+                $table->dropColumn($toDrop);
+            }
         });
     }
 };


### PR DESCRIPTION
- Update `2025_08_29_134136_add_assigned_staff_id_to_employers_table.php` to check for `assigned_staff_id` existence before adding.
- Safely handle `job_owner_id` dependency in `after` clause by checking its existence.
- Update `2025_08_30_095700_add_full_fields_to_employees_table.php` to check for individual column existence.
- Update `2025_08_30_103800_add_document_fields_to_employees_table.php` to check for individual column existence.
- Update `2025_08_30_112500_add_full_fields_to_employers_table.php` to check for individual column existence.
- Update `2025_08_30_114100_add_final_fields_to_employers_table.php` to check for individual column existence.
- Ensure `down` methods also check for existence before dropping columns.