### PR TITLE
Fix: Immediately update employee list after saving financial settings

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -397,6 +397,7 @@ class ProductionController extends Controller
              // The JS sends a clean JSON body.
 
              $jsonPayload = $request->json()->all();
+             $createdItemIds = [];
 
              // Handle Price Tier Item Creation (Auto-convert candidates to items)
              if (isset($jsonPayload['pricing_tiers']) && is_array($jsonPayload['pricing_tiers'])) {
@@ -418,6 +419,7 @@ class ProductionController extends Controller
                                      ]
                                  );
                                  $newItemIds[] = $item->id;
+                                 $createdItemIds[] = $item->id;
                              } else {
                                  $newItemIds[] = $itemId;
                              }
@@ -431,9 +433,34 @@ class ProductionController extends Controller
 
              $group->financial_data = $jsonPayload;
              $group->save();
-        }
 
-        return response()->json(['success' => true, 'group' => $group->fresh()]);
+             // Fetch newly created items to return to frontend
+             $newItems = [];
+             if (!empty($createdItemIds)) {
+                 $rawItems = \App\Models\ProductionItem::with('employee')
+                     ->whereIn('id', $createdItemIds)
+                     ->get();
+
+                 $newItems = $rawItems->map(function($item) {
+                     $emp = $item->employee;
+                     return [
+                         'id' => $item->id,
+                         'name' => $emp ? ($emp->employeeNameTh ?? $emp->employeeNameEn ?? 'New Employee') : 'New Item',
+                         'name_en' => $emp->employeeNameEn ?? '',
+                         'title_en' => $emp->employeeTitleEn ?? '',
+                         'photo' => $emp->photo_url ?? '',
+                         'nationality' => $emp->employeeNationality ?? '',
+                         'employee_id' => $item->employee_id,
+                     ];
+                 });
+             }
+
+             return response()->json([
+                 'success' => true,
+                 'group' => $group->fresh(),
+                 'new_items' => $newItems
+             ]);
+        }
     }
 
     public function destroyFinancialGroup(Request $request, $id, $groupId)

--- a/resources/js/financial-manager.js
+++ b/resources/js/financial-manager.js
@@ -781,6 +781,25 @@ if (typeof window.financialManager === 'undefined') {
                                 this.switchGroup(this.activeGroupId);
                             }
                         }
+
+                        // Add new items (converted from candidates) to productionItems list
+                        if (data.new_items && Array.isArray(data.new_items)) {
+                            data.new_items.forEach(newItem => {
+                                const exists = this.productionItems.find(pi => pi.id === newItem.id);
+                                if (!exists) {
+                                    this.productionItems.push({
+                                        id: newItem.id,
+                                        name: newItem.name,
+                                        name_en: newItem.name_en,
+                                        title_en: newItem.title_en,
+                                        photo: newItem.photo,
+                                        nationality: newItem.nationality,
+                                        employee_id: newItem.employee_id
+                                    });
+                                }
+                            });
+                        }
+
                         Swal.fire({ icon: 'success', title: 'Saved', text: 'Settings updated.', timer: 1000, showConfirmButton: false });
                     }
                 })


### PR DESCRIPTION
When setting "price per head" for new employees (candidates), saving the settings creates production items on the backend but the frontend was not updating its local list. This prevented users from immediately adding installments for those employees without a refresh.

This commit:
1. Updates `ProductionController@updateFinancialGroup` to return newly created `ProductionItem` records in the response.
2. Updates `financial-manager.js` to process these `new_items` and add them to the local `productionItems` state.