### PR TITLE
feat(admin): enhance central trash with configurable pagination

### DIFF
--- a/app/Http/Controllers/Admin/TrashController.php
+++ b/app/Http/Controllers/Admin/TrashController.php
@@ -35,6 +35,12 @@ class TrashController extends Controller
         $searchTerm = $request->input('search');
         $retentionSettings = [];
 
+        // Validate per_page, default to 25 if invalid or missing
+        $perPage = $request->input('per_page', 25);
+        if (!in_array($perPage, [25, 50, 100])) {
+            $perPage = 25;
+        }
+
         foreach ($models as $modelName => $modelClass) {
             $query = $modelClass::onlyTrashed();
 
@@ -83,9 +89,9 @@ class TrashController extends Controller
                 });
             }
 
-            $trashedData[$modelName] = $query->paginate(10, ['*'], $modelName . '_page')
+            $trashedData[$modelName] = $query->paginate($perPage, ['*'], $modelName . '_page')
                 ->withQueryString()
-                ->appends(['tab' => $modelName]);
+                ->appends(['tab' => $modelName, 'per_page' => $perPage]);
 
             // Fetch retention settings for the view
             $retentionSettings[$modelName] = SystemConfig::where('key', "trash_retention_days_{$modelName}")->value('value');
@@ -94,6 +100,7 @@ class TrashController extends Controller
         return view('admin.trash.index', [
             'trashedData' => $trashedData,
             'search' => $searchTerm,
+            'perPage' => $perPage,
             'currentView' => $request->input('view', 'table'), // Pass the view state
             'retentionSettings' => $retentionSettings,
         ]);

--- a/resources/views/admin/trash/index.blade.php
+++ b/resources/views/admin/trash/index.blade.php
@@ -35,6 +35,13 @@
                     <input type="hidden" name="tab" id="active-tab-input" value="{{ $initActiveTab }}">
                     <input type="text" name="search" class="form-control" placeholder="Search in trash..." value="{{ $search ?? '' }}">
                     <button type="submit" class="btn btn-primary">Search</button>
+
+                    <select name="per_page" class="form-select w-auto" onchange="this.form.submit()">
+                        <option value="25" {{ ($perPage ?? 25) == 25 ? 'selected' : '' }}>25 items</option>
+                        <option value="50" {{ ($perPage ?? 25) == 50 ? 'selected' : '' }}>50 items</option>
+                        <option value="100" {{ ($perPage ?? 25) == 100 ? 'selected' : '' }}>100 items</option>
+                    </select>
+
                     <a href="{{ route('admin.trash.export', request()->query()) }}" class="btn btn-info">Export</a>
                     <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#trashSettingsModal">
                         <i class="bi bi-gear"></i>
@@ -216,6 +223,10 @@
                                     </table>
                                 </div>
                                 @endif
+
+                                <div class="mt-3">
+                                    {{ $items->links() }}
+                                </div>
                             </div>
                         @endif
                     @endforeach


### PR DESCRIPTION
- Implemented dynamic pagination in TrashController (25, 50, 100 items per page).
- Added a dropdown selector to the trash index view for controlling items per page.
- Ensured pagination links are displayed correctly for each model tab.
- Set default pagination to 25 items to prevent mass loading of deleted records.
- Verified search functionality works alongside pagination.