### PR TITLE
Restore Activity Logs menu visibility for Super Admins

### DIFF
--- a/resources/views/partials/sidebar-menu.blade.php
+++ b/resources/views/partials/sidebar-menu.blade.php
@@ -5,11 +5,11 @@
 @endif
 
 @if(\App\Facades\SuperAdmin::isVisible('activity_logs'))
-@role('admin')
+@hasanyrole('admin|super-admin')
 <a href="{{ route('admin.activity-logs.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('admin.activity-logs.*') ? 'active' : '' }}">
     <i class="bi bi-activity me-2"></i>{{ __('Activity Logs') }}
 </a>
-@endrole
+@endhasanyrole
 @endif
 
 @if(\App\Facades\SuperAdmin::isVisible('notifications'))


### PR DESCRIPTION
- Modified `resources/views/partials/sidebar-menu.blade.php` to use `@hasanyrole('admin|super-admin')` for the Activity Logs menu item.
- This ensures that Super Admins can see the menu item even if they do not possess the `admin` role, while still respecting the global `SuperAdmin::isVisible` setting.
- The menu item remains positioned under the Dashboard (Overview) as requested.