### PR TITLE
Fix: Add 'url' to active_workflows items to prevent crashes in histor…

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -259,6 +259,13 @@ class Employee extends Model
                     ? 'Preparing (Pre-Production)'
                     : 'Processing';
 
+                $routeName = $isPreProduction ? 'production.index' : 'workflow.index';
+                $url = route($routeName, [
+                    'tab' => $item->order->workType->slug ?? '',
+                    'order' => $item->production_order_id,
+                    'item' => $item->id
+                ]);
+
                 return (object) [
                     'name' => $item->order->workType->name ?? 'Unknown',
                     'status_label' => $statusLabel,
@@ -268,6 +275,7 @@ class Employee extends Model
                     'order_id' => $item->production_order_id,
                     'item_id' => $item->id,
                     'tab_slug' => $item->order->workType->slug ?? '',
+                    'url' => $url,
                 ];
             });
 

--- a/resources/views/employees/_history_card.blade.php
+++ b/resources/views/employees/_history_card.blade.php
@@ -11,7 +11,7 @@
              style="background-color: rgba(255, 223, 0, 0.15); border: 2px solid #ffc107; z-index: 10; pointer-events: none;">
              <div class="d-flex flex-column gap-2" style="pointer-events: auto;">
                 @foreach($employee->active_workflows as $wf)
-                    <a href="{{ route('workflow.index', ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]) }}"
+                <a href="{{ $wf->url }}"
                        class="badge bg-warning text-dark text-decoration-none shadow-sm border border-dark fs-6 text-truncate"
                        style="max-width: 90%;">
                        <i class="bi bi-gear-fill me-1"></i> {{ $wf->status_label }}: {{ $wf->name }}

--- a/resources/views/notifications/_notification_item.blade.php
+++ b/resources/views/notifications/_notification_item.blade.php
@@ -61,7 +61,7 @@
              style="background-color: rgba(255, 223, 0, 0.15); border: 2px solid #ffc107; z-index: 10; pointer-events: none;">
              <div class="d-flex flex-column gap-2" style="pointer-events: auto;">
                 @foreach($employee->active_workflows as $wf)
-                    <a href="{{ route('workflow.index', ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]) }}"
+                <a href="{{ $wf->url }}"
                        class="badge bg-warning text-dark text-decoration-none shadow-sm border border-dark fs-6 text-truncate"
                        style="max-width: 90%;">
                        <i class="bi bi-gear-fill me-1"></i> {{ $wf->status_label }}: {{ $wf->name }}

--- a/resources/views/notifications/_notification_table_row.blade.php
+++ b/resources/views/notifications/_notification_table_row.blade.php
@@ -53,7 +53,7 @@
 
                         @if(isset($employee->active_workflows) && $employee->active_workflows->isNotEmpty())
                             @foreach($employee->active_workflows as $wf)
-                                <a href="{{ route('workflow.index', ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]) }}"
+                                <a href="{{ $wf->url }}"
                                    class="badge bg-warning text-dark text-decoration-none ms-1"
                                    title="{{ $wf->status_label }}: {{ $wf->name }}">
                                    <i class="bi bi-gear-fill me-1"></i>{{ $wf->status_label }}

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -53,33 +53,27 @@
              <div class="d-flex flex-column gap-2" style="pointer-events: auto;">
                 @foreach($employee->active_workflows as $wf)
                     @php
-                        if (isset($wf->url)) {
-                            // Synthetic Workflow (Registration / Renewal)
-                            $url = $wf->url;
-                            if (isset($wf->is_registration) && $wf->is_registration) {
-                                $style = 'background-color: #8B5CF6; color: white;';
-                                $icon = 'bi-person-badge';
-                                $tooltip = __('Go to Registration Resolution');
-                                $badgeClass = '';
-                            } elseif (isset($wf->is_renewal) && $wf->is_renewal) {
-                                $style = 'background-color: #EC4899; color: white;';
-                                $icon = 'bi-arrow-repeat';
-                                $tooltip = __('Go to Renewal Resolution');
-                                $badgeClass = '';
-                            } else {
-                                $style = '';
-                                $icon = 'bi-gear-fill';
-                                $tooltip = '';
-                                $badgeClass = 'bg-secondary';
-                            }
-                        } else {
-                            // Standard Workflow
-                            $route = $wf->is_pre_production ? 'production.index' : 'workflow.index';
-                            $url = route($route, ['tab' => $wf->tab_slug, 'order' => $wf->order_id, 'item' => $wf->item_id]);
-                            $badgeClass = $wf->is_pre_production ? 'bg-info' : 'bg-warning';
+                        $url = $wf->url;
+                        if (isset($wf->is_registration) && $wf->is_registration) {
+                            $style = 'background-color: #8B5CF6; color: white;';
+                            $icon = 'bi-person-badge';
+                            $tooltip = __('Go to Registration Resolution');
+                            $badgeClass = '';
+                        } elseif (isset($wf->is_renewal) && $wf->is_renewal) {
+                            $style = 'background-color: #EC4899; color: white;';
+                            $icon = 'bi-arrow-repeat';
+                            $tooltip = __('Go to Renewal Resolution');
+                            $badgeClass = '';
+                        } elseif (isset($wf->is_pre_production) && $wf->is_pre_production) {
                             $style = '';
-                            $icon = $wf->is_pre_production ? 'bi-hourglass-split' : 'bi-gear-fill';
-                            $tooltip = $wf->is_pre_production ? __('Go to Pre-Production') : __('Go to Workflow');
+                            $icon = 'bi-hourglass-split';
+                            $tooltip = __('Go to Pre-Production');
+                            $badgeClass = 'bg-info';
+                        } else {
+                            $style = '';
+                            $icon = 'bi-gear-fill';
+                            $tooltip = __('Go to Workflow');
+                            $badgeClass = 'bg-warning';
                         }
                     @endphp
                     <a href="{{ $url }}"


### PR DESCRIPTION
…y and notification views

The `active_workflows` accessor in `Employee` model was returning a mix of objects: standard production items (without `url`) and synthetic items (with `url`). Views like `_history_card.blade.php` and `_notification_item.blade.php` assumed all items were standard and tried to construct the route using `tab_slug`, `order_id`, and `item_id`, which are missing on synthetic items.

This commit:
- Updates `Employee::getActiveWorkflowsAttribute` to calculate and include `url` for standard production items as well.
- Updates `_history_card.blade.php`, `_notification_item.blade.php`, and `_notification_table_row.blade.php` to use `$wf->url` directly.
- Simplifies `_employee_card.blade.php` to use the pre-calculated `$wf->url` while preserving its specific styling logic.