### PR TITLE
Add workflow status overlays to history and notifications

### DIFF
--- a/resources/views/employees/_history_card.blade.php
+++ b/resources/views/employees/_history_card.blade.php
@@ -5,7 +5,21 @@
     $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);
 @endphp
 
-<div id="history-row-{{ $employee->id }}" class="list-group-item list-group-item-action">
+<div id="history-row-{{ $employee->id }}" class="list-group-item list-group-item-action position-relative">
+    @if(isset($employee->active_workflows) && $employee->active_workflows->isNotEmpty())
+        <div class="position-absolute top-0 start-0 w-100 h-100 d-flex justify-content-center align-items-center rounded"
+             style="background-color: rgba(255, 223, 0, 0.15); border: 2px solid #ffc107; z-index: 10; pointer-events: none;">
+             <div class="d-flex flex-column gap-2" style="pointer-events: auto;">
+                @foreach($employee->active_workflows as $wf)
+                    <a href="{{ route('workflow.index', ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]) }}"
+                       class="badge bg-warning text-dark text-decoration-none shadow-sm border border-dark fs-6 text-truncate"
+                       style="max-width: 90%;">
+                       <i class="bi bi-gear-fill me-1"></i> {{ $wf->status_label }}: {{ $wf->name }}
+                    </a>
+                @endforeach
+             </div>
+        </div>
+    @endif
     <div class="d-flex w-100">
         {{-- Checkbox --}}
         <div class="me-3 d-flex align-items-center">

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -55,7 +55,21 @@
     ];
 @endphp
 
-<div id="notification-item-{{ $notification->id }}" class="alert {{ $card_class }} notification-item" data-drag-payload="{{ json_encode($payload) }}">
+<div id="notification-item-{{ $notification->id }}" class="alert {{ $card_class }} notification-item position-relative" data-drag-payload="{{ json_encode($payload) }}">
+    @if($employee && isset($employee->active_workflows) && $employee->active_workflows->isNotEmpty())
+        <div class="position-absolute top-0 start-0 w-100 h-100 d-flex justify-content-center align-items-center rounded"
+             style="background-color: rgba(255, 223, 0, 0.15); border: 2px solid #ffc107; z-index: 10; pointer-events: none;">
+             <div class="d-flex flex-column gap-2" style="pointer-events: auto;">
+                @foreach($employee->active_workflows as $wf)
+                    <a href="{{ route('workflow.index', ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]) }}"
+                       class="badge bg-warning text-dark text-decoration-none shadow-sm border border-dark fs-6 text-truncate"
+                       style="max-width: 90%;">
+                       <i class="bi bi-gear-fill me-1"></i> {{ $wf->status_label }}: {{ $wf->name }}
+                    </a>
+                @endforeach
+             </div>
+        </div>
+    @endif
     <div class="d-flex align-items-start gap-3">
         {{-- Conditionally show checkbox. Disabled for employer notifications. --}}
         @if($employee)

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -50,6 +50,16 @@
                             {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'N/A' }}
                         </a>
                         <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="พรีวิวข้อมูล"> <i class="bi bi-search"></i> </button>
+
+                        @if(isset($employee->active_workflows) && $employee->active_workflows->isNotEmpty())
+                            @foreach($employee->active_workflows as $wf)
+                                <a href="{{ route('workflow.index', ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]) }}"
+                                   class="badge bg-warning text-dark text-decoration-none ms-1"
+                                   title="{{ $wf->status_label }}: {{ $wf->name }}">
+                                   <i class="bi bi-gear-fill me-1"></i>{{ $wf->status_label }}
+                                </a>
+                            @endforeach
+                        @endif
                     </div>
                     <div class="small text-muted">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }}</div>
                 </div>


### PR DESCRIPTION
- Add yellow overlay with workflow status badges to `_history_card.blade.php` (History view).
- Add similar overlay to `_notification_item.blade.php` (Notification card view).
- Add inline status badges to `_notification_table_row.blade.php` (Notification table view).
- Utilize existing `active_workflows` relationship/accessor on Employee model.