### PR TITLE
feat: enhance Employee Edit navigation and GPS button logic

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -448,11 +448,13 @@ public function create(Request $request) // เพิ่ม Request $request เ
         // Fetch missing fields to highlight in the view
         $missingFields = \App\Helpers\CompletenessHelper::getMissingFields($employee);
 
+        $returnUrl = request('return_url');
+
         if (request()->ajax()) {
-            return view('employees.partials._edit_form', compact('employee', 'employers', 'missingFields'));
+            return view('employees.partials._edit_form', compact('employee', 'employers', 'missingFields', 'returnUrl'));
         }
 
-        return view('employees.edit', compact('employee', 'employers', 'missingFields'));
+        return view('employees.edit', compact('employee', 'employers', 'missingFields', 'returnUrl'));
     }
 
     public function update(Request $request, Employee $employee)
@@ -668,12 +670,40 @@ public function create(Request $request) // เพิ่ม Request $request เ
             ]);
         }
 
-        return redirect($request->input('_previous', route('employees.index')))
-            ->with('success', 'Employee updated successfully.');
+        // Determine redirect target
+        $redirectUrl = $request->input('_previous', route('employees.index'));
+
+        // Ensure the anchor is present for highlighting
+        if (strpos($redirectUrl, '#') === false) {
+            $redirectUrl .= '#employee-card-' . $employee->id;
+        }
+
+        return redirect($redirectUrl)
+            ->with('success', 'Employee updated successfully.')
+            ->with('highlight_employee', $employee->id); // For legacy highlighting logic
     }
 
     public function locate(Employee $employee)
     {
+        // "Data to Know" / GPS Logic
+        // Check for active workflows/production items
+        $activeWorkflows = $employee->active_workflows;
+
+        if ($activeWorkflows && $activeWorkflows->isNotEmpty()) {
+            // Prioritize the first active workflow
+            $wf = $activeWorkflows->first();
+            $route = $wf->is_pre_production ? 'production.index' : 'workflow.index';
+
+            // Redirect to the dashboard with anchor to the item
+            // Note: The dashboards use order/item params for "GPS" expansion
+            return redirect()->route($route, [
+                'tab' => $wf->tab_slug,
+                'order' => $wf->order_id,
+                'item' => $wf->item_id
+            ])->with('highlight_item', $wf->item_id);
+        }
+
+        // Fallback: Go to Employer Structure (Employer Edit Page)
         return redirect()->route('employers.edit', $employee->employer_id)
                          ->with('highlight_employee', $employee->id);
     }

--- a/resources/views/components/employee-action-buttons.blade.php
+++ b/resources/views/components/employee-action-buttons.blade.php
@@ -8,7 +8,7 @@
     
     {{-- Edit Button (Yellow) --}}
     @can('edit-employees')
-        <a href="{{ route('employees.edit', ['employee' => $employee->id]) }}" class="btn btn-sm btn-warning" title="{{ __('Edit Employee') }}">
+        <a href="{{ route('employees.edit', ['employee' => $employee->id, 'return_url' => request()->fullUrl()]) }}" class="btn btn-sm btn-warning" title="{{ __('Edit Employee') }}">
             <i class="bi bi-pencil-fill"></i>
         </a>
     @endcan

--- a/resources/views/employees/partials/_edit_form.blade.php
+++ b/resources/views/employees/partials/_edit_form.blade.php
@@ -1,7 +1,7 @@
 <form id="employeeEditForm" action="{{ route('employees.update', $employee->id) }}" method="POST" enctype="multipart/form-data">
     @csrf
     @method('PUT')
-    <input type="hidden" name="_previous" value="{{ route('employees.edit', $employee->id) }}">
+    <input type="hidden" name="_previous" value="{{ old('_previous', $returnUrl ?? url()->previous()) }}">
     <input type="hidden" name="employer_id" value="{{ $employee->employer_id }}">
 
     {{-- Category 1: Personal Information --}}


### PR DESCRIPTION
- Updated `EmployeeController` `edit` and `update` methods to handle `return_url` for preserving user context.
- Updated `EmployeeController` `locate` method to redirect to active workflow/production dashboard if available, or fallback to Employer Edit.
- Updated `employee-action-buttons` component to pass `return_url` to the Edit link.
- Updated `_edit_form` partial to use `return_url` in the hidden `_previous` input.
- Ensured highlighting of employee cards upon redirection using URL hash anchors.
- Clarified "Back to Employer" button logic in Edit view to always return to Employer Structure (Edit Page).