### PR TITLE
feat: add 'Send Back to Pre-Production' button in Workflow

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -1169,6 +1169,85 @@ class WorkflowController extends Controller
     }
 
     /**
+     * Send an item back to Pre-Production (Preparation).
+     */
+    public function sendBackToPreProduction(Request $request, $itemId)
+    {
+        $item = ProductionItem::with(['order', 'employee'])->findOrFail($itemId);
+        $currentOrder = $item->order;
+
+        if ($currentOrder->status === 'pre_production') {
+            return response()->json(['success' => false, 'message' => 'Item is already in Pre-Production.'], 400);
+        }
+
+        // Check if employee is already in Pre-Production for this process
+        $hasDuplicate = ProductionItem::where('employee_id', $item->employee_id)
+            ->whereHas('order', function($q) use ($currentOrder) {
+                $q->where('work_type_id', $currentOrder->work_type_id)
+                  ->where('status', 'pre_production');
+            })
+            ->whereNotIn('status', ['cancelled', 'completed'])
+            ->exists();
+
+        if ($hasDuplicate) {
+             return response()->json([
+                 'success' => false,
+                 'message' => 'This employee is already in Pre-Production for this process.'
+             ], 400);
+        }
+
+        DB::beginTransaction();
+        try {
+            // Find a Pre-Production Order for this Employer + WorkType
+            $preProdOrder = ProductionOrder::where('employer_id', $currentOrder->employer_id)
+                                ->where('work_type_id', $currentOrder->work_type_id)
+                                ->where('status', 'pre_production')
+                                ->latest()
+                                ->first();
+
+            if (!$preProdOrder) {
+                // Create new Pre-Production Order
+                $workTypeName = $currentOrder->workType->name ?? 'Job';
+                $employerName = $currentOrder->employer->employerNameTh ?? 'Unknown';
+
+                $preProdOrder = ProductionOrder::create([
+                    'employer_id' => $currentOrder->employer_id,
+                    'work_type_id' => $currentOrder->work_type_id,
+                    'type' => $currentOrder->type,
+                    'project_name' => "$workTypeName - $employerName (Prep)",
+                    'description' => $currentOrder->description,
+                    'status' => 'pre_production',
+                    'created_by' => auth()->id(),
+                ]);
+            }
+
+            // Move Item
+            $item->update([
+                'production_order_id' => $preProdOrder->id,
+                'status' => 'pending',
+                'last_checked_at' => null,
+                'appointment_date' => null,
+                'appointment_location' => null,
+                'appointment_completed_at' => null,
+            ]);
+
+            // Clear Completed Steps (Workflow steps do not map to Preparation steps 1:1)
+            $item->completedWorkTypeSteps()->detach();
+
+            DB::commit();
+
+            // Calculate Stats for the OLD order (Workflow) to update UI
+            $orderStats = $this->calculateOrderStats($currentOrder);
+
+            return response()->json(['success' => true, 'order_stats' => $orderStats]);
+
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
      * Soft Delete an Item.
      */
     public function destroyItem(Request $request, $itemId)

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1021,6 +1021,53 @@
     }
 
     // --- Item Actions ---
+    window.sendBackToPreProduction = function(itemId) {
+        Swal.fire({
+            title: '{{ __("Send Back to Preparation?") }}',
+            text: '{{ __("Employee will be moved back to Pre-Production list.") }}',
+            icon: 'question',
+            showCancelButton: true,
+            confirmButtonText: '{{ __("Yes, Send Back") }}',
+            confirmButtonColor: '#0dcaf0'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                fetch(`/workflow/item/${itemId}/send-back`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': csrfToken },
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if(data.success) {
+                        // Remove card from UI
+                        const card = document.getElementById(`item-card-${itemId}`);
+                        const wrapper = card.closest('.order-content-wrapper');
+                        card.remove();
+                        recalculateSequenceNumbers();
+
+                        // Check if wrapper is empty
+                        if(wrapper && wrapper.querySelectorAll('.item-card-wrapper').length === 0) {
+                            const orderCard = wrapper.closest('.production-order-card');
+                            if(orderCard) {
+                                orderCard.classList.add('grayscale-mode');
+                            }
+                        }
+
+                        Swal.fire('{{ __("Sent Back!") }}', '{{ __("Employee moved to Pre-Production.") }}', 'success');
+
+                        if(data.order_stats) {
+                             if(wrapper) {
+                                 const orderId = wrapper.id.replace('order-content-', '');
+                                 updateOrderHeaderStats(orderId, data.order_stats);
+                             }
+                        }
+                    } else {
+                        Swal.fire('{{ __("Error") }}', data.message || '{{ __("Failed to send back.") }}', 'error');
+                    }
+                });
+            }
+        });
+    }
+
     window.finalizeItem = function(itemId) {
         Swal.fire({
             title: '{{ __("Complete Item?") }}',

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -404,6 +404,15 @@
                             <i class="bi bi-box-arrow-right"></i> <span class="d-none d-lg-inline">{{ __('Send to Workflow') }}</span>
                         </button>
                     @else
+                        {{-- Send Back to Pre-Production --}}
+                        @if(!$isCompleted && !$isCancelled)
+                        <button class="btn btn-info btn-sm fw-bold shadow-sm px-3 text-white"
+                                onclick="sendBackToPreProduction({{ $item->id }})"
+                                title="{{ __('Back to Preparation') }}">
+                             <i class="bi bi-arrow-counterclockwise"></i> <span class="d-none d-lg-inline">{{ __('Back to Prep') }}</span>
+                        </button>
+                        @endif
+
                         {{-- Daily Check Button (Only in Workflow) --}}
                         @if(!$isCheckedToday && !$isCompleted && !$isCancelled)
                             <button class="btn btn-warning btn-sm fw-bold shadow-sm" onclick="checkDaily({{ $item->id }})" title="Daily Check">

--- a/routes/web.php
+++ b/routes/web.php
@@ -336,6 +336,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('workflow/item/{item}/finalize', [\App\Http\Controllers\WorkflowController::class, 'finalizeItem'])->name('workflow.item.finalize');
     Route::post('workflow/item/{item}/cancel', [\App\Http\Controllers\WorkflowController::class, 'cancelItem'])->name('workflow.item.cancel');
     Route::post('workflow/item/{item}/restore', [\App\Http\Controllers\WorkflowController::class, 'restoreItem'])->name('workflow.item.restore');
+    Route::post('workflow/item/{item}/send-back', [\App\Http\Controllers\WorkflowController::class, 'sendBackToPreProduction'])->name('workflow.item.send_back');
     Route::delete('workflow/item/{item}', [\App\Http\Controllers\WorkflowController::class, 'destroyItem'])->name('workflow.item.destroy');
     Route::get('workflow/api/resigned-employees', [\App\Http\Controllers\WorkflowController::class, 'searchResignedEmployees'])->name('workflow.api.resigned');
     Route::get('workflow/api/global-employees', [\App\Http\Controllers\WorkflowController::class, 'searchGlobalEmployees'])->name('workflow.api.global');


### PR DESCRIPTION
- Added `sendBackToPreProduction` method in `WorkflowController` to handle item movement.
- Added POST route `workflow/item/{item}/send-back`.
- Added "Back to Prep" button in `_item_card.blade.php`.
- Implemented JS function `sendBackToPreProduction` in `workflow/index.blade.php`.
- Implemented logic to find or create Pre-Production order and prevent duplicates.