### PR TITLE
feat: improve access control for employers and caretakers in producti…

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -49,6 +49,7 @@ class ProductionController extends Controller
 
         // 3. Query Orders for this Tab
         $query = ProductionOrder::with(['employer', 'workType'])
+                    ->whereHas('employer')
                     ->where('status', 'pre_production');
 
         if ($activeTab) {

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -45,6 +45,7 @@ class WorkflowController extends Controller
 
         // 3. Query Orders for this Tab
         $query = ProductionOrder::with(['employer', 'workType'])
+            ->whereHas('employer')
             ->where('status', '!=', 'pre_production'); // Active workflows
 
         if ($activeTab) {

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -100,7 +100,7 @@
                        data-name-en="{{ $item->employee->employeeNameEn ?? '' }}"
                        data-photo="{{ $empPhoto }}"
                        data-employer-name="{{ $order->employer->employerNameTh ?? 'N/A' }}"
-                       {{ !$item->employee_id ? 'disabled' : '' }}>
+                       {{ (!$item->employee_id || $isReadOnly) ? 'disabled' : '' }}>
                 </div>
 
                 <div class="d-flex align-items-center gap-3 {{ $overlayClass }}" id="info-container-{{ $item->id }}">


### PR DESCRIPTION
…on/workflow

- Update ProductionController and WorkflowController to filter orders using `whereHas('employer')`. This enforces the `Employer` model's global scope (which filters by `user_id` for employers and `assigned_staff_id` for caretakers), ensuring users only see job cards they are authorized to view.
- Update `_item_card.blade.php` to disable checkboxes for Read-Only users (Employers). This prevents them from accessing bulk actions like "Advanced Edit" or "Manage Team", strictly enforcing the read-only requirement while keeping the "Preview" button accessible.
- Verified functionality with `tests/Feature/Production/WorkflowAccessTest.php`.