### PR TITLE
Fix edit employee saving issue and improve scanner reordering

### DIFF
--- a/resources/views/components/document-scanner.blade.php
+++ b/resources/views/components/document-scanner.blade.php
@@ -454,9 +454,14 @@
                 if (newIndex >= this.capturedImages.length) {
                     newIndex = this.capturedImages.length - 1;
                 }
+                if (newIndex < 0) newIndex = 0;
 
+                // Move item in the array
                 const item = this.capturedImages.splice(oldIndex, 1)[0];
                 this.capturedImages.splice(newIndex, 0, item);
+
+                // Force Reactivity for Alpine to ensure DOM matches Array
+                this.capturedImages = [...this.capturedImages];
 
                 // Clear selection to avoid confusion
                 this.selectedIndices = [];

--- a/resources/views/employees/partials/_edit_form.blade.php
+++ b/resources/views/employees/partials/_edit_form.blade.php
@@ -12,71 +12,71 @@
         <div class="col-md-8">
             <div class="row">
                 <div class="col-md-6 mb-3">
-                    <label for="employeeTitleTh" class="form-label">คำนำหน้าชื่อ (ไทย)
+                    <label for="edit_employeeTitleTh" class="form-label">คำนำหน้าชื่อ (ไทย)
                         @if(isset($missingFields) && in_array('employeeTitleTh', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                     </label>
-                    <select class="form-select" id="employeeTitleTh" name="employeeTitleTh">
+                    <select class="form-select" id="edit_employeeTitleTh" name="employeeTitleTh">
                         <option value="นาย" @selected(old('employeeTitleTh', $employee->employeeTitleTh) == 'นาย')>นาย</option>
                         <option value="นางสาว" @selected(old('employeeTitleTh', $employee->employeeTitleTh) == 'นางสาว')>นางสาว</option>
                         <option value="นาง" @selected(old('employeeTitleTh', $employee->employeeTitleTh) == 'นาง')>นาง</option>
                     </select>
                 </div>
                 <div class="col-md-6 mb-3">
-                    <label for="employeeNameTh" class="form-label">ชื่อ-สกุล (ไทย)
+                    <label for="edit_employeeNameTh" class="form-label">ชื่อ-สกุล (ไทย)
                         @if(isset($missingFields) && in_array('employeeNameTh', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                     </label>
-                    <input type="text" class="form-control" id="employeeNameTh" name="employeeNameTh" value="{{ old('employeeNameTh', $employee->employeeNameTh) }}">
+                    <input type="text" class="form-control" id="edit_employeeNameTh" name="employeeNameTh" value="{{ old('employeeNameTh', $employee->employeeNameTh) }}">
                 </div>
             </div>
 
             <div class="row">
                     <div class="col-md-6 mb-3">
-                    <label for="employeeTitleEn" class="form-label">Prefix (EN)
+                    <label for="edit_employeeTitleEn" class="form-label">Prefix (EN)
                         @if(isset($missingFields) && in_array('employeeTitleEn', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                     </label>
-                    <select class="form-select" id="employeeTitleEn" name="employeeTitleEn">
+                    <select class="form-select" id="edit_employeeTitleEn" name="employeeTitleEn">
                             <option value="Mr." @selected(old('employeeTitleEn', $employee->employeeTitleEn) == 'Mr.')>Mr.</option>
                             <option value="Miss" @selected(old('employeeTitleEn', $employee->employeeTitleEn) == 'Miss')>Miss</option>
                             <option value="Mrs." @selected(old('employeeTitleEn', $employee->employeeTitleEn) == 'Mrs.')>Mrs.</option>
                     </select>
                 </div>
                 <div class="col-md-6 mb-3">
-                    <label for="employeeNameEn" class="form-label">Full Name (EN) <span class="text-danger">*</span>
+                    <label for="edit_employeeNameEn" class="form-label">Full Name (EN) <span class="text-danger">*</span>
                         @if(isset($missingFields) && in_array('employeeNameEn', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                     </label>
-                    <input type="text" class="form-control" id="employeeNameEn" name="employeeNameEn" value="{{ old('employeeNameEn', $employee->employeeNameEn) }}" required>
+                    <input type="text" class="form-control" id="edit_employeeNameEn" name="employeeNameEn" value="{{ old('employeeNameEn', $employee->employeeNameEn) }}" required>
                 </div>
             </div>
 
                 <div class="row">
                 <div class="col-md-6 mb-3">
-                    <label for="father_name" class="form-label">ชื่อพ่อ
+                    <label for="edit_father_name" class="form-label">ชื่อพ่อ
                         @if(isset($missingFields) && in_array('father_name', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                     </label>
-                    <input type="text" class="form-control" id="father_name" name="father_name" value="{{ old('father_name', $employee->father_name) }}">
+                    <input type="text" class="form-control" id="edit_father_name" name="father_name" value="{{ old('father_name', $employee->father_name) }}">
                 </div>
                 <div class="col-md-6 mb-3">
-                    <label for="mother_name" class="form-label">ชื่อแม่
+                    <label for="edit_mother_name" class="form-label">ชื่อแม่
                         @if(isset($missingFields) && in_array('mother_name', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                     </label>
-                    <input type="text" class="form-control" id="mother_name" name="mother_name" value="{{ old('mother_name', $employee->mother_name) }}">
+                    <input type="text" class="form-control" id="edit_mother_name" name="mother_name" value="{{ old('mother_name', $employee->mother_name) }}">
                 </div>
             </div>
 
             <div class="row">
                     <div class="col-md-4 mb-3">
-                    <label for="employeeGender" class="form-label">เพศ</label>
-                    <input type="text" class="form-control" id="employeeGender" name="employeeGender" value="{{ old('employeeGender', $employee->employeeGender) }}" readonly>
+                    <label for="edit_employeeGender" class="form-label">เพศ</label>
+                    <input type="text" class="form-control" id="edit_employeeGender" name="employeeGender" value="{{ old('employeeGender', $employee->employeeGender) }}" readonly>
                     </div>
                     <div class="col-md-5 mb-3">
-                    <label for="employeeDob" class="form-label">วันเดือนปีเกิด
+                    <label for="edit_employeeDob" class="form-label">วันเดือนปีเกิด
                         @if(isset($missingFields) && in_array('employeeDob', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                     </label>
-                    <input type="date" class="form-control" id="employeeDob" name="employeeDob" value="{{ old('employeeDob', optional($employee->employeeDob)->format('Y-m-d')) }}">
+                    <input type="date" class="form-control" id="edit_employeeDob" name="employeeDob" value="{{ old('employeeDob', optional($employee->employeeDob)->format('Y-m-d')) }}">
                 </div>
                 <div class="col-md-3 mb-3">
-                    <label for="employeeAge" class="form-label">อายุ</label>
-                    <input type="text" class="form-control" id="employeeAge" name="employeeAge" value="{{ old('employeeAge', $employee->employeeAge) }}" readonly>
+                    <label for="edit_employeeAge" class="form-label">อายุ</label>
+                    <input type="text" class="form-control" id="edit_employeeAge" name="employeeAge" value="{{ old('employeeAge', $employee->employeeAge) }}" readonly>
                 </div>
             </div>
         </div>
@@ -85,22 +85,22 @@
             <label class="form-label">รูปภาพพนักงาน
                 @if(isset($missingFields) && in_array('employeePhoto', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <img id="employeePhotoPreview" src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/150x180/f8fafc/6c757d?text=Photo' }}" class="img-thumbnail mb-3" style="width: 150px; height: 180px; object-fit: cover;">
+            <img id="edit_employeePhotoPreview" src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/150x180/f8fafc/6c757d?text=Photo' }}" class="img-thumbnail mb-3" style="width: 150px; height: 180px; object-fit: cover;">
             <div class="d-grid gap-2 w-75">
-                <button type="button" class="btn btn-sm btn-outline-primary" onclick="document.getElementById('triggerFile').click();"><i class="bi bi-file-earmark-image me-1"></i> เลือกจากไฟล์</button>
-                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.getElementById('triggerCamera').click();"><i class="bi bi-camera-fill me-1"></i> ถ่ายภาพ</button>
+                <button type="button" class="btn btn-sm btn-outline-primary" onclick="document.getElementById('edit_triggerFile').click();"><i class="bi bi-file-earmark-image me-1"></i> เลือกจากไฟล์</button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.getElementById('edit_triggerCamera').click();"><i class="bi bi-camera-fill me-1"></i> ถ่ายภาพ</button>
                 @if($employee->employeePhoto)
                 <button type="button" class="btn btn-sm btn-warning"
-                        onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employeePhotoInput', initialUrl: '{{ asset('storage/' . $employee->employeePhoto) }}' } }))">
+                        onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'edit_employeePhotoInput', initialUrl: '{{ asset('storage/' . $employee->employeePhoto) }}' } }))">
                     <i class="bi bi-pencil-square me-1"></i> แก้ไขรูปภาพ
                 </button>
                 @endif
             </div>
             {{-- Hidden file inputs --}}
-            <input type="file" class="d-none" id="triggerFile" accept="image/*">
-            <input type="file" class="d-none" id="triggerCamera" accept="image/*" capture="environment">
+            <input type="file" class="d-none" id="edit_triggerFile" accept="image/*">
+            <input type="file" class="d-none" id="edit_triggerCamera" accept="image/*" capture="environment">
             {{-- Actual Input for Submission --}}
-            <input type="file" class="d-none" id="employeePhotoInput" name="employeePhoto">
+            <input type="file" class="d-none" id="edit_employeePhotoInput" name="employeePhoto">
         </div>
     </div>
 
@@ -110,16 +110,16 @@
     <hr class="mb-4">
     <div class="row">
         <div class="col-md-4 mb-3">
-            <label for="employeePhone" class="form-label">เบอร์โทรศัพท์
+            <label for="edit_employeePhone" class="form-label">เบอร์โทรศัพท์
                 @if(isset($missingFields) && in_array('employeePhone', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="tel" class="form-control" id="employeePhone" name="employeePhone" value="{{ old('employeePhone', $employee->employeePhone) }}">
+            <input type="tel" class="form-control" id="edit_employeePhone" name="employeePhone" value="{{ old('employeePhone', $employee->employeePhone) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="employeeNationality" class="form-label">สัญชาติ
+            <label for="edit_employeeNationality" class="form-label">สัญชาติ
                 @if(isset($missingFields) && in_array('employeeNationality', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <select class="form-select" id="employeeNationality" name="employeeNationality">
+            <select class="form-select" id="edit_employeeNationality" name="employeeNationality">
                 <option value="">-- เลือกสัญชาติ --</option>
                 <option value="เมียนมา" @selected(old('employeeNationality', $employee->employeeNationality) == 'เมียนมา')>เมียนมา</option>
                 <option value="ลาว" @selected(old('employeeNationality', $employee->employeeNationality) == 'ลาว')>ลาว</option>
@@ -127,21 +127,21 @@
                 <option value="เวียดนาม" @selected(old('employeeNationality', $employee->employeeNationality) == 'เวียดนาม')>เวียดนาม</option>
             </select>
         </div>
-            <div class="col-md-4 mb-3 d-none" id="passportTypeContainer">
-            <label for="passportType" class="form-label">ประเภทหนังสือเดินทาง (สำหรับเมียนมา)
+            <div class="col-md-4 mb-3 d-none" id="edit_passportTypeContainer">
+            <label for="edit_passportType" class="form-label">ประเภทหนังสือเดินทาง (สำหรับเมียนมา)
                 @if(isset($missingFields) && in_array('passportType', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <select class="form-select" id="passportType" name="passportType">
+            <select class="form-select" id="edit_passportType" name="passportType">
                 <option value="">-- เลือกประเภท --</option>
                 <option value="PJ" @selected(old('passportType', $employee->passportType) == 'PJ')>เล่ม PJ</option>
                 <option value="CI" @selected(old('passportType', $employee->passportType) == 'CI')>เล่ม CI</option>
             </select>
         </div>
-        <div class="col-md-4 mb-3 d-none" id="passportTypeCambodiaContainer">
-            <label for="passport_type_cambodia" class="form-label">ประเภทหนังสือเดินทาง (สำหรับกัมพูชา)
+        <div class="col-md-4 mb-3 d-none" id="edit_passportTypeCambodiaContainer">
+            <label for="edit_passport_type_cambodia" class="form-label">ประเภทหนังสือเดินทาง (สำหรับกัมพูชา)
                 @if(isset($missingFields) && in_array('passport_type_cambodia', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <select class="form-select" id="passport_type_cambodia" name="passport_type_cambodia">
+            <select class="form-select" id="edit_passport_type_cambodia" name="passport_type_cambodia">
                 <option value="">-- เลือกประเภท --</option>
                 <option value="เล่ม TD" @selected(old('passport_type_cambodia', $employee->passport_type_cambodia) == 'เล่ม TD')>เล่ม TD</option>
                 <option value="เล่มอินเตอร์" @selected(old('passport_type_cambodia', $employee->passport_type_cambodia) == 'เล่มอินเตอร์')>เล่มอินเตอร์</option>
@@ -154,42 +154,42 @@
     <hr class="mb-4">
     <div class="row">
         <div class="col-md-4 mb-3">
-            <label for="employeePassport" class="form-label">เลขพาสปอร์ต
+            <label for="edit_employeePassport" class="form-label">เลขพาสปอร์ต
                 @if(isset($missingFields) && in_array('employeePassport', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="text" class="form-control" id="employeePassport" name="employeePassport" value="{{ old('employeePassport', $employee->employeePassport) }}">
+            <input type="text" class="form-control" id="edit_employeePassport" name="employeePassport" value="{{ old('employeePassport', $employee->employeePassport) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="passport_issue_date" class="form-label">วันออกพาสปอร์ต
+            <label for="edit_passport_issue_date" class="form-label">วันออกพาสปอร์ต
                 @if(isset($missingFields) && in_array('passport_issue_date', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="date" class="form-control" id="passport_issue_date" name="passport_issue_date" value="{{ old('passport_issue_date', optional($employee->passport_issue_date)->format('Y-m-d')) }}">
+            <input type="date" class="form-control" id="edit_passport_issue_date" name="passport_issue_date" value="{{ old('passport_issue_date', optional($employee->passport_issue_date)->format('Y-m-d')) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="passportExpiryDate" class="form-label">วันหมดอายุพาสปอร์ต
+            <label for="edit_passportExpiryDate" class="form-label">วันหมดอายุพาสปอร์ต
                 @if(isset($missingFields) && in_array('passportExpiryDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="date" class="form-control" id="passportExpiryDate" name="passportExpiryDate" value="{{ old('passportExpiryDate', optional($employee->passportExpiryDate)->format('Y-m-d')) }}">
+            <input type="date" class="form-control" id="edit_passportExpiryDate" name="passportExpiryDate" value="{{ old('passportExpiryDate', optional($employee->passportExpiryDate)->format('Y-m-d')) }}">
         </div>
     </div>
     <div class="row">
         <div class="col-md-4 mb-3">
-            <label for="pinkCardNo" class="form-label">เลขบัตรชมพู
+            <label for="edit_pinkCardNo" class="form-label">เลขบัตรชมพู
                 @if(isset($missingFields) && in_array('pinkCardNo', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="text" class="form-control" id="pinkCardNo" name="pinkCardNo" value="{{ old('pinkCardNo', $employee->pinkCardNo) }}">
+            <input type="text" class="form-control" id="edit_pinkCardNo" name="pinkCardNo" value="{{ old('pinkCardNo', $employee->pinkCardNo) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="visaType" class="form-label">ประเภทวีซ่า
+            <label for="edit_visaType" class="form-label">ประเภทวีซ่า
                 @if(isset($missingFields) && in_array('visaType', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="text" class="form-control" id="visaType" name="visaType" value="{{ old('visaType', $employee->visaType) }}">
+            <input type="text" class="form-control" id="edit_visaType" name="visaType" value="{{ old('visaType', $employee->visaType) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="visaExpiryDate" class="form-label">วันหมดอายุวีซ่า
+            <label for="edit_visaExpiryDate" class="form-label">วันหมดอายุวีซ่า
                 @if(isset($missingFields) && in_array('visaExpiryDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="date" class="form-control" id="visaExpiryDate" name="visaExpiryDate" value="{{ old('visaExpiryDate', optional($employee->visaExpiryDate)->format('Y-m-d')) }}">
+            <input type="date" class="form-control" id="edit_visaExpiryDate" name="visaExpiryDate" value="{{ old('visaExpiryDate', optional($employee->visaExpiryDate)->format('Y-m-d')) }}">
         </div>
     </div>
 
@@ -198,50 +198,50 @@
     <hr class="mb-4">
     <div class="row">
         <div class="col-md-4 mb-3">
-            <label for="job_title" class="form-label">ตำแหน่งงาน
+            <label for="edit_job_title" class="form-label">ตำแหน่งงาน
                 @if(isset($missingFields) && in_array('job_title', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="text" class="form-control" id="job_title" name="job_title" value="{{ old('job_title', $employee->job_title) }}">
+            <input type="text" class="form-control" id="edit_job_title" name="job_title" value="{{ old('job_title', $employee->job_title) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="job_description" class="form-label">ลักษณะงาน
+            <label for="edit_job_description" class="form-label">ลักษณะงาน
                 @if(isset($missingFields) && in_array('job_description', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="text" class="form-control" id="job_description" name="job_description" value="{{ old('job_description', $employee->job_description) }}">
+            <input type="text" class="form-control" id="edit_job_description" name="job_description" value="{{ old('job_description', $employee->job_description) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="startDate" class="form-label">วันที่เริ่มงาน
+            <label for="edit_startDate" class="form-label">วันที่เริ่มงาน
                 @if(isset($missingFields) && in_array('startDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="date" class="form-control" id="startDate" name="startDate" value="{{ old('startDate', optional($employee->startDate)->format('Y-m-d')) }}">
+            <input type="date" class="form-control" id="edit_startDate" name="startDate" value="{{ old('startDate', optional($employee->startDate)->format('Y-m-d')) }}">
         </div>
     </div>
     <div class="row">
         <div class="col-md-4 mb-3">
-            <label for="employeeWorkPermit" class="form-label">เลข Work Permit
+            <label for="edit_employeeWorkPermit" class="form-label">เลข Work Permit
                 @if(isset($missingFields) && in_array('employeeWorkPermit', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="text" class="form-control" id="employeeWorkPermit" name="employeeWorkPermit" value="{{ old('employeeWorkPermit', $employee->employeeWorkPermit) }}">
+            <input type="text" class="form-control" id="edit_employeeWorkPermit" name="employeeWorkPermit" value="{{ old('employeeWorkPermit', $employee->employeeWorkPermit) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="workPermitExpiryDate" class="form-label">วันหมดอายุ Work Permit
+            <label for="edit_workPermitExpiryDate" class="form-label">วันหมดอายุ Work Permit
                 @if(isset($missingFields) && in_array('workPermitExpiryDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="date" class="form-control" id="workPermitExpiryDate" name="workPermitExpiryDate" value="{{ old('workPermitExpiryDate', optional($employee->workPermitExpiryDate)->format('Y-m-d')) }}">
+            <input type="date" class="form-control" id="edit_workPermitExpiryDate" name="workPermitExpiryDate" value="{{ old('workPermitExpiryDate', optional($employee->workPermitExpiryDate)->format('Y-m-d')) }}">
         </div>
             <div class="col-md-4 mb-3">
-            <label for="ninetyDayReportDate" class="form-label">วันรายงานตัว 90 วัน
+            <label for="edit_ninetyDayReportDate" class="form-label">วันรายงานตัว 90 วัน
                 @if(isset($missingFields) && in_array('ninetyDayReportDate', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="date" class="form-control" id="ninetyDayReportDate" name="ninetyDayReportDate" value="{{ old('ninetyDayReportDate', optional($employee->ninetyDayReportDate)->format('Y-m-d')) }}">
+            <input type="date" class="form-control" id="edit_ninetyDayReportDate" name="ninetyDayReportDate" value="{{ old('ninetyDayReportDate', optional($employee->ninetyDayReportDate)->format('Y-m-d')) }}">
         </div>
     </div>
     <div class="row">
             <div class="col-md-6 mb-3">
-            <label for="workPermitType" class="form-label">ประเภทใบอนุญาตทำงาน
+            <label for="edit_workPermitMOUGroup" class="form-label">ประเภทใบอนุญาตทำงาน
                 @if(isset($missingFields) && in_array('workPermitMOUGroup', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <select class="form-select" id="workPermitMOUGroup" name="workPermitMOUGroup">
+            <select class="form-select" id="edit_workPermitMOUGroup" name="workPermitMOUGroup">
                 <option value="">-- กรุณาเลือก --</option>
                 <option value="MOU" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'MOU')>MOU</option>
                 <option value="มติต่ออายุในประเทศ" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'มติต่ออายุในประเทศ')>มติต่ออายุในประเทศ</option>
@@ -249,38 +249,38 @@
                 <option value="อื่นๆ" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'อื่นๆ')>อื่นๆ ระบุ..</option>
             </select>
         </div>
-        <div class="col-md-6 mb-3 d-none" id="workPermitMOUGroupOtherContainer">
-            <label for="workPermitMOUGroupOther" class="form-label">ระบุประเภทอื่นๆ
+        <div class="col-md-6 mb-3 d-none" id="edit_workPermitMOUGroupOtherContainer">
+            <label for="edit_workPermitMOUGroupOther" class="form-label">ระบุประเภทอื่นๆ
                 @if(isset($missingFields) && in_array('workPermitMOUGroupOther', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-                <input type="text" class="form-control" id="workPermitMOUGroupOther" name="workPermitMOUGroupOther" value="{{ old('workPermitMOUGroupOther', $employee->workPermitMOUGroupOther) }}">
+                <input type="text" class="form-control" id="edit_workPermitMOUGroupOther" name="workPermitMOUGroupOther" value="{{ old('workPermitMOUGroupOther', $employee->workPermitMOUGroupOther) }}">
         </div>
     </div>
     <div class="row">
-            <div class="col-md-4 mb-3"><label for="name_list_number" class="form-label">เลข RA จากระบบ outsource
+            <div class="col-md-4 mb-3"><label for="edit_name_list_number" class="form-label">เลข RA จากระบบ outsource
                 @if(isset($missingFields) && in_array('name_list_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
-            </label><input type="text" class="form-control" id="name_list_number" name="name_list_number" value="{{ old('name_list_number', $employee->name_list_number) }}"></div>
-            <div class="col-md-4 mb-3"><label for="request_number" class="form-label">เลขที่คำขอ
+            </label><input type="text" class="form-control" id="edit_name_list_number" name="name_list_number" value="{{ old('name_list_number', $employee->name_list_number) }}"></div>
+            <div class="col-md-4 mb-3"><label for="edit_request_number" class="form-label">เลขที่คำขอ
                 @if(isset($missingFields) && in_array('request_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
-            </label><input type="text" class="form-control" id="request_number" name="request_number" value="{{ old('request_number', $employee->request_number) }}"></div>
-            <div class="col-md-4 mb-3"><label for="employee_id_number" class="form-label">เลขประจำตัว
+            </label><input type="text" class="form-control" id="edit_request_number" name="request_number" value="{{ old('request_number', $employee->request_number) }}"></div>
+            <div class="col-md-4 mb-3"><label for="edit_employee_id_number" class="form-label">เลขประจำตัว
                 @if(isset($missingFields) && in_array('employee_id_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
-            </label><input type="text" class="form-control" id="employee_id_number" name="employee_id_number" value="{{ old('employee_id_number', $employee->employee_id_number) }}"></div>
-            <div class="col-md-4 mb-3"><label for="tax_id_number" class="form-label">เลขประจำตัวผู้เสียภาษี
+            </label><input type="text" class="form-control" id="edit_employee_id_number" name="employee_id_number" value="{{ old('employee_id_number', $employee->employee_id_number) }}"></div>
+            <div class="col-md-4 mb-3"><label for="edit_tax_id_number" class="form-label">เลขประจำตัวผู้เสียภาษี
                 @if(isset($missingFields) && in_array('tax_id_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
-            </label><input type="text" class="form-control" id="tax_id_number" name="tax_id_number" value="{{ old('tax_id_number', $employee->tax_id_number) }}"></div>
-            <div class="col-md-4 mb-3"><label for="employer_employee_id" class="form-label">รหัสคนงาน - ของนายจ้าง
+            </label><input type="text" class="form-control" id="edit_tax_id_number" name="tax_id_number" value="{{ old('tax_id_number', $employee->tax_id_number) }}"></div>
+            <div class="col-md-4 mb-3"><label for="edit_employer_employee_id" class="form-label">รหัสคนงาน - ของนายจ้าง
                 @if(isset($missingFields) && in_array('employer_employee_id', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
-            </label><input type="text" class="form-control" id="employer_employee_id" name="employer_employee_id" value="{{ old('employer_employee_id', $employee->employer_employee_id) }}"></div>
-            <div class="col-md-4 mb-3"><label for="employee_reference_id" class="form-label">เลขอ้างอิงคนงาน
+            </label><input type="text" class="form-control" id="edit_employer_employee_id" name="employer_employee_id" value="{{ old('employer_employee_id', $employee->employer_employee_id) }}"></div>
+            <div class="col-md-4 mb-3"><label for="edit_employee_reference_id" class="form-label">เลขอ้างอิงคนงาน
                 @if(isset($missingFields) && in_array('employee_reference_id', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
-            </label><input type="text" class="form-control" id="employee_reference_id" name="employee_reference_id" value="{{ old('employee_reference_id', $employee->employee_reference_id) }}"></div>
-        <div class="col-md-4 mb-3"><label for="bank_name" class="form-label">ชื่อธนาคาร
+            </label><input type="text" class="form-control" id="edit_employee_reference_id" name="employee_reference_id" value="{{ old('employee_reference_id', $employee->employee_reference_id) }}"></div>
+        <div class="col-md-4 mb-3"><label for="edit_bank_name" class="form-label">ชื่อธนาคาร
                 @if(isset($missingFields) && in_array('bank_name', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
-            </label><input type="text" class="form-control" id="bank_name" name="bank_name" value="{{ old('bank_name', $employee->bank_name) }}"></div>
-        <div class="col-md-4 mb-3"><label for="bank_account_number" class="form-label">เลขบัญชีธนาคาร
+            </label><input type="text" class="form-control" id="edit_bank_name" name="bank_name" value="{{ old('bank_name', $employee->bank_name) }}"></div>
+        <div class="col-md-4 mb-3"><label for="edit_bank_account_number" class="form-label">เลขบัญชีธนาคาร
                 @if(isset($missingFields) && in_array('bank_account_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
-            </label><input type="text" class="form-control" id="bank_account_number" name="bank_account_number" value="{{ old('bank_account_number', $employee->bank_account_number) }}"></div>
+            </label><input type="text" class="form-control" id="edit_bank_account_number" name="bank_account_number" value="{{ old('bank_account_number', $employee->bank_account_number) }}"></div>
     </div>
 
 
@@ -289,10 +289,10 @@
     <hr class="mb-4">
     <div class="row">
         <div class="col-md-4 mb-3">
-            <label for="insurance_type" class="form-label">ประเภทประกัน
+            <label for="edit_insurance_type" class="form-label">ประเภทประกัน
                 @if(isset($missingFields) && in_array('insurance_type', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <select class="form-select" id="insurance_type" name="insurance_type">
+            <select class="form-select" id="edit_insurance_type" name="insurance_type">
                 <option value="">-- เลือกประเภท --</option>
                 <option value="ประกันสังคม" @selected(old('insurance_type', $employee->insurance_type) == 'ประกันสังคม')>ประกันสังคม</option>
                 <option value="ประกันโรงพยาบาล" @selected(old('insurance_type', $employee->insurance_type) == 'ประกันโรงพยาบาล')>ประกันโรงพยาบาล</option>
@@ -304,7 +304,7 @@
     <div class="row">
         <div class="col-md-6 mb-3">
             <x-file-input-group
-                id="medical_certificate_path"
+                id="edit_medical_certificate_path"
                 name="medical_certificate_path"
                 label="ใบรับรองแพทย์ (Medical Certificate)"
                 :value="$employee->medical_certificate_path"
@@ -312,66 +312,66 @@
             />
         </div>
         <div class="col-md-6 mb-3">
-            <label for="medical_hospital_name" class="form-label">โรงพยาบาลที่ตรวจโรค (Hospital Name)</label>
-            <input type="text" class="form-control" id="medical_hospital_name" name="medical_hospital_name" value="{{ old('medical_hospital_name', $employee->medical_hospital_name) }}">
+            <label for="edit_medical_hospital_name" class="form-label">โรงพยาบาลที่ตรวจโรค (Hospital Name)</label>
+            <input type="text" class="form-control" id="edit_medical_hospital_name" name="medical_hospital_name" value="{{ old('medical_hospital_name', $employee->medical_hospital_name) }}">
         </div>
     </div>
 
     {{-- Social Security Container --}}
-    <div id="insuranceSocialSecurity" class="d-none">
+    <div id="edit_insuranceSocialSecurity" class="d-none">
             <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="social_security_number" class="form-label">เลขประกันสังคม
+                <label for="edit_social_security_number" class="form-label">เลขประกันสังคม
                     @if(isset($missingFields) && in_array('social_security_number', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                 </label>
-                <input type="text" class="form-control" id="social_security_number" name="social_security_number" value="{{ old('social_security_number', $employee->social_security_number) }}">
+                <input type="text" class="form-control" id="edit_social_security_number" name="social_security_number" value="{{ old('social_security_number', $employee->social_security_number) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="insurance_detail" class="form-label">สิทธิ์โรงพยาบาล
+                <label for="edit_insurance_detail" class="form-label">สิทธิ์โรงพยาบาล
                     @if(isset($missingFields) && in_array('insurance_detail', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                 </label>
-                <input type="text" class="form-control" name="insurance_detail" value="{{ old('insurance_detail', $employee->insurance_detail) }}">
+                <input type="text" class="form-control" id="edit_insurance_detail" name="insurance_detail" value="{{ old('insurance_detail', $employee->insurance_detail) }}">
             </div>
             </div>
     </div>
     {{-- Hospital Insurance Container --}}
-    <div id="insuranceHospital" class="d-none">
+    <div id="edit_insuranceHospital" class="d-none">
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="insurance_detail_hospital" class="form-label">ชื่อโรงพยาบาล
+                <label for="edit_insurance_detail_hospital" class="form-label">ชื่อโรงพยาบาล
                     @if(isset($missingFields) && in_array('insurance_detail_hospital', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                 </label>
-                <input type="text" class="form-control" name="insurance_detail_hospital" value="{{ old('insurance_detail_hospital', $employee->insurance_detail_hospital) }}">
+                <input type="text" class="form-control" id="edit_insurance_detail_hospital" name="insurance_detail_hospital" value="{{ old('insurance_detail_hospital', $employee->insurance_detail_hospital) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="insurance_expiry_date_hospital" class="form-label">วันหมดอายุประกัน
+                <label for="edit_insurance_expiry_date_hospital" class="form-label">วันหมดอายุประกัน
                     @if(isset($missingFields) && in_array('insurance_expiry_date_hospital', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                 </label>
-                <input type="date" class="form-control" name="insurance_expiry_date_hospital" value="{{ old('insurance_expiry_date_hospital', optional($employee->insurance_expiry_date_hospital)->format('Y-m-d')) }}">
+                <input type="date" class="form-control" id="edit_insurance_expiry_date_hospital" name="insurance_expiry_date_hospital" value="{{ old('insurance_expiry_date_hospital', optional($employee->insurance_expiry_date_hospital)->format('Y-m-d')) }}">
             </div>
         </div>
     </div>
     {{-- Private Insurance Container --}}
-    <div id="insurancePrivate" class="d-none">
+    <div id="edit_insurancePrivate" class="d-none">
         <div class="row">
             <div class="col-md-4 mb-3">
-                <label for="insurance_detail_private" class="form-label">บริษัทประกัน
+                <label for="edit_insurance_detail_private" class="form-label">บริษัทประกัน
                     @if(isset($missingFields) && in_array('insurance_detail_private', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                 </label>
-                <input type="text" class="form-control" name="insurance_detail_private" value="{{ old('insurance_detail_private', $employee->insurance_detail_private) }}">
+                <input type="text" class="form-control" id="edit_insurance_detail_private" name="insurance_detail_private" value="{{ old('insurance_detail_private', $employee->insurance_detail_private) }}">
             </div>
             <div class="col-md-4 mb-3">
-                <label for="insurance_expiry_date_private" class="form-label">วันหมดอายุประกัน
+                <label for="edit_insurance_expiry_date_private" class="form-label">วันหมดอายุประกัน
                     @if(isset($missingFields) && in_array('insurance_expiry_date_private', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
                 </label>
-                <input type="date" class="form-control" name="insurance_expiry_date_private" value="{{ old('insurance_expiry_date_private', optional($employee->insurance_expiry_date_private)->format('Y-m-d')) }}">
+                <input type="date" class="form-control" id="edit_insurance_expiry_date_private" name="insurance_expiry_date_private" value="{{ old('insurance_expiry_date_private', optional($employee->insurance_expiry_date_private)->format('Y-m-d')) }}">
             </div>
         </div>
     </div>
     <div class="row">
         <div class="col-md-4 mb-3">
             <x-file-input-group
-                id="insurance_document_path_private"
+                id="edit_insurance_document_path_private"
                 name="insurance_document_path_private"
                 label="แนบไฟล์เอกสารประกัน"
                 :value="$employee->insurance_document_path_private"
@@ -385,24 +385,24 @@
     <hr class="mb-4">
     <div class="row">
         <div class="col-md-4 mb-3">
-            <label for="employeeEmail" class="form-label">อีเมล
+            <label for="edit_employeeEmail" class="form-label">อีเมล
                 @if(isset($missingFields) && in_array('email', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="email" class="form-control" id="employeeEmail" name="employeeEmail" value="{{ old('employeeEmail', $employee->email) }}">
+            <input type="email" class="form-control" id="edit_employeeEmail" name="employeeEmail" value="{{ old('employeeEmail', $employee->email) }}">
         </div>
         <div class="col-md-4 mb-3">
-            <label for="password" class="form-label">รหัสสำหรับอีเมล
+            <label for="edit_password" class="form-label">รหัสสำหรับอีเมล
                 @if(isset($missingFields) && in_array('password', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="text" class="form-control" id="password" name="password"
+            <input type="text" class="form-control" id="edit_password" name="password"
                     value="{{ $employee->password }}" placeholder="กรอกรหัสผ่าน">
             {{-- Note: type="text" creates a plain text box as requested --}}
         </div>
         <div class="col-md-4 mb-3">
-            <label for="outsource_code" class="form-label">รหัสสำหรับระบบ Outsource
+            <label for="edit_outsource_code" class="form-label">รหัสสำหรับระบบ Outsource
                 @if(isset($missingFields) && in_array('outsource_code', $missingFields)) <i class="bi bi-exclamation-circle-fill text-warning ms-1" title="Required"></i> @endif
             </label>
-            <input type="text" class="form-control" id="outsource_code" name="outsource_code" value="{{ old('outsource_code', $employee->outsource_code) }}">
+            <input type="text" class="form-control" id="edit_outsource_code" name="outsource_code" value="{{ old('outsource_code', $employee->outsource_code) }}">
         </div>
     </div>
 
@@ -427,12 +427,12 @@
             @endphp
             <div class="{{ in_array($i, $descSlots) ? 'col-md-6' : 'col-md-4' }} mb-3">
                 <x-file-input-group
-                    :id="$docField"
+                    :id="'edit_' . $docField"
                     :name="$docField"
                     :label="$i . '. ' . $label"
                     :value="$employee->{$docField}"
                     :pdfRoute="route('employees.documents.pdf', ['employee' => $employee->id, 'field' => $docField])"
-                    :description="in_array($i, $descSlots) ? $descField : null"
+                    :description="in_array($i, $descSlots) ? 'edit_' . $descField : null"
                     :descriptionValue="in_array($i, $descSlots) ? $employee->{$descField} : null"
                 />
             </div>

--- a/resources/views/employees/partials/_edit_scripts.blade.php
+++ b/resources/views/employees/partials/_edit_scripts.blade.php
@@ -117,8 +117,9 @@
                 const croppedImageUrl = URL.createObjectURL(blob);
 
                 // Find CURRENT elements in the DOM (since form is dynamic/AJAX loaded)
-                const employeePhotoPreview = document.getElementById('employeePhotoPreview');
-                const actualInput = document.getElementById('employeePhotoInput');
+                // UPDATE: Target 'edit_' prefixed IDs for the Edit Modal
+                const employeePhotoPreview = document.getElementById('edit_employeePhotoPreview');
+                const actualInput = document.getElementById('edit_employeePhotoInput');
 
                 if(employeePhotoPreview) employeePhotoPreview.src = croppedImageUrl;
 
@@ -138,7 +139,9 @@
                 if(actualInput) {
                     actualInput.files = dataTransfer.files;
                 } else {
-                    console.error('Actual input for employee photo not found!');
+                    // It's possible we are in a context where edit input doesn't exist?
+                    // But this script is for Edit Form.
+                    // If we were in Add Modal, this listener still runs but finds nothing (good).
                 }
 
                 // Hide the modal
@@ -153,19 +156,19 @@
         // 1. Ensure global cropper logic is ready (Idempotent call)
         window.initCropperGlobal();
 
-        // 2. Get Form Field References
-        const titleTh = document.getElementById('employeeTitleTh');
-        const titleEn = document.getElementById('employeeTitleEn');
-        const genderInput = document.getElementById('employeeGender');
-        const dobInput = document.getElementById('employeeDob');
-        const ageInput = document.getElementById('employeeAge');
-        const nationalitySelect = document.getElementById('employeeNationality');
-        const mouGroupSelect = document.getElementById('workPermitMOUGroup');
-        const insuranceSelect = document.getElementById('insurance_type');
+        // 2. Get Form Field References (Updated IDs)
+        const titleTh = document.getElementById('edit_employeeTitleTh');
+        const titleEn = document.getElementById('edit_employeeTitleEn');
+        const genderInput = document.getElementById('edit_employeeGender');
+        const dobInput = document.getElementById('edit_employeeDob');
+        const ageInput = document.getElementById('edit_employeeAge');
+        const nationalitySelect = document.getElementById('edit_employeeNationality');
+        const mouGroupSelect = document.getElementById('edit_workPermitMOUGroup');
+        const insuranceSelect = document.getElementById('edit_insurance_type');
 
         // 3. File Triggers (These are new elements in the AJAX form)
-        const triggerFileInput = document.getElementById('triggerFile');
-        const triggerCameraInput = document.getElementById('triggerCamera');
+        const triggerFileInput = document.getElementById('edit_triggerFile');
+        const triggerCameraInput = document.getElementById('edit_triggerCamera');
         const imageToCrop = document.getElementById('imageToCrop'); // Global element, but ref doesn't hurt
         const cropperModalEl = document.getElementById('cropperModal'); // Global element
 
@@ -192,7 +195,6 @@
         }
 
         if (triggerFileInput) {
-             // Since this function runs on new DOM, no need to remove old listeners from *this* specific element
              triggerFileInput.addEventListener('change', handleFileSelect);
         }
         if (triggerCameraInput) {
@@ -243,8 +245,8 @@
         if(dobInput) dobInput.addEventListener('change', calculateAge);
 
         // --- Logic: Nationality Conditionals ---
-        const myanmarPassportContainer = document.getElementById('passportTypeContainer');
-        const cambodiaPassportContainer = document.getElementById('passportTypeCambodiaContainer');
+        const myanmarPassportContainer = document.getElementById('edit_passportTypeContainer');
+        const cambodiaPassportContainer = document.getElementById('edit_passportTypeCambodiaContainer');
 
         function toggleNationalityFields() {
             if (!nationalitySelect || !myanmarPassportContainer || !cambodiaPassportContainer) return;
@@ -254,7 +256,7 @@
         if(nationalitySelect) nationalitySelect.addEventListener('change', toggleNationalityFields);
 
         // --- Logic: MOU Other ---
-        const mouGroupOtherContainer = document.getElementById('workPermitMOUGroupOtherContainer');
+        const mouGroupOtherContainer = document.getElementById('edit_workPermitMOUGroupOtherContainer');
         function toggleMouGroupOther() {
             if (!mouGroupSelect || !mouGroupOtherContainer) return;
             mouGroupOtherContainer.classList.toggle('d-none', mouGroupSelect.value !== 'อื่นๆ');
@@ -262,9 +264,9 @@
         if(mouGroupSelect) mouGroupSelect.addEventListener('change', toggleMouGroupOther);
 
         // --- Logic: Insurance Conditionals ---
-        const socialContainer = document.getElementById('insuranceSocialSecurity');
-        const hospitalContainer = document.getElementById('insuranceHospital');
-        const privateContainer = document.getElementById('insurancePrivate');
+        const socialContainer = document.getElementById('edit_insuranceSocialSecurity');
+        const hospitalContainer = document.getElementById('edit_insuranceHospital');
+        const privateContainer = document.getElementById('edit_insurancePrivate');
         function toggleInsuranceVisibility() {
             if (!insuranceSelect || !socialContainer || !hospitalContainer || !privateContainer) return;
             const selectedType = insuranceSelect.value;


### PR DESCRIPTION
- Rename IDs in `employees/partials/_edit_form.blade.php` to use `edit_` prefix to prevent collisions with Add Employee modal IDs.
- Update `employees/partials/_edit_scripts.blade.php` to target the new `edit_` prefixed IDs.
- Update `components/document-scanner.blade.php` to ensure robust array synchronization with Alpine.js after SortableJS reordering and clamp indices correctly.