### PR TITLE
Sort cancelled items/orders to the end of paginated results

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -204,6 +204,15 @@ class RegistrationController extends Controller
             $perPage = 20;
         }
 
+        // SORTING: Push cancelled employers to the end
+        $employerQuery->orderByRaw("(
+            SELECT CASE WHEN status = 'registration_resolution_cancelled' THEN 1 ELSE 0 END
+            FROM production_orders
+            WHERE production_orders.employer_id = employers.id
+            AND production_orders.status IN ('registration_resolution', 'registration_resolution_cancelled')
+            LIMIT 1
+        ) ASC");
+
         $employers = $employerQuery->paginate($perPage)->withQueryString();
 
         // --- 4. Process Employers (Assign Stats) ---
@@ -314,14 +323,6 @@ class RegistrationController extends Controller
             // NOTE: We do NOT assign $employer->employees here to keep response light.
             // The view will lazily load them.
         }
-
-        // Sort Employers (Current Page Only)
-        // To sort globally, we would need to join tables, but pagination breaks "bottom of list".
-        // We sort the current page to keep consistency.
-        $sortedCollection = $employers->getCollection()->sortBy(function($emp) {
-            return $emp->financeOrder->status === 'registration_resolution_cancelled' ? 1 : 0;
-        });
-        $employers->setCollection($sortedCollection);
 
         return view('production.registration.index', compact(
             'totalEmployees',

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -140,6 +140,15 @@ class RenewalController extends Controller
             $perPage = 20;
         }
 
+        // SORTING: Push cancelled employers to the end
+        $employerQuery->orderByRaw("(
+            SELECT CASE WHEN status = 'renewal_resolution_cancelled' THEN 1 ELSE 0 END
+            FROM production_orders
+            WHERE production_orders.employer_id = employers.id
+            AND production_orders.status IN ('renewal_resolution', 'renewal_resolution_cancelled')
+            LIMIT 1
+        ) ASC");
+
         $employers = $employerQuery->paginate($perPage)->withQueryString();
 
         // --- 5. Process Employers ---
@@ -206,12 +215,6 @@ class RenewalController extends Controller
             $employer->cancelledCount = $empCancelledCount;
             $employer->savedCount = $empSavedCount;
         }
-
-        // Sort Employers (Current Page Only)
-        $sortedCollection = $employers->getCollection()->sortBy(function($emp) {
-            return $emp->financeOrder->status === 'renewal_resolution_cancelled' ? 1 : 0;
-        });
-        $employers->setCollection($sortedCollection);
 
         // Get Current Expiry Setting
         $currentExpiryConfig = SystemConfig::where('key', 'renewal_target_expiry_date')->value('value');

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -129,11 +129,17 @@ class ProductionController extends Controller
             }
 
             // SORTING
-            $query->withCount(['items as active_items_count' => function ($q) {
-                $q->whereNotIn('status', ['cancelled', 'completed']);
-            }]);
+            $query->withCount([
+                'items as active_items_count' => function ($q) {
+                    $q->whereNotIn('status', ['cancelled', 'completed']);
+                },
+                'items as cancelled_items_count' => function ($q) {
+                    $q->where('status', 'cancelled');
+                }
+            ]);
 
             $orders = $query->orderByDesc('active_items_count')
+                            ->orderBy('cancelled_items_count')
                             ->latest('updated_at')
                             ->paginate($perPage)
                             ->withQueryString();

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -104,16 +104,23 @@ class WorkflowController extends Controller
         }
 
         // SORTING: Active items (not cancelled/completed) first, then updated_at
-        $query->withCount(['items as active_items_count' => function ($q) {
-            $q->whereNotIn('status', ['cancelled', 'completed']);
-        }]);
+        $query->withCount([
+            'items as active_items_count' => function ($q) {
+                $q->whereNotIn('status', ['cancelled', 'completed']);
+            },
+            'items as cancelled_items_count' => function ($q) {
+                $q->where('status', 'cancelled');
+            }
+        ]);
 
         $perPage = $request->input('per_page', 20);
         if (!in_array($perPage, [20, 50, 100])) {
             $perPage = 20;
         }
 
-        $orders = $query->orderByDesc('active_items_count')
+        $orders = $query->orderByRaw("CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END")
+                        ->orderByDesc('active_items_count')
+                        ->orderBy('cancelled_items_count')
                         ->latest('updated_at')
                         ->paginate($perPage)
                         ->withQueryString();


### PR DESCRIPTION
Updated Pre-Production, Workflow, Registration Resolution, and Renewal Resolution controllers to push cancelled items (or orders with all cancelled items) to the end of the list, ensuring they do not clutter the first page of results.

- Production/Workflow: Sort by cancelled status and cancelled items count.
- Registration/Renewal: Sort by subquery on ProductionOrder status.