### PR TITLE
Fix Smart Erase tool failure on single click

### DIFF
--- a/resources/views/employees/partials/_edit_scripts.blade.php
+++ b/resources/views/employees/partials/_edit_scripts.blade.php
@@ -706,6 +706,12 @@
             if (this.currentTool === 'smart_erase') {
                 this.smartPoints = []; // Start new stroke
                 this.smartPoints.push(this.lastPos);
+
+                // Visual Feedback for click
+                this.ctx.beginPath();
+                this.ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
+                this.ctx.arc(this.lastPos.x, this.lastPos.y, this.brushSize / 2, 0, Math.PI * 2);
+                this.ctx.fill();
             } else {
                 this.pushHistory(); // Save state before stroke
                 this.draw(this.lastPos);
@@ -949,15 +955,22 @@
                     // Apply User Strokes as GC_BGD (0)
                     maskCtx.globalCompositeOperation = 'destination-out';
                     maskCtx.beginPath();
-                    maskCtx.lineCap = 'round';
-                    maskCtx.lineWidth = this.brushSize * scale;
-                    for(let i=0; i<this.smartPoints.length-1; i++) {
-                        const p1 = this.smartPoints[i];
-                        const p2 = this.smartPoints[i+1];
-                        maskCtx.moveTo(p1.x * scale, p1.y * scale);
-                        maskCtx.lineTo(p2.x * scale, p2.y * scale);
+
+                    if (this.smartPoints.length === 1) {
+                         const p = this.smartPoints[0];
+                         maskCtx.arc(p.x * scale, p.y * scale, (this.brushSize * scale) / 2, 0, Math.PI * 2);
+                         maskCtx.fill();
+                    } else {
+                        maskCtx.lineCap = 'round';
+                        maskCtx.lineWidth = this.brushSize * scale;
+                        for(let i=0; i<this.smartPoints.length-1; i++) {
+                            const p1 = this.smartPoints[i];
+                            const p2 = this.smartPoints[i+1];
+                            maskCtx.moveTo(p1.x * scale, p1.y * scale);
+                            maskCtx.lineTo(p2.x * scale, p2.y * scale);
+                        }
+                        maskCtx.stroke();
                     }
-                    maskCtx.stroke();
                     maskCtx.globalCompositeOperation = 'source-over';
 
                     // Read updated mask (with user strokes removed)


### PR DESCRIPTION
- Added logic to `applySmartErase` in `_edit_scripts.blade.php` to handle single-point clicks by drawing a filled circle on the mask, ensuring `cv.grabCut` receives valid input.
- Added visual feedback (red dot) in `onMouseDown` for `smart_erase` tool to provide immediate user feedback.
- This resolves the issue where single clicks caused the segmentation to fail or error out due to an empty mask.