### PR TITLE
Fix ErrorException in workflow item card due to incorrect relationshi…

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -247,7 +247,7 @@ class WorkflowController extends Controller
         }
 
         // Return stats for UI update (Recalculate Order Stats)
-        $order = $item->productionOrder;
+        $order = $item->order;
         $orderStats = $this->calculateOrderStats($order);
 
         return response()->json([

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -1,6 +1,7 @@
-@props(['item', 'steps'])
+@props(['item', 'steps', 'order' => null])
 
 @php
+    $order = $order ?? $item->order;
     $status = $item->status ?? 'pending';
     $isCompleted = $status === 'completed';
     $isCancelled = $status === 'cancelled';
@@ -126,7 +127,7 @@
 
                 {{-- Manage Team --}}
                 <button class="btn btn-sm btn-outline-primary rounded-pill px-3"
-                    onclick="openManageTeamModal({{ $item->id }}, {{ $item->productionOrder->employer_id }})"
+                    onclick="openManageTeamModal({{ $item->id }}, {{ $order->employer_id }})"
                     title="{{ __('Manage Team') }}">
                     <i class="bi bi-people-fill"></i> <span class="d-none d-lg-inline">{{ __('Team') }}</span>
                 </button>

--- a/resources/views/workflow/partials/order_items.blade.php
+++ b/resources/views/workflow/partials/order_items.blade.php
@@ -23,7 +23,7 @@
 
         <div class="item-list">
             @foreach($items as $item)
-                @include('workflow.partials._item_card', ['item' => $item, 'steps' => $steps])
+                @include('workflow.partials._item_card', ['item' => $item, 'steps' => $steps, 'order' => $order])
             @endforeach
         </div>
     @endforeach


### PR DESCRIPTION
…p access

- Modified `resources/views/workflow/partials/order_items.blade.php` to pass the `order` object to the `_item_card` partial, optimizing data access.
- Updated `resources/views/workflow/partials/_item_card.blade.php` to accept the `order` prop and use it (or fallback to `$item->order`) instead of the non-existent `$item->productionOrder` property, which caused a null pointer exception when accessing `employer_id`.
- Fixed `app/Http/Controllers/WorkflowController.php` `toggleStep` method to use `$item->order` instead of `$item->productionOrder` for consistency and correctness.