### PR TITLE
Fix: Conditionally apply d-flex to Workflow Appointment popup

### DIFF
--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -213,7 +213,7 @@
                              </div>
                         </div>
 
-                        <div x-show="isEditing" @click.outside="isEditing = false" class="d-flex flex-column gap-1 p-2 bg-white border rounded shadow-sm" style="display: none; position: absolute; z-index: 1050; min-width: 200px;">
+                        <div x-show="isEditing" @click.outside="isEditing = false" :class="{ 'd-flex': isEditing }" class="flex-column gap-1 p-2 bg-white border rounded shadow-sm" style="display: none; position: absolute; z-index: 1050; min-width: 200px;">
                              <label class="small fw-bold">Date & Time</label>
                              <div>
                                 <input x-ref="dateInput" type="text" class="form-control form-control-sm" placeholder="Date...">


### PR DESCRIPTION
This commit resolves a UI issue where the Appointment Date/Location popup in the Workflow Employee Card would remain permanently visible (hanging) due to a CSS conflict.

The Bootstrap utility class `.d-flex` includes `display: flex !important;`, which was overriding the inline `display: none;` style applied by Alpine.js's `x-show` directive when the popup was supposed to be closed.

Changes:
- Modified `resources/views/workflow/partials/_item_card.blade.php`:
  - Removed static `.d-flex` class from the popup container.
  - Added `:class="{ 'd-flex': isEditing }"` to dynamically apply the flex layout only when the popup is active.

Verified via headless browser testing using a mocked view route.