### PR TITLE
Fix Smart Eraser tool and update OpenCV version

### DIFF
--- a/resources/views/components/cropper-modal.blade.php
+++ b/resources/views/components/cropper-modal.blade.php
@@ -151,4 +151,4 @@
 </div>
 
 <!-- Load OpenCV for Smart Eraser -->
-<script async src="https://docs.opencv.org/4.x/opencv.js" onload="document.dispatchEvent(new Event('opencv-loaded-cropper'))"></script>
+<script async src="https://docs.opencv.org/4.8.0/opencv.js" onload="document.dispatchEvent(new Event('opencv-loaded-cropper'))"></script>

--- a/resources/views/employees/partials/_edit_scripts.blade.php
+++ b/resources/views/employees/partials/_edit_scripts.blade.php
@@ -892,6 +892,7 @@
                 let srcMat = null, mask = null, bgdModel = null, fgdModel = null;
                 let binMask = null, one = null, alphaScale = null, finalMask = null;
                 let alphaMat = null, finalAlphaMat = null, tempMask = null;
+                let rgbaPlanes = null, finalRGBA = null; // New Mats for Alpha Merge
                 let srcCanvas = null, maskCanvas = null;
                 let rect = null;
 
@@ -1003,8 +1004,22 @@
                     finalMask = new cv.Mat();
                     cv.resize(binMask, finalMask, new cv.Size(width, height), 0, 0, cv.INTER_LINEAR);
 
+                    // Create RGBA Mat where Alpha = finalMask to ensure destination-in works correctly
+                    // (destination-in uses the Source Alpha to mask the Destination)
+                    rgbaPlanes = new cv.MatVector();
+                    finalRGBA = new cv.Mat();
+
+                    // Push finalMask into all channels (R, G, B, A)
+                    // We only strictly need it in Alpha, but filling all is safe.
+                    rgbaPlanes.push_back(finalMask);
+                    rgbaPlanes.push_back(finalMask);
+                    rgbaPlanes.push_back(finalMask);
+                    rgbaPlanes.push_back(finalMask);
+
+                    cv.merge(rgbaPlanes, finalRGBA);
+
                     // Apply to Work Canvas
-                    cv.imshow(this.tempCanvas, finalMask);
+                    cv.imshow(this.tempCanvas, finalRGBA);
 
                     const ctx = this.workCanvas.getContext('2d');
                     ctx.clearRect(0, 0, width, height);
@@ -1033,6 +1048,8 @@
                     if(alphaMat && !alphaMat.isDeleted()) alphaMat.delete();
                     if(finalAlphaMat && !finalAlphaMat.isDeleted()) finalAlphaMat.delete();
                     if(tempMask && !tempMask.isDeleted()) tempMask.delete();
+                    if(finalRGBA && !finalRGBA.isDeleted()) finalRGBA.delete();
+                    if(rgbaPlanes && !rgbaPlanes.isDeleted()) rgbaPlanes.delete();
                     if(rect) rect.delete(); // Delete rect (it's a C++ object, not a Mat, so no isDeleted check usually needed but safe to check if it exists)
 
                     if(srcCanvas) srcCanvas.remove();


### PR DESCRIPTION
- Updated `cropper-modal.blade.php` to use stable OpenCV 4.8.0.
- Fixed `applySmartErase` in `_edit_scripts.blade.php` to correctly apply the segmentation mask using the Alpha channel, resolving the issue where the eraser had no effect.
- Added proper memory cleanup for new OpenCV matrices.