### PR TITLE
Fix SQL error in AddressFilterTrait by correctly resetting offset/limit

### DIFF
--- a/app/Traits/AddressFilterTrait.php
+++ b/app/Traits/AddressFilterTrait.php
@@ -51,7 +51,8 @@ trait AddressFilterTrait
 
         // Remove orders and pagination for the subquery
         $subQuery->getQuery()->orders = null;
-        $subQuery->offset(null)->limit(null);
+        $subQuery->getQuery()->limit = null;
+        $subQuery->getQuery()->offset = null;
 
         // Ensure we only get the relevant ID column
         if ($joinEmployees) {


### PR DESCRIPTION
The `offset(null)` and `limit(null)` methods on the Eloquent Builder were causing invalid `OFFSET 0` clauses to be generated in subqueries used for filtering addresses, leading to SQL syntax errors.

This change replaces the method calls with direct property assignment on the underlying Query Builder (`$subQuery->getQuery()->offset = null`), ensuring the offset and limit are correctly removed from the subquery.

Verified by reproduction script showing clean SQL generation without `OFFSET 0`.