### PR TITLE
Fix workflow add button and implement specific business logic for Not…

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -681,18 +681,85 @@ class WorkflowController extends Controller
         $isPreProduction = $request->boolean('is_pre_production');
         $targetStatus = $isPreProduction ? 'pre_production' : 'active';
 
+        // Resolve WorkType first
+        $workTypeId = null;
+        if ($request->filled('production_order_id')) {
+            $existingOrder = ProductionOrder::findOrFail($request->production_order_id);
+            $workTypeId = $existingOrder->work_type_id;
+        } elseif ($request->filled('work_type_id')) {
+            $workTypeId = $request->work_type_id;
+        }
+
+        // --- Special Logic: Notify Out (Resignation) ---
+        // If adding existing employees to 'Notify Out', automatically group them by their CURRENT employer.
+        // This overrides the selected employer in the form (if any).
+        if ($workTypeId && $request->has('employee_ids') && is_array($request->employee_ids)) {
+            $workType = WorkType::find($workTypeId);
+
+            if ($workType && $workType->slug === 'notify_out') {
+                $employees = Employee::whereIn('id', $request->employee_ids)->with('employer')->get();
+                $grouped = $employees->groupBy('employer_id');
+                $updatedOrderIds = [];
+
+                foreach ($grouped as $employerId => $emps) {
+                    if (!$employerId) continue;
+
+                    // Find or Create Order for this Employer
+                    $employer = $emps->first()->employer; // Optimization: use relation from first item
+
+                    $order = ProductionOrder::firstOrCreate(
+                        [
+                            'employer_id' => $employerId,
+                            'work_type_id' => $workTypeId,
+                            'status' => $targetStatus
+                        ],
+                        [
+                            'type' => 'employer',
+                            'project_name' => $workType->name . ' - ' . ($employer->employerNameTh ?? 'Unknown') . ($isPreProduction ? ' (Prep)' : ''),
+                            'created_by' => auth()->id()
+                        ]
+                    );
+
+                    $updatedOrderIds[] = $order->id;
+
+                    foreach ($emps as $emp) {
+                         // Check duplicates (Locking)
+                         $hasActive = ProductionItem::where('employee_id', $emp->id)
+                            ->whereNotIn('status', ['completed', 'cancelled'])
+                            ->exists();
+
+                         if ($hasActive) continue;
+
+                         $exists = ProductionItem::where('production_order_id', $order->id)
+                            ->where('employee_id', $emp->id)->exists();
+
+                         if (!$exists) {
+                             ProductionItem::create([
+                                'production_order_id' => $order->id,
+                                'employee_id' => $emp->id,
+                                'group_name' => $request->group_name ?? null,
+                                'status' => 'pending'
+                             ]);
+                         }
+                    }
+                }
+
+                if ($request->ajax() || $request->wantsJson()) {
+                    return response()->json([
+                        'success' => true,
+                        'message' => 'Employees processed into resignation lists.',
+                        'redirect_url' => route('workflow.index', ['tab' => 'notify_out']) // Force refresh
+                    ]);
+                }
+                return redirect()->route('workflow.index', ['tab' => 'notify_out'])->with('success', 'Employees processed.');
+            }
+        }
+
+        // --- Original Logic for Other Types ---
+
         // 1. Validation: Check for duplicates (Existing Employees)
         // Ensure an employee cannot be in the same WorkType workflow (Active or Pre-Production) twice.
         if ($request->has('employee_ids') && is_array($request->employee_ids)) {
-            $workTypeId = null;
-
-            if ($request->filled('production_order_id')) {
-                $existingOrder = ProductionOrder::findOrFail($request->production_order_id);
-                $workTypeId = $existingOrder->work_type_id;
-            } elseif ($request->filled('work_type_id')) {
-                $workTypeId = $request->work_type_id;
-            }
-
             if ($workTypeId) {
                 // Find any items for these employees in this WorkType that are NOT cancelled or completed.
                 $duplicates = ProductionItem::whereIn('employee_id', $request->employee_ids)
@@ -706,6 +773,13 @@ class WorkflowController extends Controller
 
                 if ($duplicates->isNotEmpty()) {
                     $names = $duplicates->map(fn($item) => $item->employee->employeeNameEn ?? $item->employee->employeeNameTh)->unique()->implode(', ');
+
+                    if ($request->ajax() || $request->wantsJson()) {
+                        return response()->json([
+                            'success' => false,
+                            'message' => "Employees already in this workflow: $names"
+                        ]);
+                    }
 
                     return back()->with('duplicate_error', "Employees already in this workflow: $names. Please complete their current process first.");
                 }
@@ -725,7 +799,9 @@ class WorkflowController extends Controller
             $workType = WorkType::findOrFail($request->work_type_id);
 
             // Bucket Logic (Merge into existing if applicable)
-            if (in_array($workType->slug, ['notify_in', 'notify_out'])) {
+            // Note: notify_out is handled above for existing employees, but if "New Employee" is created,
+            // it falls through here. For New Employee, we use the selected employer (request->employer_id).
+            if (in_array($workType->slug, ['notify_in', 'notify_out', 'mou_renewal'])) {
                 $order = ProductionOrder::firstOrCreate(
                     [
                         'employer_id' => $request->employer_id,
@@ -902,7 +978,7 @@ class WorkflowController extends Controller
         $slug = $item->order->workType->slug ?? '';
 
         DB::transaction(function () use ($item, $slug) {
-            if ($slug === 'notify_in') {
+            if (in_array($slug, ['notify_in', 'mou_import', 'mou_renewal'])) {
                 if ($item->employee) {
                     $item->employee->update([
                         'employer_id' => $item->order->employer_id,
@@ -1012,6 +1088,13 @@ class WorkflowController extends Controller
                 'is_system' => true,
                 'order' => 3,
                 'steps' => ['Name List', 'Calling Visa', 'Stamp Visa', 'Work Permit', 'Card']
+            ],
+            [
+                'name' => 'ต่ออายุ MOU',
+                'slug' => 'mou_renewal',
+                'is_system' => true,
+                'order' => 4,
+                'steps' => ['ยื่นเอกสาร', 'รอผล', 'รับเล่ม']
             ]
         ];
 

--- a/resources/views/workflow/partials/add_employee_modal.blade.php
+++ b/resources/views/workflow/partials/add_employee_modal.blade.php
@@ -1,13 +1,7 @@
 {{-- resources/views/workflow/partials/add_employee_modal.blade.php --}}
 <div class="modal fade" id="addEmployeeModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-xl">
-        <form action="{{ route('workflow.store') }}" method="POST" class="modal-content" id="addEmployeeForm" enctype="multipart/form-data">
-            @csrf
-            <input type="hidden" name="employer_id" id="modal_employer_id">
-            <input type="hidden" name="work_type_id" id="modal_work_type_id">
-            <input type="hidden" name="production_order_id" id="modal_production_order_id"> {{-- For adding to existing --}}
-            <input type="hidden" name="is_pre_production" id="add_employee_is_pre_production" value="0">
-
+        <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">{{ __('Add Employees') }}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
@@ -16,58 +10,78 @@
             <div class="modal-body">
                 <ul class="nav nav-tabs mb-3" id="addEmployeeTabs" role="tablist">
                     <li class="nav-item">
-                        <button class="nav-link active" id="existing-tab" data-bs-toggle="tab" data-bs-target="#tab-existing" type="button">{{ __('Select Existing') }}</button>
+                        <button class="nav-link active" id="existing-tab" data-bs-toggle="tab" data-bs-target="#tab-existing" type="button" role="tab" aria-controls="tab-existing" aria-selected="true">{{ __('Select Existing') }}</button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link" id="new-tab" data-bs-toggle="tab" data-bs-target="#tab-new" type="button">{{ __('New / Manual') }}</button>
+                        <button class="nav-link" id="new-tab" data-bs-toggle="tab" data-bs-target="#tab-new" type="button" role="tab" aria-controls="tab-new" aria-selected="false">{{ __('New / Manual') }}</button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link" id="import-tab" data-bs-toggle="tab" data-bs-target="#tab-import" type="button">{{ __('Import Excel') }}</button>
+                        <button class="nav-link" id="import-tab" data-bs-toggle="tab" data-bs-target="#tab-import" type="button" role="tab" aria-controls="tab-import" aria-selected="false">{{ __('Import Excel') }}</button>
                     </li>
                 </ul>
 
                 <div class="tab-content" id="addEmployeeTabsContent">
                     {{-- Tab 1: Existing --}}
-                    <div class="tab-pane fade show active" id="tab-existing" role="tabpanel">
-                        <div class="mb-3">
-                            <label class="form-label">{{ __('Group / Batch Name') }} <small class="text-muted">({{ __('Optional') }})</small></label>
-                            <input type="text" name="group_name" class="form-control" placeholder="{{ __('e.g. Batch 1') }}">
-                        </div>
+                    <div class="tab-pane fade show active" id="tab-existing" role="tabpanel" aria-labelledby="existing-tab">
+                        <form action="{{ route('workflow.store') }}" method="POST" id="formExisting">
+                            @csrf
+                            <input type="hidden" name="employer_id" id="modal_employer_id">
+                            <input type="hidden" name="work_type_id" id="modal_work_type_id">
+                            <input type="hidden" name="production_order_id" id="modal_production_order_id">
+                            <input type="hidden" name="is_pre_production" id="add_employee_is_pre_production" value="0">
 
-                        {{-- Mode: Search Resigned --}}
-                        <div id="section-notify-in" class="d-none section-mode">
-                            <div class="alert alert-info py-2 small"><i class="bi bi-info-circle me-1"></i> {{ __('Searching for Resigned employees (Change Employer)') }}</div>
-                            <div class="input-group mb-2">
-                                <span class="input-group-text"><i class="bi bi-search"></i></span>
-                                <input type="text" class="form-control" id="resigned-search-input" placeholder="{{ __('Type name, passport...') }}">
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Group / Batch Name') }} <small class="text-muted">({{ __('Optional') }})</small></label>
+                                <input type="text" name="group_name" class="form-control" placeholder="{{ __('e.g. Batch 1') }}">
                             </div>
-                            <div class="list-group overflow-auto custom-scrollbar" style="max-height: 300px;" id="resigned-results">
-                                <div class="text-center text-muted py-3">{{ __('Type to search...') }}</div>
-                            </div>
-                        </div>
 
-                        {{-- Mode: Global Search --}}
-                        <div id="section-global-search" class="d-none section-mode">
-                            <div class="alert alert-primary py-2 small"><i class="bi bi-globe me-1"></i> {{ __('Search all employees (Global)') }}</div>
-                            <div class="input-group mb-2">
-                                <span class="input-group-text"><i class="bi bi-search"></i></span>
-                                <input type="text" class="form-control" id="global-search-input" placeholder="{{ __('Type name, passport to search...') }}">
+                            {{-- Mode: Search Resigned --}}
+                            <div id="section-notify-in" class="d-none section-mode">
+                                <div class="alert alert-info py-2 small"><i class="bi bi-info-circle me-1"></i> {{ __('Searching for Resigned employees (Change Employer)') }}</div>
+                                <div class="input-group mb-2">
+                                    <span class="input-group-text"><i class="bi bi-search"></i></span>
+                                    <input type="text" class="form-control" id="resigned-search-input" placeholder="{{ __('Type name, passport...') }}">
+                                </div>
+                                <div class="list-group overflow-auto custom-scrollbar" style="max-height: 300px;" id="resigned-results">
+                                    <div class="text-center text-muted py-3">{{ __('Type to search...') }}</div>
+                                </div>
                             </div>
-                            <div class="list-group overflow-auto custom-scrollbar" style="max-height: 300px;" id="global-results">
-                                <div class="text-center text-muted py-3">{{ __('Type to search...') }}</div>
+
+                            {{-- Mode: Global Search --}}
+                            <div id="section-global-search" class="d-none section-mode">
+                                <div class="alert alert-primary py-2 small"><i class="bi bi-globe me-1"></i> {{ __('Search all employees (Global)') }}</div>
+                                <div class="input-group mb-2">
+                                    <span class="input-group-text"><i class="bi bi-search"></i></span>
+                                    <input type="text" class="form-control" id="global-search-input" placeholder="{{ __('Type name, passport to search...') }}">
+                                </div>
+                                <div class="list-group overflow-auto custom-scrollbar" style="max-height: 300px;" id="global-results">
+                                    <div class="text-center text-muted py-3">{{ __('Type to search...') }}</div>
+                                </div>
                             </div>
-                        </div>
+                        </form>
                     </div>
 
                     {{-- Tab 2: New Manual --}}
-                    <div class="tab-pane fade" id="tab-new" role="tabpanel">
-                        <div class="alert alert-light border">
-                             @include('employees.partials.create_form_partial_content')
-                        </div>
+                    <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
+                        <form action="{{ route('workflow.store') }}" method="POST" id="formNew" enctype="multipart/form-data">
+                            @csrf
+                            {{-- We need these hidden inputs here too if we want to attach to an order --}}
+                            {{-- However, for New Employee, we usually use the inputs inside the partial or context --}}
+                            {{-- The partial has employer_id selector. We might need to inject work_type_id etc. --}}
+                            <input type="hidden" name="work_type_id" id="modal_work_type_id_new">
+                            <input type="hidden" name="production_order_id" id="modal_production_order_id_new">
+                            <input type="hidden" name="is_pre_production" id="add_employee_is_pre_production_new" value="0">
+                            {{-- Also inject group name if needed, or let user type it? New employee usually is 1 by 1. --}}
+                            <input type="hidden" name="group_name" id="modal_group_name_new">
+
+                            <div class="alert alert-light border">
+                                 @include('employees.partials.create_form_partial_content')
+                            </div>
+                        </form>
                     </div>
 
                     {{-- Tab 3: Import --}}
-                    <div class="tab-pane fade" id="tab-import" role="tabpanel">
+                    <div class="tab-pane fade" id="tab-import" role="tabpanel" aria-labelledby="import-tab">
                         <div class="text-center py-5">
                             <i class="bi bi-file-earmark-spreadsheet fs-1 text-success mb-3"></i>
                             <h4>{{ __('Import from Excel') }}</h4>
@@ -81,34 +95,41 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Close') }}</button>
-                <button type="submit" class="btn btn-primary" id="btn-submit-add">{{ __('Add Employees') }}</button>
+                <button type="button" class="btn btn-primary" id="btn-submit-add">{{ __('Add Employees') }}</button>
             </div>
-        </form>
+        </div>
     </div>
 </div>
 
 <script>
     window.openAddEmployeeModal = function(orderId, employerId, workTypeId, workTypeSlug, context = 'workflow') {
+        // Set values for Existing Form
         document.getElementById('modal_employer_id').value = employerId || '';
         document.getElementById('modal_work_type_id').value = workTypeId || '';
-        document.getElementById('modal_production_order_id').value = orderId || ''; // Empty if Global Add
+        document.getElementById('modal_production_order_id').value = orderId || '';
 
-        // Set Pre-Production Flag based on context
         const isPreProduction = (context === 'production');
         document.getElementById('add_employee_is_pre_production').value = isPreProduction ? '1' : '0';
+
+        // Set values for New Form
+        document.getElementById('modal_work_type_id_new').value = workTypeId || '';
+        document.getElementById('modal_production_order_id_new').value = orderId || '';
+        document.getElementById('add_employee_is_pre_production_new').value = isPreProduction ? '1' : '0';
 
         // Dispatch event to Alpine component in the partial to set/clear employer
         window.dispatchEvent(new CustomEvent('set-employer-id', {
             detail: { id: employerId } // If null/undefined, partial handles it
         }));
 
-        // Setup Import Link with return_to parameter and work_type_id
+        // Setup Import Link
         const importUrl = `{{ route('employees.import_view') }}?production_id=${orderId || ''}&employer_id=${employerId || ''}&work_type_id=${workTypeId || ''}&return_to=${context}`;
         document.getElementById('btn-go-import').href = importUrl;
 
         // Reset UI
         document.querySelectorAll('.section-mode').forEach(el => el.classList.add('d-none'));
-        document.getElementById('addEmployeeForm').reset();
+        document.getElementById('formExisting').reset();
+        document.getElementById('formNew').reset();
+
         document.getElementById('resigned-results').innerHTML = '<div class="text-center text-muted py-3">{{ __("Type to search...") }}</div>';
         const globalRes = document.getElementById('global-results');
         if(globalRes) globalRes.innerHTML = '<div class="text-center text-muted py-3">{{ __("Type to search...") }}</div>';
@@ -130,8 +151,6 @@
             document.getElementById('section-global-search').classList.remove('d-none');
         }
 
-        // Initialize Image Cropper listeners for New Employee form (Empty prefix)
-        // This fixes the image upload bug by ensuring the 'triggerFile' listener is active
         if (window.initEmployeeForm) {
             window.initEmployeeForm('');
         }
@@ -139,39 +158,70 @@
         modal.show();
     }
 
-    // AJAX Form Submission
+    // Unified Submission Logic
     document.addEventListener('DOMContentLoaded', function() {
-        const form = document.getElementById('addEmployeeForm');
-        if(form) {
-            form.addEventListener('submit', function(e) {
+        const submitBtn = document.getElementById('btn-submit-add');
+
+        // Toggle Submit Button based on Tab
+        const tabs = document.querySelectorAll('#addEmployeeTabs button[data-bs-toggle="tab"]');
+        tabs.forEach(tab => {
+            tab.addEventListener('shown.bs.tab', function (event) {
+                const target = event.target.getAttribute('data-bs-target');
+                if(target === '#tab-import') {
+                    submitBtn.classList.add('d-none');
+                } else {
+                    submitBtn.classList.remove('d-none');
+                }
+            });
+        });
+
+        if(submitBtn) {
+            submitBtn.addEventListener('click', function(e) {
                 e.preventDefault();
 
-                const btn = document.getElementById('btn-submit-add');
-                const originalText = btn.innerHTML;
-                btn.disabled = true;
-                btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Processing...';
+                // Determine active tab
+                const activeTabLink = document.querySelector('#addEmployeeTabs .nav-link.active');
+                const targetId = activeTabLink ? activeTabLink.getAttribute('data-bs-target') : null;
 
-                const formData = new FormData(this);
+                let form = null;
+                if(targetId === '#tab-existing') {
+                    form = document.getElementById('formExisting');
+                } else if (targetId === '#tab-new') {
+                    form = document.getElementById('formNew');
+                }
 
-                fetch(this.action, {
+                if (!form) {
+                    // Import tab or error
+                    return;
+                }
+
+                if (!form.checkValidity()) {
+                    form.reportValidity();
+                    return;
+                }
+
+                const originalText = submitBtn.innerHTML;
+                submitBtn.disabled = true;
+                submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Processing...';
+
+                const formData = new FormData(form);
+
+                fetch(form.action, {
                     method: 'POST',
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
                         'Accept': 'application/json'
-                        // Do NOT set Content-Type for FormData, browser sets it with boundary
                     },
                     body: formData
                 })
                 .then(res => res.json())
                 .then(data => {
-                    btn.disabled = false;
-                    btn.innerHTML = originalText;
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = originalText;
 
                     if(data.success) {
-                        // Close Modal
                         bootstrap.Modal.getInstance(document.getElementById('addEmployeeModal')).hide();
 
-                        // Sweet Alert
                         Swal.fire({
                             icon: 'success',
                             title: '{{ __("Success") }}',
@@ -182,30 +232,15 @@
 
                         // Dynamic Update
                         if (data.order_id) {
-                            // If we added to a known order, refresh it
                             if (window.refreshOrderContent) {
                                 window.refreshOrderContent(data.order_id);
                             } else {
-                                // Fallback: try to find the container manually
-                                const container = document.getElementById(`order-content-${data.order_id}`);
-                                if(container) {
-                                    // Re-fetch items
-                                    const url = `{{ route('workflow.index') }}/${data.order_id}/items`;
-                                    fetch(url)
-                                        .then(res => res.text())
-                                        .then(html => {
-                                            container.innerHTML = html;
-                                            // Init Alpine if needed (handled by scripts usually)
-                                        });
-                                }
+                                location.reload();
                             }
-
-                            // Update Header Stats
                             if (window.updateOrderHeaderStats && data.order_stats) {
                                 window.updateOrderHeaderStats(data.order_id, data.order_stats);
                             }
                         } else {
-                            // Global Add (New Order created) -> Reload Page to show new card
                             if(data.redirect_url) {
                                 window.location.href = data.redirect_url;
                             } else {
@@ -213,7 +248,6 @@
                             }
                         }
                     } else {
-                        // Error (e.g. Validation)
                         let msg = data.message || '{{ __("Something went wrong.") }}';
                         if (data.errors) {
                             msg = Object.values(data.errors).flat().join('<br>');
@@ -223,8 +257,8 @@
                 })
                 .catch(err => {
                     console.error(err);
-                    btn.disabled = false;
-                    btn.innerHTML = originalText;
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = originalText;
                     Swal.fire('{{ __("Error") }}', '{{ __("Network error or server error.") }}', 'error');
                 });
             });

--- a/resources/views/workflow/partials/create_modal.blade.php
+++ b/resources/views/workflow/partials/create_modal.blade.php
@@ -31,6 +31,12 @@
                     </select>
                 </div>
 
+                <div class="mb-3">
+                    <label class="form-label">{{ __('Project Name / Batch Name') }} <small class="text-muted">({{ __('Optional') }})</small></label>
+                    <input type="text" name="project_name" class="form-control" placeholder="{{ __('e.g. Batch 1 - Jan 2024') }}">
+                    <div class="form-text text-muted">{{ __('Use this to create multiple batches for MOU Import.') }}</div>
+                </div>
+
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Close') }}</button>


### PR DESCRIPTION
…ify Out, MOU Import, and MOU Renewal

- Refactored `add_employee_modal.blade.php` to use separate forms for existing and new employees, fixing the "Add" button silence issue caused by HTML5 validation on hidden fields.
- Updated `WorkflowController@store` to implement "Notify Out" logic: existing employees are automatically grouped by their current employer and added to the corresponding resignation job card.
- Updated `WorkflowController@store` to support "MOU Renewal" (single card per employer bucket) and "MOU Import" (multiple named batches).
- Updated `WorkflowController@finalizeItem` to handle employee transfer for "MOU Import" and status reset for "MOU Renewal" upon completion.
- Updated `create_modal.blade.php` to include an optional "Project Name" field for named batches (e.g., MOU Import).