### PR TITLE
Fix search error by replacing deleted 'companyWorkerId' with 'employe…

### DIFF
--- a/app/Http/Controllers/Api/EmployerEmployeeController.php
+++ b/app/Http/Controllers/Api/EmployerEmployeeController.php
@@ -54,7 +54,7 @@ class EmployerEmployeeController extends Controller
             }
 
             // Retrieve data with necessary fields
-             $employees = $query->get(['id', 'employer_id', 'employeeNameTh', 'employeeNameEn', 'employeePassport', 'companyWorkerId', 'employeePhoto', 'employeeNationality']);
+             $employees = $query->get(['id', 'employer_id', 'employeeNameTh', 'employeeNameEn', 'employeePassport', 'employer_employee_id', 'employeePhoto', 'employeeNationality']);
 
              return response()->json($this->formatEmployees($employees));
         }
@@ -117,7 +117,7 @@ class EmployerEmployeeController extends Controller
             }
         }
 
-        $employees = $query->get(['id', 'employer_id', 'employeeNameTh', 'employeeNameEn', 'employeePassport', 'companyWorkerId', 'employeePhoto', 'employeeNationality']);
+        $employees = $query->get(['id', 'employer_id', 'employeeNameTh', 'employeeNameEn', 'employeePassport', 'employer_employee_id', 'employeePhoto', 'employeeNationality']);
 
         return response()->json($this->formatEmployees($employees));
     }
@@ -144,7 +144,7 @@ class EmployerEmployeeController extends Controller
                 'employeeNameTh' => $employee->employeeNameTh,
                 'employeeNameEn' => $employee->employeeNameEn,
                 'employeePassport' => $employee->employeePassport,
-                'companyWorkerId' => $employee->companyWorkerId,
+                'employer_employee_id' => $employee->employer_employee_id,
                 'photo_url' => $employee->photo_url, // Accessor field
                 'nationality' => $nationality,
                 'flag_url' => $flagUrl,

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -165,7 +165,7 @@ class NotificationController extends Controller
                         $q_employee->where('employeeNameTh', 'like', "%{$search}%")
                                    ->orWhere('employeeNameEn', 'like', "%{$search}%")
                                    ->orWhere('employeePassport', 'like', "%{$search}%")
-                                   ->orWhere('companyWorkerId', 'like', "%{$search}%") // Added companyWorkerId
+                                   ->orWhere('employer_employee_id', 'like', "%{$search}%") // Replaced companyWorkerId
                                    ->orWhereHas('employer', function ($q_employer) use ($search) {
                                        $q_employer->where('employerNameTh', 'like', "%{$search}%")
                                                   ->orWhere('employerNameEn', 'like', "%{$search}%") // Added employerNameEn
@@ -499,7 +499,7 @@ class NotificationController extends Controller
                 $q->where(function ($q) use ($searchTerm) {
                     $q->where('employeeNameTh', 'like', "%{$searchTerm}%")
                       ->orWhere('employeeNameEn', 'like', "%{$searchTerm}%")
-                      ->orWhere('companyWorkerId', 'like', "%{$searchTerm}%");
+                      ->orWhere('employer_employee_id', 'like', "%{$searchTerm}%");
                 });
             });
         }


### PR DESCRIPTION
…r_employee_id'

The 'companyWorkerId' column was removed from the 'employees' table in a recent migration, causing "Column not found" errors in the Notification search and API responses. This commit replaces all references to 'companyWorkerId' with the new 'employer_employee_id' column to restore functionality and prevent crashes.