### PR TITLE
Implement strict validation and visual enhancements for Pre-Productio…

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -166,41 +166,65 @@ class ProductionController extends Controller
             return response()->json(['success' => false, 'message' => 'Item is already in Workflow.'], 400);
         }
 
+        // Strict Validation: Check if employee already exists in any Active Workflow for this WorkType
+        // "Active" means status != 'pre_production' (could be 'active' or 'completed' in workflow context?)
+        // User Requirement: Cannot be in Workflow if moving from Pre-Production.
+        $hasDuplicate = ProductionItem::where('employee_id', $item->employee_id)
+            ->whereHas('order', function($q) use ($currentOrder) {
+                $q->where('work_type_id', $currentOrder->work_type_id)
+                  ->where('status', '!=', 'pre_production') // Active Workflow Order
+                  ->where('status', '!=', 'cancelled');
+            })
+            ->whereNotIn('status', ['cancelled', 'completed']) // Assuming completed allows new entry? No, strict One-to-One.
+            ->exists();
+
+        if ($hasDuplicate) {
+             return response()->json([
+                 'success' => false,
+                 'message' => 'This employee is already active in the Workflow for this process. Please resolve the existing item first.'
+             ], 400);
+        }
+
         DB::beginTransaction();
         try {
             // Find an Active Order for this Employer + WorkType
             $activeOrder = ProductionOrder::where('employer_id', $currentOrder->employer_id)
                                 ->where('work_type_id', $currentOrder->work_type_id)
                                 ->where('status', '!=', 'pre_production') // Active
+                                ->where('status', '!=', 'cancelled')
                                 ->latest()
                                 ->first();
 
             if (!$activeOrder) {
                 // Create new Active Order
+                // Use the same project name or a clean one
+                $workTypeName = $currentOrder->workType->name ?? 'Job';
+                $employerName = $currentOrder->employer->employerNameTh ?? 'Unknown';
+
                 $activeOrder = ProductionOrder::create([
                     'employer_id' => $currentOrder->employer_id,
                     'work_type_id' => $currentOrder->work_type_id,
                     'type' => $currentOrder->type,
-                    'project_name' => $currentOrder->project_name . ' (Workflow)', // Or keep same name?
+                    // Format: "WorkType - EmployerName" as requested implicitly by "Show on Employer Card"
+                    'project_name' => "$workTypeName - $employerName",
                     'description' => $currentOrder->description,
                     'status' => 'active',
                     'created_by' => auth()->id(),
                 ]);
             }
 
-            // Move Item
+            // Move Item: Update the production_order_id to the new active order
             $item->update([
                 'production_order_id' => $activeOrder->id,
                 'status' => 'pending', // Reset status to pending in workflow
                 'last_checked_at' => null, // Reset checks
+                'appointment_date' => null, // Reset appointment date as it is stage-specific
+                'appointment_location' => null,
+                'appointment_completed_at' => null,
             ]);
 
-            // Clear Completed Steps (User said steps don't follow)
+            // Clear Completed Steps (Preparation steps do not map to Workflow steps 1:1)
             $item->completedWorkTypeSteps()->detach();
-
-            // If the old order is empty, should we delete it?
-            // Maybe keep it as empty shell or delete. User didn't specify.
-            // Let's leave it for now.
 
             DB::commit();
             return response()->json(['success' => true]);

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -802,6 +802,7 @@ class WorkflowController extends Controller
 
         // 1. Validation: Check for duplicates (Existing Employees)
         // Ensure an employee cannot be in the same WorkType workflow (Active or Pre-Production) twice.
+        // User Requirement: Strict One-to-One. Employee cannot be in Pre-Prod OR Active Workflow for the same Process.
         if ($request->has('employee_ids') && is_array($request->employee_ids)) {
             if ($workTypeId) {
                 // Find any items for these employees in this WorkType that are NOT cancelled or completed.
@@ -811,20 +812,27 @@ class WorkflowController extends Controller
                           ->where('status', '!=', 'cancelled'); // Ensure order is not cancelled
                     })
                     ->whereNotIn('status', ['cancelled', 'completed'])
-                    ->with('employee')
+                    ->with(['employee', 'order'])
                     ->get();
 
                 if ($duplicates->isNotEmpty()) {
-                    $names = $duplicates->map(fn($item) => $item->employee->employeeNameEn ?? $item->employee->employeeNameTh)->unique()->implode(', ');
+                    // Generate specific error messages
+                    $messages = [];
+                    foreach ($duplicates as $item) {
+                        $name = $item->employee->employeeNameEn ?? $item->employee->employeeNameTh ?? 'Unknown';
+                        $status = $item->order->status === 'pre_production' ? 'Pre-Production' : 'Workflow';
+                        $messages[] = "$name is already in $status";
+                    }
+                    $errorMsg = implode(', ', $messages) . ". Please complete or cancel the existing process first.";
 
                     if ($request->ajax() || $request->wantsJson()) {
                         return response()->json([
                             'success' => false,
-                            'message' => "Employees already in this workflow: $names"
+                            'message' => $errorMsg
                         ]);
                     }
 
-                    return back()->with('duplicate_error', "Employees already in this workflow: $names. Please complete their current process first.");
+                    return back()->with('duplicate_error', $errorMsg);
                 }
             }
         }
@@ -874,8 +882,14 @@ class WorkflowController extends Controller
             $groupName = $request->group_name ?? null;
 
             foreach ($ids as $empId) {
-                // Locking: Check if employee is already in an active workflow
+                // Locking: Check if employee is already in an active workflow (Scoped to WorkType)
+                // We allow employees to be in different workflows (e.g. Visa Renewal AND Change Employer) concurrently if needed,
+                // but strictly ONE per WorkType.
                 $hasActiveWorkflow = ProductionItem::where('employee_id', $empId)
+                    ->whereHas('order', function($q) use ($workTypeId) {
+                         if ($workTypeId) $q->where('work_type_id', $workTypeId);
+                         $q->where('status', '!=', 'cancelled');
+                    })
                     ->whereNotIn('status', ['completed', 'cancelled'])
                     ->exists();
 

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -229,13 +229,15 @@ class Employee extends Model
             ->get()
             ->map(function ($item) {
                 // Determine status label based on Order status
-                $statusLabel = $item->order->status === 'pre_production'
-                    ? 'Pre-Production'
-                    : 'กำลังดำเนินการ'; // "Processing"
+                $isPreProduction = $item->order->status === 'pre_production';
+                $statusLabel = $isPreProduction
+                    ? 'Preparing (Pre-Production)'
+                    : 'Processing';
 
                 return (object) [
                     'name' => $item->order->workType->name ?? 'Unknown',
                     'status_label' => $statusLabel,
+                    'is_pre_production' => $isPreProduction,
                     'order_id' => $item->production_order_id,
                     'item_id' => $item->id,
                     'tab_slug' => $item->order->workType->slug ?? '',

--- a/resources/views/employees/_employee_card.blade.php
+++ b/resources/views/employees/_employee_card.blade.php
@@ -84,7 +84,25 @@
                     @endif
                 </small>
             </div>
-            <p class="mb-1">{{ trim(($employee->employeeTitleTh ?? '') . ' ' . ($employee->employeeNameTh ?? '')) ?: 'N/A' }} ({{ $employee->job_title ?? 'N/A' }})</p>
+            <p class="mb-1">
+                {{ trim(($employee->employeeTitleTh ?? '') . ' ' . ($employee->employeeNameTh ?? '')) ?: 'N/A' }} ({{ $employee->job_title ?? 'N/A' }})
+
+                {{-- Active Workflow / Pre-Production Status Badges --}}
+                @foreach($employee->active_workflows as $workflow)
+                    @php
+                        $badgeClass = $workflow->is_pre_production ? 'bg-info text-dark' : 'bg-warning text-dark';
+                        $route = $workflow->is_pre_production ? 'production.index' : 'workflow.index';
+                        $icon = $workflow->is_pre_production ? 'bi-hourglass-split' : 'bi-gear-wide-connected';
+                    @endphp
+                    <a href="{{ route($route, ['tab' => $workflow->tab_slug, 'search' => $employee->employeeNameEn]) }}"
+                       class="badge rounded-pill {{ $badgeClass }} text-decoration-none ms-1 border border-dark shadow-sm"
+                       title="{{ $workflow->status_label }}"
+                       target="_blank">
+                        <i class="bi {{ $icon }} me-1"></i> {{ $workflow->name }}
+                        @if($workflow->is_pre_production) <small>({{ __('Prep') }})</small> @endif
+                    </a>
+                @endforeach
+            </p>
             <small class="text-muted d-block">Passport: {{ $employee->employeePassport ?? '-' }} (หมดอายุ: {{ optional($employee->passportExpiryDate)->format('d/m/Y') ?? '-' }})</small>
             <small class="text-muted d-block">Work Permit: <strong>{{ $employee->employeeWorkPermit ?? '-' }}</strong> (หมดอายุ: {{ optional($employee->workPermitExpiryDate)->format('d/m/Y') ?? '-' }})</small>
             <small class="text-muted d-block">Visa ({{ $employee->workPermitMOUGroup ?? '-' }}) | 90-Day: {{ optional($employee->ninetyDayReportDate)->format('d/m/Y') ?? '-' }}</small>

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -549,7 +549,18 @@
                 .then(data => {
                     if(data.success) {
                         // Remove card from UI
-                        document.getElementById(`item-card-${itemId}`).remove();
+                        const card = document.getElementById(`item-card-${itemId}`);
+                        const wrapper = card.closest('.order-content-wrapper');
+                        card.remove();
+
+                        // Check if wrapper is empty
+                        if(wrapper && wrapper.querySelectorAll('.item-card-wrapper').length === 0) {
+                            const orderCard = wrapper.closest('.production-order-card');
+                            if(orderCard) {
+                                orderCard.classList.add('grayscale-mode');
+                            }
+                        }
+
                         Swal.fire('{{ __("Sent!") }}', '{{ __("Employee moved to Workflow.") }}', 'success');
                     } else {
                         Swal.fire('{{ __("Error") }}', data.message, 'error');

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -21,7 +21,10 @@
     } elseif ($isCancelled) {
         $cardClass = 'bg-light border-0 text-secondary grayscale-mode';
         $overlayClass = 'opacity-50 pointer-events-none';
-    } elseif (!$isCheckedToday && !$isPreProduction) {
+    } elseif ($isPreProduction) {
+        // Pre-Production: Blue Border/Glow + "Preparing" visual cue (User Request: Blue/Cyan for Pre-Production)
+        $cardClass = 'bg-white border border-info border-3 shadow';
+    } elseif (!$isCheckedToday) {
         // Highlight Pending Check (Orange Border/Glow) ONLY in Workflow
         $cardClass = 'bg-white border border-warning border-3 shadow';
     }
@@ -137,6 +140,10 @@
                              {{-- Resolution Badge --}}
                              @if($mouGroup !== 'N/A')
                                 <span class="badge rounded-pill {{ $mouBadgeClass }} small" style="font-size: 0.65rem;">{{ $mouGroup }}</span>
+                             @endif
+                             {{-- Pre-Production Badge --}}
+                             @if($isPreProduction)
+                                <span class="badge rounded-pill bg-info text-dark small" style="font-size: 0.65rem;">{{ __('Preparing') }}</span>
                              @endif
                         </div>
                         <div class="text-muted small">


### PR DESCRIPTION
…n to Workflow handover

- Add strict validation in `WorkflowController@store` to prevent adding employees who are already in Pre-Production or Active Workflow for the same WorkType.
- Implement strict validation in `ProductionController@sendToWorkflow` to ensure employees are not duplicated in Workflow.
- Implement logic in `ProductionController@sendToWorkflow` to find or create the target Active Workflow Order and move the item, resetting its status.
- Update `Employee` model accessor `getActiveWorkflowsAttribute` to include `is_pre_production` flag.
- Update `_item_card.blade.php` to display Blue/Cyan overlay and "Preparing" badge for Pre-Production items.
- Update `_employee_card.blade.php` to display badges linking to the correct dashboard (Workflow vs Pre-Production).
- Enhance Pre-Production Dashboard JS to visually mark empty order cards as grayscale after sending items.