### PR TITLE
Fix incorrect steps display for Pre-Production items in Workflow Cont…

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -525,8 +525,13 @@ class WorkflowController extends Controller
      */
     public function fetchOrderItems(Request $request, $orderId)
     {
-        $order = ProductionOrder::with(['workType.workflowSteps'])->findOrFail($orderId);
-        $steps = $order->workType->workflowSteps ?? collect();
+        $order = ProductionOrder::with('workType')->findOrFail($orderId);
+
+        if ($order->status === 'pre_production') {
+            $steps = $order->workType->preparationSteps;
+        } else {
+            $steps = $order->workType->workflowSteps;
+        }
 
         // Query Items
         $query = ProductionItem::with(['employee', 'completedWorkTypeSteps'])
@@ -600,8 +605,13 @@ class WorkflowController extends Controller
      */
     public function fetchOrderHistory(Request $request, $orderId)
     {
-        $order = ProductionOrder::with(['workType.workflowSteps'])->findOrFail($orderId);
-        $steps = $order->workType->workflowSteps ?? collect();
+        $order = ProductionOrder::with('workType')->findOrFail($orderId);
+
+        if ($order->status === 'pre_production') {
+            $steps = $order->workType->preparationSteps;
+        } else {
+            $steps = $order->workType->workflowSteps;
+        }
 
         $items = ProductionItem::with(['employee', 'completedWorkTypeSteps'])
             ->where('production_order_id', $orderId)
@@ -1391,11 +1401,16 @@ class WorkflowController extends Controller
     public function getItemHtml($itemId)
     {
         // Load filtered workflowSteps
-        $item = ProductionItem::with(['employee', 'order.employer', 'order.workType.workflowSteps', 'completedWorkTypeSteps'])
+        $item = ProductionItem::with(['employee', 'order.employer', 'order.workType', 'completedWorkTypeSteps'])
             ->findOrFail($itemId);
 
         $order = $item->order;
-        $steps = $order->workType->workflowSteps ?? collect();
+
+        if ($order->status === 'pre_production') {
+            $steps = $order->workType->preparationSteps;
+        } else {
+            $steps = $order->workType->workflowSteps;
+        }
 
         // Render just the card partial
         $html = view('workflow.partials._item_card', compact('item', 'steps', 'order'))->render();


### PR DESCRIPTION
…roller

The `WorkflowController` previously always fetched standard `workflowSteps` for orders, regardless of their status. This caused Pre-Production orders to display incorrect steps in the item list.

This commit updates `fetchOrderItems`, `fetchOrderHistory`, and `getItemHtml` methods in `WorkflowController` to check the order status. If the status is `pre_production`, it now fetches `preparationSteps` instead. This ensures consistency with the Pre-Production dashboard and correctly displays the preparation workflow for employees in that stage.