### PR TITLE
Fix row size limit error in employee migration

### DIFF
--- a/database/migrations/2026_02_06_004838_add_appointment_fields_to_employees_table.php
+++ b/database/migrations/2026_02_06_004838_add_appointment_fields_to_employees_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::table('employees', function (Blueprint $table) {
             $table->dateTime('appointment_date')->nullable();
-            $table->string('appointment_location')->nullable();
+            $table->text('appointment_location')->nullable();
             $table->dateTime('appointment_completed_at')->nullable();
         });
     }


### PR DESCRIPTION
Modified `2026_02_06_004838_add_appointment_fields_to_employees_table` to use `TEXT` for `appointment_location` instead of `VARCHAR`. This avoids the MySQL row size limit (65,535 bytes) which the `employees` table has exceeded.