### PR TITLE
Fix document scanner crash by removing duplicate OpenCV load

### DIFF
--- a/resources/views/components/cropper-modal.blade.php
+++ b/resources/views/components/cropper-modal.blade.php
@@ -150,5 +150,3 @@
     </div>
 </div>
 
-<!-- Load OpenCV for Smart Eraser -->
-<script async src="https://docs.opencv.org/4.8.0/opencv.js" onload="document.dispatchEvent(new Event('opencv-loaded-cropper'))"></script>


### PR DESCRIPTION
The document scanner and the cropper modal both loaded `opencv.js` independently. When both components were present on the same page (e.g., in the Employee Edit view), `opencv.js` was executed twice, causing WASM memory corruption, "BindingError" in the console, and "table index out of bounds" runtime errors when attempting to use filters or save images.

This commit removes the duplicate `<script>` tag from `cropper-modal.blade.php`. The application now relies on `document-scanner.blade.php` (included in `layouts.app`) as the single source of truth for loading OpenCV. This ensures the WASM module is initialized only once and remains stable across component interactions.