### PR TITLE
feat: Add biometrics collection to registration workflow

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -66,6 +66,7 @@ class RegistrationController extends Controller
         $totalCancelled = 0;
         $totalSaved = 0;
         $notStartedCount = 0;
+        $totalBiometricsCollected = 0; // NEW
         $stepStats = $steps->pluck('id')->mapWithKeys(fn($id) => [$id => 0])->toArray();
 
         // Group by Employer for Per-Employer Stats assignment later
@@ -87,6 +88,11 @@ class RegistrationController extends Controller
                 // Not Started Logic
                 if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
                     $notStartedCount++;
+                }
+
+                // Biometrics Collected Logic
+                if ($emp->biometrics_collected_at) {
+                    $totalBiometricsCollected++;
                 }
 
                 // Step Stats (Highest Step)
@@ -142,6 +148,17 @@ class RegistrationController extends Controller
                 if ($filter === 'cancelled') {
                      return $emps->contains('status', 'registration_cancelled');
                 }
+                // Biometrics Filters
+                if ($filter === 'biometrics_collected') {
+                     return $emps->contains(function($e) {
+                         return $e->status !== 'registration_cancelled' && $e->biometrics_collected_at;
+                     });
+                }
+                if ($filter === 'biometrics_not_collected') {
+                     return $emps->contains(function($e) {
+                         return $e->status !== 'registration_cancelled' && !$e->biometrics_collected_at;
+                     });
+                }
                 // Step Filter
                 return $emps->contains(function($e) use ($filter) {
                      if ($e->status === 'registration_cancelled') return false;
@@ -193,6 +210,7 @@ class RegistrationController extends Controller
             $empActiveCount = 0;
             $empCancelledCount = 0;
             $empSavedCount = 0;
+            $empBiometricsCollected = 0;
 
             foreach ($myEmps as $emp) {
                 if ($emp->status === 'registration_cancelled') {
@@ -210,6 +228,10 @@ class RegistrationController extends Controller
                     $empNotStarted++;
                 }
 
+                if ($emp->biometrics_collected_at) {
+                    $empBiometricsCollected++;
+                }
+
                 $highestStep = $emp->registrationSteps->sortByDesc('order')->first();
                 if ($highestStep && isset($empStats[$highestStep->id])) {
                     $empStats[$highestStep->id]++;
@@ -222,6 +244,7 @@ class RegistrationController extends Controller
             $employer->activeEmployeesCount = $empActiveCount;
             $employer->cancelledCount = $empCancelledCount;
             $employer->savedCount = $empSavedCount;
+            $employer->biometricsCollectedCount = $empBiometricsCollected;
 
             // NOTE: We do NOT assign $employer->employees here to keep response light.
             // The view will lazily load them.
@@ -248,6 +271,7 @@ class RegistrationController extends Controller
             'totalEmployers',
             'cancelledEmployersCount',
             'notStartedCount',
+            'totalBiometricsCollected',
             'steps',
             'stepStats',
             'employers',
@@ -297,6 +321,12 @@ class RegistrationController extends Controller
                  $query->where('status', 'registration_completed');
             } elseif ($filter === 'cancelled') {
                  $query->where('status', 'registration_cancelled');
+            } elseif ($filter === 'biometrics_collected') {
+                 $query->where('status', '!=', 'registration_cancelled')
+                       ->whereNotNull('biometrics_collected_at');
+            } elseif ($filter === 'biometrics_not_collected') {
+                 $query->where('status', '!=', 'registration_cancelled')
+                       ->whereNull('biometrics_collected_at');
             } elseif (is_numeric($filter)) { // Step ID
                  $query->where('status', '!=', 'registration_cancelled');
                  // We filter by highest step in PHP below
@@ -1189,13 +1219,17 @@ class RegistrationController extends Controller
         // 5. Total Employers (who have any registration employees)
         $globalEmployers = (clone $globalQuery)->whereIn('status', $allStatuses)->distinct('employer_id')->count('employer_id');
 
+        // 6. Total Biometrics Collected
+        $globalBiometrics = (clone $globalQuery)->whereIn('status', $activeStatuses)->whereNotNull('biometrics_collected_at')->count();
+
         $stats = [
             'global' => [
                 'total' => $globalTotal,
                 'not_started' => $globalNotStarted,
                 'cancelled' => $globalCancelled,
                 'saved' => $globalSaved,
-                'employers_count' => $globalEmployers
+                'employers_count' => $globalEmployers,
+                'biometrics_collected' => $globalBiometrics
             ]
         ];
 
@@ -1231,17 +1265,59 @@ class RegistrationController extends Controller
 
             $empCancelled = (clone $empQuery)->where('status', 'registration_cancelled')->count();
             $empSaved = (clone $empQuery)->where('status', 'registration_completed')->count();
+            $empBiometrics = (clone $empQuery)->whereIn('status', $activeStatuses)->whereNotNull('biometrics_collected_at')->count();
 
             $stats['employer'] = [
                 'id' => $employerId,
                 'total' => $empTotal,
                 'not_started' => $empNotStarted,
                 'cancelled' => $empCancelled,
-                'saved' => $empSaved
+                'saved' => $empSaved,
+                'biometrics_collected' => $empBiometrics
             ];
         }
 
         return $stats;
+    }
+
+    /**
+     * Update Biometrics Collection Status and File.
+     */
+    public function updateBiometrics(Request $request, Employee $employee)
+    {
+        if (!auth()->user()->can('edit-employees')) {
+            abort(403);
+        }
+
+        // Validate File
+        $request->validate([
+            'biometrics_file' => 'required|file|max:10240', // 10MB
+        ]);
+
+        if ($request->hasFile('biometrics_file')) {
+            // Delete old file if exists (optional, but good practice)
+            if ($employee->employee_doc_9) {
+                Storage::disk('public')->delete($employee->employee_doc_9);
+            }
+
+            $file = $request->file('biometrics_file');
+            $filename = Str::random(20) . '.' . $file->getClientOriginalExtension();
+            $path = $file->storeAs("employee_files/{$employee->employer_id}", $filename, 'public');
+
+            // Update Employee: Set Doc 9 AND Biometrics Timestamp
+            $employee->update([
+                'employee_doc_9' => $path,
+                'biometrics_collected_at' => now(),
+            ]);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Biometrics updated successfully.',
+                'stats' => $this->getStats($employee->employer_id, $request)
+            ]);
+        }
+
+        return response()->json(['success' => false, 'message' => 'No file uploaded.'], 400);
     }
 
     /**

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -129,11 +129,13 @@ class Employee extends Model
         'outsource_code',
         'bank_name',
         'bank_account_number',
+        'biometrics_collected_at',
     ];
 
     protected $casts = [
         'passportExpiryDate' => 'date:Y-m-d',
         'workPermitExpiryDate' => 'date:Y-m-d',
+        'biometrics_collected_at' => 'datetime',
         'visaExpiryDate' => 'date:Y-m-d',
         'ninetyDayReportDate' => 'date:Y-m-d',
         'employeeDob' => 'date:Y-m-d',

--- a/database/migrations/2026_02_04_000000_add_biometrics_collected_at_to_employees_table.php
+++ b/database/migrations/2026_02_04_000000_add_biometrics_collected_at_to_employees_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('employees')) {
+            Schema::table('employees', function (Blueprint $table) {
+                if (!Schema::hasColumn('employees', 'biometrics_collected_at')) {
+                    $table->timestamp('biometrics_collected_at')->nullable()->after('status');
+                }
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('employees')) {
+            Schema::table('employees', function (Blueprint $table) {
+                if (Schema::hasColumn('employees', 'biometrics_collected_at')) {
+                    $table->dropColumn('biometrics_collected_at');
+                }
+            });
+        }
+    }
+};

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -30,6 +30,7 @@
      data-status="{{ $employee->status }}"
      data-is-not-started="{{ $isNotStarted ? 'true' : 'false' }}"
      data-employer-id="{{ $employee->employer_id }}"
+     data-biometrics-collected="{{ $employee->biometrics_collected_at ? 'true' : 'false' }}"
      style="transition: all 0.3s ease; {{ $isCancelled ? 'filter: grayscale(100%);' : '' }}">
 
     {{-- Sequence Number (Outside Card) --}}
@@ -216,6 +217,20 @@
 
             {{-- Actions --}}
             <div class="d-flex gap-2 flex-wrap justify-content-end">
+                 @can('edit-employees')
+                 {{-- Biometrics Button --}}
+                 <input type="file" id="biometrics-input-{{ $employee->id }}" class="d-none" onchange="uploadBiometrics({{ $employee->id }})">
+                 <button class="btn btn-sm {{ $employee->biometrics_collected_at ? 'btn-success' : 'btn-outline-warning' }} rounded-pill px-3 biometrics-btn"
+                     id="btn-biometrics-{{ $employee->id }}"
+                     data-collected="{{ $employee->biometrics_collected_at ? 'true' : 'false' }}"
+                     title="{{ __('Collect Biometrics') }}"
+                     onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'biometrics-input-{{ $employee->id }}' } }))">
+                     <i class="bi {{ $employee->biometrics_collected_at ? 'bi-fingerprint' : 'bi-fingerprint' }}"></i>
+                     <span class="d-none d-lg-inline">{{ $employee->biometrics_collected_at ? __('Collected') : __('Biometrics') }}</span>
+                     @if($employee->biometrics_collected_at) <i class="bi bi-check-lg ms-1"></i> @endif
+                 </button>
+                 @endcan
+
                  {{-- Preview Button (Universal) --}}
                  <button class="btn btn-sm btn-outline-info btn-preview rounded-pill px-3"
                     data-model-type="employee"

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -110,6 +110,19 @@
             </div>
         </div>
 
+        {{-- Biometrics Collected --}}
+        <div class="col">
+            <div class="card text-white h-100 shadow-sm cursor-pointer filter-card"
+                 id="filter-biometrics-collected"
+                 onclick="toggleFilter('biometrics_collected')"
+                 style="background-color: #06b6d4; border: none;"> {{-- Cyan-500 --}}
+                <div class="card-body text-center d-flex flex-column justify-content-center py-4">
+                    <h1 class="display-4 fw-bold mb-0" id="global-biometrics-collected-count">{{ $totalBiometricsCollected ?? 0 }}</h1>
+                    <p class="fs-5 fw-light mb-0">{{ __('Biometrics Collected') }}</p>
+                </div>
+            </div>
+        </div>
+
         {{-- Total Employers --}}
         <div class="col">
             <div class="card bg-dark text-white h-100 shadow-sm" style="border: none;">
@@ -403,6 +416,11 @@
                                         <span class="fw-bold" id="employer-cancelled-{{ $employer->id }}">{{ $employer->cancelledCount ?? 0 }}</span>
                                         <span class="small ms-1 opacity-75" style="font-size: 0.70rem;">{{ __('CANCEL') }}</span>
                                     </span>
+                                    {{-- Biometrics --}}
+                                    <span class="badge bg-info bg-opacity-10 text-info border border-info d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 95px;" title="{{ __('Biometrics Collected') }}">
+                                        <i class="bi bi-fingerprint"></i>
+                                        <span class="fw-bold" id="employer-biometrics-collected-{{ $employer->id }}">{{ $employer->biometricsCollectedCount ?? 0 }}</span>
+                                    </span>
                                  </div>
 
                                  <div class="vr d-none d-xl-block me-2"></div>
@@ -441,6 +459,10 @@
 
                                 <button class="btn btn-outline-secondary btn-sm ms-1" id="btn-employer-toggle-cancelled-{{ $employer->id }}" onclick="toggleEmployerCancelled({{ $employer->id }}); event.stopPropagation();" title="{{ __('Hide Cancelled Items') }}">
                                     <i class="bi bi-eye-slash"></i>
+                                </button>
+
+                                <button class="btn btn-outline-info btn-sm ms-1" id="btn-employer-toggle-biometrics-{{ $employer->id }}" onclick="toggleEmployerBiometrics({{ $employer->id }}); event.stopPropagation();" title="{{ __('Filter Biometrics Collected') }}">
+                                    <i class="bi bi-fingerprint"></i>
                                 </button>
 
                                 {{-- Collapse Chevron --}}
@@ -784,6 +806,7 @@
              else if (currentStepFilter === 'saved') document.getElementById('filter-saved')?.classList.add('filter-active');
              else if (currentStepFilter === 'cancelled') document.getElementById('filter-cancelled')?.classList.add('filter-active');
              else if (currentStepFilter === 'cancelled_employer') document.getElementById('filter-cancelled-employer')?.classList.add('filter-active');
+             else if (currentStepFilter === 'biometrics_collected') document.getElementById('filter-biometrics-collected')?.classList.add('filter-active');
              else {
                  const pill = document.getElementById(`filter-step-${currentStepFilter}`);
                  if (pill) pill.classList.add('filter-active');
@@ -851,6 +874,47 @@
             // Show cancelled employees in this employer container
             if (listContainer) {
                 listContainer.querySelectorAll('.employee-card-wrapper[data-status="registration_cancelled"]').forEach(el => el.classList.remove('d-none'));
+            }
+        }
+    }
+
+    // Toggle Biometrics Filter (Employer Level)
+    window.employerBiometricsFilter = {};
+
+    window.toggleEmployerBiometrics = function(employerId) {
+        if (typeof window.employerBiometricsFilter[employerId] === 'undefined') {
+            window.employerBiometricsFilter[employerId] = false;
+        }
+
+        window.employerBiometricsFilter[employerId] = !window.employerBiometricsFilter[employerId];
+        const btn = document.getElementById(`btn-employer-toggle-biometrics-${employerId}`);
+        const listContainer = document.getElementById(`employee-list-${employerId}`);
+
+        if (window.employerBiometricsFilter[employerId]) {
+            btn.classList.add('active', 'bg-info', 'text-white');
+            // Show ONLY biometrics collected
+            if (listContainer) {
+                listContainer.querySelectorAll('.employee-card-wrapper').forEach(el => {
+                    if (el.dataset.biometricsCollected !== 'true') {
+                        el.classList.add('d-none');
+                    }
+                });
+            }
+        } else {
+            btn.classList.remove('active', 'bg-info', 'text-white');
+            // Reset visibility (respecting cancelled filter if active)
+            if (listContainer) {
+                listContainer.querySelectorAll('.employee-card-wrapper').forEach(el => {
+                    // Check if we should keep it hidden due to cancelled filter
+                    const isCancelled = el.dataset.status === 'registration_cancelled';
+                    const isCancelledHidden = window.employerCancelledHidden[employerId];
+
+                    if (isCancelled && isCancelledHidden) {
+                        // Keep hidden
+                    } else {
+                        el.classList.remove('d-none');
+                    }
+                });
             }
         }
     }
@@ -959,6 +1023,10 @@
                  visible = (card.dataset.status === 'registration_completed');
             } else if (filter === 'cancelled') {
                  visible = (card.dataset.status === 'registration_cancelled');
+            } else if (filter === 'biometrics_collected') {
+                 visible = (card.dataset.biometricsCollected === 'true');
+            } else if (filter === 'biometrics_not_collected') {
+                 visible = (card.dataset.biometricsCollected === 'false');
             } else if (!isNaN(filter)) {
                  // Step ID
                  visible = (card.dataset.highestStepId == filter && card.dataset.status !== 'registration_cancelled');
@@ -1059,13 +1127,96 @@
             updateText('global-cancelled-count', stats.global.cancelled);
             updateText('global-saved-count', stats.global.saved);
             updateText('global-employers-count', stats.global.employers_count);
+            if(typeof stats.global.biometrics_collected !== 'undefined') {
+                updateText('global-biometrics-collected-count', stats.global.biometrics_collected);
+            }
         }
         if (stats.employer && typeof stats.employer.total !== 'undefined') {
             updateText(`employer-total-${stats.employer.id}`, stats.employer.total);
             updateText(`employer-not-started-${stats.employer.id}`, stats.employer.not_started);
             updateText(`employer-cancelled-${stats.employer.id}`, stats.employer.cancelled);
             updateText(`employer-saved-${stats.employer.id}`, stats.employer.saved);
+            if(typeof stats.employer.biometrics_collected !== 'undefined') {
+                updateText(`employer-biometrics-collected-${stats.employer.id}`, stats.employer.biometrics_collected);
+            }
         }
+    }
+
+    // --- Biometrics Upload Handler ---
+    window.uploadBiometrics = function(employeeId) {
+        const input = document.getElementById(`biometrics-input-${employeeId}`);
+        if (!input || !input.files || input.files.length === 0) return;
+
+        const file = input.files[0];
+        const formData = new FormData();
+        formData.append('biometrics_file', file);
+
+        // Append current search/filter params to URL to ensure stats returned are consistent with view
+        const currentQuery = window.location.search;
+
+        // Show loading state
+        const btn = document.getElementById(`btn-biometrics-${employeeId}`);
+        if(btn) {
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+        }
+
+        fetch(`/production/registration/${employeeId}/biometrics` + currentQuery, {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': csrfToken,
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: formData
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data.success) {
+                Swal.fire({
+                    icon: 'success',
+                    title: '{{ __('Success') }}',
+                    text: '{{ __('Biometrics updated!') }}',
+                    timer: 1500,
+                    showConfirmButton: false
+                });
+
+                // Update UI Button
+                if(btn) {
+                    btn.disabled = false;
+                    btn.className = 'btn btn-sm btn-success rounded-pill px-3 biometrics-btn';
+                    btn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Collected') }}</span> <i class="bi bi-check-lg ms-1"></i>';
+                    btn.dataset.collected = 'true';
+                }
+
+                // Update Card Data Attribute
+                const card = document.getElementById(`employee-card-${employeeId}`);
+                if(card) {
+                    card.dataset.biometricsCollected = 'true';
+                }
+
+                // Update Stats
+                updateStatsUI(data.stats);
+                applyFilters();
+
+            } else {
+                Swal.fire('{{ __('Error') }}', data.message || 'Upload failed', 'error');
+                if(btn) { // Reset button
+                    btn.disabled = false;
+                    // We assume it was not collected before if it failed? Or check dataset.
+                    const wasCollected = btn.dataset.collected === 'true';
+                    if(wasCollected) {
+                         btn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Collected') }}</span> <i class="bi bi-check-lg ms-1"></i>';
+                    } else {
+                         btn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Biometrics') }}</span>';
+                    }
+                }
+            }
+        })
+        .catch(err => {
+            console.error(err);
+            Swal.fire('{{ __('Error') }}', '{{ __('Network error') }}', 'error');
+            if(btn) btn.disabled = false; // Basic reset
+        });
     }
 
     function updateText(id, value) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -244,6 +244,9 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/employer/{employer}/cancel', [App\Http\Controllers\Production\RegistrationController::class, 'cancelEmployer'])->name('cancel_employer');
         Route::post('/employer/{employer}/restore', [App\Http\Controllers\Production\RegistrationController::class, 'restoreEmployer'])->name('restore_employer');
         Route::post('/employer/{employer}/resolution-status', [App\Http\Controllers\Production\RegistrationController::class, 'updateResolutionStatus'])->name('employer_resolution.update');
+
+        // Biometrics
+        Route::post('/{employee}/biometrics', [App\Http\Controllers\Production\RegistrationController::class, 'updateBiometrics'])->name('biometrics.update');
     });
 
     // Renewal Resolution Routes (NEW)


### PR DESCRIPTION
- Added `biometrics_collected_at` timestamp to `employees` table.
- Added "Biometrics" button to Registration Card, integrating with Document Scanner.
- Implemented AJAX upload for biometrics file (saves to `employee_doc_9`).
- Added "Biometrics Collected" scoreboard and filters (Global & Employer-level).
- Updated `RegistrationController` stats calculation to include biometrics status.