### PR TITLE
Restore Thai address data and fix address display logic

### DIFF
--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -55,9 +55,41 @@ class Address extends Model
         if ($this->addrMoo) $parts[] = 'หมู่ ' . $this->addrMoo;
         if ($this->addrSoi) $parts[] = 'ซอย ' . $this->addrSoi;
         if ($this->addrRoad) $parts[] = 'ถนน ' . $this->addrRoad;
-        if ($this->addrSubDistrict) $parts[] = 'ต.' . $this->addrSubDistrict;
-        if ($this->addrDistrict) $parts[] = 'อ.' . $this->addrDistrict;
-        if ($this->addrProvince) $parts[] = 'จ.' . $this->addrProvince;
+
+        $isBangkok = $this->addrProvince && (str_contains($this->addrProvince, 'กรุงเทพ') || str_contains($this->addrProvince, 'Bangkok'));
+
+        if ($this->addrSubDistrict) {
+            $val = trim($this->addrSubDistrict);
+            $prefix = $isBangkok ? 'แขวง' : 'ต.';
+            // Only add prefix if not already present
+            if (!str_starts_with($val, $prefix)) {
+                $parts[] = $prefix . $val;
+            } else {
+                $parts[] = $val;
+            }
+        }
+
+        if ($this->addrDistrict) {
+            $val = trim($this->addrDistrict);
+            $prefix = $isBangkok ? 'เขต' : 'อ.';
+            if (!str_starts_with($val, $prefix)) {
+                $parts[] = $prefix . $val;
+            } else {
+                $parts[] = $val;
+            }
+        }
+
+        if ($this->addrProvince) {
+            $val = trim($this->addrProvince);
+            // For Bangkok, typically no prefix or just the name. For others, use 'จ.'
+            $prefix = $isBangkok ? '' : 'จ.';
+            if ($prefix && !str_starts_with($val, $prefix)) {
+                $parts[] = $prefix . $val;
+            } else {
+                $parts[] = $val;
+            }
+        }
+
         if ($this->addrZipCode) $parts[] = $this->addrZipCode;
 
         return implode(' ', $parts);

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -213,7 +213,8 @@
     <div class="vstack gap-3">
         @forelse ($employer->addresses->where('type', 'registered') as $address)
             <div class="address-card p-3 border rounded">
-                <p class="mb-0">{{ $address->full_address }}</p>
+                <p class="mb-1"><strong>TH:</strong> {{ $address->full_address_th }}</p>
+                <p class="mb-0 text-muted"><strong>EN:</strong> {{ $address->full_address_en }}</p>
             </div>
         @empty
             <p class="text-muted">ยังไม่มีที่อยู่</p>
@@ -227,7 +228,8 @@
     <div class="vstack gap-3">
         @forelse ($employer->addresses->where('type', 'workplace') as $address)
              <div class="address-card p-3 border rounded">
-                <p class="mb-0">{{ $address->full_address }}</p>
+                <p class="mb-1"><strong>TH:</strong> {{ $address->full_address_th }}</p>
+                <p class="mb-0 text-muted"><strong>EN:</strong> {{ $address->full_address_en }}</p>
             </div>
         @empty
             <p class="text-muted">ยังไม่มีที่อยู่</p>


### PR DESCRIPTION
- Restored missing `storage/app/public/data/thai-address-data.json` to populate address dropdowns.
- Updated `app/Models/Address.php` `getFullAddressThAttribute` to correctly handle Bangkok vs Upcountry prefixes (Khwaeng/Khet vs Tambon/Amphoe/Changwat) and prevent double prefixing.
- Updated `resources/views/previews/_employer_data.blade.php` to explicitly display both Thai and English addresses, fixing the missing English address issue in the preview.