### PR TITLE
Fix migration failure by making column additions idempotent

### DIFF
--- a/database/migrations/2025_12_06_000005_add_readiness_flags_to_production_orders_table.php
+++ b/database/migrations/2025_12_06_000005_add_readiness_flags_to_production_orders_table.php
@@ -12,10 +12,18 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('production_orders', function (Blueprint $table) {
-            $table->timestamp('document_ready_at')->nullable()->after('financial_data');
-            $table->unsignedBigInteger('document_ready_by')->nullable()->after('document_ready_at');
-            $table->timestamp('financial_approved_at')->nullable()->after('document_ready_by');
-            $table->unsignedBigInteger('financial_approved_by')->nullable()->after('financial_approved_at');
+            if (!Schema::hasColumn('production_orders', 'document_ready_at')) {
+                $table->timestamp('document_ready_at')->nullable()->after('financial_data');
+            }
+            if (!Schema::hasColumn('production_orders', 'document_ready_by')) {
+                $table->unsignedBigInteger('document_ready_by')->nullable()->after('document_ready_at'); // Note: 'after' works best if the previous column exists.
+            }
+            if (!Schema::hasColumn('production_orders', 'financial_approved_at')) {
+                $table->timestamp('financial_approved_at')->nullable()->after('document_ready_by');
+            }
+            if (!Schema::hasColumn('production_orders', 'financial_approved_by')) {
+                $table->unsignedBigInteger('financial_approved_by')->nullable()->after('financial_approved_at');
+            }
         });
     }
 
@@ -25,12 +33,24 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('production_orders', function (Blueprint $table) {
-            $table->dropColumn([
-                'document_ready_at',
-                'document_ready_by',
-                'financial_approved_at',
-                'financial_approved_by'
-            ]);
+            $columnsToDrop = [];
+
+            if (Schema::hasColumn('production_orders', 'document_ready_at')) {
+                $columnsToDrop[] = 'document_ready_at';
+            }
+            if (Schema::hasColumn('production_orders', 'document_ready_by')) {
+                $columnsToDrop[] = 'document_ready_by';
+            }
+            if (Schema::hasColumn('production_orders', 'financial_approved_at')) {
+                $columnsToDrop[] = 'financial_approved_at';
+            }
+            if (Schema::hasColumn('production_orders', 'financial_approved_by')) {
+                $columnsToDrop[] = 'financial_approved_by';
+            }
+
+            if (!empty($columnsToDrop)) {
+                $table->dropColumn($columnsToDrop);
+            }
         });
     }
 };

--- a/database/migrations/2025_12_07_000000_update_production_tables.php
+++ b/database/migrations/2025_12_07_000000_update_production_tables.php
@@ -12,22 +12,43 @@ return new class extends Migration
     public function up(): void
     {
         // Update production_orders
-        Schema::table('production_orders', function (Blueprint $table) {
-            // Make employer_id nullable
-            $table->unsignedBigInteger('employer_id')->nullable()->change();
+        if (Schema::hasTable('production_orders')) {
+            Schema::table('production_orders', function (Blueprint $table) {
+                // Make employer_id nullable
+                if (Schema::hasColumn('production_orders', 'employer_id')) {
+                    $table->unsignedBigInteger('employer_id')->nullable()->change();
+                }
 
-            // Add type column for 'employer' or 'independent'
-            $table->string('type')->default('employer')->after('employer_id');
-        });
+                // Add type column for 'employer' or 'independent'
+                if (!Schema::hasColumn('production_orders', 'type')) {
+                    // Check if employer_id exists to place 'after', otherwise just add it
+                    if (Schema::hasColumn('production_orders', 'employer_id')) {
+                        $table->string('type')->default('employer')->after('employer_id');
+                    } else {
+                        $table->string('type')->default('employer');
+                    }
+                }
+            });
+        }
 
         // Update production_items
-        Schema::table('production_items', function (Blueprint $table) {
-            // Make employee_id nullable to support "New/Temp" employees
-            $table->unsignedBigInteger('employee_id')->nullable()->change();
+        if (Schema::hasTable('production_items')) {
+            Schema::table('production_items', function (Blueprint $table) {
+                // Make employee_id nullable to support "New/Temp" employees
+                if (Schema::hasColumn('production_items', 'employee_id')) {
+                    $table->unsignedBigInteger('employee_id')->nullable()->change();
+                }
 
-            // Add new_employee_data column
-            $table->json('new_employee_data')->nullable()->after('employee_id');
-        });
+                // Add new_employee_data column
+                if (!Schema::hasColumn('production_items', 'new_employee_data')) {
+                    if (Schema::hasColumn('production_items', 'employee_id')) {
+                        $table->json('new_employee_data')->nullable()->after('employee_id');
+                    } else {
+                        $table->json('new_employee_data')->nullable();
+                    }
+                }
+            });
+        }
     }
 
     /**
@@ -35,14 +56,26 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('production_orders', function (Blueprint $table) {
-            $table->unsignedBigInteger('employer_id')->nullable(false)->change();
-            $table->dropColumn('type');
-        });
+        if (Schema::hasTable('production_orders')) {
+            Schema::table('production_orders', function (Blueprint $table) {
+                if (Schema::hasColumn('production_orders', 'employer_id')) {
+                    $table->unsignedBigInteger('employer_id')->nullable(false)->change();
+                }
+                if (Schema::hasColumn('production_orders', 'type')) {
+                    $table->dropColumn('type');
+                }
+            });
+        }
 
-        Schema::table('production_items', function (Blueprint $table) {
-            $table->unsignedBigInteger('employee_id')->nullable(false)->change();
-            $table->dropColumn('new_employee_data');
-        });
+        if (Schema::hasTable('production_items')) {
+            Schema::table('production_items', function (Blueprint $table) {
+                if (Schema::hasColumn('production_items', 'employee_id')) {
+                    $table->unsignedBigInteger('employee_id')->nullable(false)->change();
+                }
+                if (Schema::hasColumn('production_items', 'new_employee_data')) {
+                    $table->dropColumn('new_employee_data');
+                }
+            });
+        }
     }
 };


### PR DESCRIPTION
Modified `2025_12_06_000005_add_readiness_flags_to_production_orders_table.php` and `2025_12_07_000000_update_production_tables.php` to use `Schema::hasColumn` and `Schema::hasTable` checks. This prevents `Column already exists` errors when running migrations on a database where these columns are already present, ensuring robust deployment across environments with varying schema states.