### PR TITLE
Fix workflow appointment date saving and dashboard stats

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -174,10 +174,15 @@ class WorkflowController extends Controller
         $stats = [
             'total_projects' => ProductionOrder::where('status', '!=', 'pre_production')->count(),
             'total_employees' => ProductionItem::whereHas('order', fn($q) => $q->where('status', '!=', 'pre_production'))
-                                               ->where('status', '!=', 'cancelled')->count(),
-            'not_started' => 0, // Harder to calc globally efficiently without step context
-            'cancelled' => ProductionItem::where('status', 'cancelled')->count(),
-            'completed' => ProductionItem::where('status', 'completed')->count(),
+                                               ->count(),
+            'not_started' => ProductionItem::whereHas('order', fn($q) => $q->where('status', '!=', 'pre_production'))
+                                           ->where('status', 'pending')
+                                           ->doesntHave('completedWorkTypeSteps')
+                                           ->count(),
+            'cancelled' => ProductionItem::whereHas('order', fn($q) => $q->where('status', '!=', 'pre_production'))
+                                         ->where('status', 'cancelled')->count(),
+            'completed' => ProductionItem::whereHas('order', fn($q) => $q->where('status', '!=', 'pre_production'))
+                                         ->where('status', 'completed')->count(),
         ];
 
         // 2. Upcoming Appointments

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -116,37 +116,55 @@
                         });
                     },
                     saveDate() {
-                        fetch('/workflow/item/{{ $item->id }}/appointment', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content },
-                            body: JSON.stringify({ appointment_date: this.dateValue })
-                        }).then(res => res.json()).then(data => {
-                            if(data.success) {
-                                this.isEditing = false;
-                                Swal.fire({
-                                    toast: true,
-                                    position: 'top-end',
-                                    icon: 'success',
-                                    title: 'Saved',
-                                    showConfirmButton: false,
-                                    timer: 1500
-                                });
-                                // Simple update display logic
-                                if (!this.dateValue) {
-                                    this.displayValue = '-';
-                                } else {
-                                    // Basic parse to check time (simplified)
-                                    if(this.dateValue.endsWith('00:00')) {
-                                        let d = new Date(this.dateValue); // Browser parse might vary but ok for basic
-                                        // To be safe, just show what flatpickr returned or reload if critical
-                                        // Let's just use the string for now, user sees what they picked.
-                                        this.displayValue = this.dateValue;
-                                    } else {
-                                        this.displayValue = this.dateValue;
+                        Swal.fire({
+                            title: '{{ __("Confirm Appointment") }}',
+                            text: '{{ __("Are you sure you want to set this appointment date?") }}',
+                            icon: 'question',
+                            showCancelButton: true,
+                            confirmButtonColor: '#3085d6',
+                            cancelButtonColor: '#d33',
+                            confirmButtonText: '{{ __("Yes, save it!") }}',
+                            cancelButtonText: '{{ __("Cancel") }}'
+                        }).then((result) => {
+                            if (result.isConfirmed) {
+                                fetch('/workflow/item/{{ $item->id }}/appointment', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content },
+                                    body: JSON.stringify({ appointment_date: this.dateValue })
+                                }).then(res => res.json()).then(data => {
+                                    if(data.success) {
+                                        this.isEditing = false;
+                                        Swal.fire({
+                                            toast: true,
+                                            position: 'top-end',
+                                            icon: 'success',
+                                            title: '{{ __("Appointment Saved") }}',
+                                            showConfirmButton: false,
+                                            timer: 1500
+                                        });
+
+                                        // Update display logic
+                                        if (!this.dateValue) {
+                                            this.displayValue = '-';
+                                        } else {
+                                            try {
+                                                let parts = this.dateValue.split(' ');
+                                                let dateParts = parts[0].split('-'); // [YYYY, MM, DD]
+                                                let timePart = parts[1];
+
+                                                let displayDate = `${dateParts[2]}/${dateParts[1]}/${dateParts[0]}`;
+
+                                                if (timePart === '00:00') {
+                                                    this.displayValue = displayDate;
+                                                } else {
+                                                    this.displayValue = `${displayDate} ${timePart}`;
+                                                }
+                                            } catch (e) {
+                                                this.displayValue = this.dateValue;
+                                            }
+                                        }
                                     }
-                                }
-                                // Ideally reload partial to format correctly server-side
-                                // location.reload(); // Too heavy?
+                                });
                             }
                         });
                     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -301,6 +301,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('workflow/store', [\App\Http\Controllers\WorkflowController::class, 'store'])->name('workflow.store');
     Route::get('workflow/{order}/items', [\App\Http\Controllers\WorkflowController::class, 'fetchOrderItems'])->name('workflow.items');
     Route::post('workflow/item/{item}/step-toggle', [\App\Http\Controllers\WorkflowController::class, 'toggleStep'])->name('workflow.step.toggle');
+    Route::post('workflow/item/{item}/appointment', [\App\Http\Controllers\WorkflowController::class, 'updateAppointmentDate'])->name('workflow.item.appointment');
     Route::post('workflow/item/{item}/group', [\App\Http\Controllers\WorkflowController::class, 'updateGroup'])->name('workflow.item.group');
     Route::post('workflow/item/{item}/finalize', [\App\Http\Controllers\WorkflowController::class, 'finalizeItem'])->name('workflow.item.finalize');
     Route::post('workflow/item/{item}/cancel', [\App\Http\Controllers\WorkflowController::class, 'cancelItem'])->name('workflow.item.cancel');


### PR DESCRIPTION
- Add missing `workflow.item.appointment` route in `web.php` to enable appointment date saving.
- Update `_item_card.blade.php` to include SweetAlert2 confirmation dialog before saving appointment date and improve date display logic.
- Update `WorkflowController@dashboard` to correctly calculate statistics (Total Employees, Cancelled, Completed, Not Started) by strictly scoping them to Active Projects (`status != 'pre_production'`).