### PR TITLE
Fix Super Admin menu visibility and admin route access

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -428,6 +428,14 @@
                     </a>
                 @endcan
                 @endif
+
+                @role('super-admin')
+                <hr>
+                <a class="list-group-item list-group-item-action {{ request()->routeIs('super-admin.settings.index') ? 'active' : '' }}" href="{{ route('super-admin.settings.index') }}">
+                    <i class="bi bi-gear-fill me-2"></i>
+                    {{ __('Super Admin Settings') }}
+                </a>
+                @endrole
             </div>
             </div>
         </aside>

--- a/routes/web.php
+++ b/routes/web.php
@@ -387,7 +387,7 @@ use App\Http\Controllers\Admin\NotificationSettingController;
 use App\Http\Controllers\Admin\ActivityLogController;
 
 // === Existing Admin Routes (role:admin) ===
-Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->group(function () {
+Route::middleware(['auth', 'role:admin|super-admin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('/activity-logs', [ActivityLogController::class, 'index'])->middleware('menu:activity_logs')->name('activity-logs.index');
     Route::get('/activity-logs/search', [ActivityLogController::class, 'search'])->name('activity-logs.search');
     Route::get('/activity-logs/{year}', [ActivityLogController::class, 'showYear'])->name('activity-logs.year');


### PR DESCRIPTION
- Updated `routes/web.php` to allow `super-admin` role on admin routes (changed `role:admin` to `role:admin|super-admin`).
- Added "Super Admin Settings" menu item to `resources/views/layouts/app.blade.php`, visible only to users with the `super-admin` role.
- This resolves the 403 Forbidden error when Super Admins access User Management and restores the missing settings menu.