### PR TITLE
Fix Document Scanner image rotation logic to preserve orientation

### DIFF
--- a/resources/views/components/document-scanner.blade.php
+++ b/resources/views/components/document-scanner.blade.php
@@ -1083,8 +1083,18 @@
                 let newNormCorners = [];
                 if (degrees === 90) {
                     newNormCorners = normCorners.map(c => ({ u: 1 - c.v, v: c.u }));
+                    // FIX: Shift array to maintain TL, TR, BR, BL order
+                    // Old TL (0) -> New TR. We need New TL to be at index 0.
+                    // The point that became New TL is Old BL (3).
+                    // So we move last element to first.
+                    if (newNormCorners.length === 4) newNormCorners.unshift(newNormCorners.pop());
                 } else if (degrees === -90) {
                     newNormCorners = normCorners.map(c => ({ u: c.v, v: 1 - c.u }));
+                    // FIX: Shift array to maintain TL, TR, BR, BL order
+                    // Old TL (0) -> New BL. We need New TL to be at index 0.
+                    // The point that became New TL is Old TR (1).
+                    // So we move first element to last.
+                    if (newNormCorners.length === 4) newNormCorners.push(newNormCorners.shift());
                 } else {
                     newNormCorners = normCorners;
                 }


### PR DESCRIPTION
The image rotation feature in the document scanner previously resulted in incorrect crop orientation after saving, causing vertical images to revert to horizontal crops.

This issue was caused by the `rotateImage` function correctly rotating the coordinate space but failing to reorder the corner points array. This mismatch caused the subsequent OpenCV warp operation to map corners incorrectly (e.g., mapping Top-Right to Top-Left), effectively cancelling out the rotation.

This commit fixes the issue by implementing a cyclic shift of the `newNormCorners` array when rotating:
- For 90° CW rotation: Shift array right (move last element to first).
- For 90° CCW rotation: Shift array left (move first element to last).

This ensures that index 0 of the corners array always corresponds to the Top-Left corner of the new visual orientation, ensuring the crop result matches the user's preview.