### PR TITLE
Fix address filter and improve address display

### DIFF
--- a/app/Traits/AddressFilterTrait.php
+++ b/app/Traits/AddressFilterTrait.php
@@ -90,7 +90,7 @@ trait AddressFilterTrait
             ->values();
 
         $districts = collect();
-        $selectedProvince = request('addrProvince') ? trim(request('addrProvince')) : null;
+        $selectedProvince = request('addrProvince');
 
         if ($selectedProvince) {
             $districts = (clone $baseAddressQuery)
@@ -103,7 +103,7 @@ trait AddressFilterTrait
         }
 
         $subDistricts = collect();
-        $selectedDistrict = request('addrDistrict') ? trim(request('addrDistrict')) : null;
+        $selectedDistrict = request('addrDistrict');
 
         if ($selectedProvince && $selectedDistrict) {
             $subDistricts = (clone $baseAddressQuery)

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -432,24 +432,8 @@
             @forelse ($employer->addresses->where('type', 'registered') as $address)
                 <div class="address-card d-flex justify-content-between align-items-start" id="address-card-{{$address->id}}">
                     <div>
-                        <p class="mb-0">
-                            {{ $address->addrNo ? 'เลขที่ ' . $address->addrNo : '' }}
-                            {{ $address->addrMoo ? 'หมู่ ' . $address->addrMoo : '' }}
-                            {{ $address->addrSoi ? 'ซอย' . $address->addrSoi : '' }}
-                            {{ $address->addrRoad ? 'ถนน' . $address->addrRoad : '' }}
-                            {{ $address->addrSubDistrict ? 'แขวง/ตำบล ' . $address->addrSubDistrict : '' }}
-                            {{ $address->addrDistrict ? 'เขต/อำเภอ ' . $address->addrDistrict : '' }}
-                            {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
-                        </p>
-                        <p class="mb-0 text-muted small">
-                            {{ $address->addrNoEn ? 'Addr: ' . $address->addrNoEn . ', ' : '' }}
-                            {{ $address->addrMooEn ? 'Moo: ' . $address->addrMooEn . ', ' : '' }}
-                            {{ $address->addrSoiEn ? 'Soi: ' . $address->addrSoiEn . ', ' : '' }}
-                            {{ $address->addrRoadEn ? 'Road: ' . $address->addrRoadEn . ', ' : '' }}
-                            {{ $address->addrSubDistrictEn ? $address->addrSubDistrictEn . ', ' : '' }}
-                            {{ $address->addrDistrictEn ? $address->addrDistrictEn . ', ' : '' }}
-                            {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
-                        </p>
+                        <p class="mb-0">{{ $address->full_address_th }}</p>
+                        <p class="mb-0 text-muted small">{{ $address->full_address_en }}</p>
                     </div>
                     <div class="btn-group btn-group-sm">
                         <button type="button" class="btn btn-sm btn-danger btn-delete-address" data-address-id="{{ $address->id }}">{{ __('Delete') }}</button>

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -213,24 +213,8 @@
     <div class="vstack gap-3">
         @forelse ($employer->addresses->where('type', 'registered') as $address)
             <div class="address-card p-3 border rounded">
-                <p class="mb-0">
-                    {{ $address->addrNo ? 'เลขที่ ' . $address->addrNo : '' }}
-                    {{ $address->addrMoo ? 'หมู่ ' . $address->addrMoo : '' }}
-                    {{ $address->addrSoi ? 'ซอย' . $address->addrSoi : '' }}
-                    {{ $address->addrRoad ? 'ถนน' . $address->addrRoad : '' }}
-                    {{ $address->addrSubDistrict ? 'แขวง/ตำบล ' . $address->addrSubDistrict : '' }}
-                    {{ $address->addrDistrict ? 'เขต/อำเภอ ' . $address->addrDistrict : '' }}
-                    {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
-                </p>
-                <p class="mb-0 text-muted small">
-                    {{ $address->addrNoEn ? 'Addr: ' . $address->addrNoEn . ', ' : '' }}
-                    {{ $address->addrMooEn ? 'Moo: ' . $address->addrMooEn . ', ' : '' }}
-                    {{ $address->addrSoiEn ? 'Soi: ' . $address->addrSoiEn . ', ' : '' }}
-                    {{ $address->addrRoadEn ? 'Road: ' . $address->addrRoadEn . ', ' : '' }}
-                    {{ $address->addrSubDistrictEn ? $address->addrSubDistrictEn . ', ' : '' }}
-                    {{ $address->addrDistrictEn ? $address->addrDistrictEn . ', ' : '' }}
-                    {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
-                </p>
+                <p class="mb-0">{{ $address->full_address_th }}</p>
+                <p class="mb-0 text-muted small">{{ $address->full_address_en }}</p>
             </div>
         @empty
             <p class="text-muted">ยังไม่มีที่อยู่</p>
@@ -244,24 +228,8 @@
     <div class="vstack gap-3">
         @forelse ($employer->addresses->where('type', 'workplace') as $address)
              <div class="address-card p-3 border rounded">
-                <p class="mb-0">
-                    {{ $address->addrNo ? 'เลขที่ ' . $address->addrNo : '' }}
-                    {{ $address->addrMoo ? 'หมู่ ' . $address->addrMoo : '' }}
-                    {{ $address->addrSoi ? 'ซอย' . $address->addrSoi : '' }}
-                    {{ $address->addrRoad ? 'ถนน' . $address->addrRoad : '' }}
-                    {{ $address->addrSubDistrict ? 'แขวง/ตำบล ' . $address->addrSubDistrict : '' }}
-                    {{ $address->addrDistrict ? 'เขต/อำเภอ ' . $address->addrDistrict : '' }}
-                    {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
-                </p>
-                <p class="mb-0 text-muted small">
-                    {{ $address->addrNoEn ? 'Addr: ' . $address->addrNoEn . ', ' : '' }}
-                    {{ $address->addrMooEn ? 'Moo: ' . $address->addrMooEn . ', ' : '' }}
-                    {{ $address->addrSoiEn ? 'Soi: ' . $address->addrSoiEn . ', ' : '' }}
-                    {{ $address->addrRoadEn ? 'Road: ' . $address->addrRoadEn . ', ' : '' }}
-                    {{ $address->addrSubDistrictEn ? $address->addrSubDistrictEn . ', ' : '' }}
-                    {{ $address->addrDistrictEn ? $address->addrDistrictEn . ', ' : '' }}
-                    {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
-                </p>
+                <p class="mb-0">{{ $address->full_address_th }}</p>
+                <p class="mb-0 text-muted small">{{ $address->full_address_en }}</p>
             </div>
         @empty
             <p class="text-muted">ยังไม่มีที่อยู่</p>


### PR DESCRIPTION
- Added `thai-address-data.json` with Bang Bon district data.
- Updated `employers/edit.blade.php` and `previews/_employer_data.blade.php` to use `full_address_th` and `full_address_en` accessors for complete address display.
- Removed `trim()` in `AddressFilterTrait.php` to fix disabled cascading dropdowns (District/Sub-district) caused by whitespace mismatches.