### PR TITLE
Fix Trash Bin error and link Employee Card password to outsource_code

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -308,14 +308,17 @@ class WorkflowController extends Controller
                 $employeeId ? \Illuminate\Validation\Rule::unique('employees', 'email')->ignore($employeeId) : 'unique:employees,email'
             ],
             'password' => 'nullable|string|max:255',
+            'outsource_code' => 'nullable|string|max:255',
         ]);
 
         if ($item->employee) {
             try {
-                $item->employee->update([
-                    'email' => $request->email,
-                    'password' => $request->password,
-                ]);
+                $data = [];
+                if ($request->has('email')) $data['email'] = $request->email;
+                if ($request->has('password')) $data['password'] = $request->password;
+                if ($request->has('outsource_code')) $data['outsource_code'] = $request->outsource_code;
+
+                $item->employee->update($data);
             } catch (\Exception $e) {
                 return response()->json([
                     'success' => false,
@@ -986,7 +989,7 @@ class WorkflowController extends Controller
                 'employer_id', 'employeeTitleTh', 'employeeNameTh', 'employeeTitleEn', 'employeeNameEn',
                 'father_name', 'mother_name', 'employeeGender', 'employeeDob', 'employeeAge', 'employeePhone',
                 'employeeNationality', 'passportType', 'passport_type_cambodia', 'employeePassport',
-                'passport_issue_date', 'passportExpiryDate', 'pinkCardNo', 'visaType', 'visaExpiryDate',
+                'passport_issue_date', 'passportExpiryDate', 'pinkCardNo', 'visaExpiryDate',
                 'job_title', 'job_description', 'startDate', 'employeeWorkPermit', 'workPermitExpiryDate',
                 'workPermitType', 'workPermitMOUGroup', 'workPermitMOUGroupOther', 'ninetyDayReportDate',
                 'name_list_number', 'request_number', 'employee_id_number', 'tax_id_number',

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -305,7 +305,7 @@
                 <div class="ms-md-4" x-data="{
                     isEditing: false,
                     email: {{ json_encode($item->employee->email ?? '') }},
-                    password: {{ json_encode($item->employee->password ?? '') }},
+                    outsource_code: {{ json_encode($item->employee->outsource_code ?? '') }},
                     copy(el, text) {
                         if (!text) return;
                         navigator.clipboard.writeText(text).then(() => {
@@ -318,7 +318,7 @@
                         fetch('/workflow/item/{{ $item->id }}/update-credentials', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content },
-                            body: JSON.stringify({ email: this.email, password: this.password })
+                            body: JSON.stringify({ email: this.email, outsource_code: this.outsource_code })
                         })
                         .then(res => {
                             if (!res.ok) {
@@ -367,8 +367,8 @@
                              </div>
                              <div class="d-flex align-items-center gap-1 border rounded px-2 py-1 bg-white shadow-sm" style="min-width: 200px;">
                                 <i class="bi bi-key text-muted me-1"></i>
-                                <span x-text="password || '-'" class="small text-truncate" style="max-width: 150px;" :title="password"></span>
-                                <button @click="copy($event.currentTarget, password)" class="btn btn-link p-0 ms-auto text-secondary" title="Copy Password" x-show="password">
+                                <span x-text="outsource_code || '-'" class="small text-truncate" style="max-width: 150px;" :title="outsource_code"></span>
+                                <button @click="copy($event.currentTarget, outsource_code)" class="btn btn-link p-0 ms-auto text-secondary" title="Copy Outsource Code" x-show="outsource_code">
                                     <i class="bi bi-clipboard"></i>
                                 </button>
                              </div>
@@ -383,7 +383,7 @@
                     {{-- Edit Mode --}}
                     <div x-show="isEditing" @click.outside="isEditing = false" class="flex-column gap-1 p-2 bg-white border rounded shadow-sm" :class="{ 'd-flex': isEditing }" style="display: none; min-width: 220px;">
                         <input x-model="email" type="email" class="form-control form-control-sm" placeholder="Email">
-                        <input x-model="password" type="text" class="form-control form-control-sm" placeholder="Password">
+                        <input x-model="outsource_code" type="text" class="form-control form-control-sm" placeholder="Outsource Code">
                         <div class="d-flex gap-1 mt-1">
                             <button @click="save()" class="btn btn-sm btn-success flex-grow-1"><i class="bi bi-check-lg"></i></button>
                             <button @click="isEditing = false" class="btn btn-sm btn-outline-secondary"><i class="bi bi-x-lg"></i></button>

--- a/resources/views/workflow/partials/trash_list.blade.php
+++ b/resources/views/workflow/partials/trash_list.blade.php
@@ -22,8 +22,8 @@
             @forelse($items as $item)
                 <tr id="trash-row-{{ $item->id }}">
                     <td>
-                        <div class="fw-bold">{{ $item->order->project_name ?? '-' }}</div>
-                        <div class="small text-muted">{{ $item->order->employer->employerNameTh ?? '-' }}</div>
+                        <div class="fw-bold">{{ $item->order?->project_name ?? '-' }}</div>
+                        <div class="small text-muted">{{ $item->order?->employer?->employerNameTh ?? '-' }}</div>
                     </td>
                     <td>
                         @if($item->employee)


### PR DESCRIPTION
1.  **Trash Bin Fix:** Updated `resources/views/workflow/partials/trash_list.blade.php` to use the null-safe operator (`?->`) when accessing `order` and `employer` relationships. This prevents `ErrorException` when viewing trash items whose parent records have been permanently deleted.
2.  **Employee Card Update:** Modified `resources/views/workflow/partials/_item_card.blade.php` to display and edit the `outsource_code` instead of the system user `password`. This aligns the UI with the user's requirement to manage the Outsource Code from the card.
3.  **Backend Logic:** Updated `WorkflowController@updateCredentials` to validate and update the `outsource_code` field on the `Employee` model.
4.  **Bug Fix:** Removed `visaType` from the `WorkflowController@store` input filtering, as this column does not exist in the database and was causing 500 errors during employee creation.