### PR TITLE
Fix 500 error in history and notification views due to orphaned records

### DIFF
--- a/resources/views/employees/_history_card.blade.php
+++ b/resources/views/employees/_history_card.blade.php
@@ -1,5 +1,5 @@
 @php
-    $employerName = $employee->employer->employerNameTh ?? 'N/A';
+    $employerName = $employee->employer?->employerNameTh ?? 'N/A';
     $employeeFullNameTh = ($employee->employeeTitleTh ? $employee->employeeTitleTh . ' ' : '') . ($employee->employeeNameTh ?? 'N/A');
     $employeeFullNameEn = ($employee->employeeTitleEn ? $employee->employeeTitleEn . ' ' : '') . ($employee->employeeNameEn ?? 'N/A');
     $countryCode = \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality);

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -113,7 +113,7 @@
                     <p class="mb-1 small">{{ $employee->employeeTitleTh ?? '' }} {{ $employee->employeeNameTh ?? 'N/A' }}</p>
                 @endif
                 <p class="mb-1 small">
-                    <strong>นายจ้าง:</strong> {{ $employer->employerNameTh ?? 'N/A' }}
+                    <strong>นายจ้าง:</strong> {{ $employer?->employerNameTh ?? 'N/A' }}
                     @if(request('addrProvince') && $employer)
                         @foreach($employer->getMatchedAddressLabels(request('addrProvince'), request('addrDistrict'), request('addrSubDistrict')) as $label)
                             <span class="text-primary small fw-bold ms-1">{{ $label }}</span>

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -84,7 +84,7 @@
         @endif
     </td>
     <td>
-        {{ $employer->employerNameTh ?? 'N/A' }}
+        {{ $employer?->employerNameTh ?? 'N/A' }}
         @if(request('addrProvince') && $employer)
             @foreach($employer->getMatchedAddressLabels(request('addrProvince'), request('addrDistrict'), request('addrSubDistrict')) as $label)
                 <div class="text-primary small fw-bold">{{ $label }}</div>


### PR DESCRIPTION
- Use optional chaining for employer relationship access in _history_card.blade.php
- Use optional chaining for employer relationship access in notification views
- Prevents crash when accessing properties on null employer object