### PR TITLE
Fix: Filter workflow items by search term when expanding order

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -572,6 +572,44 @@ class WorkflowController extends Controller
             }
         }
 
+        // 3. Apply Search Filter
+        if ($request->has('search') && $request->search) {
+            $search = $request->search;
+
+            // Check if Order matches the search criteria (Project, Employer, etc.)
+            // If it DOES match, we show ALL items (user found the order).
+            // If it DOES NOT match, we assume the user found the order via a specific item/employee, so we show ONLY matching items.
+            $orderMatches = ProductionOrder::where('id', $orderId)
+                ->where(function($q) use ($search) {
+                    $q->where('project_name', 'like', "%{$search}%")
+                      ->orWhereHas('employer', function($e) use ($search) {
+                          $e->where('employerNameTh', 'like', "%{$search}%")
+                            ->orWhere('employerNameEn', 'like', "%{$search}%")
+                            ->orWhere(function($addrQ) use ($search) {
+                                $addrQ->filterByAddress($search);
+                            });
+                      })
+                      ->orWhereHas('creator', function($creator) use ($search) {
+                          $creator->where('name', 'like', "%{$search}%");
+                      })
+                      ->orWhereHas('updater', function($updater) use ($search) {
+                          $updater->where('name', 'like', "%{$search}%");
+                      })
+                      ->orWhereHas('employer.jobOwner', function($owner) use ($search) {
+                          $owner->where('name', 'like', "%{$search}%");
+                      });
+                })
+                ->exists();
+
+            if (!$orderMatches) {
+                 $query->whereHas('employee', function($q) use ($search) {
+                      $q->where('employeeNameTh', 'like', "%{$search}%")
+                        ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                        ->orWhere('employeePassport', 'like', "%{$search}%");
+                 });
+            }
+        }
+
         $items = $query->orderBy('group_name')
                        ->orderBy('id')
                        ->get();


### PR DESCRIPTION
- Updated `WorkflowController@fetchOrderItems` to respect the `search` query parameter.
- Implemented logic to check if the Order matches the search context (Project, Employer, etc.).
- If the Order does NOT match, the query now filters `ProductionItem`s to show only those matching the search term (Employee Name/Passport).
- If the Order DOES match, all items are shown (preserving existing functionality for employer-level searches).

This resolves the issue where searching for a specific employee would correctly find the job card, but expanding it would display all employees in that job instead of just the relevant one.