### PR TITLE
Fix Automated PDF Generation errors by ensuring compatibility with FPDI.

### DIFF
--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -329,33 +329,32 @@ class PdfGeneratorService
         $nodeScriptPath = base_path('scripts/normalize_pdf.cjs');
         if (file_exists($nodeScriptPath)) {
 
-            // Check if node_modules exists to avoid silent failures or generic errors
+            // Check if node_modules exists
             $nodeModulesPath = base_path('node_modules/pdf-lib');
-            if (!file_exists($nodeModulesPath)) {
-                $errorMsg = "Node.js dependency 'pdf-lib' is missing. Please run 'npm install' to enable PDF repair.";
-                Log::error($errorMsg);
-                // Throw immediately so we don't try other strategies that will also fail or are less preferred
-                throw new \Exception($errorMsg);
+
+            // Only attempt Node strategy if dependencies exist
+            if (file_exists($nodeModulesPath)) {
+                $cmd = sprintf(
+                    'node %s %s %s 2>&1',
+                    escapeshellarg($nodeScriptPath),
+                    escapeshellarg($inputPath),
+                    escapeshellarg($outputPath)
+                );
+
+                exec($cmd, $output, $returnVar);
+
+                if ($returnVar === 0 && file_exists($outputPath) && filesize($outputPath) > 0) {
+                    return $outputPath;
+                }
+
+                Log::warning('Node.js PDF normalization failed', [
+                    'cmd' => $cmd,
+                    'return' => $returnVar,
+                    'output' => $output
+                ]);
+            } else {
+                Log::warning("Node.js dependency 'pdf-lib' missing. Skipping Node strategy.");
             }
-
-            $cmd = sprintf(
-                'node %s %s %s 2>&1',
-                escapeshellarg($nodeScriptPath),
-                escapeshellarg($inputPath),
-                escapeshellarg($outputPath)
-            );
-
-            exec($cmd, $output, $returnVar);
-
-            if ($returnVar === 0 && file_exists($outputPath) && filesize($outputPath) > 0) {
-                return $outputPath;
-            }
-
-            Log::warning('Node.js PDF normalization failed', [
-                'cmd' => $cmd,
-                'return' => $returnVar,
-                'output' => $output
-            ]);
         }
 
         // Fallback strategies: Ghostscript or Python

--- a/scripts/normalize_pdf.cjs
+++ b/scripts/normalize_pdf.cjs
@@ -16,7 +16,8 @@ async function normalize() {
     const pdfDoc = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
 
     // Convert to standard PDF structure
-    const pdfBytesSaved = await pdfDoc.save();
+    // Disable object streams for FPDI compatibility (FPDI free version does not support PDF 1.5+ compressed object streams)
+    const pdfBytesSaved = await pdfDoc.save({ useObjectStreams: false });
 
     fs.writeFileSync(outputPath, pdfBytesSaved);
     console.log("PDF normalized successfully");


### PR DESCRIPTION
- Modified `scripts/normalize_pdf.cjs` to save PDFs with `{ useObjectStreams: false }`. This disables compressed object streams (PDF 1.5+), which are not supported by the free version of FPDI used in `PdfGeneratorService`.
- Updated `app/Services/PdfGeneratorService.php` to handle missing Node.js dependencies gracefully. Instead of throwing an exception when `pdf-lib` is missing, it now logs a warning and proceeds to fallback strategies (Ghostscript/Python), preventing application crashes in environments without Node.js.

This resolves the "Failed to process PDF template" error caused by unsupported compression techniques.