### PR TITLE
Fix PDF text alignment baseline and improve employer search UX

### DIFF
--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -299,19 +299,14 @@ class PdfGeneratorService
                              $textX = $x + 1; // 1mm padding
                         }
 
-                        // 4. Vertical Alignment (Bottom)
-                        // We align vertically to the bottom of the box so users can align the box bottom with the line.
-                        $lineHeight = $fontSize / 2.83; // Approx height in mm
+                        // 4. Vertical Alignment (Bottom - Baseline)
+                        // We align the BASELINE of the text to the bottom of the box ($y + $boxH).
+                        // This allows Thai descenders (tails) to naturally protrude below the line,
+                        // while the main character body sits exactly on the line.
+                        $textY = $y + $boxH;
 
-                        // Align Bottom: Top of box + BoxHeight - TextHeight
-                        // Visual correction: THSarabunNew has large line height, so strict bottom align might still look high
-                        // Modified to align baseline closer to bottom line (dotted line).
-                        // THSarabunNew has a large internal leading, so subtracting full lineHeight makes text float.
-                        // Subtracting ~80% of lineHeight places baseline roughly on the bottom line.
-                        $textY = $y + $boxH - ($lineHeight * 0.8);
-
-                        $pdf->SetXY($textX, $textY);
-                        $pdf->Write(0, $encodedText);
+                        // Use Text() instead of Write() because Text() accepts baseline coordinates directly.
+                        $pdf->Text($textX, $textY, $encodedText);
                     }
                 }
             }

--- a/resources/views/pdf_templates/generate_modal.blade.php
+++ b/resources/views/pdf_templates/generate_modal.blade.php
@@ -47,7 +47,7 @@
                                 );
                             @endphp
 
-                            <div x-data="employerSelector()" @click.outside="open = false">
+                            <div x-data="employerSelector()" @click.outside="open = false; search = selectedName">
                                 <div class="position-relative">
                                     <div class="input-group">
                                         <span class="input-group-text"><i class="bi bi-search"></i></span>
@@ -55,7 +55,7 @@
                                                class="form-control"
                                                placeholder="Type to search employer or select Global..."
                                                x-model="search"
-                                               @focus="open = true"
+                                               @focus="open = true; search = ''"
                                                @keydown.escape="open = false"
                                                autocomplete="off">
                                         <button class="btn btn-outline-secondary dropdown-toggle" type="button" @click="open = !open"></button>


### PR DESCRIPTION
- Modified `PdfGeneratorService` to use `Text()` instead of `Write()` for field values, setting the Y-coordinate to the bottom of the field box (`$y + $boxH`). This ensures strict baseline alignment, allowing Thai descenders to naturally protrude below the line as requested.
- Updated `generate_modal.blade.php` to automatically clear the employer search input on focus (`@focus="open = true; search = ''"`) and restore the selected name when clicking outside (`@click.outside="open = false; search = selectedName"`). This resolves the issue where users had to manually delete the pre-filled text before searching.