### PR TITLE
Fix: Initialize edit form listener for static edit page

### DIFF
--- a/resources/views/employees/partials/_edit_scripts.blade.php
+++ b/resources/views/employees/partials/_edit_scripts.blade.php
@@ -332,8 +332,9 @@
     }
 
     document.addEventListener('DOMContentLoaded', function () {
-        // Initialize Edit Form (AJAX loaded later usually, but calling here is safe)
-        // window.initEmployeeForm('edit_'); // Actually, edit form is loaded via AJAX, script there calls it.
+        // Initialize Edit Form (Static Page Load)
+        // This is required for the standalone Edit Page (employees.edit) which renders _edit_form.blade.php directly.
+        window.initEmployeeForm('edit_');
 
         // Initialize Create Form (Static HTML)
         window.initEmployeeForm('');


### PR DESCRIPTION
- Uncommented `window.initEmployeeForm('edit_')` in `_edit_scripts.blade.php`.
- This ensures that when the standalone Edit Employee page (`employees.edit`) is loaded, the event listeners for form elements (specifically the file input `edit_triggerFile`) are correctly attached.
- Previously, the initialization was commented out, causing the file selection for photo editing to have no effect (no change event listener).
- This fixes the issue where the "Select photo from file" button did not trigger the cropper modal on the Edit Employee page.