### PR TITLE
Fix address filtering dropdowns, full address display, and Bang Bon data

### DIFF
--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -36,4 +36,34 @@ class Address extends Model
     {
         return $this->morphTo();
     }
+
+    public function getFullAddressThAttribute()
+    {
+        $parts = [];
+        if ($this->addrNo) $parts[] = 'เลขที่ ' . $this->addrNo;
+        if ($this->addrMoo) $parts[] = 'หมู่ ' . $this->addrMoo;
+        if ($this->addrSoi) $parts[] = 'ซอย ' . $this->addrSoi;
+        if ($this->addrRoad) $parts[] = 'ถนน ' . $this->addrRoad;
+        if ($this->addrSubDistrict) $parts[] = 'ต.' . $this->addrSubDistrict;
+        if ($this->addrDistrict) $parts[] = 'อ.' . $this->addrDistrict;
+        if ($this->addrProvince) $parts[] = 'จ.' . $this->addrProvince;
+        if ($this->addrZipCode) $parts[] = $this->addrZipCode;
+
+        return implode(' ', $parts);
+    }
+
+    public function getFullAddressEnAttribute()
+    {
+        $parts = [];
+        if ($this->addrNoEn) $parts[] = 'No. ' . $this->addrNoEn;
+        if ($this->addrMooEn) $parts[] = 'Moo ' . $this->addrMooEn;
+        if ($this->addrSoiEn) $parts[] = 'Soi ' . $this->addrSoiEn;
+        if ($this->addrRoadEn) $parts[] = 'Rd. ' . $this->addrRoadEn;
+        if ($this->addrSubDistrictEn) $parts[] = $this->addrSubDistrictEn;
+        if ($this->addrDistrictEn) $parts[] = $this->addrDistrictEn;
+        if ($this->addrProvinceEn) $parts[] = $this->addrProvinceEn;
+        if ($this->addrZipCodeEn) $parts[] = $this->addrZipCodeEn;
+
+        return implode(', ', $parts);
+    }
 }

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -127,4 +127,18 @@ class Employer extends Model
         }
         return array_unique($labels);
     }
+
+    public function getMatchedAddresses($province, $district = null, $subDistrict = null)
+    {
+        if (!$province) return collect();
+        // Ensure addresses are loaded or load them
+        $addresses = $this->relationLoaded('addresses') ? $this->addresses : $this->addresses()->get();
+
+        return $addresses->filter(function ($address) use ($province, $district, $subDistrict) {
+            if ($address->addrProvince !== $province) return false;
+            if ($district && $address->addrDistrict !== $district) return false;
+            if ($subDistrict && $address->addrSubDistrict !== $subDistrict) return false;
+            return true;
+        });
+    }
 }

--- a/app/Traits/AddressFilterTrait.php
+++ b/app/Traits/AddressFilterTrait.php
@@ -68,8 +68,9 @@ trait AddressFilterTrait
             $joinColumn = str_contains($employerIdField, '.') ? last(explode('.', $employerIdField)) : $employerIdField;
         }
 
-        // Get the correct morph class for Employer to ensure matching regardless of MorphMap
-        $morphClass = (new Employer)->getMorphClass();
+        // Get the correct morph class for the model to ensure matching regardless of MorphMap
+        $model = $query->getModel();
+        $morphClass = $model->getMorphClass();
         // Also include the short class name to handle legacy data or direct saves
         $possibleMorphs = array_unique([$morphClass, class_basename($morphClass)]);
 
@@ -89,7 +90,8 @@ trait AddressFilterTrait
             ->values();
 
         $districts = collect();
-        $selectedProvince = request('addrProvince');
+        $selectedProvince = request('addrProvince') ? trim(request('addrProvince')) : null;
+
         if ($selectedProvince) {
             $districts = (clone $baseAddressQuery)
                 ->where('addrProvince', $selectedProvince)
@@ -101,7 +103,8 @@ trait AddressFilterTrait
         }
 
         $subDistricts = collect();
-        $selectedDistrict = request('addrDistrict');
+        $selectedDistrict = request('addrDistrict') ? trim(request('addrDistrict')) : null;
+
         if ($selectedProvince && $selectedDistrict) {
             $subDistricts = (clone $baseAddressQuery)
                 ->where('addrProvince', $selectedProvince)

--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -63,8 +63,11 @@
                         <td>
                             {{ $employer->employerNameTh }}
                             @if(request('addrProvince'))
-                                @foreach($employer->getMatchedAddressLabels(request('addrProvince'), request('addrDistrict'), request('addrSubDistrict')) as $label)
-                                    <div class="text-primary small fw-bold">{{ $label }}</div>
+                                @foreach($employer->getMatchedAddresses(request('addrProvince'), request('addrDistrict'), request('addrSubDistrict')) as $address)
+                                    <div class="text-primary small fw-bold mt-1">
+                                        {{ $address->full_address_th }}
+                                        <span class="text-muted fw-normal">({{ $address->type === 'registered' ? 'ที่อยู่ตามทะเบียนบ้าน' : 'ที่อยู่สถานที่ทำงาน' }})</span>
+                                    </div>
                                 @endforeach
                             @endif
                         </td>


### PR DESCRIPTION
- Created `storage/app/public/data/thai-address-data.json` with correct Bang Bon sub-district data to fix incomplete options.
- Refactored `AddressFilterTrait` to dynamically determine the model class and trim request inputs, fixing disabled dropdowns caused by whitespace mismatches or incorrect class resolution.
- Added `getFullAddressThAttribute` and `getFullAddressEnAttribute` to `Address` model for consistent full address formatting.
- Updated `resources/views/employers/index.blade.php` to display the full address string instead of just the address type label.
- Added `getMatchedAddresses` to `Employer` model to retrieve filtered Address objects.