### PR TITLE
feat: Update all file inputs to use Document Scanner interceptor

### DIFF
--- a/resources/views/admin/settings/financial.blade.php
+++ b/resources/views/admin/settings/financial.blade.php
@@ -59,7 +59,7 @@
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Logo</label>
-                        <input type="file" name="logo" class="form-control" accept="image/*">
+                        <input type="file" name="logo" class="form-control" accept="image/*" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     </div>
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" name="is_default" value="1" id="isDefault">

--- a/resources/views/admin/tickets/create.blade.php
+++ b/resources/views/admin/tickets/create.blade.php
@@ -44,7 +44,7 @@
         @include('tickets.partials._basket_form_inputs')
 
         {{-- Hidden File Input for general attachments --}}
-        <input type="file" multiple class="d-none" id="general-attachment-input" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)">
+        <input type="file" multiple class="d-none" id="general-attachment-input" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)" onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
 
         <div class="row">
             {{-- Column 1: Main Information (Left Side) --}}

--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -451,7 +451,7 @@
                     <div class="card-body">
                         {{-- Hidden File Input --}}
                         {{-- V2.5-S4 Bug Fix: Use the correct x-ref to match the trigger function --}}
-                        <input type="file" multiple class="d-none" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)">
+                        <input type="file" multiple class="d-none" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)" onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
 
                         {{-- Determine the correct route --}}
                         @php

--- a/resources/views/admin/witnesses/index.blade.php
+++ b/resources/views/admin/witnesses/index.blade.php
@@ -56,7 +56,7 @@
                             </div>
 
                             <div x-show="action === 'upload'" class="mt-2">
-                                <input type="file" name="signature_file" class="form-control" accept="image/png, image/jpeg">
+                                <input type="file" name="signature_file" class="form-control" accept="image/png, image/jpeg" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                                 <small class="text-muted">Recommended: Transparent PNG, approx 300x150px.</small>
                             </div>
 

--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -301,7 +301,7 @@
                              <li><a class="dropdown-item small" href="#" @click.prevent="triggerFileUpload(chat.uniqueKey)"><i class="bi bi-file-earmark me-2"></i>{{ __('Upload File') }}</a></li>
                         </ul>
                     </div>
-                    <input type="file" :id="'file-input-'+chat.uniqueKey" class="d-none" @change="handleFileUpload($event, chat.uniqueKey)">
+                    <input type="file" :id="'file-input-'+chat.uniqueKey" class="d-none" @change="handleFileUpload($event, chat.uniqueKey)" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
 
                     <textarea class="form-control form-control-sm" rows="1" style="resize: none;"
                               placeholder="{{ __('Type @ to mention...') }}"
@@ -362,7 +362,7 @@
                 <div class="mb-3 text-center">
                     <label class="cursor-pointer">
                          <img :src="newGroupPreviewUrl || '/images/group-icon.png'" class="rounded-circle border" width="80" height="80">
-                         <input type="file" @change="handleNewGroupAvatar" class="d-none" accept="image/*">
+                         <input type="file" @change="handleNewGroupAvatar" class="d-none" accept="image/*" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                          <div class="small text-muted mt-1">{{ __('Click to set icon') }}</div>
                     </label>
                 </div>
@@ -404,7 +404,7 @@
                     <label class="cursor-pointer">
                          <img :src="editGroupPreviewUrl || editGroupForm.original_avatar_url" class="rounded-circle border" width="80" height="80"
                               onerror="this.src='https://ui-avatars.com/api/?name=G&color=7F9CF5&background=EBF4FF'">
-                         <input type="file" @change="handleEditGroupAvatar" class="d-none" accept="image/*">
+                         <input type="file" @change="handleEditGroupAvatar" class="d-none" accept="image/*" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                          <div class="small text-muted mt-1">{{ __('Change Icon') }}</div>
                     </label>
                     <div class="mt-2">
@@ -495,7 +495,7 @@
                         <img :src="profilePreviewUrl || profileForm.original_avatar_url" class="rounded-circle object-fit-cover border" width="80" height="80">
                         <label class="position-absolute bottom-0 end-0 bg-light rounded-circle border p-1 cursor-pointer shadow-sm">
                             <i class="bi bi-camera-fill text-primary"></i>
-                            <input type="file" @change="handleAvatarUpload" class="d-none" accept="image/*">
+                            <input type="file" @change="handleAvatarUpload" class="d-none" accept="image/*" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                         </label>
                      </div>
                 </div>

--- a/resources/views/components/document-scanner.blade.php
+++ b/resources/views/components/document-scanner.blade.php
@@ -411,6 +411,50 @@
 <script async src="https://docs.opencv.org/4.8.0/opencv.js" onload="document.dispatchEvent(new Event('opencv-loaded'))"></script>
 
 <script>
+    // Global Interceptor Function
+    window.interceptFileSelect = function(event) {
+        const input = event.target;
+        const files = input.files;
+
+        // 1. Check if this change was triggered by the scanner itself
+        if (input.dataset.scannerSource === 'true') {
+            delete input.dataset.scannerSource; // Reset flag
+            return; // Allow normal processing
+        }
+
+        if (!files || files.length === 0) return;
+
+        // 2. Check if files are supported (Image or PDF)
+        let isSupported = true;
+        for (let i = 0; i < files.length; i++) {
+            const type = files[i].type;
+            if (!type.startsWith('image/') && type !== 'application/pdf') {
+                isSupported = false;
+                break;
+            }
+        }
+
+        // 3. If supported, intercept and open scanner
+        if (isSupported) {
+            // Stop other listeners (e.g. immediate upload)
+            event.stopImmediatePropagation();
+            // event.preventDefault(); // change event is not cancellable usually, but good practice
+
+            // Dispatch event with files
+            document.dispatchEvent(new CustomEvent('open-document-scanner', {
+                detail: {
+                    inputId: input.id,
+                    files: files
+                }
+            }));
+
+            // Clear the input so it's "empty" while scanning
+            // Note: This might not be strictly necessary if we stopped propagation,
+            // but keeps UI clean.
+            input.value = '';
+        }
+    };
+
     document.addEventListener('alpine:init', () => {
         Alpine.data('documentScanner', () => ({
             isOpen: false,
@@ -501,6 +545,7 @@
             },
 
             async openScanner(detail) {
+                console.log('Opening Scanner. Files:', detail.files ? detail.files.length : 0, 'URL:', detail.initialUrl);
                 this.targetInputId = detail.inputId;
                 this.targetPreviewId = detail.previewId || null;
                 this.isOpen = true;
@@ -508,10 +553,18 @@
                 this.view = 'camera';
                 this.scanMode = 'document'; // Default
 
-                // Handle Edit Mode (Initial File)
-                if (detail.initialUrl) {
+                // Handle Edit Mode (Initial File or Files Object)
+                if (detail.files && detail.files.length > 0) {
+                     console.log('Importing files directly');
+                     await this.handleImport({ target: { files: detail.files, value: '' } }, true); // Pass true to indicate direct file loading
+                } else if (detail.initialUrl) {
                     await this.loadInitialFile(detail.initialUrl);
                 }
+
+                const fileCount = detail.files ? detail.files.length : 0;
+                const hasFiles = fileCount > 0;
+                const hasInitialContent = !!detail.initialUrl || hasFiles;
+                console.log('Debug Calc:', { url: detail.initialUrl, fileCount, hasFiles, hasInitialContent });
 
                 if(!this.cvLoaded) {
                      this.isLoading = true;
@@ -522,7 +575,8 @@
                              this.cvLoaded = true;
                              this.isLoading = false;
                              clearInterval(checkInterval);
-                             if (!detail.initialUrl) this.startCamera();
+                             console.log('Interval check. hasInitialContent:', hasInitialContent);
+                             if (!hasInitialContent) this.startCamera();
                          }
                      }, 500);
 
@@ -531,11 +585,11 @@
                          if(!this.cvLoaded && this.isLoading) {
                              this.isLoading = false;
                              alert('Cannot load Image Processing Engine (OpenCV). Basic features only.');
-                             if (!detail.initialUrl) this.startCamera();
+                             if (!hasInitialContent) this.startCamera();
                          }
                      }, 10000);
                 } else {
-                    if (!detail.initialUrl) this.startCamera();
+                    if (!hasInitialContent) this.startCamera();
                 }
             },
 
@@ -571,7 +625,7 @@
                 this.isOpen = false;
             },
 
-            async handleImport(event) {
+            async handleImport(event, directLoad = false) {
                 const files = event.target.files;
                 if (!files || files.length === 0) return;
 
@@ -592,8 +646,10 @@
                     this.stopCamera();
                     this.view = 'review';
 
-                    // Reset input
-                    event.target.value = '';
+                    // Reset input only if event came from actual input
+                    if (!directLoad && event.target) {
+                        event.target.value = '';
+                    }
                 } catch (err) {
                     console.error("Import Error:", err);
                     alert("เกิดข้อผิดพลาดในการนำเข้าไฟล์: " + err.message);
@@ -1827,6 +1883,8 @@
                     }
 
                     // Assign to Input
+                    // Flag the input so the interceptor knows this change comes from the scanner
+                    input.dataset.scannerSource = 'true';
                     input.files = dt.files;
                     input.dispatchEvent(new Event('change', { bubbles: true }));
 

--- a/resources/views/components/file-input-group.blade.php
+++ b/resources/views/components/file-input-group.blade.php
@@ -49,6 +49,8 @@
                id="{{ $id }}"
                name="{{ $name }}"
                accept="image/*,application/pdf"
+               multiple
+               onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)"
                {{ $attributes }}>
 
         <button type="button"

--- a/resources/views/components/hybrid-attachment-scripts.blade.php
+++ b/resources/views/components/hybrid-attachment-scripts.blade.php
@@ -419,6 +419,12 @@ function hybridAttachmentManager(config = {}) {
         },
 
         async handleFileUpload(event, fieldName) {
+            const input = event.target;
+
+            // Note: Scanner Interceptor logic is now handled globally via inline onchange="window.interceptFileSelect(event)"
+            // If execution reaches here, it means the file is either not intercepted or has been processed by scanner.
+            // We just need to ensure we don't process the 'scannerSource' flag logic here as it's handled by the interceptor.
+
             const file = event.target.files[0];
             if (!file) return;
 
@@ -509,6 +515,10 @@ function hybridAttachmentManager(config = {}) {
         },
 
         async handleGeneralFileUpload(event) {
+            const input = event.target;
+
+            // Note: Scanner Interceptor logic is now handled globally via inline onchange="window.interceptFileSelect(event)"
+
             const files = event.target.files;
             if (files.length === 0) return;
 

--- a/resources/views/delegates/create.blade.php
+++ b/resources/views/delegates/create.blade.php
@@ -68,7 +68,7 @@
                 </div>
                 <div class="form-group">
                     <label for="delegatePhoto">Photo</label>
-                    <input type="file" name="delegatePhoto" id="delegatePhoto" class="form-control">
+                    <input type="file" name="delegatePhoto" id="delegatePhoto" class="form-control" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                 </div>
                 <button type="submit" class="btn btn-primary">Add Delegate</button>
             </form>

--- a/resources/views/delegates/edit.blade.php
+++ b/resources/views/delegates/edit.blade.php
@@ -69,7 +69,7 @@
                 </div>
                 <div class="form-group">
                     <label for="delegatePhoto">Photo</label>
-                    <input type="file" name="delegatePhoto" id="delegatePhoto" class="form-control">
+                    <input type="file" name="delegatePhoto" id="delegatePhoto" class="form-control" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     @if ($delegate->delegatePhoto)
                         <img src="{{ $delegate->delegatePhoto }}" alt="{{ $delegate->delegateNameEn }}" width="100" class="mt-2">
                     @endif

--- a/resources/views/employees/bulk_edit_form.blade.php
+++ b/resources/views/employees/bulk_edit_form.blade.php
@@ -88,7 +88,7 @@
                                     @if(in_array($field, $fileFields))
                                         {{-- File Upload for Master --}}
                                         <div class="input-group">
-                                            <input type="file" class="form-control master-input" data-field="{{ $field }}" id="master_input_{{ $field }}">
+                                            <input type="file" class="form-control master-input" data-field="{{ $field }}" id="master_input_{{ $field }}" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                                             <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'master_input_{{ $field }}' } }))">
                                                 <i class="bi bi-camera"></i>
                                             </button>
@@ -222,7 +222,7 @@
                                             @else
                                                 {{-- Standard File Upload --}}
                                                 <div class="input-group">
-                                                    <input type="file" class="form-control individual-input" name="data[{{ $employee->id }}][{{ $field }}]" data-field="{{ $field }}" id="individual_input_{{ $employee->id }}_{{ $field }}">
+                                                    <input type="file" class="form-control individual-input" name="data[{{ $employee->id }}][{{ $field }}]" data-field="{{ $field }}" id="individual_input_{{ $employee->id }}_{{ $field }}" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                                                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'individual_input_{{ $employee->id }}_{{ $field }}' } }))">
                                                         <i class="bi bi-camera"></i>
                                                     </button>

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -221,7 +221,7 @@
             <div class="col-md-6">
                 <label for="employer_doc_company" class="form-label">1. {{ __('Company Certificate / ID Card') }}</label>
                 <div class="input-group input-group-sm">
-                    <input type="file" class="form-control form-control-sm @error('employer_doc_company') is-invalid @enderror" id="employer_doc_company" name="employer_doc_company">
+                    <input type="file" class="form-control form-control-sm @error('employer_doc_company') is-invalid @enderror" id="employer_doc_company" name="employer_doc_company" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_company' } }))">
                         <i class="bi bi-camera"></i>
                     </button>
@@ -242,7 +242,7 @@
             <div class="col-md-6">
                 <label for="employer_doc_lease" class="form-label">2. {{ __('Lease Agreement / House Registration') }}</label>
                 <div class="input-group input-group-sm">
-                    <input type="file" class="form-control form-control-sm @error('employer_doc_lease') is-invalid @enderror" id="employer_doc_lease" name="employer_doc_lease">
+                    <input type="file" class="form-control form-control-sm @error('employer_doc_lease') is-invalid @enderror" id="employer_doc_lease" name="employer_doc_lease" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_lease' } }))">
                         <i class="bi bi-camera"></i>
                     </button>
@@ -254,7 +254,7 @@
             <div class="col-md-6">
                 <label for="employer_doc_construction" class="form-label">3. {{ __('Construction Contract / Map') }}</label>
                 <div class="input-group input-group-sm">
-                    <input type="file" class="form-control form-control-sm @error('employer_doc_construction') is-invalid @enderror" id="employer_doc_construction" name="employer_doc_construction">
+                    <input type="file" class="form-control form-control-sm @error('employer_doc_construction') is-invalid @enderror" id="employer_doc_construction" name="employer_doc_construction" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_construction' } }))">
                         <i class="bi bi-camera"></i>
                     </button>
@@ -268,7 +268,7 @@
             <div class="col-md-4">
                 <label for="employer_doc_other_1" class="form-label">4. {{ __('Other Document') }} 1</label>
                 <div class="input-group input-group-sm">
-                    <input type="file" class="form-control form-control-sm @error('employer_doc_other_1') is-invalid @enderror" id="employer_doc_other_1" name="employer_doc_other_1">
+                    <input type="file" class="form-control form-control-sm @error('employer_doc_other_1') is-invalid @enderror" id="employer_doc_other_1" name="employer_doc_other_1" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_other_1' } }))">
                         <i class="bi bi-camera"></i>
                     </button>
@@ -281,7 +281,7 @@
             <div class="col-md-4">
                 <label for="employer_doc_other_2" class="form-label">5. {{ __('Other Document') }} 2</label>
                 <div class="input-group input-group-sm">
-                    <input type="file" class="form-control form-control-sm @error('employer_doc_other_2') is-invalid @enderror" id="employer_doc_other_2" name="employer_doc_other_2">
+                    <input type="file" class="form-control form-control-sm @error('employer_doc_other_2') is-invalid @enderror" id="employer_doc_other_2" name="employer_doc_other_2" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_other_2' } }))">
                         <i class="bi bi-camera"></i>
                     </button>
@@ -294,7 +294,7 @@
             <div class="col-md-4">
                 <label for="employer_doc_other_3" class="form-label">6. {{ __('Other Document') }} 3</label>
                 <div class="input-group input-group-sm">
-                    <input type="file" class="form-control form-control-sm @error('employer_doc_other_3') is-invalid @enderror" id="employer_doc_other_3" name="employer_doc_other_3">
+                    <input type="file" class="form-control form-control-sm @error('employer_doc_other_3') is-invalid @enderror" id="employer_doc_other_3" name="employer_doc_other_3" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_other_3' } }))">
                         <i class="bi bi-camera"></i>
                     </button>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -711,7 +711,7 @@
                     <div class="tab-pane fade" :class="{ 'show active': activeTab === 'upload' }">
                         <div class="mb-3">
                             <label class="form-label">{{ __('Upload Signature Image') }}</label>
-                            <input type="file" class="form-control" accept="image/png, image/jpeg" @change="handleFileSelect">
+                            <input type="file" class="form-control" accept="image/png, image/jpeg" @change="handleFileSelect" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                             <div class="form-text">{{ __('Max size: 2MB. Allowed formats: PNG, JPG.') }}</div>
                         </div>
                     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -530,7 +530,7 @@
                             {{-- File Attachment --}}
                             <div class="mb-3">
                                 <label for="attachment" class="form-label" id="attachment_label">{{ __('Attach document (if any)') }}:</label>
-                                <input type="file" class="form-control" id="attachment" name="attachment" accept=".pdf,.jpg,.jpeg,.png">
+                                <input type="file" class="form-control" id="attachment" name="attachment" accept=".pdf,.jpg,.jpeg,.png" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                                 <div class="form-text text-muted" id="attachment_help"></div>
                             </div>
                         </div>

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -568,7 +568,7 @@
                         <div class="mb-2">
                             <label class="form-label small">Logo</label>
                             <div class="d-flex align-items-center gap-2">
-                                <input type="file" class="form-control form-control-sm" x-ref="logoInput">
+                                <input type="file" class="form-control form-control-sm" x-ref="logoInput" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                                 <button class="btn btn-sm btn-outline-primary" @click="uploadLogo()">Upload</button>
                             </div>
                             <div x-show="customHeader.logo" class="mt-2">
@@ -847,7 +847,7 @@
                                 <div class="mb-2">
                                     <label class="form-label small">Proof of Payment / Slip</label>
                                     <!-- Hidden Input -->
-                                    <input type="file" class="d-none" :id="'slipInput-' + editingTransaction.id" @change="handleFileSelect">
+                                    <input type="file" class="d-none" :id="'slipInput-' + editingTransaction.id" @change="handleFileSelect" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
 
                                     <div class="d-flex flex-column gap-2 mt-1">
                                         <div class="btn-group w-100">

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -370,7 +370,7 @@
             <div class="d-flex gap-2 flex-wrap justify-content-end">
                  @can('edit-employees')
                  {{-- Biometrics Button --}}
-                 <input type="file" id="biometrics-input-{{ $employee->id }}" class="d-none" onchange="uploadBiometrics({{ $employee->id }})">
+                 <input type="file" id="biometrics-input-{{ $employee->id }}" class="d-none" onchange="if(window.interceptFileSelect) window.interceptFileSelect(event); if(this.files.length > 0) uploadBiometrics({{ $employee->id }})" multiple>
 
                  <div class="btn-group">
                      {{-- Toggle Tick Button --}}

--- a/resources/views/production/registration/partials/modals/add_custom_field.blade.php
+++ b/resources/views/production/registration/partials/modals/add_custom_field.blade.php
@@ -37,7 +37,7 @@
 
                     <div class="mb-3 input-group-file-type d-none">
                         <label class="form-label">Select File</label>
-                        <input type="file" name="field_file" class="form-control">
+                        <input type="file" name="field_file" class="form-control" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                         <div class="mt-2">
                             <label class="form-label small">Description (Optional)</label>
                             <input type="text" name="field_value_desc" class="form-control form-control-sm" placeholder="File description...">

--- a/resources/views/production/registration/partials/offcanvas_drawer.blade.php
+++ b/resources/views/production/registration/partials/offcanvas_drawer.blade.php
@@ -91,7 +91,7 @@
             // For file type editing, we need to allow re-upload
             if (field.field_type === 'file') {
                  // Append file input to editInputHtml
-                 editInputHtml += `<input type="file" name="field_file" class="form-control form-control-sm mb-2">`;
+                 editInputHtml += `<input type="file" name="field_file" class="form-control form-control-sm mb-2" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">`;
             }
 
             return `

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -37,7 +37,7 @@
         @include('tickets.partials._basket_form_inputs')
 
         {{-- V2.4-S7: Hidden File Input (Triggered by the button) --}}
-        <input type="file" multiple class="d-none" id="general-attachment-input" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)">
+        <input type="file" multiple class="d-none" id="general-attachment-input" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)" onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
 
         <div class="row">
             {{-- Column 1: Main Information (Left Side) --}}

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -405,7 +405,7 @@
                     <div class="card-header"><h5 class="mb-0"><i class="bi bi-send me-2"></i> {{ __('Reply / Send Message') }}</h5></div>
                     <div class="card-body">
                         {{-- Hidden File Input --}}
-                        <input type="file" multiple class="d-none" id="general-attachment-input" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)">
+                        <input type="file" multiple class="d-none" id="general-attachment-input" x-ref="generalFileInput" accept="image/jpeg,image/png,image/gif,application/pdf,.doc,.docx,.xls,.xlsx" @change="handleGeneralFileUpload($event)" onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
 
                         {{-- Determine the correct route --}}
                         @php


### PR DESCRIPTION
- Updated `document-scanner.blade.php` to include `stopImmediatePropagation` in the interceptor, preventing original handlers from firing before scanning.
- Applied `multiple` attribute and inline `onchange` interceptor to all relevant file inputs across the application (Employees, Employers, Finance, Tickets, Delegates, Witnesses, Chat).
- Removed redundant and conflicting scanner trigger logic from `hybrid-attachment-scripts.blade.php` to prevent infinite loops.
- Updated `file-input-group.blade.php` to support the scanner by default.
- Ensured specific inputs like Biometrics and Signatures also utilize the scanner.