### PR TITLE
Fix: Email edit fields always visible in workflow card

### DIFF
--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -328,7 +328,7 @@
                     }
                 }">
                     {{-- Display Mode --}}
-                    <div x-show="!isEditing" class="d-flex align-items-center gap-2">
+                    <div x-show="!isEditing" class="align-items-center gap-2" :class="{ 'd-flex': !isEditing }">
                         <div class="d-flex flex-column gap-1">
                              <div class="d-flex align-items-center gap-1 border rounded px-2 py-1 bg-white shadow-sm" style="min-width: 200px;">
                                 <i class="bi bi-envelope text-muted me-1"></i>
@@ -353,7 +353,7 @@
                     </div>
 
                     {{-- Edit Mode --}}
-                    <div x-show="isEditing" @click.outside="isEditing = false" class="d-flex flex-column gap-1 p-2 bg-white border rounded shadow-sm" style="display: none; min-width: 220px;">
+                    <div x-show="isEditing" @click.outside="isEditing = false" class="flex-column gap-1 p-2 bg-white border rounded shadow-sm" :class="{ 'd-flex': isEditing }" style="display: none; min-width: 220px;">
                         <input x-model="email" type="email" class="form-control form-control-sm" placeholder="Email">
                         <input x-model="password" type="text" class="form-control form-control-sm" placeholder="Password">
                         <div class="d-flex gap-1 mt-1">

--- a/tests/Feature/Production/CardVisibilityTest.php
+++ b/tests/Feature/Production/CardVisibilityTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Production;
+
+use App\Models\ProductionItem;
+use App\Models\ProductionOrder;
+use App\Models\User;
+use App\Models\Employer;
+use App\Models\Employee;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CardVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function email_edit_fields_have_conditional_visibility()
+    {
+        $user = User::factory()->create();
+        $employer = Employer::factory()->create();
+        $employee = Employee::factory()->create(['employer_id' => $employer->id]);
+
+        $order = ProductionOrder::create([
+            'employer_id' => $employer->id,
+            'status' => 'active',
+            'created_by' => $user->id
+        ]);
+
+        $item = ProductionItem::create([
+            'production_order_id' => $order->id,
+            'employee_id' => $employee->id,
+            'status' => 'pending'
+        ]);
+
+        $response = $this->actingAs($user)->get(route('workflow.item.card', ['item' => $item->id]));
+
+        $response->assertStatus(200);
+
+        // Response is JSON with 'html' key
+        $json = $response->json();
+        $this->assertArrayHasKey('html', $json);
+        $html = $json['html'];
+
+        // 1. Verify Display Mode Div
+        $this->assertStringContainsString('x-show="!isEditing"', $html);
+        $this->assertStringContainsString(':class="{ \'d-flex\': !isEditing }"', $html);
+
+        // Ensure the static class attribute does NOT contain d-flex
+        // We verify that the string 'class="d-flex align-items-center gap-2"' is NOT present
+        // And 'class="align-items-center gap-2"' IS present
+        $this->assertStringNotContainsString('class="d-flex align-items-center gap-2"', $html);
+        $this->assertStringContainsString('class="align-items-center gap-2"', $html);
+
+        // 2. Verify Edit Mode Div
+        $this->assertStringContainsString('x-show="isEditing"', $html);
+        $this->assertStringContainsString(':class="{ \'d-flex\': isEditing }"', $html);
+
+        // Ensure the static class attribute does NOT contain d-flex
+        // The original was 'class="d-flex flex-column gap-1 p-2 bg-white border rounded shadow-sm"'
+        // The new one is 'class="flex-column gap-1 p-2 bg-white border rounded shadow-sm"'
+        $this->assertStringNotContainsString('class="d-flex flex-column gap-1 p-2 bg-white border rounded shadow-sm"', $html);
+        $this->assertStringContainsString('class="flex-column gap-1 p-2 bg-white border rounded shadow-sm"', $html);
+    }
+}


### PR DESCRIPTION
- Modified `resources/views/workflow/partials/_item_card.blade.php` to conditionally apply `d-flex` class based on `isEditing` state. Previously, `d-flex` was hardcoded, overriding Alpine.js `x-show` and keeping the fields visible.
- Added regression test `tests/Feature/Production/CardVisibilityTest.php` to verify the HTML structure of the card.