### PR TITLE
Fix finance billing logic: invoice grouping and frontend counts

### DIFF
--- a/app/Http/Controllers/FinancialController.php
+++ b/app/Http/Controllers/FinancialController.php
@@ -46,6 +46,7 @@ class FinancialController extends Controller
         ]);
 
         $finalItemIds = $request->item_ids ?? [];
+        $createdItemMap = []; // empId => itemId for syncing pricing tiers
 
         // Handle direct Employee IDs (Create items on the fly)
         if ($request->has('employee_ids') && is_array($request->employee_ids)) {
@@ -62,6 +63,7 @@ class FinancialController extends Controller
                     ]
                 );
                 $finalItemIds[] = $item->id;
+                $createdItemMap[$empId] = $item->id;
             }
         }
 
@@ -70,6 +72,10 @@ class FinancialController extends Controller
         if (!empty($finalItemIds)) {
             $transaction->items()->attach($finalItemIds);
         }
+
+        // Sync Pricing Tiers: Replace emp_X with new Item IDs in the pricing group
+        // This ensures invoices can map the new item back to its price tier correctly.
+        $this->syncPricingTiers($request->financial_group_id, $createdItemMap);
 
         // Return transaction with items to update frontend state if needed
         $transaction->load('items.employee'); // Load employee for name display
@@ -144,6 +150,7 @@ class FinancialController extends Controller
         if ($request->has('item_ids') || $request->has('employee_ids')) {
             $itemIds = $request->input('item_ids', []);
             $employeeIds = $request->input('employee_ids', []);
+            $createdItemMap = []; // empId => itemId
 
             // Handle FormData format (strings)
             if (is_string($itemIds)) {
@@ -169,6 +176,7 @@ class FinancialController extends Controller
                     ]
                 );
                 $itemIds[] = $item->id;
+                $createdItemMap[$empId] = $item->id;
             }
 
             $itemIds = array_unique($itemIds);
@@ -178,11 +186,61 @@ class FinancialController extends Controller
             if ($request->has('item_ids') || $request->has('employee_ids')) {
                 $transaction->items()->sync($itemIds);
             }
+
+            // Sync Pricing Tiers if items were created
+            if (!empty($createdItemMap)) {
+                $this->syncPricingTiers($transaction->production_financial_group_id, $createdItemMap);
+            }
         }
 
         $transaction->load('items.employee');
 
         return response()->json(['success' => true, 'transaction' => $transaction]);
+    }
+
+    /**
+     * Helper to update Pricing Tiers: Replace candidate emp_IDs with real ProductionItem IDs.
+     */
+    private function syncPricingTiers($financialGroupId, $createdItemMap)
+    {
+        if (empty($createdItemMap)) return;
+
+        $group = \App\Models\ProductionFinancialGroup::find($financialGroupId);
+        if (!$group) return;
+
+        $financialData = $group->financial_data;
+        $tiers = $financialData['pricing_tiers'] ?? [];
+        $updated = false;
+
+        foreach ($tiers as &$tier) {
+            if (isset($tier['item_ids']) && is_array($tier['item_ids'])) {
+                $newItemIds = [];
+                foreach ($tier['item_ids'] as $id) {
+                    // Check if this ID is a candidate placeholder (string starting with 'emp_')
+                    if (is_string($id) && str_starts_with($id, 'emp_')) {
+                        $empId = str_replace('emp_', '', $id);
+                        // If we have created a ProductionItem for this Employee ID, swap it
+                        if (isset($createdItemMap[$empId])) {
+                            $newItemIds[] = $createdItemMap[$empId];
+                            $updated = true;
+                        } else {
+                            $newItemIds[] = $id;
+                        }
+                    } else {
+                        $newItemIds[] = $id;
+                    }
+                }
+                $tier['item_ids'] = $newItemIds;
+                // Update count
+                $tier['count'] = count($newItemIds);
+            }
+        }
+
+        if ($updated) {
+            $financialData['pricing_tiers'] = $tiers;
+            $group->financial_data = $financialData;
+            $group->save();
+        }
     }
 
     /**

--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -925,6 +925,50 @@ if (typeof window.financialManager === 'undefined') {
             saveAsNewProfile() {
                  Swal.fire('Info', 'Feature coming soon.', 'info');
             },
+
+            get billedItemIds() {
+                const ids = new Set();
+                this.transactions.forEach(t => {
+                    // Only count active transactions
+                    if (t.status === 'cancelled') return;
+
+                    if (t.items && Array.isArray(t.items)) {
+                        t.items.forEach(i => ids.add(i.id));
+                    }
+                });
+                return ids;
+            },
+
+            getTierRemainingCount(index) {
+                const tier = this.pricingTiers[index];
+                if (!tier || !tier.item_ids) return 0;
+                // item_ids can be integers (ProductionItem) or strings (Candidate emp_X)
+                // billedItemIds are always integers (from transactions)
+                // So any 'emp_X' is automatically NOT billed (remains available)
+                // Any integer ID is checked against the set
+                const billed = this.billedItemIds;
+                return tier.item_ids.filter(id => {
+                    if (String(id).startsWith('emp_')) return true;
+                    return !billed.has(parseInt(id));
+                }).length;
+            },
+
+            get unassignedEmployeeCount() {
+                // Calculate Total Unique People Pool
+                // 1. All Production Items
+                const linkedEmployeeIds = new Set();
+                this.productionItems.forEach(pi => {
+                    if (pi.employee_id) linkedEmployeeIds.add(pi.employee_id);
+                });
+
+                // 2. Add Candidates who are NOT already linked to a ProductionItem
+                const uniqueCandidates = this.employees.filter(e => !linkedEmployeeIds.has(e.id)).length;
+
+                const totalPool = this.productionItems.length + uniqueCandidates;
+
+                return Math.max(0, totalPool - this.tierCountSum);
+            },
+
             loadAgentData() {
                 if(!this.selectedAgentId) return;
                 // Basic stub if we don't have an endpoint for this yet

--- a/tests/Feature/Production/FinancialTest.php
+++ b/tests/Feature/Production/FinancialTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature\Production;
+
+use App\Models\ProductionOrder;
+use App\Models\ProductionFinancialGroup;
+use App\Models\Employee;
+use App\Models\Employer;
+use App\Models\User;
+use App\Models\WorkType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FinancialTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_transaction_syncs_pricing_tiers()
+    {
+        // 1. Setup
+        // Create Role
+        \Spatie\Permission\Models\Role::create(['name' => 'admin']);
+
+        $user = User::factory()->create();
+        $user->assignRole('admin'); // Ensure permission
+
+        $employer = Employer::factory()->create();
+        $workType = WorkType::create(['name' => 'Test Job', 'slug' => 'test-job']);
+
+        $order = ProductionOrder::create([
+            'employer_id' => $employer->id,
+            'work_type_id' => $workType->id,
+            'status' => 'pre_production'
+        ]);
+
+        $employee = Employee::factory()->create();
+        $candidateId = $employee->id;
+
+        // Create Financial Group with pricing tier using emp_{id}
+        $group = $order->financialGroups()->create([
+            'name' => 'Group 1',
+            'financial_data' => [
+                'pricing_tiers' => [
+                    [
+                        'price' => 1000,
+                        'count' => 1,
+                        'item_ids' => ['emp_' . $candidateId] // Placeholder
+                    ]
+                ]
+            ]
+        ]);
+
+        // 2. Act: Call storeTransaction
+        $response = $this->actingAs($user)->postJson("/production/{$order->id}/transactions", [
+            'type' => 'installment',
+            'amount' => 1000,
+            'financial_group_id' => $group->id,
+            'employee_ids' => [$candidateId] // Passing candidate ID
+        ]);
+
+        // 3. Assert
+        $response->assertStatus(200);
+        $response->assertJson(['success' => true]);
+
+        // Verify Items Created
+        $this->assertDatabaseHas('production_items', [
+            'production_order_id' => $order->id,
+            'employee_id' => $candidateId
+        ]);
+
+        $newItem = \App\Models\ProductionItem::where('employee_id', $candidateId)->first();
+        $this->assertNotNull($newItem);
+
+        // Verify Pricing Tier Updated
+        $group->refresh();
+        $tiers = $group->financial_data['pricing_tiers'];
+        $this->assertCount(1, $tiers);
+        $this->assertContains($newItem->id, $tiers[0]['item_ids']);
+        $this->assertNotContains('emp_' . $candidateId, $tiers[0]['item_ids']);
+    }
+
+    public function test_update_transaction_syncs_pricing_tiers()
+    {
+        // 1. Setup
+        \Spatie\Permission\Models\Role::create(['name' => 'admin']);
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        $employer = Employer::factory()->create();
+        $workType = WorkType::create(['name' => 'Test Job 2', 'slug' => 'test-job-2']);
+
+        $order = ProductionOrder::create([
+            'employer_id' => $employer->id,
+            'work_type_id' => $workType->id,
+            'status' => 'pre_production'
+        ]);
+
+        $employee = Employee::factory()->create();
+        $candidateId = $employee->id;
+
+        // Create Financial Group
+        $group = $order->financialGroups()->create([
+            'name' => 'Group 1',
+            'financial_data' => [
+                'pricing_tiers' => [
+                    [
+                        'price' => 1000,
+                        'count' => 1,
+                        'item_ids' => ['emp_' . $candidateId]
+                    ]
+                ]
+            ]
+        ]);
+
+        // Create transaction first
+        $transaction = $group->transactions()->create([
+            'production_order_id' => $order->id,
+            'amount' => 1000,
+            'type' => 'installment',
+            'status' => 'pending'
+        ]);
+
+        // 2. Act: Call updateTransaction adding the candidate
+        $response = $this->actingAs($user)->putJson("/production/transactions/{$transaction->id}", [
+            'employee_ids' => [$candidateId]
+        ]);
+
+        // 3. Assert
+        $response->assertStatus(200);
+
+        // Verify Items Created
+        $newItem = \App\Models\ProductionItem::where('employee_id', $candidateId)->first();
+        $this->assertNotNull($newItem);
+
+        // Verify Pricing Tier Updated
+        $group->refresh();
+        $tiers = $group->financial_data['pricing_tiers'];
+        $this->assertContains($newItem->id, $tiers[0]['item_ids']);
+        $this->assertNotContains('emp_' . $candidateId, $tiers[0]['item_ids']);
+    }
+}


### PR DESCRIPTION
- Update `FinancialController.php` to sync pricing tiers in `ProductionFinancialGroup` when transactions are created or updated, replacing candidate placeholders (`emp_X`) with actual `ProductionItem` IDs. This ensures invoices can correctly group items by price tier.
- Update `financial-manager.js` to implement `billedItemIds`, `getTierRemainingCount`, and `unassignedEmployeeCount` getters. This ensures the UI accurately reflects available quantities for pricing tiers (subtracting billed items) and the total number of unassigned employees.
- Add `tests/Feature/Production/FinancialTest.php` to verify backend syncing logic.