### PR TITLE
Add Passport Status Filter to Employee and Employer Views

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -164,6 +164,18 @@ public function reinstate(Employee $employee)
               ->where('employeeNationality', 'กัมพูชา');
     }
 
+    if ($request->filled('passport_status')) {
+        if ($request->input('passport_status') === 'has_passport') {
+            $query->where(function ($q) {
+                $q->whereNotNull('employeePassport')->where('employeePassport', '!=', '');
+            });
+        } elseif ($request->input('passport_status') === 'no_passport') {
+            $query->where(function ($q) {
+                $q->whereNull('employeePassport')->orWhere('employeePassport', '=', '');
+            });
+        }
+    }
+
     if ($request->filled('bank_account_status')) {
         $status = $request->input('bank_account_status');
         if ($status === 'opened') {
@@ -689,6 +701,18 @@ public function create(Request $request) // เพิ่ม Request $request เ
             }
         }
 
+        if ($request->filled('passport_status')) {
+            if ($request->input('passport_status') === 'has_passport') {
+                $query->where(function ($q) {
+                    $q->whereNotNull('employeePassport')->where('employeePassport', '!=', '');
+                });
+            } elseif ($request->input('passport_status') === 'no_passport') {
+                $query->where(function ($q) {
+                    $q->whereNull('employeePassport')->orWhere('employeePassport', '=', '');
+                });
+            }
+        }
+
         if ($request->filled('passport_type_myanmar')) {
             $query->where('passportType', $request->input('passport_type_myanmar'))
                   ->where('employeeNationality', 'เมียนมา');
@@ -811,6 +835,18 @@ public function create(Request $request) // เพิ่ม Request $request เ
             } elseif ($request->input('pink_card') === 'no') {
                 $query->where(function ($q) {
                     $q->whereNull('pinkCardNo')->orWhere('pinkCardNo', '=', '');
+                });
+            }
+        }
+
+        if ($request->filled('passport_status')) {
+            if ($request->input('passport_status') === 'has_passport') {
+                $query->where(function ($q) {
+                    $q->whereNotNull('employeePassport')->where('employeePassport', '!=', '');
+                });
+            } elseif ($request->input('passport_status') === 'no_passport') {
+                $query->where(function ($q) {
+                    $q->whereNull('employeePassport')->orWhere('employeePassport', '=', '');
                 });
             }
         }

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -195,6 +195,18 @@ class EmployerController extends Controller
             }
         }
 
+        if ($request->filled('passport_status')) {
+            if ($request->input('passport_status') === 'has_passport') {
+                $employeeQuery->where(function ($q) {
+                    $q->whereNotNull('employeePassport')->where('employeePassport', '!=', '');
+                });
+            } elseif ($request->input('passport_status') === 'no_passport') {
+                $employeeQuery->where(function ($q) {
+                    $q->whereNull('employeePassport')->orWhere('employeePassport', '=', '');
+                });
+            }
+        }
+
         if ($request->filled('work_permit_expiry_date')) {
             $employeeQuery->whereDate('workPermitExpiryDate', $request->input('work_permit_expiry_date'));
         }
@@ -447,6 +459,18 @@ class EmployerController extends Controller
                     $query->where(fn($q) => $q->whereNotNull('pinkCardNo')->where('pinkCardNo', '!=', ''));
                 } elseif ($request->input('pink_card') === 'no') {
                     $query->where(fn($q) => $q->whereNull('pinkCardNo')->orWhere('pinkCardNo', '=', ''));
+                }
+            }
+
+            if ($request->filled('passport_status')) {
+                if ($request->input('passport_status') === 'has_passport') {
+                    $query->where(function ($q) {
+                        $q->whereNotNull('employeePassport')->where('employeePassport', '!=', '');
+                    });
+                } elseif ($request->input('passport_status') === 'no_passport') {
+                    $query->where(function ($q) {
+                        $q->whereNull('employeePassport')->orWhere('employeePassport', '=', '');
+                    });
                 }
             }
 

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -59,6 +59,11 @@
                 <option value="yes" {{ request('pink_card') == 'yes' ? 'selected' : '' }}>{{ __('Has Pink Card') }}</option>
                 <option value="no" {{ request('pink_card') == 'no' ? 'selected' : '' }}>{{ __('No Pink Card') }}</option>
             </select>
+            <select name="passport_status" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- {{ __('Passport Status') }} --</option>
+                <option value="has_passport" {{ request('passport_status') == 'has_passport' ? 'selected' : '' }}>{{ __('Has Passport') }}</option>
+                <option value="no_passport" {{ request('passport_status') == 'no_passport' ? 'selected' : '' }}>{{ __('No Passport') }}</option>
+            </select>
             <select name="passport_type_myanmar" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- {{ __('Passport Type (Myanmar)') }} --</option>
                 <option value="CI" {{ request('passport_type_myanmar') == 'CI' ? 'selected' : '' }}>{{ __('CI Book') }}</option>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -476,6 +476,11 @@
                     <option value="yes" @if(request('pink_card') == 'yes') selected @endif>{{ __('Has Pink Card') }}</option>
                     <option value="no" @if(request('pink_card') == 'no') selected @endif>{{ __('No Pink Card') }}</option>
                 </select>
+                <select name="passport_status" class="form-select form-select-sm" style="width: auto;">
+                    <option value="">-- {{ __('Passport Status') }} --</option>
+                    <option value="has_passport" {{ request('passport_status') == 'has_passport' ? 'selected' : '' }}>{{ __('Has Passport') }}</option>
+                    <option value="no_passport" {{ request('passport_status') == 'no_passport' ? 'selected' : '' }}>{{ __('No Passport') }}</option>
+                </select>
                 <select name="passport_type_myanmar" class="form-select form-select-sm" style="width: auto;">
                     <option value="">-- {{ __('Passport Type (Myanmar)') }} --</option>
                     <option value="CI" {{ request('passport_type_myanmar') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>


### PR DESCRIPTION
- Added `passport_status` filter dropdown to `resources/views/employees/index.blade.php`.
- Added `passport_status` filter dropdown to `resources/views/employers/edit.blade.php`.
- Updated `EmployeeController@index` and `EmployeeController@export` to handle `passport_status` filtering.
- Updated `EmployerController@edit` and `EmployerController@exportEmployees` to handle `passport_status` filtering.
- Implemented logic: 'Has Passport' checks for non-null/non-empty `employeePassport`, 'No Passport' checks for null/empty.