### PR TITLE
Update employee card layout to vertical stack for extra fields

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -40,7 +40,8 @@
     <div class="card-body p-3">
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-3">
             {{-- Checkbox & Basic Info --}}
-            <div class="d-flex align-items-center gap-3 w-100">
+            <div class="d-flex align-items-start gap-3 w-100">
+                <div class="d-flex align-items-center gap-3">
                 @can('edit-employees')
                 {{-- Only show checkbox if Active (Pending) --}}
                 <div class="form-check {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}" id="checkbox-container-{{ $employee->id }}">
@@ -112,9 +113,10 @@
                         </div>
                     </div>
                 </div>
+                </div>
 
             {{-- 3 Extra Fields (Editable) --}}
-            <div class="d-flex align-items-center gap-2 flex-wrap" x-data="{
+            <div class="d-flex flex-column gap-2" x-data="{
                 isEditing: false,
                 nameList: '{{ $employee->name_list_number }}',
                 reqNo: '{{ $employee->request_number }}',
@@ -179,38 +181,40 @@
                     });
                 }
             }">
-                <div class="d-flex gap-2">
+                <div class="d-flex align-items-end gap-2">
                     {{-- Field 1: Name List (Renamed to RA) --}}
                     <div style="width: 140px;">
                         <small class="text-muted d-block" style="font-size: 0.7rem;">เลข RA จากระบบ outsource</small>
                         <div x-show="!isEditing" x-ref="raDisplay" x-init="fitText($el)" class="small text-dark border rounded px-2 py-1 bg-light text-nowrap overflow-hidden" style="min-height: 31px;" x-text="nameList || '-'"></div>
                         <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="nameList" placeholder="RA No.">
                     </div>
-                    {{-- Field 2: Request No --}}
-                    <div style="width: 140px;">
-                        <small class="text-muted d-block" style="font-size: 0.7rem;">เลขที่คำขอ</small>
-                        <div x-show="!isEditing" x-ref="reqDisplay" x-init="fitText($el)" class="small text-dark border rounded px-2 py-1 bg-light text-nowrap overflow-hidden" style="min-height: 31px;" x-text="reqNo || '-'"></div>
-                        <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="reqNo" placeholder="Request No.">
-                    </div>
-                    {{-- Field 3: Ref ID --}}
-                    <div style="width: 140px;">
-                        <small class="text-muted d-block" style="font-size: 0.7rem;">เลขอ้างอิงคนงาน</small>
-                        <div x-show="!isEditing" x-ref="refDisplay" x-init="fitText($el)" class="small text-dark border rounded px-2 py-1 bg-light text-nowrap overflow-hidden" style="min-height: 31px;" x-text="refId || '-'"></div>
-                        <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="refId" placeholder="Ref ID">
+
+                    {{-- Action Buttons --}}
+                    <div class="d-flex gap-1 mb-1">
+                        <button x-show="!isEditing" @click="isEditing = true" class="btn btn-sm btn-outline-secondary rounded-circle" title="Edit Fields">
+                            <i class="bi bi-pencil-fill"></i>
+                        </button>
+                        <button x-show="isEditing" @click="saveFields()" class="btn btn-sm btn-success rounded-circle" title="Save Fields">
+                            <i class="bi bi-check-lg"></i>
+                        </button>
+                        <button x-show="isEditing" @click="isEditing = false" class="btn btn-sm btn-outline-danger rounded-circle" title="Cancel">
+                            <i class="bi bi-x-lg"></i>
+                        </button>
                     </div>
                 </div>
 
-                {{-- Action Buttons for 3 Fields --}}
-                <div class="mt-3">
-                    <button x-show="!isEditing" @click="isEditing = true" class="btn btn-sm btn-outline-secondary rounded-circle" title="Edit Fields">
-                        <i class="bi bi-pencil-fill"></i>
-                    </button>
-                    <button x-show="isEditing" @click="saveFields()" class="btn btn-sm btn-success rounded-circle" title="Save Fields">
-                        <i class="bi bi-check-lg"></i>
-                    </button>
-                    <button x-show="isEditing" @click="isEditing = false" class="btn btn-sm btn-outline-danger rounded-circle" title="Cancel">
-                        <i class="bi bi-x-lg"></i>
-                    </button>
+                {{-- Field 2: Request No --}}
+                <div style="width: 140px;">
+                    <small class="text-muted d-block" style="font-size: 0.7rem;">เลขที่คำขอ</small>
+                    <div x-show="!isEditing" x-ref="reqDisplay" x-init="fitText($el)" class="small text-dark border rounded px-2 py-1 bg-light text-nowrap overflow-hidden" style="min-height: 31px;" x-text="reqNo || '-'"></div>
+                    <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="reqNo" placeholder="Request No.">
+                </div>
+
+                {{-- Field 3: Ref ID --}}
+                <div style="width: 140px;">
+                    <small class="text-muted d-block" style="font-size: 0.7rem;">เลขอ้างอิงคนงาน</small>
+                    <div x-show="!isEditing" x-ref="refDisplay" x-init="fitText($el)" class="small text-dark border rounded px-2 py-1 bg-light text-nowrap overflow-hidden" style="min-height: 31px;" x-text="refId || '-'"></div>
+                    <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="refId" placeholder="Ref ID">
                 </div>
             </div>
             </div>


### PR DESCRIPTION
Refactored the layout of the 3 extra input fields (RA Number, Request Number, Reference ID) in the employee card.
- Changed from horizontal flex row to vertical column stack to prevent squeezing the employee photo on mobile devices.
- Moved the action buttons (Edit/Save/Cancel) to be adjacent to the first field (RA Number).
- Adjusted the parent container alignment to `align-items-start` to accommodate the increased height of the stacked fields while maintaining proper alignment of the avatar and checkbox.