### PR TITLE
Fix Python process environment initialization on Windows

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -422,7 +422,19 @@ public function create(Request $request) // เพิ่ม Request $request เ
         }
 
         // Use detected python command
-        $process = new Process([$pythonCmd, $scriptPath, '--input', $fullPath, '--output', $fullOutputPath]);
+        $env = [
+            'PATH' => getenv('PATH'),
+            'TEMP' => getenv('TEMP'),
+            'TMP' => getenv('TMP'),
+        ];
+
+        // Pass necessary environment variables for Windows
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $env['SystemRoot'] = getenv('SystemRoot') ?: 'C:\\Windows';
+            $env['COMSPEC'] = getenv('COMSPEC') ?: 'C:\\Windows\\System32\\cmd.exe';
+        }
+
+        $process = new Process([$pythonCmd, $scriptPath, '--input', $fullPath, '--output', $fullOutputPath], null, $env);
         $process->setTimeout(120); // Increased timeout to 120s for model download/processing
         $process->run();
 


### PR DESCRIPTION
- Update `EmployeeController::enhancePhoto` to explicitly pass `SystemRoot`, `PATH`, `TEMP`, and `TMP` environment variables to the Python process.
- This resolves the "Fatal Python error: _Py_HashRandomization_Init" caused by missing `SystemRoot` when running Python from a PHP/Apache context on Windows.