### PR TITLE
feat: allow multiple caretakers for employers

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -30,7 +30,7 @@ class EmployerController extends Controller
 
     public function index(Request $request)
     {
-        $query = Employer::with(['jobOwner', 'assignedStaff', 'addresses'])->latest();
+        $query = Employer::with(['jobOwner', 'caretakers', 'addresses'])->latest();
 
         if ($request->filled('search')) {
             $searchTerm = '%' . $request->input('search') . '%';
@@ -42,7 +42,7 @@ class EmployerController extends Controller
                   ->orWhereHas('jobOwner', function($subQ) use ($searchTerm) {
                       $subQ->where('name', 'like', $searchTerm);
                   })
-                  ->orWhereHas('assignedStaff', function($subQ) use ($searchTerm) {
+                  ->orWhereHas('caretakers', function($subQ) use ($searchTerm) {
                       $subQ->where('name', 'like', $searchTerm);
                   })
                   ->orWhere(function($subQ) use ($searchTerm) {
@@ -104,7 +104,8 @@ class EmployerController extends Controller
             'employer_doc_other_3' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:5120',
             'employer_doc_other_3_desc' => 'nullable|string|max:255',
             'job_owner_id' => 'required|exists:job_owners,id',
-            'assigned_staff_id' => 'nullable|exists:users,id',
+            'assigned_staff_ids' => 'nullable|array',
+            'assigned_staff_ids.*' => 'exists:users,id',
             // Signatures
             'signature_1_file' => 'nullable|image|max:2048',
             'signature_2_file' => 'nullable|image|max:2048',
@@ -137,12 +138,18 @@ class EmployerController extends Controller
         unset($validated['signature_1_file']);
         unset($validated['signature_2_file']);
 
-        Employer::create($validated);
+        $staffIds = $validated['assigned_staff_ids'] ?? [];
+        unset($validated['assigned_staff_ids']);
+
+        $employer = Employer::create($validated);
+        $employer->caretakers()->sync($staffIds);
+
         return redirect()->route('employers.index')->with('success', 'Employer created successfully.');
     }
 
     public function edit(Request $request, Employer $employer)
     {
+        $employer->load('caretakers');
         $jobOwners = JobOwner::orderBy('name')->get();
         $staffUsers = User::role(['admin', 'staff', 'caretaker'])->orderBy('name')->get();
 
@@ -272,7 +279,8 @@ class EmployerController extends Controller
             'employer_doc_other_3' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:5120',
             'employer_doc_other_3_desc' => 'nullable|string|max:255',
             'job_owner_id' => 'required|exists:job_owners,id',
-            'assigned_staff_id' => 'nullable|exists:users,id',
+            'assigned_staff_ids' => 'nullable|array',
+            'assigned_staff_ids.*' => 'exists:users,id',
             // Signatures
             'signature_1_action' => 'nullable|in:keep,generate,upload,draw',
             'signature_1_file' => 'nullable|required_if:signature_1_action,upload|image|max:2048',
@@ -352,7 +360,11 @@ class EmployerController extends Controller
         unset($validated['signature_2_file']);
         unset($validated['signature_2_base64']);
 
+        $staffIds = $validated['assigned_staff_ids'] ?? [];
+        unset($validated['assigned_staff_ids']);
+
         $employer->update($validated);
+        $employer->caretakers()->sync($staffIds);
 
         if ($request->ajax() || $request->wantsJson()) {
             return response()->json([

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -26,8 +26,10 @@ class Employer extends Model
                     $builder->where('user_id', $user->id);
                 } elseif ($user->hasRole('caretaker')) {
                     // This user is a 'caretaker'. Filter their view to *only*
-                    // Employer records where they are the assigned staff.
-                    $builder->where('assigned_staff_id', $user->id);
+                    // Employer records where they are one of the assigned caretakers.
+                    $builder->whereHas('caretakers', function ($q) use ($user) {
+                        $q->where('users.id', $user->id);
+                    });
                 }
             }
         });
@@ -109,6 +111,12 @@ class Employer extends Model
     public function assignedStaff()
     {
         return $this->belongsTo(User::class, 'assigned_staff_id');
+    }
+
+    public function caretakers()
+    {
+        return $this->belongsToMany(User::class, 'employer_user', 'employer_id', 'user_id')
+                    ->withTimestamps();
     }
 
     public function customFields()

--- a/database/migrations/2026_02_16_150614_create_employer_user_table.php
+++ b/database/migrations/2026_02_16_150614_create_employer_user_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employer_user', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('employer_id');
+            $table->unsignedBigInteger('user_id');
+            $table->timestamps();
+
+            $table->foreign('employer_id')->references('id')->on('employers')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+
+            // Unique constraint to prevent duplicate assignments
+            $table->unique(['employer_id', 'user_id']);
+        });
+
+        // Migrate existing data
+        $employers = DB::table('employers')->whereNotNull('assigned_staff_id')->get();
+        foreach ($employers as $employer) {
+            // Check if user exists first to avoid foreign key constraint error
+            if (DB::table('users')->where('id', $employer->assigned_staff_id)->exists()) {
+                DB::table('employer_user')->insert([
+                    'employer_id' => $employer->id,
+                    'user_id' => $employer->assigned_staff_id,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employer_user');
+    }
+};

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -49,13 +49,37 @@
         </div>
         <div class="row mb-3">
             <div class="col-md-6">
-                <label for="assigned_staff_id" class="form-label">{{ __('Responsible Person') }}</label>
-                <select class="form-select" id="assigned_staff_id" name="assigned_staff_id">
-                    <option value="">{{ __('Select Responsible Person') }}</option>
-                    @foreach($staffUsers as $staff)
-                        <option value="{{ $staff->id }}">{{ $staff->name }}</option>
-                    @endforeach
-                </select>
+                <label class="form-label">{{ __('Responsible Person') }}</label>
+                <div class="position-relative" x-data="{
+                    open: false,
+                    selected: {{ json_encode(old('assigned_staff_ids', [])) }},
+                    options: {{ $staffUsers->map(fn($u) => ['id' => $u->id, 'name' => $u->name])->toJson() }},
+                    search: '',
+                    get filteredOptions() {
+                        if (this.search === '') return this.options;
+                        return this.options.filter(option => option.name.toLowerCase().includes(this.search.toLowerCase()));
+                    },
+                    get buttonText() {
+                        if (this.selected.length === 0) return '{{ __('Select Responsible Person') }}';
+                        if (this.selected.length <= 2) {
+                            return this.selected.map(id => this.options.find(o => o.id == id)?.name).filter(Boolean).join(', ');
+                        }
+                        return this.selected.length + ' {{ __('Selected') }}';
+                    }
+                }">
+                    <button type="button" class="form-select text-start" @click="open = !open" x-text="buttonText"></button>
+
+                    <div x-show="open" @click.outside="open = false" style="display: none; z-index: 1050; max-height: 300px; overflow-y: auto;" class="position-absolute w-100 bg-white border rounded shadow mt-1 p-2">
+                        <input type="text" class="form-control form-control-sm mb-2" placeholder="{{ __('Search...') }}" x-model="search">
+                        <template x-for="option in filteredOptions" :key="option.id">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" :id="'staff_' + option.id" :value="option.id" x-model="selected" name="assigned_staff_ids[]">
+                                <label class="form-check-label w-100" :for="'staff_' + option.id" x-text="option.name" style="cursor: pointer;"></label>
+                            </div>
+                        </template>
+                        <div x-show="filteredOptions.length === 0" class="text-muted small text-center">{{ __('No results found') }}</div>
+                    </div>
+                </div>
             </div>
         </div>
         <div class="row mb-3">

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -78,13 +78,37 @@
         </div>
         <div class="row mb-3">
             <div class="col-md-6">
-                <label for="assigned_staff_id" class="form-label">{{ __('Responsible Person') }}</label>
-                <select class="form-select" id="assigned_staff_id" name="assigned_staff_id">
-                    <option value="">{{ __('Select Responsible Person') }}</option>
-                    @foreach($staffUsers as $staff)
-                        <option value="{{ $staff->id }}" {{ $employer->assigned_staff_id == $staff->id ? 'selected' : '' }}>{{ $staff->name }}</option>
-                    @endforeach
-                </select>
+                <label class="form-label">{{ __('Responsible Person') }}</label>
+                <div class="position-relative" x-data="{
+                    open: false,
+                    selected: {{ json_encode(old('assigned_staff_ids', $employer->caretakers->pluck('id')->toArray())) }},
+                    options: {{ $staffUsers->map(fn($u) => ['id' => $u->id, 'name' => $u->name])->toJson() }},
+                    search: '',
+                    get filteredOptions() {
+                        if (this.search === '') return this.options;
+                        return this.options.filter(option => option.name.toLowerCase().includes(this.search.toLowerCase()));
+                    },
+                    get buttonText() {
+                        if (this.selected.length === 0) return '{{ __('Select Responsible Person') }}';
+                        if (this.selected.length <= 2) {
+                            return this.selected.map(id => this.options.find(o => o.id == id)?.name).filter(Boolean).join(', ');
+                        }
+                        return this.selected.length + ' {{ __('Selected') }}';
+                    }
+                }">
+                    <button type="button" class="form-select text-start" @click="open = !open" x-text="buttonText"></button>
+
+                    <div x-show="open" @click.outside="open = false" style="display: none; z-index: 1050; max-height: 300px; overflow-y: auto;" class="position-absolute w-100 bg-white border rounded shadow mt-1 p-2">
+                        <input type="text" class="form-control form-control-sm mb-2" placeholder="{{ __('Search...') }}" x-model="search">
+                        <template x-for="option in filteredOptions" :key="option.id">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" :id="'staff_' + option.id" :value="option.id" x-model="selected" name="assigned_staff_ids[]">
+                                <label class="form-check-label w-100" :for="'staff_' + option.id" x-text="option.name" style="cursor: pointer;"></label>
+                            </div>
+                        </template>
+                        <div x-show="filteredOptions.length === 0" class="text-muted small text-center">{{ __('No results found') }}</div>
+                    </div>
+                </div>
             </div>
         </div>
         <div class="row mb-3">

--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -80,7 +80,13 @@
                         <td>{{ $employer->employerId }}</td>
                         <td>{{ $employer->businessType }}</td>
                         <td>{{ $employer->jobOwner->name ?? 'N/A' }}</td>
-                        <td>{{ $employer->assignedStaff->name ?? '-' }}</td>
+                        <td>
+                            @if($employer->caretakers->isNotEmpty())
+                                {{ $employer->caretakers->pluck('name')->join(', ') }}
+                            @else
+                                -
+                            @endif
+                        </td>
                         <td class="text-center">
                             <div class="d-flex flex-column flex-md-row gap-1 justify-content-center">
                                 <button type="button" class="btn btn-sm btn-outline-info btn-preview" data-model-type="employer" data-model-id="{{ $employer->id }}" title="{{ __('Preview Data') }}"> <i class="bi bi-search"></i> </button>


### PR DESCRIPTION
- Create `employer_user` pivot table and migrate existing data.
- Update `Employer` model to use `caretakers()` Many-to-Many relationship.
- Update `EmployerController` to handle syncing of multiple staff IDs.
- Update `index`, `create`, and `edit` views to support multi-select UI for caretakers.
- Update global scope `employerTenancy` to filter based on the new relationship.