### PR TITLE
feat: add 4 new columns to employee excel import template and logic

### DIFF
--- a/app/Http/Controllers/ImportEmployeeController.php
+++ b/app/Http/Controllers/ImportEmployeeController.php
@@ -178,6 +178,10 @@ class ImportEmployeeController extends Controller
             'CI/PJ/TD/Inter',                 // N
             'Visa Expiry Date',               // O (New)
             '90-Day Report Date',             // P (New)
+            'Employer\'s Employee ID',        // Q (New)
+            'Start Date',                     // R (New)
+            'Employee ID Number',             // S (New)
+            'Passport Issue Date',            // T (New)
         ];
 
         foreach ($columns as $index => $header) {
@@ -206,8 +210,8 @@ class ImportEmployeeController extends Controller
         // Set dimensions
         $sheet->getColumnDimension('A')->setWidth(30);
 
-        // Auto-size other columns (B to P)
-        foreach (range('B', 'P') as $col) {
+        // Auto-size other columns (B to T)
+        foreach (range('B', 'T') as $col) {
             $sheet->getColumnDimension($col)->setAutoSize(true);
         }
 
@@ -224,8 +228,8 @@ class ImportEmployeeController extends Controller
         for ($r = $startDataRow; $r <= $endDataRow; $r++) {
             $sheet->getRowDimension($r)->setRowHeight(150);
 
-            // Apply borders to all cells in the grid (A to P)
-            $rowRange = "A{$r}:P{$r}";
+            // Apply borders to all cells in the grid (A to T)
+            $rowRange = "A{$r}:T{$r}";
             $sheet->getStyle($rowRange)->getBorders()->getAllBorders()->setBorderStyle(Border::BORDER_THIN);
             $sheet->getStyle($rowRange)->getAlignment()->setVertical(Alignment::VERTICAL_CENTER);
 
@@ -357,10 +361,14 @@ class ImportEmployeeController extends Controller
                 // N (14) = Book Type (Old L)
                 // O (15) = Visa Expiry (New)
                 // P (16) = 90 Day Expiry (New)
+                // Q (17) = Employer's Employee ID (New)
+                // R (18) = Start Date (New)
+                // S (19) = Employee ID Number (New)
+                // T (20) = Passport Issue Date (New)
 
                 $row = [];
-                // We read columns 2 (B) through 16 (P) for text data
-                for ($colIdx = 2; $colIdx <= 16; $colIdx++) {
+                // We read columns 2 (B) through 20 (T) for text data
+                for ($colIdx = 2; $colIdx <= 20; $colIdx++) {
                     $colLetter = Coordinate::stringFromColumnIndex($colIdx);
                     $val = $sheet->getCell($colLetter . $rowIdx)->getValue();
                     $row[] = trim((string)$val);
@@ -387,6 +395,10 @@ class ImportEmployeeController extends Controller
                 $bookType = $row[12];
                 $visaExpiryRaw = $row[13];
                 $ninetyDayRaw = $row[14];
+                $employerEmployeeId = $row[15];
+                $startDateRaw = $row[16];
+                $employeeIdNumber = $row[17];
+                $passportIssueDateRaw = $row[18];
 
                 // Validate and Parse Dates
                 $dob = $this->parseDateStrict($dobRaw, $sheet->getCell('F' . $rowIdx));
@@ -417,6 +429,18 @@ class ImportEmployeeController extends Controller
                 if ($ninetyDayRaw && !$ninetyDay) {
                     $errors[] = "Row $rowIdx: Invalid 90-Day Report format ($ninetyDayRaw). Expected D/M/Y.";
                     continue;
+                }
+
+                $startDate = $this->parseDateStrict($startDateRaw, $sheet->getCell('R' . $rowIdx));
+                if ($startDateRaw && !$startDate) {
+                     $errors[] = "Row $rowIdx: Invalid Start Date format ($startDateRaw). Expected D/M/Y.";
+                     continue;
+                }
+
+                $passportIssueDate = $this->parseDateStrict($passportIssueDateRaw, $sheet->getCell('T' . $rowIdx));
+                if ($passportIssueDateRaw && !$passportIssueDate) {
+                     $errors[] = "Row $rowIdx: Invalid Passport Issue Date format ($passportIssueDateRaw). Expected D/M/Y.";
+                     continue;
                 }
 
                 // Process Image from Column A
@@ -563,6 +587,10 @@ class ImportEmployeeController extends Controller
                     'ninetyDayReportDate' => $ninetyDay,
                     'employeePhoto' => $photoPath,
                     'status' => $status,
+                    'employer_employee_id' => $employerEmployeeId,
+                    'startDate' => $startDate,
+                    'employee_id_number' => $employeeIdNumber,
+                    'passport_issue_date' => $passportIssueDate,
                 ];
 
                 if ($nationality === 'กัมพูชา') {

--- a/tests/Feature/EmployeeImportFeatureTest.php
+++ b/tests/Feature/EmployeeImportFeatureTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Employee;
+use App\Models\User;
+use App\Models\Employer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\UploadedFile;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class EmployeeImportFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_import_employee_with_new_columns()
+    {
+        // Setup permissions
+        $user = User::factory()->create();
+        $permission = Permission::create(['name' => 'create-employees']);
+        $user->givePermissionTo($permission);
+        $this->actingAs($user);
+
+        // Setup Employer
+        $employer = Employer::create([
+            'employerNameTh' => 'Test Employer',
+            'employerNameEn' => 'Test Employer EN',
+            'employerId' => '1234567890123',
+            'employerTaxId' => '1234567890123',
+        ]);
+
+        // Create Excel File
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        // Row 12 Headers (Mock)
+        $sheet->setCellValue('A12', 'Photo');
+        // ... set other headers if strict checking existed, but it doesn't.
+
+        // Row 13 Data
+        // A=1, B=2 ... P=16, Q=17, R=18, S=19, T=20
+        $sheet->setCellValue('B13', 'Mr.');       // Title EN
+        $sheet->setCellValue('C13', 'John');      // Name EN
+        $sheet->setCellValue('D13', 'นาย');      // Title TH
+        $sheet->setCellValue('E13', 'สมชาย');    // Name TH
+        $sheet->setCellValue('F13', '01/01/1990');// DOB
+        $sheet->setCellValue('G13', 'ลาว');       // Nationality
+        $sheet->setCellValue('H13', 'PP123456');  // Passport
+        $sheet->setCellValue('I13', '01/01/2030');// PP Expiry
+        $sheet->setCellValue('J13', 'WP987654');  // WP No
+        $sheet->setCellValue('K13', '01/01/2025');// WP Expiry
+        $sheet->setCellValue('L13', 'MOU');       // WP Type
+        $sheet->setCellValue('M13', 'PINK001');   // Pink Card
+        $sheet->setCellValue('N13', 'CI');        // Book Type
+        $sheet->setCellValue('O13', '01/01/2026');// Visa Expiry
+        $sheet->setCellValue('P13', '01/06/2024');// 90 Day
+
+        // NEW COLUMNS
+        $sheet->setCellValue('Q13', 'EMP_REF_001'); // Employer's Employee ID
+        $sheet->setCellValue('R13', '15/05/2024');  // Start Date
+        $sheet->setCellValue('S13', 'ID_NUM_999');  // Employee ID Number
+        $sheet->setCellValue('T13', '20/05/2020');  // Passport Issue Date
+
+        $writer = new Xlsx($spreadsheet);
+        $tempFile = tempnam(sys_get_temp_dir(), 'import_test');
+        $writer->save($tempFile);
+
+        $file = new UploadedFile($tempFile, 'import.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', null, true);
+
+        // Perform Request
+        $response = $this->post(route('employees.import'), [
+            'employer_id' => $employer->id,
+            'file' => $file,
+        ]);
+
+        // Assertions
+        $response->assertSessionHas('success');
+        $response->assertSessionHasNoErrors();
+
+        $this->assertDatabaseHas('employees', [
+            'employer_id' => $employer->id,
+            'employeeNameEn' => 'John',
+            'employer_employee_id' => 'EMP_REF_001',
+            'startDate' => '2024-05-15', // formatted
+            'employee_id_number' => 'ID_NUM_999',
+            'passport_issue_date' => '2020-05-20', // formatted
+        ]);
+
+        unlink($tempFile);
+    }
+
+    public function test_can_download_template()
+    {
+        $user = User::factory()->create();
+        // Permission check might be needed if the controller enforces it, but the method itself seems public/protected by auth middleware usually.
+        // Assuming route is protected by auth.
+        $this->actingAs($user);
+
+        $response = $this->get(route('employees.template'));
+
+        $response->assertStatus(200);
+        $response->assertHeader('content-disposition', 'attachment; filename=employee_import_template.xlsx');
+    }
+}


### PR DESCRIPTION
- Add Employer's Employee ID, Start Date, Employee ID Number, and Passport Issue Date to the Excel template headers.
- Update import logic to read these 4 new columns and map them to the database.
- Add strict date parsing for Start Date and Passport Issue Date.
- Add Feature test to verify the new import columns.