### PR TITLE
Fix workflow trash retention, UI updates, and photo caching

### DIFF
--- a/app/Console/Commands/PruneTrash.php
+++ b/app/Console/Commands/PruneTrash.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\ProductionItem;
+use App\Models\SystemSetting;
+use Carbon\Carbon;
+
+class PruneTrash extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'workflow:prune-trash';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prune soft-deleted items older than the retention period.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $setting = SystemSetting::where('key', 'trash_retention_days')->first();
+        $days = $setting ? (int) $setting->value : 30; // Default 30 days
+
+        if ($days <= 0) {
+            $this->info('Trash retention is set to Forever (0). No items pruned.');
+            return;
+        }
+
+        $cutoff = Carbon::now()->subDays($days);
+
+        $count = ProductionItem::onlyTrashed()
+            ->where('deleted_at', '<', $cutoff)
+            ->count();
+
+        if ($count > 0) {
+            $this->info("Pruning {$count} items deleted before {$cutoff->toDateTimeString()}...");
+            ProductionItem::onlyTrashed()
+                ->where('deleted_at', '<', $cutoff)
+                ->forceDelete();
+            $this->info('Done.');
+        } else {
+            $this->info('No items to prune.');
+        }
+    }
+}

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -318,7 +318,11 @@ class ProductionController extends Controller
             $item->completedWorkTypeSteps()->detach();
 
             DB::commit();
-            return response()->json(['success' => true]);
+
+            // Calculate Stats for the OLD order (Preparation) to update UI
+            $orderStats = $this->calculateOrderStats($currentOrder);
+
+            return response()->json(['success' => true, 'order_stats' => $orderStats]);
 
         } catch (\Exception $e) {
             DB::rollBack();
@@ -457,5 +461,54 @@ class ProductionController extends Controller
          // we might use a similar Modal to create jobs.
 
          return parent::callAction('store', [$request]); // Fallback or implement
+    }
+
+    /**
+     * Helper to calculate stats for a single order (Production/Preparation Context).
+     */
+    private function calculateOrderStats(ProductionOrder $order)
+    {
+        // Ensure relations are loaded
+        $order->load(['items.completedWorkTypeSteps']);
+
+        // Get Preparation Steps for this WorkType
+        $steps = WorkTypeStep::where('work_type_id', $order->work_type_id)
+                    ->where('stage', 'preparation')
+                    ->orderBy('order')
+                    ->get();
+
+        $items = $order->items;
+        $total = 0;
+        $notStarted = 0;
+        $cancelled = 0;
+        $completed = 0;
+        $stepStats = $steps->pluck('id')->mapWithKeys(fn($id) => [$id => 0])->toArray();
+
+        foreach ($items as $item) {
+            if ($item->status === 'cancelled') {
+                $cancelled++;
+                continue;
+            }
+            $total++;
+            if ($item->status === 'completed') {
+                $completed++;
+            }
+            $completedSteps = $item->completedWorkTypeSteps->pluck('id')->toArray();
+            if (empty($completedSteps)) {
+                $notStarted++;
+            }
+            $highestStep = $item->completedWorkTypeSteps->sortByDesc('order')->first();
+            if ($highestStep && isset($stepStats[$highestStep->id])) {
+                $stepStats[$highestStep->id]++;
+            }
+        }
+
+        return [
+            'total' => $total,
+            'not_started' => $notStarted,
+            'cancelled' => $cancelled,
+            'completed' => $completed,
+            'step_stats' => $stepStats
+        ];
     }
 }

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -9,6 +9,7 @@ use App\Models\WorkType;
 use App\Models\WorkTypeStep;
 use App\Models\Employee;
 use App\Models\Employer;
+use App\Models\SystemSetting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
@@ -639,7 +640,21 @@ class WorkflowController extends Controller
         // Ensure relations are loaded
         $order->load(['items.completedWorkTypeSteps', 'workType.steps']);
         $items = $order->items;
-        $steps = $order->workType->steps ?? collect();
+
+        // Determine Steps based on Stage
+        if ($order->status === 'pre_production') {
+             $steps = WorkTypeStep::where('work_type_id', $order->work_type_id)
+                        ->where('stage', 'preparation')
+                        ->orderBy('order')
+                        ->get();
+        } else {
+             // Default to existing logic (all steps or workflow steps)
+             // To be safe and match Index logic:
+             $steps = $order->workType->steps ?? collect();
+             // Ideally we should filter out preparation steps if this is main workflow,
+             // but strictly following existing Index logic which uses $activeTab->steps.
+        }
+
         $stepOneId = $steps->sortBy('order')->first()?->id;
 
         $total = 0;
@@ -1320,7 +1335,11 @@ class WorkflowController extends Controller
 
         $items = $query->paginate(10);
 
-        return view('workflow.partials.trash_list', compact('items'));
+        // Get Retention Setting
+        $retentionSetting = SystemSetting::where('key', 'trash_retention_days')->first();
+        $retentionDays = $retentionSetting ? $retentionSetting->value : '30'; // Default 30
+
+        return view('workflow.partials.trash_list', compact('items', 'retentionDays'));
     }
 
     /**
@@ -1345,6 +1364,42 @@ class WorkflowController extends Controller
         if ($item->order && $item->order->trashed()) {
             $item->order->restore();
         }
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
+     * Permanently Delete Item (Force Delete)
+     */
+    public function forceDeleteTrash(Request $request, $id)
+    {
+        if (!auth()->user()->can('edit-employees') && !auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
+        $item = ProductionItem::onlyTrashed()->findOrFail($id);
+        $item->forceDelete();
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
+     * Update Trash Retention Settings
+     */
+    public function updateTrashSettings(Request $request)
+    {
+        if (!auth()->user()->can('manage-own-workflow')) { // Or admin check
+             abort(403);
+        }
+
+        $request->validate([
+            'retention_days' => 'required|string', // 'forever' or numeric
+        ]);
+
+        SystemSetting::updateOrCreate(
+            ['key' => 'trash_retention_days'],
+            ['value' => $request->retention_days, 'group' => 'workflow']
+        );
 
         return response()->json(['success' => true]);
     }

--- a/app/Models/SystemSetting.php
+++ b/app/Models/SystemSetting.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SystemSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['key', 'value', 'group'];
+}

--- a/database/migrations/2026_02_08_165226_create_system_settings_table.php
+++ b/database/migrations/2026_02_08_165226_create_system_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('system_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->string('group')->default('general');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('system_settings');
+    }
+};

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -696,6 +696,18 @@
                         }
 
                         Swal.fire('{{ __("Sent!") }}', '{{ __("Employee moved to Workflow.") }}', 'success');
+
+                        if(data.order_stats) {
+                             const card = document.getElementById(`item-card-${itemId}`);
+                             // The card is removed above, but we can get orderId from wrapper if we saved reference,
+                             // OR we assume we can find the order header by ID if we pass orderId.
+                             // But wait, the card is removed!
+                             // "const wrapper = card.closest('.order-content-wrapper');" was called BEFORE removal.
+                             if(wrapper) {
+                                 const orderId = wrapper.id.replace('order-content-', '');
+                                 updateOrderHeaderStats(orderId, data.order_stats);
+                             }
+                        }
                     } else {
                         Swal.fire('{{ __("Error") }}', data.message, 'error');
                     }
@@ -749,7 +761,7 @@
         }
     }
 
-    function updateOrderHeaderStats(orderId, stats) {
+    window.updateOrderHeaderStats = function(orderId, stats) {
         if (!stats) return;
         // Basic implementation for Pre-Production if needed (badges are slightly different)
         // Usually Pre-Prod doesn't have detailed stats like Workflow, but if badges exist:

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -38,7 +38,7 @@
     $nameTh = $item->employee->employeeNameTh ?? $item->new_employee_data['name_th'] ?? '';
     $empNameTh = trim("$titleTh $nameTh");
 
-    $empPhoto = $item->employee && $item->employee->employeePhoto ? asset('storage/' . $item->employee->employeePhoto) : 'https://placehold.co/50x50/e2e8f0/6c757d?text=PIC';
+    $empPhoto = $item->employee && $item->employee->employeePhoto ? asset('storage/' . $item->employee->employeePhoto) . '?t=' . time() : 'https://placehold.co/50x50/e2e8f0/6c757d?text=PIC';
     $empPassport = $item->employee->employeePassport ?? $item->new_employee_data['passport_no'] ?? '-';
     $empNationality = $item->employee->employeeNationality ?? $item->new_employee_data['nationality'] ?? '-';
     $empId = $item->employee_id;

--- a/resources/views/workflow/partials/trash_list.blade.php
+++ b/resources/views/workflow/partials/trash_list.blade.php
@@ -1,3 +1,13 @@
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="text-muted small">
+        <i class="bi bi-info-circle me-1"></i> {{ __('Items are automatically deleted after') }}
+        <span class="fw-bold text-dark">{{ $retentionDays > 0 ? $retentionDays . ' ' . __('days') : __('Never (Forever)') }}</span>.
+    </div>
+    <button class="btn btn-sm btn-outline-secondary" onclick="openTrashSettings()">
+        <i class="bi bi-gear-fill me-1"></i> {{ __('Settings') }}
+    </button>
+</div>
+
 <div class="table-responsive">
     <table class="table table-hover align-middle">
         <thead class="table-light">
@@ -10,7 +20,7 @@
         </thead>
         <tbody>
             @forelse($items as $item)
-                <tr>
+                <tr id="trash-row-{{ $item->id }}">
                     <td>
                         <div class="fw-bold">{{ $item->order->project_name ?? '-' }}</div>
                         <div class="small text-muted">{{ $item->order->employer->employerNameTh ?? '-' }}</div>
@@ -28,8 +38,11 @@
                         <div class="small text-muted">{{ $item->deleted_at->diffForHumans() }}</div>
                     </td>
                     <td class="text-end">
-                        <button class="btn btn-sm btn-success" onclick="restoreTrashItem({{ $item->id }})">
-                            <i class="bi bi-arrow-counterclockwise me-1"></i> {{ __('Restore') }}
+                        <button class="btn btn-sm btn-success me-1" onclick="restoreTrashItem({{ $item->id }})" title="{{ __('Restore') }}">
+                            <i class="bi bi-arrow-counterclockwise"></i>
+                        </button>
+                        <button class="btn btn-sm btn-danger" onclick="forceDeleteTrashItem({{ $item->id }})" title="{{ __('Delete Forever') }}">
+                            <i class="bi bi-trash"></i>
                         </button>
                     </td>
                 </tr>
@@ -47,3 +60,105 @@
         {{ $items->links() }}
     </div>
 </div>
+
+<script>
+    window.openTrashSettings = function() {
+        const currentDays = '{{ $retentionDays }}';
+
+        Swal.fire({
+            title: '{{ __("Trash Retention Settings") }}',
+            text: '{{ __("How long should deleted items be kept before permanent deletion?") }}',
+            input: 'select',
+            inputOptions: {
+                '7': '7 Days',
+                '15': '15 Days',
+                '30': '30 Days',
+                '60': '60 Days',
+                '90': '90 Days',
+                '365': '1 Year',
+                'forever': 'Forever (Never Auto-delete)'
+            },
+            inputValue: currentDays === '0' ? 'forever' : currentDays,
+            showCancelButton: true,
+            confirmButtonText: '{{ __("Save") }}',
+            showLoaderOnConfirm: true,
+            preConfirm: (value) => {
+                return fetch('{{ route("workflow.trash.settings.update") }}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                    },
+                    body: JSON.stringify({ retention_days: value === 'forever' ? 0 : value })
+                })
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(response.statusText)
+                    }
+                    return response.json()
+                })
+                .catch(error => {
+                    Swal.showValidationMessage(
+                        `Request failed: ${error}`
+                    )
+                })
+            },
+            allowOutsideClick: () => !Swal.isLoading()
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Swal.fire({
+                    title: '{{ __("Saved!") }}',
+                    icon: 'success'
+                }).then(() => {
+                    // Reload trash content
+                    const modalBody = document.getElementById('trashModalBody');
+                    if(modalBody) {
+                        // Re-fetch current url or default
+                        // We need to keep current page/search if possible, but simple reload is fine
+                        const url = '{{ route("workflow.trash") }}' + window.location.search;
+                        // Using window.location.search might append dashboard filters to trash fetch which is good or bad?
+                        // Controller handles 'is_pre_production' param.
+                        // Let's just call the open function if available or fetch
+                        if(window.openTrashModal) {
+                            window.openTrashModal();
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    window.forceDeleteTrashItem = function(id) {
+        Swal.fire({
+            title: '{{ __("Delete Forever?") }}',
+            text: '{{ __("You will not be able to recover this item!") }}',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: '{{ __("Yes, delete it!") }}'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                fetch(`/workflow/trash/${id}/force-delete`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Accept': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                    }
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if(data.success) {
+                        document.getElementById('trash-row-' + id).remove();
+                        Swal.fire(
+                            '{{ __("Deleted!") }}',
+                            '{{ __("Item has been permanently deleted.") }}',
+                            'success'
+                        )
+                    }
+                });
+            }
+        })
+    }
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -354,6 +354,8 @@ Route::middleware(['auth'])->group(function () {
     // Workflow Trash Routes
     Route::get('workflow/trash', [\App\Http\Controllers\WorkflowController::class, 'fetchTrash'])->name('workflow.trash');
     Route::post('workflow/trash/{id}/restore', [\App\Http\Controllers\WorkflowController::class, 'restoreTrash'])->name('workflow.trash.restore');
+    Route::delete('workflow/trash/{id}/force-delete', [\App\Http\Controllers\WorkflowController::class, 'forceDeleteTrash'])->name('workflow.trash.force_delete');
+    Route::post('workflow/trash/settings', [\App\Http\Controllers\WorkflowController::class, 'updateTrashSettings'])->name('workflow.trash.settings.update');
 
     // Workflow API Routes
     Route::post('workflow/api/bulk-step', [\App\Http\Controllers\WorkflowController::class, 'bulkStoreStep'])->name('workflow.api.bulk_step');


### PR DESCRIPTION
- Implemented SystemSetting model and migration for configurable trash retention.
- Added workflow:prune-trash console command to auto-delete old trash.
- Updated Trash UI with "Delete Forever" and "Settings" buttons.
- Fixed instant UI updates when sending items from Pre-Production to Workflow by returning order stats.
- Fixed instant UI updates when adding employees by handling Pre-Production order stats correctly.
- Added timestamp to employee photo URLs to fix browser caching issues.
- Exposed updateOrderHeaderStats globally in Production dashboard to fix JS scope issues.