### PR TITLE
Fix Super Admin menu visibility toggle persistence issue

### DIFF
--- a/app/Http/Controllers/SuperAdmin/SettingsController.php
+++ b/app/Http/Controllers/SuperAdmin/SettingsController.php
@@ -124,9 +124,21 @@ class SettingsController extends Controller
         ]);
 
         $key = $request->input('key');
+        $isVisible = $request->boolean('is_visible');
+
+        // Logic Change: If setting to visible and no password, delete the record to use default (true)
+        // This prevents issues where 'true' is stored but not read correctly, or cache issues.
         $setting = SuperAdminSetting::firstOrNew(['key' => $key]);
-        $setting->is_visible = $request->boolean('is_visible');
-        $setting->save();
+
+        if ($isVisible && empty($setting->access_password)) {
+            if ($setting->exists) {
+                $setting->delete();
+            }
+            // If it was new, we just don't create it.
+        } else {
+            $setting->is_visible = $isVisible;
+            $setting->save();
+        }
 
         // Clear cache to apply changes immediately
         Cache::forget(\App\Services\SuperAdminService::CACHE_KEY);
@@ -137,8 +149,13 @@ class SettingsController extends Controller
     /**
      * Render the sidebar menu HTML.
      */
-    public function renderSidebar()
+    public function renderSidebar(Request $request)
     {
+        // Force cache clear if requested (e.g., immediately after update)
+        if ($request->has('refresh')) {
+            Cache::forget(\App\Services\SuperAdminService::CACHE_KEY);
+        }
+
         return response(view('partials.sidebar-menu'))
             ->header('Cache-Control', 'no-cache, no-store, must-revalidate')
             ->header('Pragma', 'no-cache')

--- a/resources/views/super-admin/settings.blade.php
+++ b/resources/views/super-admin/settings.blade.php
@@ -169,8 +169,8 @@
     }
 
     function reloadSidebar() {
-        // Append timestamp to prevent browser caching
-        const url = '{{ route('super-admin.sidebar') }}' + '?t=' + new Date().getTime();
+        // Append timestamp to prevent browser caching, and 'refresh' to force server cache clear
+        const url = '{{ route('super-admin.sidebar') }}' + '?t=' + new Date().getTime() + '&refresh=1';
         fetch(url)
         .then(res => res.text())
         .then(html => {

--- a/tests/Feature/SuperAdmin/SuperAdminSettingsTest.php
+++ b/tests/Feature/SuperAdmin/SuperAdminSettingsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\SuperAdmin;
+
+use App\Models\SuperAdminSetting;
+use App\Models\User;
+use App\Services\SuperAdminService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class SuperAdminSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Clear cache before each test
+        Cache::forget(SuperAdminService::CACHE_KEY);
+    }
+
+    public function test_toggle_visibility_deletes_record_on_true()
+    {
+        // Create role
+        \Spatie\Permission\Models\Role::create(['name' => 'super-admin']);
+
+        $user = User::factory()->create();
+        $user->assignRole('super-admin');
+
+        $key = 'dashboard';
+
+        // Initial state: Default is visible (no record)
+        $this->assertTrue(\App\Facades\SuperAdmin::isVisible($key));
+        $this->assertDatabaseMissing('super_admin_settings', ['key' => $key]);
+
+        // 1. Hide it
+        $response = $this->actingAs($user)
+            ->postJson(route('super-admin.settings.update-visibility'), [
+                'key' => $key,
+                'is_visible' => false,
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        // Verify DB: Record created with false
+        $this->assertDatabaseHas('super_admin_settings', [
+            'key' => $key,
+            'is_visible' => 0,
+        ]);
+
+        // Verify Service (cache cleared by controller)
+        // Simulate sidebar rendering
+        $this->assertFalse(\App\Facades\SuperAdmin::isVisible($key));
+
+        // 2. Show it again (Delete record logic)
+        $response = $this->actingAs($user)
+            ->postJson(route('super-admin.settings.update-visibility'), [
+                'key' => $key,
+                'is_visible' => true,
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        // Verify DB: Record should be DELETED because default is true
+        $this->assertDatabaseMissing('super_admin_settings', [
+            'key' => $key,
+        ]);
+
+        // Verify Service
+        $this->assertTrue(\App\Facades\SuperAdmin::isVisible($key));
+    }
+}


### PR DESCRIPTION
Modified `SettingsController::updateVisibility` to delete the setting record when visibility is set to true (default state), ensuring the "default-true" logic in `SuperAdminService` is respected. Added logic to `renderSidebar` to clear the cache when a `refresh` parameter is present, preventing stale UI. Updated `settings.blade.php` to append `refresh=1` to the sidebar reload request. Added `SuperAdminSettingsTest` to verify the fix.