### PR TITLE
Fix: Decouple Biometrics Scan/Tick UI and Fix Global Filter

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -42,7 +42,7 @@ class RegistrationController extends Controller
         // We only fetch ID, Status, EmployerID to keep it fast.
         $employeeQuery = Employee::query()
             ->whereIn('status', ['registration_pending', 'registration_completed', 'registration_cancelled'])
-            ->select('id', 'employer_id', 'status'); // Lightweight Select
+            ->select('id', 'employer_id', 'status', 'biometrics_collected_at', 'employee_doc_9'); // Lightweight Select
 
         if (auth()->user()->can('manage-tickets')) {
             $employeeQuery->withoutGlobalScope('employerTenancy');

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -232,13 +232,13 @@
                      </button>
 
                      {{-- Scan/Upload Button --}}
-                     <button class="btn btn-sm {{ $employee->biometrics_collected_at ? 'btn-success' : 'btn-outline-warning' }} rounded-end-pill px-3 biometrics-btn border-start-0"
+                     <button class="btn btn-sm {{ $employee->employee_doc_9 ? 'btn-success' : 'btn-outline-warning' }} rounded-end-pill px-3 biometrics-btn border-start-0"
                          id="btn-biometrics-{{ $employee->id }}"
-                         data-collected="{{ $employee->biometrics_collected_at ? 'true' : 'false' }}"
+                         data-collected="{{ $employee->employee_doc_9 ? 'true' : 'false' }}"
                          title="{{ __('Scan / Upload Biometrics') }}"
                          onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'biometrics-input-{{ $employee->id }}' } }))">
                          <i class="bi bi-fingerprint"></i>
-                         <span class="d-none d-lg-inline">{{ $employee->biometrics_collected_at ? __('Collected') : __('Biometrics') }}</span>
+                         <span class="d-none d-lg-inline">{{ $employee->employee_doc_9 ? __('Collected') : __('Biometrics') }}</span>
                      </button>
                  </div>
                  @endcan

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -1283,27 +1283,8 @@
                 }
 
                 // Update Scan Button (Reflect status, but keep function)
-                if (scanBtn) {
-                     if (data.collected) {
-                        scanBtn.classList.remove('btn-outline-warning');
-                        scanBtn.classList.add('btn-success');
-                        scanBtn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Collected') }}</span>';
-                        scanBtn.dataset.collected = 'true';
-                     } else {
-                        // Only revert scan button if no file... actually requirement says "File stays".
-                        // But status "Collected" depends on tick.
-                        // If we untick, status becomes "Not Collected".
-                        // Should the scan button turn orange?
-                        // User said: "The system filtering... checks for employees who have collected biometrics... does not rely on the file attached".
-                        // So yes, visual indication of "Collected" should match the tick.
-                        // However, if file exists, maybe keep green?
-                        // Let's stick to the status: if unticked (not collected), scan button goes back to orange/warning.
-                        scanBtn.classList.remove('btn-success');
-                        scanBtn.classList.add('btn-outline-warning');
-                        scanBtn.innerHTML = '<i class="bi bi-fingerprint"></i> <span class="d-none d-lg-inline">{{ __('Biometrics') }}</span>';
-                        scanBtn.dataset.collected = 'false';
-                     }
-                }
+                // MODIFIED: Scan button only changes on file upload, not on manual tick.
+                // if (scanBtn) { ... } logic removed to decouple.
 
                 updateStatsUI(data.stats);
                 applyFilters();


### PR DESCRIPTION
- Decouple the 'Scan' button (fingerprint) color from the 'Tick' (collected) status. Scan button now only turns green if a file exists (`employee_doc_9`).
- Fix the Global Biometrics Filter showing 0 by adding `biometrics_collected_at` to the lightweight employee query in `RegistrationController`.
- Ensure `employee_doc_9` is selected in `RegistrationController` to correctly drive the UI state.
- Update `index.blade.php` JS to stop programmatically linking the two buttons.