### PR TITLE
Refactor Financial Manager to support real-time continuous updates an…

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -390,19 +390,19 @@ class ProductionController extends Controller
     public function updateFinancialGroup(Request $request, $id, $groupId)
     {
         $group = \App\Models\ProductionFinancialGroup::where('production_order_id', $id)->findOrFail($groupId);
+        $jsonPayload = $request->json()->all();
 
-        $data = $request->all();
-
-        // If simple rename
-        if ($request->has('name') && count($data) === 1) {
+        // 1. Handle Rename (Explicitly check for name, and absence of complex data)
+        // If the request is just { name: "..." }, treat as rename.
+        // We check if 'pricing_tiers' is missing to confirm it's not a full save.
+        if ($request->has('name') && !isset($jsonPayload['pricing_tiers'])) {
              $group->update(['name' => $request->name]);
-        } else {
-             // Saving Settings
-             // Filter out token or method if present, though $request->all() usually has them.
-             // Typically we want to save the payload as financial_data.
-             // The JS sends a clean JSON body.
+             return response()->json(['success' => true, 'group' => $group]);
+        }
 
-             $jsonPayload = $request->json()->all();
+        // 2. Handle Full Settings Save
+        // Check for key indicators of a full save payload
+        if (isset($jsonPayload['pricing_tiers']) || isset($jsonPayload['fixed_base_amount'])) {
              $createdItemIds = [];
 
              // Handle Price Tier Item Creation (Auto-convert candidates to items)
@@ -480,6 +480,8 @@ class ProductionController extends Controller
                  'new_items' => $newItems
              ]);
         }
+
+        return response()->json(['success' => false, 'message' => 'Invalid payload'], 400);
     }
 
     public function destroyFinancialGroup(Request $request, $id, $groupId)

--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -442,7 +442,7 @@ if (typeof window.financialManager === 'undefined') {
                 }
             },
 
-            addTransaction() {
+            addTransaction(shouldClose = false) {
                 if (!this.activeGroupId) {
                     Swal.fire('Error', 'Please select a financial tab first.', 'error');
                     return;
@@ -477,7 +477,11 @@ if (typeof window.financialManager === 'undefined') {
                 .then(data => {
                     if(data.success) {
                         this.transactions.push(data.transaction);
-                        bootstrap.Modal.getOrCreateInstance(this.$refs.addModal).hide();
+
+                        if (shouldClose) {
+                            bootstrap.Modal.getOrCreateInstance(this.$refs.addModal).hide();
+                        }
+
                         this.newTransaction = { type: 'installment', amount: '', due_date: '', notes: '' };
                         this.selectedTransactionItems = [];
 
@@ -495,12 +499,17 @@ if (typeof window.financialManager === 'undefined') {
                             });
                         }
 
-                        Swal.fire({
+                        // Use Toast for non-blocking success
+                        const Toast = Swal.mixin({
+                            toast: true,
+                            position: 'top-end',
+                            showConfirmButton: false,
+                            timer: 3000,
+                            timerProgressBar: true
+                        });
+                        Toast.fire({
                             icon: 'success',
-                            title: 'Success',
-                            text: 'Transaction added successfully',
-                            timer: 1500,
-                            showConfirmButton: false
+                            title: 'Transaction added successfully'
                         });
                     } else {
                          throw new Error(data.message || 'Unknown error');
@@ -562,12 +571,17 @@ if (typeof window.financialManager === 'undefined') {
                         }
 
                         bootstrap.Modal.getInstance(this.$refs.payModal).hide();
-                        Swal.fire({
+
+                        const Toast = Swal.mixin({
+                            toast: true,
+                            position: 'top-end',
+                            showConfirmButton: false,
+                            timer: 3000,
+                            timerProgressBar: true
+                        });
+                        Toast.fire({
                             icon: 'success',
-                            title: 'Success',
-                            text: 'Updated successfully',
-                            timer: 1500,
-                            showConfirmButton: false
+                            title: 'Updated successfully'
                         });
                     } else {
                         throw new Error(data.message || 'Unknown error');
@@ -836,7 +850,17 @@ if (typeof window.financialManager === 'undefined') {
                             });
                         }
 
-                        Swal.fire({ icon: 'success', title: 'Saved', text: 'Settings updated.', timer: 1000, showConfirmButton: false });
+                        const Toast = Swal.mixin({
+                            toast: true,
+                            position: 'top-end',
+                            showConfirmButton: false,
+                            timer: 3000,
+                            timerProgressBar: true
+                        });
+                        Toast.fire({
+                            icon: 'success',
+                            title: 'Settings updated'
+                        });
                     }
                 })
                 .catch(err => Swal.fire('Error', 'Failed to save settings', 'error'))

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -734,7 +734,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
-                    <form @submit.prevent="addTransaction">
+                    <form @submit.prevent="addTransaction(false)">
                         <div class="row">
                             <div class="col-md-6">
                                 <div class="mb-2">
@@ -800,7 +800,10 @@
                                 </div>
                             </div>
                         </div>
-                        <button type="submit" class="btn btn-primary btn-sm w-100 mt-3" :disabled="isSavingTransaction">Save</button>
+                        <div class="d-flex gap-2 mt-3">
+                             <button type="button" class="btn btn-outline-secondary btn-sm flex-grow-1" @click="if($el.closest('form').reportValidity()) { addTransaction(true); }" :disabled="isSavingTransaction">Save & Close</button>
+                             <button type="submit" class="btn btn-primary btn-sm flex-grow-1" :disabled="isSavingTransaction">Save & Add Another</button>
+                        </div>
                     </form>
                 </div>
             </div>
@@ -822,8 +825,11 @@
                                 <div class="mb-2">
                                     <label class="form-label small">Paid Amount</label>
                                     <input type="number" step="0.01" class="form-control form-control-sm" x-model="editingTransaction.paid_amount">
-                                    <div class="form-text small text-danger fw-bold">
-                                        {{ __('Total Balance Due') }}: <span x-text="formatCurrency(remainingBalance)"></span>
+                                    <div class="d-flex justify-content-between small text-muted mt-1" style="font-size: 0.75rem;">
+                                         <span>Total: <span x-text="formatCurrency(editingTransaction.amount)"></span></span>
+                                         <span :class="(editingTransaction.amount - (parseFloat(editingTransaction.paid_amount) || 0)) > 0.01 ? 'text-danger fw-bold' : 'text-success'">
+                                             Remaining: <span x-text="formatCurrency(Math.max(0, editingTransaction.amount - (parseFloat(editingTransaction.paid_amount) || 0)))"></span>
+                                         </span>
                                     </div>
                                 </div>
                                 <div class="mb-2">


### PR DESCRIPTION
…d fix renaming bug

- Fix `ProductionController@updateFinancialGroup` to correctly distinguish between renaming a tab (which only updates `name`) and saving settings (which updates `financial_data`), preventing settings from being overwritten.
- Enhance `financial-manager.js` to support continuous installment creation by keeping the modal open and resetting the form after adding a transaction.
- Replace blocking Swal success alerts with non-blocking Toast notifications for smoother workflow in `addTransaction`, `updateTransaction`, and `saveFinancialData`.
- Update `financial-tab.blade.php` "Add Installment" modal with "Save & Close" and "Save & Add Another" buttons.
- Update `financial-tab.blade.php` "Update Payment" modal to display the specific transaction's "Full Amount" and "Remaining Balance" dynamically.