### PR TITLE
Fix address filtering, display, and Bang Bon sub-districts

### DIFF
--- a/database/migrations/2026_02_03_020706_repair_thai_addresses.php
+++ b/database/migrations/2026_02_03_020706_repair_thai_addresses.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $provinceMap = [
+            'Bangkok' => 'กรุงเทพมหานคร',
+            'Krabi' => 'กระบี่',
+            'Kanchanaburi' => 'กาญจนบุรี',
+            'Kalasin' => 'กาฬสินธุ์',
+            'Kamphaeng Phet' => 'กำแพงเพชร',
+            'Khon Kaen' => 'ขอนแก่น',
+            'Chanthaburi' => 'จันทบุรี',
+            'Chachoengsao' => 'ฉะเชิงเทรา',
+            'Chon Buri' => 'ชลบุรี',
+            'Chai Nat' => 'ชัยนาท',
+            'Chaiyaphum' => 'ชัยภูมิ',
+            'Chumphon' => 'ชุมพร',
+            'Chiang Rai' => 'เชียงราย',
+            'Chiang Mai' => 'เชียงใหม่',
+            'Trang' => 'ตรัง',
+            'Trat' => 'ตราด',
+            'Tak' => 'ตาก',
+            'Nakhon Nayok' => 'นครนายก',
+            'Nakhon Pathom' => 'นครปฐม',
+            'Nakhon Phanom' => 'นครพนม',
+            'Nakhon Ratchasima' => 'นครราชสีมา',
+            'Nakhon Si Thammarat' => 'นครศรีธรรมราช',
+            'Nakhon Sawan' => 'นครสวรรค์',
+            'Nonthaburi' => 'นนทบุรี',
+            'Narathiwat' => 'นราธิวาส',
+            'Nan' => 'น่าน',
+            'Bueng Kan' => 'บึงกาฬ',
+            'Buriram' => 'บุรีรัมย์',
+            'Pathum Thani' => 'ปทุมธานี',
+            'Prachuap Khiri Khan' => 'ประจวบคีรีขันธ์',
+            'Prachin Buri' => 'ปราจีนบุรี',
+            'Pattani' => 'ปัตตานี',
+            'Phra Nakhon Si Ayutthaya' => 'พระนครศรีอยุธยา',
+            'Phayao' => 'พะเยา',
+            'Phangnga' => 'พังงา',
+            'Phatthalung' => 'พัทลุง',
+            'Phichit' => 'พิจิตร',
+            'Phitsanulok' => 'พิษณุโลก',
+            'Phetchaburi' => 'เพชรบุรี',
+            'Phetchabun' => 'เพชรบูรณ์',
+            'Phrae' => 'แพร่',
+            'Phuket' => 'ภูเก็ต',
+            'Maha Sarakham' => 'มหาสารคาม',
+            'Mukdahan' => 'มุกดาหาร',
+            'Mae Hong Son' => 'แม่ฮ่องสอน',
+            'Yasothon' => 'ยโสธร',
+            'Yala' => 'ยะลา',
+            'Roi Et' => 'ร้อยเอ็ด',
+            'Ranong' => 'ระนอง',
+            'Rayong' => 'ระยอง',
+            'Ratchaburi' => 'ราชบุรี',
+            'Lopburi' => 'ลพบุรี',
+            'Lampang' => 'ลำปาง',
+            'Lamphun' => 'ลำพูน',
+            'Loei' => 'เลย',
+            'Si Sa Ket' => 'ศรีสะเกษ',
+            'Sakon Nakhon' => 'สกลนคร',
+            'Songkhla' => 'สงขลา',
+            'Satun' => 'สตูล',
+            'Samut Prakan' => 'สมุทรปราการ',
+            'Samut Songkhram' => 'สมุทรสงคราม',
+            'Samut Sakhon' => 'สมุทรสาคร',
+            'Sa Kaeo' => 'สระแก้ว',
+            'Saraburi' => 'สระบุรี',
+            'Sing Buri' => 'สิงห์บุรี',
+            'Sukhothai' => 'สุโขทัย',
+            'Suphan Buri' => 'สุพรรณบุรี',
+            'Surat Thani' => 'สุราษฎร์ธานี',
+            'Surin' => 'สุรินทร์',
+            'Nong Khai' => 'หนองคาย',
+            'Nong Bua Lam Phu' => 'หนองบัวลำภู',
+            'Ang Thong' => 'อ่างทอง',
+            'Amnat Charoen' => 'อำนาจเจริญ',
+            'Udon Thani' => 'อุดรธานี',
+            'Uttaradit' => 'อุตรดิตถ์',
+            'Uthai Thani' => 'อุทัยธานี',
+            'Ubon Ratchathani' => 'อุบลราชธานี'
+        ];
+
+        $addresses = DB::table('addresses')
+            ->where(function($q) {
+                $q->whereNull('addrProvince')
+                  ->orWhere('addrProvince', '')
+                  ->orWhere('addrProvince', '-- ทุกจังหวัด --'); // Just in case
+            })
+            ->whereNotNull('addrProvinceEn')
+            ->where('addrProvinceEn', '!=', '')
+            ->get();
+
+        foreach ($addresses as $address) {
+            $en = trim($address->addrProvinceEn);
+            if (isset($provinceMap[$en])) {
+                DB::table('addresses')
+                    ->where('id', $address->id)
+                    ->update(['addrProvince' => $provinceMap[$en]]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // No reverse operation needed as this is a data repair
+    }
+};

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -433,13 +433,21 @@
                 <div class="address-card d-flex justify-content-between align-items-start" id="address-card-{{$address->id}}">
                     <div>
                         <p class="mb-0">
-                            เลขที่ {{ $address->addrNo ?? '' }} หมู่ {{ $address->addrMoo ?? '' }} ซอย{{ $address->addrSoi ?? '' }} ถนน{{ $address->addrRoad ?? '' }}
-                            แขวง/ตำบล {{ $address->addrSubDistrict ?? '' }} เขต/อำเภอ {{ $address->addrDistrict ?? '' }}
+                            {{ $address->addrNo ? 'เลขที่ ' . $address->addrNo : '' }}
+                            {{ $address->addrMoo ? 'หมู่ ' . $address->addrMoo : '' }}
+                            {{ $address->addrSoi ? 'ซอย' . $address->addrSoi : '' }}
+                            {{ $address->addrRoad ? 'ถนน' . $address->addrRoad : '' }}
+                            {{ $address->addrSubDistrict ? 'แขวง/ตำบล ' . $address->addrSubDistrict : '' }}
+                            {{ $address->addrDistrict ? 'เขต/อำเภอ ' . $address->addrDistrict : '' }}
                             {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
                         </p>
                         <p class="mb-0 text-muted small">
-                            Addr: {{ $address->addrNoEn ?? '' }}, Moo: {{ $address->addrMooEn ?? '' }}, Soi: {{ $address->addrSoiEn ?? '' }}, Road: {{ $address->addrRoadEn ?? '' }},
-                            {{ $address->addrSubDistrictEn ?? '' }}, {{ $address->addrDistrictEn ?? '' }},
+                            {{ $address->addrNoEn ? 'Addr: ' . $address->addrNoEn . ', ' : '' }}
+                            {{ $address->addrMooEn ? 'Moo: ' . $address->addrMooEn . ', ' : '' }}
+                            {{ $address->addrSoiEn ? 'Soi: ' . $address->addrSoiEn . ', ' : '' }}
+                            {{ $address->addrRoadEn ? 'Road: ' . $address->addrRoadEn . ', ' : '' }}
+                            {{ $address->addrSubDistrictEn ? $address->addrSubDistrictEn . ', ' : '' }}
+                            {{ $address->addrDistrictEn ? $address->addrDistrictEn . ', ' : '' }}
                             {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
                         </p>
                     </div>
@@ -470,13 +478,21 @@
                 <div class="address-card d-flex justify-content-between align-items-start" id="address-card-{{$address->id}}">
                     <div>
                         <p class="mb-0">
-                            เลขที่ {{ $address->addrNo ?? '' }} หมู่ {{ $address->addrMoo ?? '' }} ซอย{{ $address->addrSoi ?? '' }} ถนน{{ $address->addrRoad ?? '' }}
-                            แขวง/ตำบล {{ $address->addrSubDistrict ?? '' }} เขต/อำเภอ {{ $address->addrDistrict ?? '' }}
+                            {{ $address->addrNo ? 'เลขที่ ' . $address->addrNo : '' }}
+                            {{ $address->addrMoo ? 'หมู่ ' . $address->addrMoo : '' }}
+                            {{ $address->addrSoi ? 'ซอย' . $address->addrSoi : '' }}
+                            {{ $address->addrRoad ? 'ถนน' . $address->addrRoad : '' }}
+                            {{ $address->addrSubDistrict ? 'แขวง/ตำบล ' . $address->addrSubDistrict : '' }}
+                            {{ $address->addrDistrict ? 'เขต/อำเภอ ' . $address->addrDistrict : '' }}
                             {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
                         </p>
                         <p class="mb-0 text-muted small">
-                            Addr: {{ $address->addrNoEn ?? '' }}, Moo: {{ $address->addrMooEn ?? '' }}, Soi: {{ $address->addrSoiEn ?? '' }}, Road: {{ $address->addrRoadEn ?? '' }},
-                            {{ $address->addrSubDistrictEn ?? '' }}, {{ $address->addrDistrictEn ?? '' }},
+                            {{ $address->addrNoEn ? 'Addr: ' . $address->addrNoEn . ', ' : '' }}
+                            {{ $address->addrMooEn ? 'Moo: ' . $address->addrMooEn . ', ' : '' }}
+                            {{ $address->addrSoiEn ? 'Soi: ' . $address->addrSoiEn . ', ' : '' }}
+                            {{ $address->addrRoadEn ? 'Road: ' . $address->addrRoadEn . ', ' : '' }}
+                            {{ $address->addrSubDistrictEn ? $address->addrSubDistrictEn . ', ' : '' }}
+                            {{ $address->addrDistrictEn ? $address->addrDistrictEn . ', ' : '' }}
                             {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
                         </p>
                     </div>

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -214,13 +214,21 @@
         @forelse ($employer->addresses->where('type', 'registered') as $address)
             <div class="address-card p-3 border rounded">
                 <p class="mb-0">
-                    เลขที่ {{ $address->addrNo ?? '' }} หมู่ {{ $address->addrMoo ?? '' }} ซอย{{ $address->addrSoi ?? '' }} ถนน{{ $address->addrRoad ?? '' }}
-                    แขวง/ตำบล {{ $address->addrSubDistrict ?? '' }} เขต/อำเภอ {{ $address->addrDistrict ?? '' }}
+                    {{ $address->addrNo ? 'เลขที่ ' . $address->addrNo : '' }}
+                    {{ $address->addrMoo ? 'หมู่ ' . $address->addrMoo : '' }}
+                    {{ $address->addrSoi ? 'ซอย' . $address->addrSoi : '' }}
+                    {{ $address->addrRoad ? 'ถนน' . $address->addrRoad : '' }}
+                    {{ $address->addrSubDistrict ? 'แขวง/ตำบล ' . $address->addrSubDistrict : '' }}
+                    {{ $address->addrDistrict ? 'เขต/อำเภอ ' . $address->addrDistrict : '' }}
                     {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
                 </p>
                 <p class="mb-0 text-muted small">
-                    Addr: {{ $address->addrNoEn ?? '' }}, Moo: {{ $address->addrMooEn ?? '' }}, Soi: {{ $address->addrSoiEn ?? '' }}, Road: {{ $address->addrRoadEn ?? '' }},
-                    {{ $address->addrSubDistrictEn ?? '' }}, {{ $address->addrDistrictEn ?? '' }},
+                    {{ $address->addrNoEn ? 'Addr: ' . $address->addrNoEn . ', ' : '' }}
+                    {{ $address->addrMooEn ? 'Moo: ' . $address->addrMooEn . ', ' : '' }}
+                    {{ $address->addrSoiEn ? 'Soi: ' . $address->addrSoiEn . ', ' : '' }}
+                    {{ $address->addrRoadEn ? 'Road: ' . $address->addrRoadEn . ', ' : '' }}
+                    {{ $address->addrSubDistrictEn ? $address->addrSubDistrictEn . ', ' : '' }}
+                    {{ $address->addrDistrictEn ? $address->addrDistrictEn . ', ' : '' }}
                     {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
                 </p>
             </div>
@@ -237,13 +245,21 @@
         @forelse ($employer->addresses->where('type', 'workplace') as $address)
              <div class="address-card p-3 border rounded">
                 <p class="mb-0">
-                    เลขที่ {{ $address->addrNo ?? '' }} หมู่ {{ $address->addrMoo ?? '' }} ซอย{{ $address->addrSoi ?? '' }} ถนน{{ $address->addrRoad ?? '' }}
-                    แขวง/ตำบล {{ $address->addrSubDistrict ?? '' }} เขต/อำเภอ {{ $address->addrDistrict ?? '' }}
+                    {{ $address->addrNo ? 'เลขที่ ' . $address->addrNo : '' }}
+                    {{ $address->addrMoo ? 'หมู่ ' . $address->addrMoo : '' }}
+                    {{ $address->addrSoi ? 'ซอย' . $address->addrSoi : '' }}
+                    {{ $address->addrRoad ? 'ถนน' . $address->addrRoad : '' }}
+                    {{ $address->addrSubDistrict ? 'แขวง/ตำบล ' . $address->addrSubDistrict : '' }}
+                    {{ $address->addrDistrict ? 'เขต/อำเภอ ' . $address->addrDistrict : '' }}
                     {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
                 </p>
                 <p class="mb-0 text-muted small">
-                    Addr: {{ $address->addrNoEn ?? '' }}, Moo: {{ $address->addrMooEn ?? '' }}, Soi: {{ $address->addrSoiEn ?? '' }}, Road: {{ $address->addrRoadEn ?? '' }},
-                    {{ $address->addrSubDistrictEn ?? '' }}, {{ $address->addrDistrictEn ?? '' }},
+                    {{ $address->addrNoEn ? 'Addr: ' . $address->addrNoEn . ', ' : '' }}
+                    {{ $address->addrMooEn ? 'Moo: ' . $address->addrMooEn . ', ' : '' }}
+                    {{ $address->addrSoiEn ? 'Soi: ' . $address->addrSoiEn . ', ' : '' }}
+                    {{ $address->addrRoadEn ? 'Road: ' . $address->addrRoadEn . ', ' : '' }}
+                    {{ $address->addrSubDistrictEn ? $address->addrSubDistrictEn . ', ' : '' }}
+                    {{ $address->addrDistrictEn ? $address->addrDistrictEn . ', ' : '' }}
                     {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
                 </p>
             </div>

--- a/storage/app/public/.gitignore
+++ b/storage/app/public/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!data/


### PR DESCRIPTION
- Fix: Add missing sub-districts (Bang Bon Nuea, Bang Bon Tai, Khlong Bang Phran, Bang Bon) to `thai-address-data.json`.
- Fix: Repair existing address records via migration `2026_02_03_020706_repair_thai_addresses` to populate missing Thai province names, fixing the filter dropdown.
- Fix: Hide empty address labels (Moo, Soi, Road) in Employer Edit and Preview views.
- Chore: Whitelist `storage/app/public/data/` in `.gitignore` to ensure address data is tracked.