### PR TITLE
Implement 24-hour restore window and history archive for Renewal and …

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -321,7 +321,16 @@ class RegistrationController extends Controller
             $query->withoutGlobalScope('employerTenancy');
         }
 
-        $query->whereIn('status', ['registration_pending', 'registration_completed', 'registration_cancelled'])
+        $query->where(function($q) {
+                $q->whereIn('status', ['registration_pending', 'registration_cancelled'])
+                  ->orWhere(function($sub) {
+                      $sub->where('status', 'registration_completed')
+                          ->where(function($t) {
+                              $t->whereNull('resolution_completed_at')
+                                ->orWhere('resolution_completed_at', '>=', now()->subHours(24));
+                          });
+                  });
+            })
             ->with(['registrationSteps', 'customFields']); // Load everything needed for the card
 
         // Apply Search (if global search is active)
@@ -444,7 +453,10 @@ class RegistrationController extends Controller
         }
 
         // Change status to 'registration_completed'
-        $employee->update(['status' => 'registration_completed']);
+        $employee->update([
+            'status' => 'registration_completed',
+            'resolution_completed_at' => now()
+        ]);
 
         if ($request->ajax()) {
             return response()->json([
@@ -484,7 +496,10 @@ class RegistrationController extends Controller
             abort(403);
         }
 
-        $employee->update(['status' => 'registration_pending']);
+        $employee->update([
+            'status' => 'registration_pending',
+            'resolution_completed_at' => null
+        ]);
 
         if ($request->ajax()) {
             return response()->json([
@@ -493,6 +508,31 @@ class RegistrationController extends Controller
             ]);
         }
         return back()->with('success', 'Employee restored to pending.');
+    }
+
+    /**
+     * Fetch Historic Items (Completed > 24h).
+     */
+    public function fetchHistory(Request $request, $employerId)
+    {
+        $employer = Employer::findOrFail($employerId);
+
+        $employees = $employer->employees()
+            ->where('status', 'registration_completed')
+            ->where(function($q) {
+                 $q->whereNotNull('resolution_completed_at')
+                   ->where('resolution_completed_at', '<', now()->subHours(24));
+            })
+            ->with(['registrationSteps'])
+            ->get();
+
+        $steps = RegistrationStep::registration()->orderBy('order')->get();
+
+        return view('production.registration._employee_list_content', [
+            'employees' => $employees,
+            'steps' => $steps,
+            'employer' => $employer
+        ])->with('isHistory', true);
     }
 
     /**

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -241,7 +241,16 @@ class RenewalController extends Controller
             $query->withoutGlobalScope('employerTenancy');
         }
 
-        $query->whereIn('status', ['renewal_pending', 'renewal_completed', 'renewal_cancelled'])
+        $query->where(function($q) {
+                $q->whereIn('status', ['renewal_pending', 'renewal_cancelled'])
+                  ->orWhere(function($sub) {
+                      $sub->where('status', 'renewal_completed')
+                          ->where(function($t) {
+                              $t->whereNull('resolution_completed_at')
+                                ->orWhere('resolution_completed_at', '>=', now()->subHours(24));
+                          });
+                  });
+            })
             ->with(['registrationSteps', 'customFields']);
 
         if ($request->has('search') && $request->search) {
@@ -740,7 +749,10 @@ class RenewalController extends Controller
     public function finalize(Request $request, Employee $employee)
     {
         if (!auth()->user()->can('edit-employees')) abort(403);
-        $employee->update(['status' => 'renewal_completed']);
+        $employee->update([
+            'status' => 'renewal_completed',
+            'resolution_completed_at' => now()
+        ]);
         if ($request->ajax()) {
             return response()->json(['success' => true]);
         }
@@ -760,11 +772,39 @@ class RenewalController extends Controller
     public function restore(Request $request, Employee $employee)
     {
         if (!auth()->user()->can('edit-employees')) abort(403);
-        $employee->update(['status' => 'renewal_pending']);
+        $employee->update([
+            'status' => 'renewal_pending',
+            'resolution_completed_at' => null
+        ]);
         if ($request->ajax()) {
             return response()->json(['success' => true]);
         }
         return back()->with('success', 'Employee restored.');
+    }
+
+    /**
+     * Fetch Historic Items (Completed > 24h).
+     */
+    public function fetchHistory(Request $request, $employerId)
+    {
+        $employer = Employer::findOrFail($employerId);
+
+        $employees = $employer->employees()
+            ->where('status', 'renewal_completed')
+            ->where(function($q) {
+                 $q->whereNotNull('resolution_completed_at')
+                   ->where('resolution_completed_at', '<', now()->subHours(24));
+            })
+            ->with(['registrationSteps'])
+            ->get();
+
+        $steps = RegistrationStep::renewal()->orderBy('order')->get();
+
+        return view('production.renewal._employee_list_content', [
+            'employees' => $employees,
+            'employer' => $employer,
+            'steps' => $steps
+        ])->with('isHistory', true);
     }
 
     public function destroy(Request $request, Employee $employee)

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -133,6 +133,7 @@ class Employee extends Model
         'appointment_date',
         'appointment_location',
         'appointment_completed_at',
+        'resolution_completed_at',
     ];
 
     protected $casts = [
@@ -141,6 +142,7 @@ class Employee extends Model
         'biometrics_collected_at' => 'datetime',
         'appointment_date' => 'datetime',
         'appointment_completed_at' => 'datetime',
+        'resolution_completed_at' => 'datetime',
         'visaExpiryDate' => 'date:Y-m-d',
         'ninetyDayReportDate' => 'date:Y-m-d',
         'employeeDob' => 'date:Y-m-d',

--- a/database/migrations/2026_02_07_124108_add_resolution_completed_at_to_employees_table.php
+++ b/database/migrations/2026_02_07_124108_add_resolution_completed_at_to_employees_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            if (!Schema::hasColumn('employees', 'resolution_completed_at')) {
+                $table->timestamp('resolution_completed_at')->nullable()->after('status');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            if (Schema::hasColumn('employees', 'resolution_completed_at')) {
+                $table->dropColumn('resolution_completed_at');
+            }
+        });
+    }
+};

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -1,8 +1,12 @@
-@props(['employee', 'steps'])
+@props(['employee', 'steps', 'isHistory' => false])
 
 @php
-    $isCompleted = $employee->status === 'registration_completed';
-    $isCancelled = $employee->status === 'registration_cancelled';
+    $isCompleted = in_array($employee->status, ['registration_completed', 'renewal_completed']);
+    $isCancelled = in_array($employee->status, ['registration_cancelled', 'renewal_cancelled']);
+
+    if ($isHistory) {
+        // $isCompleted = true; // Force completed styling if not already
+    }
 
     // Style: if completed/cancelled, flat/grey out.
     // Cancelled gets a specific flat grey look.
@@ -388,7 +392,7 @@
                 </button>
 
                 {{-- SAVE TO DB --}}
-                <button class="btn btn-sm btn-success rounded-pill px-3 {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}"
+                <button class="btn btn-sm btn-success rounded-pill px-3 {{ ($isCompleted || $isCancelled || $isHistory) ? 'd-none' : '' }}"
                     id="btn-save-{{ $employee->id }}"
                     title="Save to Database"
                     onclick="finalizeEmployee({{ $employee->id }})">
@@ -396,7 +400,7 @@
                 </button>
 
                 {{-- CANCEL --}}
-                <button class="btn btn-sm btn-outline-secondary rounded-pill px-3 {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}"
+                <button class="btn btn-sm btn-outline-secondary rounded-pill px-3 {{ ($isCompleted || $isCancelled || $isHistory) ? 'd-none' : '' }}"
                     id="btn-cancel-{{ $employee->id }}"
                     title="Cancel Registration"
                     onclick="cancelEmployee({{ $employee->id }})">
@@ -404,7 +408,7 @@
                 </button>
 
                 {{-- RESTORE (For Cancelled) --}}
-                <button class="btn btn-sm btn-outline-warning rounded-pill px-3 {{ !$isCancelled ? 'd-none' : '' }}"
+                <button class="btn btn-sm btn-outline-warning rounded-pill px-3 {{ (!$isCancelled || $isHistory) ? 'd-none' : '' }}"
                     id="btn-restore-{{ $employee->id }}"
                     title="Restore"
                     onclick="restoreEmployeeState({{ $employee->id }})">
@@ -412,7 +416,7 @@
                 </button>
 
                 {{-- UNDO (For Completed) --}}
-                <button class="btn btn-sm btn-outline-warning rounded-pill px-3 {{ !$isCompleted ? 'd-none' : '' }}"
+                <button class="btn btn-sm btn-outline-warning rounded-pill px-3 {{ (!$isCompleted || $isHistory) ? 'd-none' : '' }}"
                     id="btn-undo-{{ $employee->id }}"
                     title="Undo / Restore"
                     onclick="restoreEmployeeState({{ $employee->id }})">

--- a/resources/views/production/registration/_employee_list_content.blade.php
+++ b/resources/views/production/registration/_employee_list_content.blade.php
@@ -1,3 +1,8 @@
 @foreach($employees as $employee)
-    @include('production.registration._employee_card', ['employee' => $employee, 'steps' => $steps, 'loop' => $loop])
+    @include('production.registration._employee_card', [
+        'employee' => $employee,
+        'steps' => $steps,
+        'loop' => $loop,
+        'isHistory' => $isHistory ?? false
+    ])
 @endforeach

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -454,6 +454,11 @@
                                  <a href="{{ route('production.registration.create', ['employer_id' => $employer->id]) }}" class="btn btn-outline-warning btn-sm fw-bold {{ $isEmployerCancelled ? 'd-none' : '' }}">
                                     <i class="bi bi-plus-lg"></i> {{ __('Add') }}
                                  </a>
+
+                                 {{-- History Button --}}
+                                 <button class="btn btn-outline-secondary btn-sm" onclick="openHistoryModal({{ $employer->id }})" title="{{ __('View History') }}">
+                                     <i class="bi bi-clock-history"></i>
+                                 </button>
                                  @endcan
 
                                  {{-- Finance Button --}}
@@ -839,6 +844,23 @@
     </div>
 </div>
 
+{{-- History Modal --}}
+<div class="modal fade" id="historyModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content border-0 shadow">
+            <div class="modal-header bg-secondary text-white">
+                <h5 class="modal-title fw-bold"><i class="bi bi-clock-history me-2"></i>{{ __('Job History') }}</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body bg-light" id="historyModalBody">
+                 <div class="d-flex justify-content-center py-5">
+                     <div class="spinner-border text-secondary" role="status"></div>
+                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 @endsection
 
 @include('employees.partials._edit_scripts')
@@ -1142,6 +1164,24 @@
             }
         })
         .catch(err => Swal.fire('{{ __('Error') }}', '{{ __('Network error') }}', 'error'));
+    }
+
+    // --- History Modal ---
+    window.openHistoryModal = function(employerId) {
+        const modal = new bootstrap.Modal(document.getElementById('historyModal'));
+        modal.show();
+
+        const body = document.getElementById('historyModalBody');
+        body.innerHTML = '<div class="d-flex justify-content-center py-5"><div class="spinner-border text-secondary" role="status"></div></div>';
+
+        fetch(`/production/registration/employer/${employerId}/history`)
+            .then(res => res.text())
+            .then(html => {
+                body.innerHTML = html;
+            })
+            .catch(err => {
+                body.innerHTML = '<div class="text-danger text-center p-4">Failed to load history.</div>';
+            });
     }
 
     // Modal variable init inside DOMContentLoaded to ensure Bootstrap is loaded

--- a/resources/views/production/renewal/_employee_list_content.blade.php
+++ b/resources/views/production/renewal/_employee_list_content.blade.php
@@ -1,3 +1,8 @@
 @foreach($employees as $employee)
-    @include('production.registration._employee_card', ['employee' => $employee, 'steps' => $steps, 'loop' => $loop])
+    @include('production.registration._employee_card', [
+        'employee' => $employee,
+        'steps' => $steps,
+        'loop' => $loop,
+        'isHistory' => $isHistory ?? false
+    ])
 @endforeach

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -418,6 +418,11 @@
                                  <a href="{{ route('production.registration.create', ['employer_id' => $employer->id]) }}" class="btn btn-outline-warning btn-sm fw-bold {{ $isEmployerCancelled ? 'd-none' : '' }}">
                                     <i class="bi bi-plus-lg"></i> {{ __('Add') }}
                                  </a>
+
+                                 {{-- History Button --}}
+                                 <button class="btn btn-outline-secondary btn-sm" onclick="openHistoryModal({{ $employer->id }})" title="{{ __('View History') }}">
+                                     <i class="bi bi-clock-history"></i>
+                                 </button>
                                  @endcan
 
                                  {{-- Finance Button --}}
@@ -760,6 +765,23 @@
     </div>
 </div>
 
+{{-- History Modal --}}
+<div class="modal fade" id="historyModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content border-0 shadow">
+            <div class="modal-header bg-secondary text-white">
+                <h5 class="modal-title fw-bold"><i class="bi bi-clock-history me-2"></i>{{ __('Job History') }}</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body bg-light" id="historyModalBody">
+                 <div class="d-flex justify-content-center py-5">
+                     <div class="spinner-border text-secondary" role="status"></div>
+                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 @endsection
 
 @include('employees.partials._edit_scripts')
@@ -864,6 +886,24 @@
             }
         })
         .catch(err => Swal.fire('{{ __('Error') }}', '{{ __('Network error') }}', 'error'));
+    }
+
+    // --- History Modal ---
+    window.openHistoryModal = function(employerId) {
+        const modal = new bootstrap.Modal(document.getElementById('historyModal'));
+        modal.show();
+
+        const body = document.getElementById('historyModalBody');
+        body.innerHTML = '<div class="d-flex justify-content-center py-5"><div class="spinner-border text-secondary" role="status"></div></div>';
+
+        fetch(`/production/renewal/employer/${employerId}/history`)
+            .then(res => res.text())
+            .then(html => {
+                body.innerHTML = html;
+            })
+            .catch(err => {
+                body.innerHTML = '<div class="text-danger text-center p-4">Failed to load history.</div>';
+            });
     }
 
     // --- Global & Employer Cancelled Toggle ---

--- a/routes/web.php
+++ b/routes/web.php
@@ -208,6 +208,7 @@ Route::middleware(['auth'])->group(function () {
     Route::prefix('production/registration')->name('production.registration.')->group(function () {
         Route::get('/', [App\Http\Controllers\Production\RegistrationController::class, 'index'])->name('index');
         Route::get('/employer/{employer}/employees', [App\Http\Controllers\Production\RegistrationController::class, 'fetchEmployees'])->name('employer.employees')->withTrashed();
+        Route::get('/employer/{employer}/history', [App\Http\Controllers\Production\RegistrationController::class, 'fetchHistory'])->name('employer.history');
         Route::get('/import', [App\Http\Controllers\Production\RegistrationController::class, 'importView'])->name('import');
         Route::get('/create', [App\Http\Controllers\Production\RegistrationController::class, 'create'])->name('create');
         Route::post('/store', [App\Http\Controllers\Production\RegistrationController::class, 'store'])->name('store');
@@ -263,6 +264,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/create', [App\Http\Controllers\Production\RenewalController::class, 'create'])->name('create');
         Route::post('/store', [App\Http\Controllers\Production\RenewalController::class, 'store'])->name('store');
         Route::get('/employer/{employer}/employees', [App\Http\Controllers\Production\RenewalController::class, 'fetchEmployees'])->name('employer.employees')->withTrashed();
+        Route::get('/employer/{employer}/history', [App\Http\Controllers\Production\RenewalController::class, 'fetchHistory'])->name('employer.history');
         Route::get('/import', [App\Http\Controllers\Production\RenewalController::class, 'importView'])->name('import');
         Route::post('/configure-expiry', [App\Http\Controllers\Production\RenewalController::class, 'configureExpiry'])->name('configure_expiry');
         Route::post('/steps/reorder', [App\Http\Controllers\Production\RenewalController::class, 'reorderSteps'])->name('steps.reorder');


### PR DESCRIPTION
…Registration resolutions.

- Added `resolution_completed_at` to `employees` table.
- Updated `RenewalController` and `RegistrationController` to manage this timestamp on finalize/restore.
- Updated `fetchEmployees` to filter out old completed items (>24h).
- Added `fetchHistory` method and route to retrieve archived items.
- Updated views to include a "History" button and modal.
- Updated `_employee_card` component to support read-only history mode (hiding restore actions).