### PR TITLE
Fix employer search in Add Employee modal to fallback to English name

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -618,7 +618,7 @@ class EmployerController extends Controller
             });
         }
 
-        $employers = $query->select(['id', 'employerNameTh', 'employerId'])->take(10)->get();
+        $employers = $query->select(['id', 'employerNameTh', 'employerNameEn', 'employerId'])->take(10)->get();
         return response()->json($employers);
     }
 

--- a/resources/views/workflow/partials/add_employee_modal.blade.php
+++ b/resources/views/workflow/partials/add_employee_modal.blade.php
@@ -450,7 +450,7 @@
     function selectEmployer(emp) {
         document.getElementById('modal_employer_id').value = emp.id;
         document.getElementById('employer-search-input').value = emp.employerNameTh || emp.employerNameEn;
-        document.getElementById('selected-employer-text').innerText = `Selected: ${emp.employerNameTh} (${emp.employerId})`;
+        document.getElementById('selected-employer-text').innerText = `Selected: ${emp.employerNameTh || emp.employerNameEn} (${emp.employerId})`;
         document.getElementById('employer-search-results').style.display = 'none';
         document.getElementById('btn-clear-employer').classList.remove('d-none');
 


### PR DESCRIPTION
- Updated `EmployerController@listApi` to include `employerNameEn` in the response.
- Updated `resources/views/workflow/partials/add_employee_modal.blade.php` to use `employerNameEn` if `employerNameTh` is missing in the selection text and search results.
- This resolves an issue where employers with only English names were not selectable or displayed correctly in the "Add Internal Employee" (Select Existing) channel.