### PR TITLE
feat: add distinct color and GPS nav for Pre-Production employees

### DIFF
--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -24,14 +24,33 @@
 
 <div id="{{ $cardId }}" class="employee-card card mb-3 position-relative">
     @if(isset($employee->active_workflows) && $employee->active_workflows->isNotEmpty())
+        @php
+            // Determine primary status for card overlay color (Priority: Workflow (Yellow) > Pre-Production (Blue))
+            $hasStandardWorkflow = $employee->active_workflows->contains('is_pre_production', false);
+
+            if ($hasStandardWorkflow) {
+                // Yellow (Standard Workflow)
+                $overlayStyle = 'background-color: rgba(255, 223, 0, 0.15); border: 2px solid #ffc107;';
+            } else {
+                // Light Blue (Pre-Production)
+                $overlayStyle = 'background-color: rgba(13, 202, 240, 0.15); border: 2px solid #0dcaf0;';
+            }
+        @endphp
         <div class="position-absolute top-0 start-0 w-100 h-100 d-flex justify-content-center align-items-center rounded"
-             style="background-color: rgba(255, 223, 0, 0.15); border: 2px solid #ffc107; z-index: 10; pointer-events: none;">
+             style="{{ $overlayStyle }} z-index: 10; pointer-events: none;">
              <div class="d-flex flex-column gap-2" style="pointer-events: auto;">
                 @foreach($employee->active_workflows as $wf)
-                    <a href="{{ route('workflow.index', ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]) }}"
-                       class="badge bg-warning text-dark text-decoration-none shadow-sm border border-dark fs-6 text-truncate"
+                    @php
+                        $route = $wf->is_pre_production ? 'production.index' : 'workflow.index';
+                        $badgeClass = $wf->is_pre_production ? 'bg-info' : 'bg-warning';
+                        $icon = $wf->is_pre_production ? 'bi-hourglass-split' : 'bi-gear-fill';
+                        $tooltip = $wf->is_pre_production ? __('Go to Pre-Production') : __('Go to Workflow');
+                    @endphp
+                    <a href="{{ route($route, ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]) }}"
+                       class="badge {{ $badgeClass }} text-dark text-decoration-none shadow-sm border border-dark fs-6 text-truncate"
+                       title="{{ $tooltip }}"
                        style="max-width: 90%;">
-                       <i class="bi bi-gear-fill me-1"></i> {{ $wf->status_label }}: {{ $wf->name }}
+                       <i class="bi {{ $icon }} me-1"></i> {{ $wf->status_label }}: {{ $wf->name }}
                     </a>
                 @endforeach
              </div>

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -1091,5 +1091,67 @@
         });
     }
 
+    // --- GPS / Deep Linking ---
+    document.addEventListener('DOMContentLoaded', function() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const targetOrderId = urlParams.get('order');
+        const targetItemId = urlParams.get('item');
+
+        if (targetOrderId && targetItemId) {
+            const orderHeading = document.getElementById('heading-' + targetOrderId);
+            const collapseElement = document.getElementById('collapse-' + targetOrderId);
+
+            if (orderHeading && collapseElement) {
+                // Scroll to Order
+                orderHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+                // Check if collapsed
+                if (!collapseElement.classList.contains('show')) {
+                    // Trigger click on the button
+                    const btn = orderHeading.querySelector('button[data-bs-toggle="collapse"]');
+                    if(btn) btn.click();
+                }
+
+                // Wait for Item to Load
+                const observer = new MutationObserver(function(mutations, obs) {
+                    const itemCard = document.getElementById('item-card-' + targetItemId);
+                    if (itemCard) {
+                        // Found it!
+                        setTimeout(() => {
+                             itemCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                             // Add highlight class
+                             const innerCard = itemCard.querySelector('.card') || itemCard;
+                             // Use info border for pre-production to match
+                             innerCard.classList.add('border-info', 'border-3', 'shadow-lg');
+                             // Optional: Blink effect removal
+                             setTimeout(() => {
+                                 innerCard.classList.remove('border-info', 'border-3', 'shadow-lg');
+                                 innerCard.classList.add('shadow-sm');
+                             }, 5000);
+                        }, 500); // Small delay for rendering
+                        obs.disconnect();
+                    }
+                });
+
+                // Start observing the content wrapper
+                const contentWrapper = document.getElementById('order-content-' + targetOrderId);
+                if (contentWrapper) {
+                    observer.observe(contentWrapper, { childList: true, subtree: true });
+
+                    // Fallback check
+                    setTimeout(() => {
+                         const itemCard = document.getElementById('item-card-' + targetItemId);
+                         if(itemCard) {
+                             const innerCard = itemCard.querySelector('.card') || itemCard;
+                             itemCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                             innerCard.classList.add('border-info', 'border-3', 'shadow-lg');
+                             observer.disconnect();
+                         }
+                    }, 1500);
+                }
+            }
+        }
+    });
+
 </script>
 @endpush


### PR DESCRIPTION
- Update `_employee_card.blade.php` to use Light Blue (Info) overlay for Pre-Production status.
- Update `_employee_card.blade.php` to use Yellow (Warning) overlay for Workflow status (default).
- Update badge links to point to the correct dashboard (`production.index` or `workflow.index`) with context params.
- Implement GPS navigation logic in `production/index.blade.php` to auto-expand orders and scroll to items.
- Highlight target items in Pre-Production with a matching blue border.