### PR TITLE
fix(employees): resolve background removal process hanging

### DIFF
--- a/resources/views/components/cropper-modal.blade.php
+++ b/resources/views/components/cropper-modal.blade.php
@@ -12,6 +12,9 @@
                         <span class="visually-hidden">Loading...</span>
                     </div>
                     <div id="cropperLoadingText" class="mt-2 text-primary fw-bold">{{ __('Processing...') }}</div>
+                    <button type="button" id="cancelProcessingBtn" class="btn btn-danger btn-sm mt-3">
+                        <i class="bi bi-x-circle"></i> {{ __('Cancel') }}
+                    </button>
                 </div>
 
                 <style>

--- a/resources/views/employees/partials/_edit_scripts.blade.php
+++ b/resources/views/employees/partials/_edit_scripts.blade.php
@@ -107,6 +107,9 @@
         const bgToolbar = document.getElementById('bgToolbar');
         const loadingOverlay = document.getElementById('cropperLoadingOverlay');
         const loadingText = document.getElementById('cropperLoadingText');
+        const cancelBtn = document.getElementById('cancelProcessingBtn'); // New button
+
+        let currentCancellationToken = null;
 
         if (bgToolbar) {
             bgToolbar.addEventListener('click', async function(e) {
@@ -121,15 +124,26 @@
                     return;
                 }
 
+                // Disable UI
+                const allButtons = cropperModalEl.querySelectorAll('button');
+                allButtons.forEach(b => b.disabled = true);
+                if(cancelBtn) cancelBtn.disabled = false;
+
                 try {
                     // Show Loading
                     if (loadingOverlay) loadingOverlay.classList.remove('d-none');
                     if (loadingText) loadingText.textContent = 'Processing...';
 
+                    // Create Token
+                    currentCancellationToken = { cancelled: false, onCancel: null };
+
                     // Process
                     const processedBlob = await window.backgroundRemoval.process(originalFile, action, (active, text) => {
                         if (loadingText && text) loadingText.textContent = text;
-                    });
+                    }, currentCancellationToken);
+
+                    // Check Cancellation
+                    if (currentCancellationToken.cancelled) return;
 
                     // Update Mime Type for Saving
                     if (action === 'transparent') {
@@ -150,11 +164,30 @@
                     initCropperInstance();
 
                 } catch (err) {
-                    console.error(err);
-                    alert('Failed to process image: ' + err.message);
+                    if (err.message === 'Cancelled by user') {
+                        console.log('Processing cancelled');
+                    } else {
+                        console.error(err);
+                        alert('Failed to process image: ' + err.message);
+                    }
                 } finally {
                     // Hide Loading
                     if (loadingOverlay) loadingOverlay.classList.add('d-none');
+                    // Enable UI
+                    const allButtons = cropperModalEl.querySelectorAll('button');
+                    allButtons.forEach(b => b.disabled = false);
+                    currentCancellationToken = null;
+                }
+            });
+        }
+
+        // Cancel Button Listener
+        if (cancelBtn) {
+            cancelBtn.addEventListener('click', function() {
+                if (currentCancellationToken) {
+                    currentCancellationToken.cancelled = true;
+                    if (currentCancellationToken.onCancel) currentCancellationToken.onCancel();
+                    if (loadingText) loadingText.textContent = 'Cancelling...';
                 }
             });
         }

--- a/resources/views/partials/background-removal-scripts.blade.php
+++ b/resources/views/partials/background-removal-scripts.blade.php
@@ -19,7 +19,7 @@
         },
 
         // Main function to process image
-        async process(file, colorType, onProgress) {
+        async process(file, colorType, onProgress, cancellationToken) {
             // 1. Reset cache if file changed
             if (this.cache.originalFile !== file) {
                 this.cache.originalFile = file;
@@ -39,12 +39,18 @@
                     if (onProgress) onProgress(true, 'Initializing AI Model...');
 
                     // Check if library is loaded (Wait up to 10 seconds)
-                    const removeBackgroundFn = await this.waitForLibrary();
+                    const removeBackgroundFn = await this.waitForLibrary(cancellationToken);
+
+                    if (cancellationToken && cancellationToken.cancelled) {
+                        throw new Error('Cancelled by user');
+                    }
 
                     if (onProgress) onProgress(true, 'Removing background (this may take a moment)...');
 
                     // Configuration for better quality and progress tracking
                     const config = {
+                        publicPath: 'https://cdn.jsdelivr.net/npm/@imgly/background-removal-data@1.7.0/dist/',
+                        debug: true,
                         progress: (key, current, total) => {
                             if (onProgress) {
                                 const percent = Math.round((current / total) * 100);
@@ -58,18 +64,29 @@
                         }
                     };
 
-                    // Execute removal with timeout race
+                    // Execute removal with timeout and cancellation race
                     const processPromise = removeBackgroundFn(file, config);
+
                     const timeoutPromise = new Promise((_, reject) =>
-                        setTimeout(() => reject(new Error('Processing timed out (30s). Please check your connection.')), 30000)
+                        setTimeout(() => reject(new Error('Processing timed out (60s). Please check your connection.')), 60000)
                     );
 
-                    transparentBlob = await Promise.race([processPromise, timeoutPromise]);
+                    const cancellationPromise = new Promise((_, reject) => {
+                        if (cancellationToken) {
+                            cancellationToken.onCancel = () => reject(new Error('Cancelled by user'));
+                            if (cancellationToken.cancelled) reject(new Error('Cancelled by user'));
+                        }
+                    });
+
+                    transparentBlob = await Promise.race([processPromise, timeoutPromise, cancellationPromise]);
 
                     this.cache.transparentBlob = transparentBlob;
                 } catch (error) {
                     console.error('Background removal failed:', error);
                     // Provide user-friendly error
+                    if (error.message === 'Cancelled by user') {
+                        throw error; // Propagate cancellation
+                    }
                     if (error.message && error.message.includes('fetch')) {
                         throw new Error('Failed to download AI model. Please check your internet connection.');
                     }
@@ -87,6 +104,9 @@
             // 5. Composite for colors
             if (onProgress) onProgress(true, 'Applying background color...');
             try {
+                // Check cancellation before compositing
+                if (cancellationToken && cancellationToken.cancelled) throw new Error('Cancelled by user');
+
                 const color = this.colors[colorType] || '#FFFFFF';
                 return await this.compositeBackground(transparentBlob, color);
             } finally {
@@ -95,7 +115,7 @@
         },
 
         // Helper to wait for the ESM module to load
-        waitForLibrary() {
+        waitForLibrary(cancellationToken) {
             return new Promise((resolve, reject) => {
                 if (window.imglyRemoveBackground) {
                     resolve(window.imglyRemoveBackground);
@@ -104,6 +124,11 @@
 
                 let retries = 0;
                 const interval = setInterval(() => {
+                    if (cancellationToken && cancellationToken.cancelled) {
+                        clearInterval(interval);
+                        reject(new Error('Cancelled by user'));
+                        return;
+                    }
                     if (window.imglyRemoveBackground) {
                         clearInterval(interval);
                         resolve(window.imglyRemoveBackground);


### PR DESCRIPTION
- Update `@imgly/background-removal` configuration to use jsDelivr CDN for data assets (`publicPath`) to prevent loading hangs.
- Enable `debug` mode for better error visibility.
- Add a "Cancel" button to the processing overlay in `cropper-modal.blade.php`.
- Implement cancellation logic in `_edit_scripts.blade.php` and `background-removal-scripts.blade.php` to allow users to abort the process.
- Increase process timeout to 60s.