### PR TITLE
Fix PDF Template creation permissions for Super Admin

### DIFF
--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -21,8 +21,8 @@ class PdfTemplateController extends Controller
 
         $user = Auth::user();
 
-        // Admin/Staff filtering logic
-        if ($user->hasRole('admin') || $user->hasRole('staff')) {
+        // Admin/Staff/SuperAdmin filtering logic
+        if ($user->hasRole('super-admin') || $user->hasRole('admin') || $user->hasRole('staff')) {
             if ($request->filled('employer_id')) {
                 if ($request->employer_id === 'global') {
                     $query->where('type', 'global');
@@ -69,7 +69,7 @@ class PdfTemplateController extends Controller
 
         // Prepare employers list for filter dropdown (if admin/staff)
         $employers = [];
-        if ($user->hasRole('admin') || $user->hasRole('staff') || $user->hasRole('caretaker')) {
+        if ($user->hasRole('super-admin') || $user->hasRole('admin') || $user->hasRole('staff') || $user->hasRole('caretaker')) {
              // Optimize: only select necessary columns
              $empQuery = Employer::select('id', 'employerNameTh', 'employerNameEn');
              if ($user->hasRole('caretaker')) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,6 +15,7 @@ use Illuminate\Auth\Events\Logout;
 use App\Listeners\LogSuccessfulLogin;
 use App\Listeners\LogSuccessfulLogout;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -31,6 +32,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Implicitly grant "super-admin" role all permissions
+        // "admin" is also granted here for consistency, ensuring both roles bypass standard checks
+        Gate::before(function ($user, $ability) {
+            return $user->hasRole('super-admin') || $user->hasRole('admin') ? true : null;
+        });
+
         Paginator::useBootstrapFive();
         Employer::observe(EmployerObserver::class);
         Employee::observe(EmployeeObserver::class);

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -23,10 +23,11 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // dd('AuthServiceProvider Loaded');
         // Implicitly grant "admin" role all permissions
         // This works in the app by using Gate::before() interception
         Gate::before(function ($user, $ability) {
-            return $user->hasRole('admin') ? true : null;
+            return $user->hasRole('admin') || $user->hasRole('super-admin') ? true : null;
         });
     }
 }

--- a/resources/views/pdf_templates/create.blade.php
+++ b/resources/views/pdf_templates/create.blade.php
@@ -15,7 +15,7 @@
                         search: '',
                         open: false,
                         selectedEmployerName: '',
-                        employers: @if(isset($employers) && (auth()->user()->hasRole('admin') || auth()->user()->hasRole('staff'))) {{ $employers->map(fn($e) => [
+                        employers: @if(isset($employers) && (auth()->user()->hasRole('super-admin') || auth()->user()->hasRole('admin') || auth()->user()->hasRole('staff'))) {{ $employers->map(fn($e) => [
                             'id' => $e->id,
                             'name' => $e->employerNameTh . ' (' . $e->employerNameEn . ')',
                             'search_str' => strtolower($e->employerNameTh . ' ' . $e->employerNameEn)
@@ -58,7 +58,7 @@
                             <label class="form-label">Template Type</label>
                             <select name="type" class="form-select" x-model="type">
                                 <option value="global">Global (All Employers)</option>
-                                @if(auth()->user()->hasRole('admin') || auth()->user()->hasRole('staff'))
+                                @if(auth()->user()->hasRole('super-admin') || auth()->user()->hasRole('admin') || auth()->user()->hasRole('staff'))
                                     <option value="employer">Specific Employer</option>
                                 @elseif(auth()->user()->hasRole('employer'))
                                     <option value="employer" {{ old('type') == 'employer' ? 'selected' : '' }}>My Organization</option>
@@ -66,7 +66,7 @@
                             </select>
                         </div>
 
-                        @if(auth()->user()->hasRole('admin') || auth()->user()->hasRole('staff'))
+                        @if(auth()->user()->hasRole('super-admin') || auth()->user()->hasRole('admin') || auth()->user()->hasRole('staff'))
                         <div class="mb-3" x-show="type === 'employer'" style="display: none;" x-transition>
                             <label class="form-label">Select Employer</label>
 

--- a/resources/views/pdf_templates/index.blade.php
+++ b/resources/views/pdf_templates/index.blade.php
@@ -12,7 +12,7 @@
     </div>
 
     {{-- Filter Section --}}
-    @if(auth()->user()->hasRole('admin') || auth()->user()->hasRole('staff') || auth()->user()->hasRole('caretaker'))
+    @if(auth()->user()->hasRole('super-admin') || auth()->user()->hasRole('admin') || auth()->user()->hasRole('staff') || auth()->user()->hasRole('caretaker'))
     <div class="card shadow-sm border-0 mb-4">
         <div class="card-body bg-light rounded">
             <form action="{{ route('admin.pdf-templates.index') }}" method="GET" class="row g-3 align-items-end">


### PR DESCRIPTION
- Grant implicit permissions to `super-admin` via `Gate::before` in `AppServiceProvider`.
- Update `PdfTemplateController` to include `super-admin` in role checks.
- Update `create.blade.php` to show employer selection for `super-admin`.
- Update `index.blade.php` to show filters for `super-admin`.