### PR TITLE
Fix background removal 'Resource metadata not found' and improve quality

### DIFF
--- a/resources/views/partials/background-removal-scripts.blade.php
+++ b/resources/views/partials/background-removal-scripts.blade.php
@@ -48,8 +48,9 @@
                     if (onProgress) onProgress(true, 'Removing background (this may take a moment)...');
 
                     // Configuration for better quality and progress tracking
+                    // NOTE: Removed publicPath to let the library use its default (matching version 1.7.0).
+                    // This fixes the "Resource metadata not found" error caused by version mismatch.
                     const config = {
-                        publicPath: 'https://cdn.jsdelivr.net/npm/@imgly/background-removal-data@1.4.5/dist/',
                         debug: true,
                         progress: (key, current, total) => {
                             if (onProgress) {
@@ -57,10 +58,10 @@
                                 onProgress(true, `Processing: ${percent}%`);
                             }
                         },
-                        model: 'small', // Use small model for faster processing
+                        // model: 'small', // Removed to use default (medium/isnet_fp16) for higher quality ("state-of-the-art")
                         output: {
                             format: 'image/png',
-                            quality: 0.8
+                            quality: 0.95 // Increased for better output
                         }
                     };
 


### PR DESCRIPTION
Removed incorrect `publicPath` configuration in `background-removal-scripts.blade.php`, allowing the library to use its default path matching version 1.7.0. This fixes the "Resource metadata not found" error caused by mismatch with version 1.4.5 assets. Also removed `model: 'small'` to use the default higher-quality model (isnet_fp16) and increased output quality to 0.95.