### PR TITLE
Fix GPS button to locate employee on Employer Edit page

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -725,34 +725,36 @@ public function create(Request $request) // เพิ่ม Request $request เ
 
     public function locate(Employee $employee)
     {
-        // "Data to Know" / GPS Logic
-        // Check for active workflows/production items
-        $activeWorkflows = $employee->active_workflows;
+        // GPS Logic: Always go to Employer Edit page and locate the employee card
 
-        if ($activeWorkflows && $activeWorkflows->isNotEmpty()) {
-            // Prioritize the first active workflow
-            $wf = $activeWorkflows->first();
+        $perPage = 10; // Default pagination size in EmployerController
 
-            // Handle Synthetic Workflows (Registration / Renewal) which have a direct URL property
-            if (isset($wf->url)) {
-                return redirect($wf->url);
-            }
+        // Base query matching EmployerController@edit default view
+        $query = $employee->employer->employees()
+            ->whereNull('terminated_at')
+            ->where(function($q) {
+                $q->whereNotIn('status', ['registration_cancelled'])
+                  ->orWhereNull('status');
+            });
 
-            // Standard Workflows (Pre-Production / Workflow)
-            $route = $wf->is_pre_production ? 'production.index' : 'workflow.index';
+        // Count employees appearing BEFORE the target based on sorting: created_at DESC, id DESC
+        // In DESC sort, "before" means (created_at > target) OR (created_at == target AND id > target)
+        $position = (clone $query)->where(function ($q) use ($employee) {
+            $q->where('created_at', '>', $employee->created_at)
+              ->orWhere(function ($subQ) use ($employee) {
+                  $subQ->where('created_at', $employee->created_at)
+                       ->where('id', '>', $employee->id);
+              });
+        })->count();
 
-            // Redirect to the dashboard with anchor to the item
-            // Note: The dashboards use order/item params for "GPS" expansion
-            return redirect()->route($route, [
-                'tab' => $wf->tab_slug,
-                'order' => $wf->order_id,
-                'item' => $wf->item_id
-            ])->with('highlight_item', $wf->item_id);
-        }
+        $page = floor($position / $perPage) + 1;
 
-        // Fallback: Go to Employer Structure (Employer Edit Page)
-        return redirect()->route('employers.edit', $employee->employer_id)
-                         ->with('highlight_employee', $employee->id);
+        // Redirect to Employer Structure (Employer Edit Page) with calculated page
+        return redirect()->route('employers.edit', [
+                'employer' => $employee->employer_id,
+                'page' => $page
+            ])
+            ->with('highlight_employee', $employee->id);
     }
 
     public function destroy(Employee $employee)

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -151,7 +151,9 @@ class EmployerController extends Controller
             ->where(function($q) {
                 $q->whereNotIn('status', ['registration_cancelled'])
                   ->orWhereNull('status');
-            });
+            })
+            ->orderBy('created_at', 'desc')
+            ->orderBy('id', 'desc');
 
         // Filter Logic
         if ($request->filled('search')) {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/yWCIyX66705QQcjx8Y1MvWknM="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/tests/Feature/EmployeeLocateTest.php
+++ b/tests/Feature/EmployeeLocateTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Employee;
+use App\Models\Employer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Spatie\Permission\Models\Role;
+
+class EmployeeLocateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_locate_redirects_to_correct_page_on_employer_edit()
+    {
+        // 1. Create User (Admin) to access routes
+        Role::create(['name' => 'admin']);
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+        $this->actingAs($user);
+
+        // 2. Create Employer
+        $employer = Employer::factory()->create();
+
+        // 3. Create 15 Employees.
+        // We want strict ordering.
+        // Page size is 10.
+        // We want target to be on Page 2 (items 11-20).
+        // Sorting is created_at DESC, id DESC.
+
+        // Let's create them in loop with distinct created_at
+        $employees = [];
+        for ($i = 0; $i < 15; $i++) {
+            $employees[] = Employee::factory()->create([
+                'employer_id' => $employer->id,
+                'created_at' => now()->subMinutes($i), // Newest first (index 0 is newest)
+            ]);
+        }
+
+        // Index 0 is newest (Row 1, Page 1)
+        // Index 9 is 10th newest (Row 10, Page 1)
+        // Index 10 is 11th newest (Row 11, Page 2)
+
+        $targetEmployee = $employees[10];
+
+        // 4. Call locate
+        $response = $this->get(route('employees.locate', $targetEmployee->id));
+
+        // 5. Assert Redirect
+        // Expected URL: employers/{id}/edit?page=2
+        $expectedUrl = route('employers.edit', [
+            'employer' => $employer->id,
+            'page' => 2
+        ]);
+
+        $response->assertRedirect($expectedUrl);
+
+        // 6. Assert Session
+        $response->assertSessionHas('highlight_employee', $targetEmployee->id);
+    }
+
+    public function test_locate_redirects_to_page_1_for_newest_employee()
+    {
+        Role::firstOrCreate(['name' => 'admin']);
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+        $this->actingAs($user);
+
+        $employer = Employer::factory()->create();
+
+        // Create 5 employees
+        $employees = [];
+        for ($i = 0; $i < 5; $i++) {
+            $employees[] = Employee::factory()->create([
+                'employer_id' => $employer->id,
+                'created_at' => now()->subMinutes($i),
+            ]);
+        }
+
+        $targetEmployee = $employees[0]; // Newest
+
+        $response = $this->get(route('employees.locate', $targetEmployee->id));
+
+        $expectedUrl = route('employers.edit', [
+            'employer' => $employer->id,
+            'page' => 1
+        ]);
+
+        $response->assertRedirect($expectedUrl);
+        $response->assertSessionHas('highlight_employee', $targetEmployee->id);
+    }
+}


### PR DESCRIPTION
- Modified `EmployerController@edit` to enforce deterministic sorting (`created_at` DESC, `id` DESC) for employee list.
- Modified `EmployeeController@locate` to calculate the pagination page of the target employee based on the same sort order and redirect to the correct page of `employers.edit` with `highlight_employee` session data, removing previous workflow redirection logic.
- Added `tests/Feature/EmployeeLocateTest.php` to verify the fix.
- Added `APP_KEY` to `phpunit.xml` for testing environment.