### PR TITLE
Fix empty province dropdown in Address Filter by supporting short pol…

### DIFF
--- a/app/Traits/AddressFilterTrait.php
+++ b/app/Traits/AddressFilterTrait.php
@@ -70,11 +70,13 @@ trait AddressFilterTrait
 
         // Get the correct morph class for Employer to ensure matching regardless of MorphMap
         $morphClass = (new Employer)->getMorphClass();
+        // Also include the short class name to handle legacy data or direct saves
+        $possibleMorphs = array_unique([$morphClass, class_basename($morphClass)]);
 
         // Use a joinSub to robustly filter addresses belonging to the filtered employers
         // This avoids limitations of whereIn with subqueries and handles bindings correctly
         $baseAddressQuery = Address::query()
-            ->where('addressable_type', $morphClass)
+            ->whereIn('addressable_type', $possibleMorphs)
             ->joinSub($subQuery, 'filtered_source', function ($join) use ($joinColumn) {
                 $join->on('addresses.addressable_id', '=', 'filtered_source.' . $joinColumn);
             });


### PR DESCRIPTION
…ymorphic class names

This commit modifies `AddressFilterTrait` to check for both the fully qualified class name (e.g., `App\Models\Employer`) and the short class name (e.g., `Employer`) in the `addressable_type` column. This resolves an issue where the address filter dropdown would be empty if legacy data or direct database insertions used the short class name format.

- Updated `getAddressOptions` in `app/Traits/AddressFilterTrait.php` to use `whereIn` for `addressable_type`.
- Verified the fix with a reproduction script simulating both data formats.