### PR TITLE
Fix address display to respect locale and use consistent accessor

### DIFF
--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -37,6 +37,17 @@ class Address extends Model
         return $this->morphTo();
     }
 
+    public function getFullAddressAttribute()
+    {
+        if (app()->getLocale() === 'th') {
+            return $this->full_address_th;
+        }
+        // Fallback to English fields if not Thai,
+        // OR if you want to support other languages, handle them here.
+        // For now, default to English structure for non-Thai.
+        return $this->full_address_en;
+    }
+
     public function getFullAddressThAttribute()
     {
         $parts = [];

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -381,8 +381,7 @@
             @forelse ($employer->addresses->where('type', 'registered') as $address)
                 <div class="address-card d-flex justify-content-between align-items-start" id="address-card-{{$address->id}}">
                     <div>
-                        <p class="mb-0">{{ $address->full_address_th }}</p>
-                        <p class="mb-0 text-muted small">{{ $address->full_address_en }}</p>
+                        <p class="mb-0">{{ $address->full_address }}</p>
                     </div>
                     <div class="btn-group btn-group-sm">
                         <button type="button" class="btn btn-sm btn-danger btn-delete-address" data-address-id="{{ $address->id }}">{{ __('Delete') }}</button>
@@ -410,24 +409,7 @@
             @forelse ($employer->addresses->where('type', 'workplace') as $address)
                 <div class="address-card d-flex justify-content-between align-items-start" id="address-card-{{$address->id}}">
                     <div>
-                        <p class="mb-0">
-                            {{ $address->addrNo ? 'เลขที่ ' . $address->addrNo : '' }}
-                            {{ $address->addrMoo ? 'หมู่ ' . $address->addrMoo : '' }}
-                            {{ $address->addrSoi ? 'ซอย' . $address->addrSoi : '' }}
-                            {{ $address->addrRoad ? 'ถนน' . $address->addrRoad : '' }}
-                            {{ $address->addrSubDistrict ? 'แขวง/ตำบล ' . $address->addrSubDistrict : '' }}
-                            {{ $address->addrDistrict ? 'เขต/อำเภอ ' . $address->addrDistrict : '' }}
-                            {{ $address->addrProvince ?? '' }} {{ $address->addrZipCode ?? '' }}
-                        </p>
-                        <p class="mb-0 text-muted small">
-                            {{ $address->addrNoEn ? 'Addr: ' . $address->addrNoEn . ', ' : '' }}
-                            {{ $address->addrMooEn ? 'Moo: ' . $address->addrMooEn . ', ' : '' }}
-                            {{ $address->addrSoiEn ? 'Soi: ' . $address->addrSoiEn . ', ' : '' }}
-                            {{ $address->addrRoadEn ? 'Road: ' . $address->addrRoadEn . ', ' : '' }}
-                            {{ $address->addrSubDistrictEn ? $address->addrSubDistrictEn . ', ' : '' }}
-                            {{ $address->addrDistrictEn ? $address->addrDistrictEn . ', ' : '' }}
-                            {{ $address->addrProvinceEn ?? '' }} {{ $address->addrZipCodeEn ?? '' }}
-                        </p>
+                        <p class="mb-0">{{ $address->full_address }}</p>
                     </div>
                     <div class="btn-group btn-group-sm">
                         <button type="button" class="btn btn-sm btn-danger btn-delete-address" data-address-id="{{ $address->id }}">{{ __('Delete') }}</button>

--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -65,8 +65,8 @@
                             @if(request('addrProvince'))
                                 @foreach($employer->getMatchedAddresses(request('addrProvince'), request('addrDistrict'), request('addrSubDistrict')) as $address)
                                     <div class="text-primary small fw-bold mt-1">
-                                        {{ $address->full_address_th }}
-                                        <span class="text-muted fw-normal">({{ $address->type === 'registered' ? 'ที่อยู่ตามทะเบียนบ้าน' : 'ที่อยู่สถานที่ทำงาน' }})</span>
+                                        {{ $address->full_address }}
+                                        <span class="text-muted fw-normal">({{ $address->type === 'registered' ? __('Registered Address') : __('Workplace Address') }})</span>
                                     </div>
                                 @endforeach
                             @endif

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -213,8 +213,7 @@
     <div class="vstack gap-3">
         @forelse ($employer->addresses->where('type', 'registered') as $address)
             <div class="address-card p-3 border rounded">
-                <p class="mb-0">{{ $address->full_address_th }}</p>
-                <p class="mb-0 text-muted small">{{ $address->full_address_en }}</p>
+                <p class="mb-0">{{ $address->full_address }}</p>
             </div>
         @empty
             <p class="text-muted">ยังไม่มีที่อยู่</p>
@@ -228,8 +227,7 @@
     <div class="vstack gap-3">
         @forelse ($employer->addresses->where('type', 'workplace') as $address)
              <div class="address-card p-3 border rounded">
-                <p class="mb-0">{{ $address->full_address_th }}</p>
-                <p class="mb-0 text-muted small">{{ $address->full_address_en }}</p>
+                <p class="mb-0">{{ $address->full_address }}</p>
             </div>
         @empty
             <p class="text-muted">ยังไม่มีที่อยู่</p>


### PR DESCRIPTION
Modified `Address` model to introduce `getFullAddressAttribute`, which dynamically switches between Thai and English fields based on the application locale. Refactored `edit.blade.php`, `index.blade.php`, and `_employer_data.blade.php` to use this new accessor, ensuring that English addresses are hidden when viewing in Thai mode (and vice-versa). Fixed the "Workplace Address" display in the Edit view to use the standardized Model accessor, correcting missing prefixes (e.g., "จ.") and ensuring consistency with the "Registered Address" display.