### PR TITLE
feat: Separate Biometrics Tick/Scan & Add Global Filter

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -1321,6 +1321,33 @@ class RegistrationController extends Controller
     }
 
     /**
+     * Toggle Biometrics Collected Status (without file).
+     */
+    public function toggleBiometrics(Request $request, Employee $employee)
+    {
+        if (!auth()->user()->can('edit-employees')) {
+            abort(403);
+        }
+
+        $isCollected = $employee->biometrics_collected_at !== null;
+
+        if ($isCollected) {
+            $employee->update(['biometrics_collected_at' => null]);
+            $message = 'Biometrics marked as not collected.';
+        } else {
+            $employee->update(['biometrics_collected_at' => now()]);
+            $message = 'Biometrics marked as collected.';
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+            'collected' => !$isCollected,
+            'stats' => $this->getStats($employee->employer_id, $request)
+        ]);
+    }
+
+    /**
      * Apply Search Filter to Global Query
      */
     private function applySearchToQuery($query, $search)

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -220,15 +220,27 @@
                  @can('edit-employees')
                  {{-- Biometrics Button --}}
                  <input type="file" id="biometrics-input-{{ $employee->id }}" class="d-none" onchange="uploadBiometrics({{ $employee->id }})">
-                 <button class="btn btn-sm {{ $employee->biometrics_collected_at ? 'btn-success' : 'btn-outline-warning' }} rounded-pill px-3 biometrics-btn"
-                     id="btn-biometrics-{{ $employee->id }}"
-                     data-collected="{{ $employee->biometrics_collected_at ? 'true' : 'false' }}"
-                     title="{{ __('Collect Biometrics') }}"
-                     onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'biometrics-input-{{ $employee->id }}' } }))">
-                     <i class="bi {{ $employee->biometrics_collected_at ? 'bi-fingerprint' : 'bi-fingerprint' }}"></i>
-                     <span class="d-none d-lg-inline">{{ $employee->biometrics_collected_at ? __('Collected') : __('Biometrics') }}</span>
-                     @if($employee->biometrics_collected_at) <i class="bi bi-check-lg ms-1"></i> @endif
-                 </button>
+
+                 <div class="btn-group">
+                     {{-- Toggle Tick Button --}}
+                     <button class="btn btn-sm {{ $employee->biometrics_collected_at ? 'btn-success' : 'btn-outline-secondary' }} rounded-start-pill px-3"
+                         id="btn-biometrics-toggle-{{ $employee->id }}"
+                         title="{{ __('Mark Biometrics Collected') }}"
+                         onclick="toggleBiometricsStatus({{ $employee->id }})">
+                         <i class="bi bi-person-bounding-box"></i>
+                         @if($employee->biometrics_collected_at) <i class="bi bi-check-lg ms-1"></i> @endif
+                     </button>
+
+                     {{-- Scan/Upload Button --}}
+                     <button class="btn btn-sm {{ $employee->biometrics_collected_at ? 'btn-success' : 'btn-outline-warning' }} rounded-end-pill px-3 biometrics-btn border-start-0"
+                         id="btn-biometrics-{{ $employee->id }}"
+                         data-collected="{{ $employee->biometrics_collected_at ? 'true' : 'false' }}"
+                         title="{{ __('Scan / Upload Biometrics') }}"
+                         onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'biometrics-input-{{ $employee->id }}' } }))">
+                         <i class="bi bi-fingerprint"></i>
+                         <span class="d-none d-lg-inline">{{ $employee->biometrics_collected_at ? __('Collected') : __('Biometrics') }}</span>
+                     </button>
+                 </div>
                  @endcan
 
                  {{-- Preview Button (Universal) --}}

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -227,6 +227,13 @@
                 </form>
 
                 <div class="d-flex gap-2 flex-wrap justify-content-end">
+                    <button class="btn btn-outline-info fw-bold"
+                            id="btn-global-filter-biometrics"
+                            onclick="toggleFilter('biometrics_collected')"
+                            title="{{ __('Filter Biometrics Collected') }}">
+                        <i class="bi bi-person-bounding-box me-1"></i>
+                    </button>
+
                     @can('edit-employees')
                     <a href="{{ route('production.registration.create') }}" class="btn btn-warning text-white fw-bold">
                         <i class="bi bi-plus-lg me-1"></i> {{ __('New Employee') }}
@@ -806,7 +813,12 @@
              else if (currentStepFilter === 'saved') document.getElementById('filter-saved')?.classList.add('filter-active');
              else if (currentStepFilter === 'cancelled') document.getElementById('filter-cancelled')?.classList.add('filter-active');
              else if (currentStepFilter === 'cancelled_employer') document.getElementById('filter-cancelled-employer')?.classList.add('filter-active');
-             else if (currentStepFilter === 'biometrics_collected') document.getElementById('filter-biometrics-collected')?.classList.add('filter-active');
+             else if (currentStepFilter === 'biometrics_collected') {
+                 document.getElementById('filter-biometrics-collected')?.classList.add('filter-active');
+                 // Highlight global button too
+                 const btn = document.getElementById('btn-global-filter-biometrics');
+                 if(btn) btn.classList.add('active', 'bg-info', 'text-white');
+             }
              else {
                  const pill = document.getElementById(`filter-step-${currentStepFilter}`);
                  if (pill) pill.classList.add('filter-active');
@@ -1180,12 +1192,23 @@
                     showConfirmButton: false
                 });
 
-                // Update UI Button
+                // Update Scan Button State
                 if(btn) {
                     btn.disabled = false;
-                    btn.className = 'btn btn-sm btn-success rounded-pill px-3 biometrics-btn';
-                    btn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Collected') }}</span> <i class="bi bi-check-lg ms-1"></i>';
+                    btn.classList.remove('btn-outline-warning');
+                    btn.classList.add('btn-success');
+                    btn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Collected') }}</span>';
                     btn.dataset.collected = 'true';
+                }
+
+                // Update Tick Button State
+                const tickBtn = document.getElementById(`btn-biometrics-toggle-${employeeId}`);
+                if (tickBtn) {
+                    tickBtn.classList.remove('btn-outline-secondary');
+                    tickBtn.classList.add('btn-success');
+                    if(!tickBtn.querySelector('.bi-check-lg')) {
+                        tickBtn.innerHTML += ' <i class="bi bi-check-lg ms-1"></i>';
+                    }
                 }
 
                 // Update Card Data Attribute
@@ -1202,11 +1225,9 @@
                 Swal.fire('{{ __('Error') }}', data.message || 'Upload failed', 'error');
                 if(btn) { // Reset button
                     btn.disabled = false;
-                    // We assume it was not collected before if it failed? Or check dataset.
+                    // Reset to initial state logic if needed
                     const wasCollected = btn.dataset.collected === 'true';
-                    if(wasCollected) {
-                         btn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Collected') }}</span> <i class="bi bi-check-lg ms-1"></i>';
-                    } else {
+                    if(!wasCollected) {
                          btn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Biometrics') }}</span>';
                     }
                 }
@@ -1216,6 +1237,86 @@
             console.error(err);
             Swal.fire('{{ __('Error') }}', '{{ __('Network error') }}', 'error');
             if(btn) btn.disabled = false; // Basic reset
+        });
+    }
+
+    // --- Toggle Biometrics (Tick) Handler ---
+    window.toggleBiometricsStatus = function(employeeId) {
+        const btn = document.getElementById(`btn-biometrics-toggle-${employeeId}`);
+        const scanBtn = document.getElementById(`btn-biometrics-${employeeId}`);
+
+        // Optimistic UI Update can be tricky if we want exact sync, let's wait for response or simple toggle
+        if(btn) btn.disabled = true;
+
+        fetch(`/production/registration/${employeeId}/biometrics-toggle` + window.location.search, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': csrfToken,
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data.success) {
+                // Update Card Data
+                const card = document.getElementById(`employee-card-${employeeId}`);
+                if(card) {
+                    card.dataset.biometricsCollected = data.collected ? 'true' : 'false';
+                }
+
+                // Update Tick Button
+                if(btn) {
+                    btn.disabled = false;
+                    if (data.collected) {
+                        btn.classList.remove('btn-outline-secondary');
+                        btn.classList.add('btn-success');
+                        if(!btn.querySelector('.bi-check-lg')) {
+                            btn.innerHTML += ' <i class="bi bi-check-lg ms-1"></i>';
+                        }
+                    } else {
+                        btn.classList.remove('btn-success');
+                        btn.classList.add('btn-outline-secondary');
+                        const icon = btn.querySelector('.bi-check-lg');
+                        if(icon) icon.remove();
+                    }
+                }
+
+                // Update Scan Button (Reflect status, but keep function)
+                if (scanBtn) {
+                     if (data.collected) {
+                        scanBtn.classList.remove('btn-outline-warning');
+                        scanBtn.classList.add('btn-success');
+                        scanBtn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Collected') }}</span>';
+                        scanBtn.dataset.collected = 'true';
+                     } else {
+                        // Only revert scan button if no file... actually requirement says "File stays".
+                        // But status "Collected" depends on tick.
+                        // If we untick, status becomes "Not Collected".
+                        // Should the scan button turn orange?
+                        // User said: "The system filtering... checks for employees who have collected biometrics... does not rely on the file attached".
+                        // So yes, visual indication of "Collected" should match the tick.
+                        // However, if file exists, maybe keep green?
+                        // Let's stick to the status: if unticked (not collected), scan button goes back to orange/warning.
+                        scanBtn.classList.remove('btn-success');
+                        scanBtn.classList.add('btn-outline-warning');
+                        scanBtn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Biometrics') }}</span>';
+                        scanBtn.dataset.collected = 'false';
+                     }
+                }
+
+                updateStatsUI(data.stats);
+                applyFilters();
+
+            } else {
+                Swal.fire('{{ __('Error') }}', data.message, 'error');
+                if(btn) btn.disabled = false;
+            }
+        })
+        .catch(err => {
+            console.error(err);
+            Swal.fire('{{ __('Error') }}', '{{ __('Network error') }}', 'error');
+            if(btn) btn.disabled = false;
         });
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -247,6 +247,7 @@ Route::middleware(['auth'])->group(function () {
 
         // Biometrics
         Route::post('/{employee}/biometrics', [App\Http\Controllers\Production\RegistrationController::class, 'updateBiometrics'])->name('biometrics.update');
+        Route::post('/{employee}/biometrics-toggle', [App\Http\Controllers\Production\RegistrationController::class, 'toggleBiometrics'])->name('biometrics.toggle');
     });
 
     // Renewal Resolution Routes (NEW)


### PR DESCRIPTION
- Added `toggleBiometrics` endpoint to RegistrationController to toggle `biometrics_collected_at` without file upload.
- Updated `_employee_card.blade.php` to include a new "Tick" button next to the "Scan" button, using a `btn-group`.
- Updated `index.blade.php` to include a global filter button for Biometrics Collected.
- Implemented JavaScript logic to handle toggle interactions and update UI/Stats optimistically.
- Verified with Playwright tests.