### PR TITLE
Fix document scanner drag-and-drop reordering issue

### DIFF
--- a/resources/views/components/document-scanner.blade.php
+++ b/resources/views/components/document-scanner.blade.php
@@ -444,7 +444,10 @@
                         // Strict DOM-to-Data Sync
                         // Instead of relying on oldIndex/newIndex which can be flaky with templates and static items,
                         // we read the actual DOM order of the items and re-align our data to match.
-                        this.syncOrderFromDom();
+                        // Add delay to ensure Sortable animation/DOM updates are settled
+                        setTimeout(() => {
+                            this.syncOrderFromDom();
+                        }, 50);
                     }
                 });
             },
@@ -462,8 +465,8 @@
                     return this.capturedImages.find(img => String(img.id) === String(id));
                 }).filter(Boolean); // Filter out undefined just in case
 
-                // Update State
-                this.capturedImages = newCapturedImages;
+                // Update State - Force new array reference for Alpine
+                this.capturedImages = [...newCapturedImages];
 
                 // Clear selection to avoid confusion
                 this.selectedIndices = [];


### PR DESCRIPTION
- Modified `document-scanner.blade.php` to add a delay in the SortableJS `onEnd` handler, allowing DOM updates to settle before syncing state.
- Enforced a deep reactivity update for `capturedImages` in AlpineJS by spreading the new array, ensuring the UI correctly reflects the new order.
- This resolves the issue where dragged documents would visually revert to their original position or fail to update the data model.