### PR TITLE
Fix dashboard link, password menu redirect, and finance menu actions

### DIFF
--- a/app/Http/Middleware/CheckMenuAccess.php
+++ b/app/Http/Middleware/CheckMenuAccess.php
@@ -37,6 +37,9 @@ class CheckMenuAccess
 
             if (!$expiry || now()->timestamp > $expiry) {
                 // Redirect to unlock screen
+                if ($request->isMethod('get') && !$request->ajax()) {
+                    session()->put('url.intended', $request->fullUrl());
+                }
                 return redirect()->route('menu.unlock.form', ['key' => $key]);
             }
 

--- a/resources/views/financial/index.blade.php
+++ b/resources/views/financial/index.blade.php
@@ -167,7 +167,7 @@
                                     <i class="bi bi-eye"></i>
                                 </a>
                                 @if($txn->slip_path)
-                                    <a href="{{ Storage::url($txn->slip_path) }}" target="_blank" class="btn btn-sm btn-outline-secondary" title="View Slip">
+                                    <a href="{{ asset('storage/' . $txn->slip_path) }}" target="_blank" class="btn btn-sm btn-outline-secondary" title="View Slip">
                                         <i class="bi bi-receipt"></i>
                                     </a>
                                 @endif

--- a/resources/views/partials/sidebar-menu.blade.php
+++ b/resources/views/partials/sidebar-menu.blade.php
@@ -1,6 +1,6 @@
 @if(\App\Facades\SuperAdmin::isVisible('dashboard'))
 @can('view-dashboard')
-<a href="#" class="list-group-item list-group-item-action"><i class="bi bi-pie-chart-fill me-2"></i>{{ __('Dashboard') }}</a>
+<a href="{{ route('dashboard') }}" class="list-group-item list-group-item-action"><i class="bi bi-pie-chart-fill me-2"></i>{{ __('Dashboard') }}</a>
 @endcan
 @endif
 

--- a/resources/views/production/prepare.blade.php
+++ b/resources/views/production/prepare.blade.php
@@ -354,6 +354,18 @@
 </div>
 
 <script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const tab = urlParams.get('tab');
+        if (tab) {
+            const tabEl = document.querySelector(`#${tab}-tab`);
+            if (tabEl) {
+                const tabInstance = new bootstrap.Tab(tabEl);
+                tabInstance.show();
+            }
+        }
+    });
+
     function preparationManager() {
         return {
             documentReady: {{ $production->document_ready_at ? 'true' : 'false' }},


### PR DESCRIPTION
- Update Dashboard link in sidebar to use `route('dashboard')` instead of `href="#"`.
- Enhance `CheckMenuAccess` middleware to store the intended URL in the session before redirecting to the password unlock form, ensuring users are returned to their destination.
- Add JavaScript logic to `prepare.blade.php` (Production Edit/Prepare view) to automatically activate the requested tab (e.g., `?tab=financial`) when navigating from Finance Hub.
- Update Finance Hub (`financial/index.blade.php`) slip attachment links to use `asset('storage/...')` for reliable public access.