### PR TITLE
Fix: Make registration steps migration idempotent

### DIFF
--- a/database/migrations/2025_12_10_060925_add_type_to_registration_steps_table.php
+++ b/database/migrations/2025_12_10_060925_add_type_to_registration_steps_table.php
@@ -12,20 +12,32 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('registration_steps', function (Blueprint $table) {
-            $table->string('type')->default('registration')->after('id')->index();
-        });
+        if (!Schema::hasColumn('registration_steps', 'type')) {
+            Schema::table('registration_steps', function (Blueprint $table) {
+                $table->string('type')->default('registration')->after('id')->index();
+            });
+        }
 
         // Duplicate existing steps for renewal
-        $steps = DB::table('registration_steps')->get();
+        // We filter by 'registration' to get the base steps (either pre-existing or just marked as default)
+        $steps = DB::table('registration_steps')->where('type', 'registration')->get();
+
         foreach ($steps as $step) {
-            DB::table('registration_steps')->insert([
-                'type' => 'renewal',
-                'name' => $step->name,
-                'order' => $step->order,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]);
+            // Check if this renewal step already exists to prevent duplication
+            $exists = DB::table('registration_steps')
+                ->where('type', 'renewal')
+                ->where('name', $step->name)
+                ->exists();
+
+            if (!$exists) {
+                DB::table('registration_steps')->insert([
+                    'type' => 'renewal',
+                    'name' => $step->name,
+                    'order' => $step->order,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
         }
     }
 
@@ -34,8 +46,17 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('registration_steps', function (Blueprint $table) {
-            $table->dropColumn('type');
-        });
+        if (Schema::hasColumn('registration_steps', 'type')) {
+            Schema::table('registration_steps', function (Blueprint $table) {
+                $table->dropColumn('type');
+            });
+        }
+
+        // Optionally remove renewal steps?
+        // The original down() only dropped the column.
+        // Dropping the column implicitly removes the 'type' data, but rows remain.
+        // If we want to be strict, we might remove the 'renewal' rows,
+        // but since the column is gone, they just become 'nameless' or duplicate rows without distinction?
+        // Original down() just dropped column. I'll stick to that but add the hasColumn check for safety.
     }
 };


### PR DESCRIPTION
- Wrap `Schema::table` call with `!Schema::hasColumn` check to prevent `Duplicate column name` error.
- Check for existence of 'renewal' steps before inserting to prevent duplicate data in partial re-runs.
- Ensures `php artisan migrate` runs successfully even if the database state is inconsistent.