### PR TITLE
Fix job creation in Pre-Production and add duplicate employee validation

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -623,6 +623,40 @@ class WorkflowController extends Controller
      */
     public function store(Request $request)
     {
+        $isPreProduction = $request->boolean('is_pre_production');
+        $targetStatus = $isPreProduction ? 'pre_production' : 'active';
+
+        // 1. Validation: Check for duplicates (Existing Employees)
+        // Ensure an employee cannot be in the same WorkType workflow (Active or Pre-Production) twice.
+        if ($request->has('employee_ids') && is_array($request->employee_ids)) {
+            $workTypeId = null;
+
+            if ($request->filled('production_order_id')) {
+                $existingOrder = ProductionOrder::findOrFail($request->production_order_id);
+                $workTypeId = $existingOrder->work_type_id;
+            } elseif ($request->filled('work_type_id')) {
+                $workTypeId = $request->work_type_id;
+            }
+
+            if ($workTypeId) {
+                // Find any items for these employees in this WorkType that are NOT cancelled or completed.
+                $duplicates = ProductionItem::whereIn('employee_id', $request->employee_ids)
+                    ->whereHas('order', function($q) use ($workTypeId) {
+                        $q->where('work_type_id', $workTypeId)
+                          ->where('status', '!=', 'cancelled'); // Ensure order is not cancelled
+                    })
+                    ->whereNotIn('status', ['cancelled', 'completed'])
+                    ->with('employee')
+                    ->get();
+
+                if ($duplicates->isNotEmpty()) {
+                    $names = $duplicates->map(fn($item) => $item->employee->employeeNameEn ?? $item->employee->employeeNameTh)->unique()->implode(', ');
+
+                    return back()->with('duplicate_error', "Employees already in this workflow: $names. Please complete their current process first.");
+                }
+            }
+        }
+
         $order = null;
 
         if ($request->filled('production_order_id')) {
@@ -635,16 +669,17 @@ class WorkflowController extends Controller
 
             $workType = WorkType::findOrFail($request->work_type_id);
 
+            // Bucket Logic (Merge into existing if applicable)
             if (in_array($workType->slug, ['notify_in', 'notify_out'])) {
                 $order = ProductionOrder::firstOrCreate(
                     [
                         'employer_id' => $request->employer_id,
                         'work_type_id' => $workType->id,
-                        'status' => 'active'
+                        'status' => $targetStatus // Separate buckets for Active vs Pre-Production
                     ],
                     [
                         'type' => 'employer',
-                        'project_name' => $workType->name . ' - ' . Employer::find($request->employer_id)->employerNameTh,
+                        'project_name' => $workType->name . ' - ' . Employer::find($request->employer_id)->employerNameTh . ($isPreProduction ? ' (Prep)' : ''),
                         'created_by' => auth()->id()
                     ]
                 );
@@ -654,7 +689,7 @@ class WorkflowController extends Controller
                     'work_type_id' => $workType->id,
                     'type' => 'employer',
                     'project_name' => $request->project_name ?? ($workType->name . ' - ' . now()->format('d/m/Y')),
-                    'status' => 'active',
+                    'status' => $targetStatus,
                     'created_by' => auth()->id()
                 ]);
             }
@@ -691,6 +726,12 @@ class WorkflowController extends Controller
         }
 
         $slug = $order->workType->slug ?? ($request->work_type_id ? WorkType::find($request->work_type_id)->slug : 'notify_in');
+
+        // Redirect based on status/context
+        if ($isPreProduction || $order->status === 'pre_production') {
+             return redirect()->route('production.index', ['tab' => $slug])
+                         ->with('success', 'Preparation Job updated successfully.');
+        }
 
         return redirect()->route('workflow.index', ['tab' => $slug])
                          ->with('success', 'Job updated successfully.');

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -475,6 +475,20 @@
                 </div>
             @endif
 
+            @if (session('duplicate_error'))
+                <script>
+                    document.addEventListener('DOMContentLoaded', function() {
+                        Swal.fire({
+                            title: '{{ __("Duplicate Employee") }}',
+                            text: "{!! session('duplicate_error') !!}",
+                            icon: 'warning',
+                            confirmButtonText: '{{ __("OK") }}',
+                            confirmButtonColor: '#F97316'
+                        });
+                    });
+                </script>
+            @endif
+
             @if ($errors->any())
                 <div class="alert alert-danger">
                     <ul class="mb-0">

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -220,6 +220,24 @@
     const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
     const activeTabId = @json($activeTab->id ?? null);
 
+    // --- Pre-Production Flag Setting ---
+    document.addEventListener('DOMContentLoaded', function() {
+        // Set Create Job Modal Flag
+        const createJobInput = document.getElementById('create_job_is_pre_production');
+        if(createJobInput) createJobInput.value = '1';
+
+        // Override OpenAddEmployeeModal to set flag after opening (as form might reset)
+        if(typeof window.openAddEmployeeModal === 'function') {
+            const originalOpenFn = window.openAddEmployeeModal;
+            window.openAddEmployeeModal = function(orderId, employerId, workTypeId, workTypeSlug) {
+                originalOpenFn(orderId, employerId, workTypeId, workTypeSlug);
+                // Force set the flag again
+                const addEmpInput = document.getElementById('add_employee_is_pre_production');
+                if(addEmpInput) addEmpInput.value = '1';
+            }
+        }
+    });
+
     // --- Lazy Load ---
     const loadedOrders = {};
     document.getElementById('productionAccordion').addEventListener('show.bs.collapse', function (e) {

--- a/resources/views/workflow/partials/add_employee_modal.blade.php
+++ b/resources/views/workflow/partials/add_employee_modal.blade.php
@@ -6,6 +6,7 @@
             <input type="hidden" name="employer_id" id="modal_employer_id">
             <input type="hidden" name="work_type_id" id="modal_work_type_id">
             <input type="hidden" name="production_order_id" id="modal_production_order_id"> {{-- For adding to existing --}}
+            <input type="hidden" name="is_pre_production" id="add_employee_is_pre_production" value="0">
 
             <div class="modal-header">
                 <h5 class="modal-title">{{ __('Add Employees') }}</h5>

--- a/resources/views/workflow/partials/create_modal.blade.php
+++ b/resources/views/workflow/partials/create_modal.blade.php
@@ -3,6 +3,7 @@
     <div class="modal-dialog">
         <form action="{{ route('workflow.store') }}" method="POST" class="modal-content">
             @csrf
+            <input type="hidden" name="is_pre_production" id="create_job_is_pre_production" value="0">
             <div class="modal-header">
                 <h5 class="modal-title">{{ __('Create New Job') }}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>

--- a/tests/Feature/Production/PreProductionWorkflowTest.php
+++ b/tests/Feature/Production/PreProductionWorkflowTest.php
@@ -121,4 +121,65 @@ class PreProductionWorkflowTest extends TestCase
         $this->assertEquals('active', $newOrder->status);
         $this->assertEquals($this->employer->id, $newOrder->employer_id);
     }
+
+    /** @test */
+    public function cannot_add_employee_if_already_in_active_workflow()
+    {
+        $employee = Employee::factory()->create(['employer_id' => $this->employer->id]);
+
+        // 1. Create Active Order & Item
+        $activeOrder = ProductionOrder::create([
+            'employer_id' => $this->employer->id,
+            'work_type_id' => $this->workType->id,
+            'status' => 'active', // Already in workflow
+            'created_by' => $this->user->id
+        ]);
+
+        ProductionItem::create([
+            'production_order_id' => $activeOrder->id,
+            'employee_id' => $employee->id,
+            'status' => 'pending'
+        ]);
+
+        // 2. Try to add same employee to Pre-Production (Create new job)
+        // We simulate the form submission to 'workflow.store' with 'is_pre_production' = true
+        $response = $this->actingAs($this->user)
+            ->from(route('production.index'))
+            ->post(route('workflow.store'), [
+                'employer_id' => $this->employer->id,
+                'work_type_id' => $this->workType->id,
+                'employee_ids' => [$employee->id],
+                'is_pre_production' => true
+            ]);
+
+        // 3. Assert redirected back with error
+        $response->assertRedirect(route('production.index'));
+        $response->assertSessionHas('duplicate_error');
+
+        // Verify NO new pre-production order created (because validation happens first)
+        $this->assertDatabaseMissing('production_orders', [
+            'status' => 'pre_production',
+            'employer_id' => $this->employer->id
+        ]);
+    }
+
+    /** @test */
+    public function create_job_from_pre_production_sets_correct_status()
+    {
+        // Simulate creating a new empty job (bucket) from Pre-Prod modal
+        $response = $this->actingAs($this->user)
+            ->post(route('workflow.store'), [
+                'employer_id' => $this->employer->id,
+                'work_type_id' => $this->workType->id,
+                'is_pre_production' => true // The flag
+            ]);
+
+        $response->assertRedirect(route('production.index', ['tab' => 'notify_in']));
+
+        $this->assertDatabaseHas('production_orders', [
+            'employer_id' => $this->employer->id,
+            'work_type_id' => $this->workType->id,
+            'status' => 'pre_production'
+        ]);
+    }
 }


### PR DESCRIPTION
- Modified `WorkflowController@store` to respect `is_pre_production` flag.
- Added duplicate employee validation to prevent adding employees to multiple workflows of the same type.
- Updated `create_modal` and `add_employee_modal` with hidden flag.
- Updated `production/index.blade.php` to set the flag.
- Added SweetAlert error handling for duplicates.