### PR TITLE
Enable Edit, Preview, and Team buttons on Workflow and Pre-Production…

### DIFF
--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -213,6 +213,59 @@
     </div>
 </div>
 
+{{-- Edit Employee Modal (Full Form) --}}
+<div class="modal fade" id="editEmployeeModal" tabindex="-1" aria-labelledby="editEmployeeModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 class="modal-title" id="editEmployeeModalLabel"><i class="bi bi-pencil-square me-2"></i>{{ __('Edit Employee') }}</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body bg-light" id="editEmployeeModalBody">
+                <div class="d-flex justify-content-center align-items-center py-5">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">{{ __('Loading...') }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- Cropper Modal (Required for Employee Edit) --}}
+<div class="modal fade" id="cropperModal" tabindex="-1" aria-labelledby="cropperModalLabel" aria-hidden="true" style="z-index: 1060;">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="cropperModalLabel">ครอบตัดรูปภาพ</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <style>
+                    .img-container {
+                        max-height: 500px;
+                        display: block;
+                    }
+                    .img-container img {
+                        max-width: 100%;
+                        display: block;
+                    }
+                </style>
+                <div class="img-container">
+                    <img id="imageToCrop" src="" alt="Picture" style="display: block; max-width: 100%;">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                <button type="button" class="btn btn-primary" id="cropImageBtn">ครอบตัดและบันทึก</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@include('employees.partials._edit_scripts')
+@include('production.registration.partials.edit_modal_script')
+
 @endsection
 
 @push('scripts')

--- a/resources/views/workflow/dashboard.blade.php
+++ b/resources/views/workflow/dashboard.blade.php
@@ -239,6 +239,59 @@
 {{-- Create Job Modal --}}
 @include('workflow.partials.create_modal')
 
+{{-- Edit Employee Modal (Full Form) --}}
+<div class="modal fade" id="editEmployeeModal" tabindex="-1" aria-labelledby="editEmployeeModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 class="modal-title" id="editEmployeeModalLabel"><i class="bi bi-pencil-square me-2"></i>{{ __('Edit Employee') }}</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body bg-light" id="editEmployeeModalBody">
+                <div class="d-flex justify-content-center align-items-center py-5">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">{{ __('Loading...') }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- Cropper Modal (Required for Employee Edit) --}}
+<div class="modal fade" id="cropperModal" tabindex="-1" aria-labelledby="cropperModalLabel" aria-hidden="true" style="z-index: 1060;">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="cropperModalLabel">ครอบตัดรูปภาพ</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <style>
+                    .img-container {
+                        max-height: 500px;
+                        display: block;
+                    }
+                    .img-container img {
+                        max-width: 100%;
+                        display: block;
+                    }
+                </style>
+                <div class="img-container">
+                    <img id="imageToCrop" src="" alt="Picture" style="display: block; max-width: 100%;">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                <button type="button" class="btn btn-primary" id="cropImageBtn">ครอบตัดและบันทึก</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@include('employees.partials._edit_scripts')
+@include('production.registration.partials.edit_modal_script')
+
 @endsection
 
 @push('scripts')

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -386,7 +386,60 @@
     </div>
 </div>
 
+{{-- Edit Employee Modal (Full Form) --}}
+<div class="modal fade" id="editEmployeeModal" tabindex="-1" aria-labelledby="editEmployeeModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 class="modal-title" id="editEmployeeModalLabel"><i class="bi bi-pencil-square me-2"></i>{{ __('Edit Employee') }}</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body bg-light" id="editEmployeeModalBody">
+                <div class="d-flex justify-content-center align-items-center py-5">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">{{ __('Loading...') }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- Cropper Modal (Required for Employee Edit) --}}
+<div class="modal fade" id="cropperModal" tabindex="-1" aria-labelledby="cropperModalLabel" aria-hidden="true" style="z-index: 1060;">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="cropperModalLabel">ครอบตัดรูปภาพ</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <style>
+                    .img-container {
+                        max-height: 500px;
+                        display: block;
+                    }
+                    .img-container img {
+                        max-width: 100%;
+                        display: block;
+                    }
+                </style>
+                <div class="img-container">
+                    <img id="imageToCrop" src="" alt="Picture" style="display: block; max-width: 100%;">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                <button type="button" class="btn btn-primary" id="cropImageBtn">ครอบตัดและบันทึก</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 @endsection
+
+@include('employees.partials._edit_scripts')
+@include('production.registration.partials.edit_modal_script')
 
 @push('scripts')
 <script>

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -284,15 +284,25 @@
                     @endif
                 @endif
 
-                 @if($empId)
                  {{-- Edit Button --}}
-                 <a href="{{ route('employees.edit', $empId) }}" target="_blank" class="btn btn-sm btn-outline-primary rounded-pill px-3" title="Edit Employee">
-                    <i class="bi bi-pencil-square"></i>
-                 </a>
+                 @if($empId)
+                    <button class="btn btn-sm btn-outline-primary rounded-pill px-3"
+                        onclick="openEditEmployeeModal({{ $empId }})"
+                        title="Edit Employee">
+                        <i class="bi bi-pencil-square"></i>
+                    </button>
+                 @else
+                    {{-- Temp Employee (Edit not fully linked yet, but button visible as requested) --}}
+                    <button class="btn btn-sm btn-outline-primary rounded-pill px-3"
+                        onclick="Swal.fire('{{ __('Notice') }}', '{{ __('Please register this employee first to edit full details.') }}', 'info')"
+                        title="Edit Employee">
+                        <i class="bi bi-pencil-square"></i>
+                    </button>
+                 @endif
 
                  <button class="btn btn-sm btn-outline-info btn-preview rounded-pill px-3"
                     data-model-type="employee"
-                    data-model-id="{{ $empId }}"
+                    data-model-id="{{ $empId ?? 0 }}"
                     title="Preview">
                     <i class="bi bi-eye-fill"></i>
                 </button>
@@ -305,7 +315,6 @@
                     title="{{ __('Manage Team') }}">
                     <i class="bi bi-people-fill"></i> <span class="d-none d-lg-inline">{{ __('Team') }}</span>
                 </button>
-                @endif
 
                 {{-- SAVE TO DB (Finalize) --}}
                 <button class="btn btn-sm btn-success rounded-pill px-3 {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}"


### PR DESCRIPTION
… cards

- Unhide Edit, Preview, and Team buttons for all items (including temporary/unlinked employees) in `_item_card.blade.php`.
- Wire up the Edit button to open the "Full Edit Employee Modal" (`editEmployeeModal`) for linked employees.
- Implement a fallback alert for the Edit button on temporary employees (prompting registration first).
- Add the `editEmployeeModal` HTML structure and required scripts to `workflow/index.blade.php`, `workflow/dashboard.blade.php`, and `production/index.blade.php` to support the popup functionality.