### PR TITLE
Fix Super Admin menu visibility toggle not updating sidebar

### DIFF
--- a/app/Http/Controllers/SuperAdmin/SettingsController.php
+++ b/app/Http/Controllers/SuperAdmin/SettingsController.php
@@ -139,6 +139,9 @@ class SettingsController extends Controller
      */
     public function renderSidebar()
     {
-        return view('partials.sidebar-menu');
+        return response(view('partials.sidebar-menu'))
+            ->header('Cache-Control', 'no-cache, no-store, must-revalidate')
+            ->header('Pragma', 'no-cache')
+            ->header('Expires', '0');
     }
 }

--- a/resources/views/super-admin/settings.blade.php
+++ b/resources/views/super-admin/settings.blade.php
@@ -169,7 +169,9 @@
     }
 
     function reloadSidebar() {
-        fetch('{{ route('super-admin.sidebar') }}')
+        // Append timestamp to prevent browser caching
+        const url = '{{ route('super-admin.sidebar') }}' + '?t=' + new Date().getTime();
+        fetch(url)
         .then(res => res.text())
         .then(html => {
             document.getElementById('main-nav').innerHTML = html;


### PR DESCRIPTION
- Modified `resources/views/super-admin/settings.blade.php` to append a timestamp query parameter to the sidebar reload request, preventing browser caching of old HTML.
- Updated `app/Http/Controllers/SuperAdmin/SettingsController.php` to include `Cache-Control: no-cache, no-store, must-revalidate` headers in the `renderSidebar` response.
- Verified backend logic with temporary tests (removed) confirming correct state updates.

This resolves the issue where toggling a menu item to 'Visible' would not reflect in the sidebar due to the browser serving a cached 'Hidden' version of the sidebar HTML.