### PR TITLE
feat: add employer address search to global search across menus

### DIFF
--- a/app/Http/Controllers/Admin/IncompleteEmployeeController.php
+++ b/app/Http/Controllers/Admin/IncompleteEmployeeController.php
@@ -39,7 +39,10 @@ class IncompleteEmployeeController extends Controller
                   ->orWhere('employeeWorkPermit', 'like', $searchTerm)
                   ->orWhereHas('employer', function ($employerQuery) use ($searchTerm) {
                       $employerQuery->where('employerNameTh', 'like', $searchTerm)
-                                    ->orWhere('employerNameEn', 'like', $searchTerm);
+                                    ->orWhere('employerNameEn', 'like', $searchTerm)
+                                    ->orWhere(function($addrQ) use ($searchTerm) {
+                                        $addrQ->filterByAddress($searchTerm);
+                                    });
                   });
             });
         }

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -109,7 +109,10 @@ public function reinstate(Employee $employee)
               ->orWhere('employeeWorkPermit', 'like', $searchTerm)
               ->orWhereHas('employer', function ($employerQuery) use ($searchTerm) {
                   $employerQuery->where('employerNameTh', 'like', $searchTerm)
-                                ->orWhere('employerNameEn', 'like', $searchTerm);
+                                ->orWhere('employerNameEn', 'like', $searchTerm)
+                                ->orWhere(function($addrQ) use ($searchTerm) {
+                                    $addrQ->filterByAddress($searchTerm);
+                                });
               });
         });
     }
@@ -637,7 +640,10 @@ public function create(Request $request) // เพิ่ม Request $request เ
                   ->orWhere('employeeWorkPermit', 'like', $searchTerm)
                   ->orWhereHas('employer', function ($employerQuery) use ($searchTerm) {
                       $employerQuery->where('employerNameTh', 'like', $searchTerm)
-                                    ->orWhere('employerNameEn', 'like', $searchTerm);
+                                    ->orWhere('employerNameEn', 'like', $searchTerm)
+                                    ->orWhere(function($addrQ) use ($searchTerm) {
+                                        $addrQ->filterByAddress($searchTerm);
+                                    });
                   });
             });
         }
@@ -760,7 +766,10 @@ public function create(Request $request) // เพิ่ม Request $request เ
                   ->orWhere('employeeWorkPermit', 'like', $searchTerm)
                   ->orWhereHas('employer', function ($employerQuery) use ($searchTerm) {
                       $employerQuery->where('employerNameTh', 'like', $searchTerm)
-                                    ->orWhere('employerNameEn', 'like', $searchTerm);
+                                    ->orWhere('employerNameEn', 'like', $searchTerm)
+                                    ->orWhere(function($addrQ) use ($searchTerm) {
+                                        $addrQ->filterByAddress($searchTerm);
+                                    });
                   });
             });
         }

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -41,6 +41,9 @@ class EmployerController extends Controller
                   })
                   ->orWhereHas('assignedStaff', function($subQ) use ($searchTerm) {
                       $subQ->where('name', 'like', $searchTerm);
+                  })
+                  ->orWhere(function($subQ) use ($searchTerm) {
+                      $subQ->filterByAddress($searchTerm);
                   });
             });
         }
@@ -510,6 +513,9 @@ class EmployerController extends Controller
                   ->orWhere('employerNameEn', 'like', $searchTerm)
                   ->orWhereHas('jobOwner', function($subQ) use ($searchTerm) {
                       $subQ->where('name', 'like', $searchTerm);
+                  })
+                  ->orWhere(function($subQ) use ($searchTerm) {
+                      $subQ->filterByAddress($searchTerm);
                   });
             });
         }
@@ -564,7 +570,10 @@ class EmployerController extends Controller
             $query->where(function($q) use ($searchTerm) {
                 $q->where('employerNameTh', 'like', $searchTerm)
                   ->orWhere('employerNameEn', 'like', $searchTerm)
-                  ->orWhere('employerId', 'like', $searchTerm);
+                  ->orWhere('employerId', 'like', $searchTerm)
+                  ->orWhere(function($subQ) use ($searchTerm) {
+                      $subQ->filterByAddress($searchTerm);
+                  });
             });
         }
 

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -139,7 +139,10 @@ class NotificationController extends Controller
                 if ($type === 'employer_document_expiry') {
                     $q->whereHas('employer', function ($q_employer) use ($search) {
                         $q_employer->where('employerNameTh', 'like', "%{$search}%")
-                                   ->orWhere('employerNameEn', 'like', "%{$search}%");
+                                   ->orWhere('employerNameEn', 'like', "%{$search}%")
+                                   ->orWhere(function($addrQ) use ($search) {
+                                       $addrQ->filterByAddress($search);
+                                   });
                     });
                 } else {
                     $q->whereHas('employee', function ($q_employee) use ($search) {
@@ -149,7 +152,10 @@ class NotificationController extends Controller
                                    ->orWhere('companyWorkerId', 'like', "%{$search}%") // Added companyWorkerId
                                    ->orWhereHas('employer', function ($q_employer) use ($search) {
                                        $q_employer->where('employerNameTh', 'like', "%{$search}%")
-                                                  ->orWhere('employerNameEn', 'like', "%{$search}%"); // Added employerNameEn
+                                                  ->orWhere('employerNameEn', 'like', "%{$search}%") // Added employerNameEn
+                                                  ->orWhere(function($addrQ) use ($search) {
+                                                      $addrQ->filterByAddress($search);
+                                                  });
                                    });
                     });
                 }

--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -1248,6 +1248,9 @@ class RegistrationController extends Controller
                      ->orWhere('employerNameEn', 'like', "%{$search}%")
                      ->orWhereHas('jobOwner', function($q3) use ($search) {
                          $q3->where('name', 'like', "%{$search}%");
+                     })
+                     ->orWhere(function($addrQ) use ($search) {
+                         $addrQ->filterByAddress($search);
                      });
               });
         });
@@ -1266,6 +1269,18 @@ class RegistrationController extends Controller
 
         if (!$employerMatches && $employer->jobOwner && stripos($employer->jobOwner->name, $search) !== false) {
             $employerMatches = true;
+        }
+
+        // Check address match
+        if (!$employerMatches) {
+             $addressMatch = $employer->addresses()->where(function($q) use ($search) {
+                 $q->where('addrProvince', 'like', "%{$search}%")
+                   ->orWhere('addrDistrict', 'like', "%{$search}%");
+             })->exists();
+
+             if ($addressMatch) {
+                 $employerMatches = true;
+             }
         }
 
         if ($employerMatches) {

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -808,18 +808,46 @@ class RenewalController extends Controller
               ->orWhere('employeePassport', 'like', "%{$search}%")
               ->orWhereHas('employer', function($q2) use ($search) {
                   $q2->where('employerNameTh', 'like', "%{$search}%")
-                     ->orWhere('employerNameEn', 'like', "%{$search}%");
+                     ->orWhere('employerNameEn', 'like', "%{$search}%")
+                     ->orWhere(function($addrQ) use ($search) {
+                         $addrQ->filterByAddress($search);
+                     });
               });
         });
     }
 
     private function applyEmployerSearchToQuery($query, $employer, $search)
     {
-        // Simple search for now
-        return $query->where(function($q) use ($search) {
-            $q->where('employeeNameTh', 'like', "%{$search}%")
-              ->orWhere('employeeNameEn', 'like', "%{$search}%")
-              ->orWhere('employeePassport', 'like', "%{$search}%");
-        });
+        $employerMatches = false;
+        if (stripos($employer->employerNameTh, $search) !== false ||
+            stripos($employer->employerNameEn, $search) !== false) {
+            $employerMatches = true;
+        }
+
+        if (!$employerMatches && $employer->jobOwner && stripos($employer->jobOwner->name, $search) !== false) {
+            $employerMatches = true;
+        }
+
+        // Check address match
+        if (!$employerMatches) {
+             $addressMatch = $employer->addresses()->where(function($q) use ($search) {
+                 $q->where('addrProvince', 'like', "%{$search}%")
+                   ->orWhere('addrDistrict', 'like', "%{$search}%");
+             })->exists();
+
+             if ($addressMatch) {
+                 $employerMatches = true;
+             }
+        }
+
+        if ($employerMatches) {
+            return $query;
+        } else {
+            return $query->where(function($q) use ($search) {
+                $q->where('employeeNameTh', 'like', "%{$search}%")
+                  ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                  ->orWhere('employeePassport', 'like', "%{$search}%");
+            });
+        }
     }
 }

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -55,7 +55,10 @@ class WorkflowController extends Controller
                 $q->where('project_name', 'like', "%{$search}%")
                   ->orWhereHas('employer', function($e) use ($search) {
                       $e->where('employerNameTh', 'like', "%{$search}%")
-                        ->orWhere('employerNameEn', 'like', "%{$search}%");
+                        ->orWhere('employerNameEn', 'like', "%{$search}%")
+                        ->orWhere(function($addrQ) use ($search) {
+                            $addrQ->filterByAddress($search);
+                        });
                   });
             });
         }
@@ -399,7 +402,10 @@ class WorkflowController extends Controller
             $query->where(function($q) use ($search) {
                 $q->where('employeeNameTh', 'like', "%{$search}%")
                   ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                  ->orWhere('employeePassport', 'like', "%{$search}%");
+                  ->orWhere('employeePassport', 'like', "%{$search}%")
+                  ->orWhereHas('employer', function($e) use ($search) {
+                      $e->filterByAddress($search);
+                  });
             });
         }
 
@@ -422,7 +428,10 @@ class WorkflowController extends Controller
             $query->where(function($q) use ($search) {
                 $q->where('employeeNameTh', 'like', "%{$search}%")
                   ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                  ->orWhere('employeePassport', 'like', "%{$search}%");
+                  ->orWhere('employeePassport', 'like', "%{$search}%")
+                  ->orWhereHas('employer', function($e) use ($search) {
+                      $e->filterByAddress($search);
+                  });
             });
         }
 

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -9,10 +9,11 @@ use App\Models\JobOwner;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Builder;
 use App\Traits\LogActivity;
+use App\Traits\SearchableByAddress;
 
 class Employer extends Model
 {
-    use HasFactory, SoftDeletes, LogActivity;
+    use HasFactory, SoftDeletes, LogActivity, SearchableByAddress;
 
     protected static function booted(): void
     {

--- a/app/Traits/SearchableByAddress.php
+++ b/app/Traits/SearchableByAddress.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait SearchableByAddress
+{
+    /**
+     * Scope a query to search by address (Province and District).
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  string  $search
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeFilterByAddress(Builder $query, string $search): Builder
+    {
+        return $query->whereHas('addresses', function ($q) use ($search) {
+            $q->where('addrProvince', 'like', "%{$search}%")
+              ->orWhere('addrDistrict', 'like', "%{$search}%");
+        });
+    }
+}


### PR DESCRIPTION
Implemented address filtering (Province and District) in search functionality across multiple controllers including Employer, Employee, Workflow, Notification, Production, and Incomplete Employees.

- Created `SearchableByAddress` trait for `Employer` model.
- Updated `EmployerController`, `EmployeeController`, `WorkflowController` to use address filtering.
- Updated `NotificationController` to filter employer documents by address.
- Updated `IncompleteEmployeeController` for admin lists.
- Updated `RegistrationController` and `RenewalController` for production workflows.