### PR TITLE
Fix workflow finalization failure for Notify In workflow due to null …

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -863,7 +863,7 @@ class WorkflowController extends Controller
                 if ($item->employee) {
                     $item->employee->update([
                         'employer_id' => $item->order->employer_id,
-                        'status' => null,
+                        'status' => 'active',
                         'terminated_at' => null,
                         'termination_reason' => null
                     ]);

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -738,7 +738,10 @@
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken },
                 })
-                .then(res => res.json())
+                .then(res => {
+                    if (!res.ok) throw new Error(res.statusText);
+                    return res.json();
+                })
                 .then(data => {
                     if(data.success) {
                         // Refresh card to show "Saved/Completed" state (Green/Flat)
@@ -762,7 +765,13 @@
                                  }
                              }
                         }
+                    } else {
+                         Swal.fire('Error', data.message || '{{ __("Something went wrong") }}', 'error');
                     }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    Swal.fire('Error', '{{ __("Failed to save data.") }}', 'error');
                 });
             }
         });


### PR DESCRIPTION
…status

- Updated `WorkflowController::finalizeItem` to set employee status to 'active' instead of null for Notify In workflow, fixing a database constraint violation.
- Added error handling to `workflow/index.blade.php` to display API errors to the user instead of failing silently.