### PR TITLE
Update Operator button position and add confirmation dialog

### DIFF
--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -1029,20 +1029,40 @@
     }
 
     // --- Operator Toggle ---
-    window.toggleOperator = function(itemId, btn) {
-        btn.disabled = true;
-        fetch(`/workflow/item/${itemId}/toggle-operator`, {
-            method: 'POST',
-            headers: { 'X-CSRF-TOKEN': csrfToken }
-        })
-        .then(res => res.json())
-        .then(data => {
-            if(data.success) {
-                refreshItemCard(itemId);
-            } else {
-                btn.disabled = false;
-            }
-        });
+    window.toggleOperator = function(itemId, btn, hasOperator) {
+        const performToggle = () => {
+            btn.disabled = true;
+            fetch(`/workflow/item/${itemId}/toggle-operator`, {
+                method: 'POST',
+                headers: { 'X-CSRF-TOKEN': csrfToken }
+            })
+            .then(res => res.json())
+            .then(data => {
+                if(data.success) {
+                    refreshItemCard(itemId);
+                } else {
+                    btn.disabled = false;
+                }
+            });
+        };
+
+        if (hasOperator) {
+            Swal.fire({
+                title: '{{ __("Change Operator?") }}',
+                text: '{{ __("Are you sure you want to change or remove the operator?") }}',
+                icon: 'question',
+                showCancelButton: true,
+                confirmButtonText: '{{ __("Yes, Change") }}',
+                confirmButtonColor: '#0d6efd',
+                cancelButtonText: '{{ __("Cancel") }}'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    performToggle();
+                }
+            });
+        } else {
+            performToggle();
+        }
     }
 
     // --- Reuse Toggle Step from Workflow (Global Function) ---

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -48,11 +48,11 @@
 
     <div class="card {{ $cardClass }} w-100 position-relative">
 
-    {{-- Operator Badge (Top Right) --}}
-    <div class="position-absolute top-0 end-0 m-2 z-index-10">
+    {{-- Operator Badge (Bottom Right) --}}
+    <div class="position-absolute bottom-0 end-0 m-2 z-index-10">
         <button class="btn btn-sm {{ $operatorId ? ($isMe ? 'btn-primary' : 'btn-secondary') : 'btn-outline-secondary' }} rounded-pill shadow-sm py-0 px-2"
                 style="font-size: 0.75rem; border-width: 1px;"
-                onclick="window.toggleOperator ? window.toggleOperator({{ $employee->id }}, this) : console.error('toggleOperator not defined')"
+                onclick="window.toggleOperator ? window.toggleOperator({{ $employee->id }}, this, {{ $operatorId ? 'true' : 'false' }}) : console.error('toggleOperator not defined')"
                 title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Claim' }}">
             <i class="bi bi-person-badge-fill"></i>
             @if($operatorName)

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -1251,19 +1251,39 @@
     }
 
     // --- Operator Toggle ---
-    window.toggleOperator = function(employeeId, btn) {
-        btn.disabled = true;
-        fetch(`/production/registration/${employeeId}/toggle-operator`, {
-            method: 'POST',
-            headers: { 'X-CSRF-TOKEN': csrfToken }
-        })
-        .then(res => res.json())
-        .then(data => {
-            if(data.success) {
-                if(data.html) updateCardHTML(employeeId, data.html);
-            }
-            btn.disabled = false;
-        });
+    window.toggleOperator = function(employeeId, btn, hasOperator) {
+        const performToggle = () => {
+            btn.disabled = true;
+            fetch(`/production/registration/${employeeId}/toggle-operator`, {
+                method: 'POST',
+                headers: { 'X-CSRF-TOKEN': csrfToken }
+            })
+            .then(res => res.json())
+            .then(data => {
+                if(data.success) {
+                    if(data.html) updateCardHTML(employeeId, data.html);
+                }
+                btn.disabled = false;
+            });
+        };
+
+        if (hasOperator) {
+            Swal.fire({
+                title: '{{ __("Change Operator?") }}',
+                text: '{{ __("Are you sure you want to change or remove the operator?") }}',
+                icon: 'question',
+                showCancelButton: true,
+                confirmButtonText: '{{ __("Yes, Change") }}',
+                confirmButtonColor: '#0d6efd',
+                cancelButtonText: '{{ __("Cancel") }}'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    performToggle();
+                }
+            });
+        } else {
+            performToggle();
+        }
     }
 
     // --- Resolution Status & Note Functions ---

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -887,19 +887,39 @@
     });
 
     // --- Operator Toggle ---
-    window.toggleOperator = function(employeeId, btn) {
-        btn.disabled = true;
-        fetch(`/production/renewal/${employeeId}/toggle-operator`, {
-            method: 'POST',
-            headers: { 'X-CSRF-TOKEN': csrfToken }
-        })
-        .then(res => res.json())
-        .then(data => {
-            if(data.success) {
-                if(data.html) updateCardHTML(employeeId, data.html);
-            }
-            btn.disabled = false;
-        });
+    window.toggleOperator = function(employeeId, btn, hasOperator) {
+        const performToggle = () => {
+            btn.disabled = true;
+            fetch(`/production/renewal/${employeeId}/toggle-operator`, {
+                method: 'POST',
+                headers: { 'X-CSRF-TOKEN': csrfToken }
+            })
+            .then(res => res.json())
+            .then(data => {
+                if(data.success) {
+                    if(data.html) updateCardHTML(employeeId, data.html);
+                }
+                btn.disabled = false;
+            });
+        };
+
+        if (hasOperator) {
+            Swal.fire({
+                title: '{{ __("Change Operator?") }}',
+                text: '{{ __("Are you sure you want to change or remove the operator?") }}',
+                icon: 'question',
+                showCancelButton: true,
+                confirmButtonText: '{{ __("Yes, Change") }}',
+                confirmButtonColor: '#0d6efd',
+                cancelButtonText: '{{ __("Cancel") }}'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    performToggle();
+                }
+            });
+        } else {
+            performToggle();
+        }
     }
 
     // --- Resolution Status & Note Functions ---

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1382,20 +1382,40 @@
     }
 
     // --- Operator Toggle ---
-    window.toggleOperator = function(itemId, btn) {
-        btn.disabled = true;
-        fetch(`/workflow/item/${itemId}/toggle-operator`, {
-            method: 'POST',
-            headers: { 'X-CSRF-TOKEN': csrfToken }
-        })
-        .then(res => res.json())
-        .then(data => {
-            if(data.success) {
-                refreshItemCard(itemId);
-            } else {
-                btn.disabled = false;
-            }
-        });
+    window.toggleOperator = function(itemId, btn, hasOperator) {
+        const performToggle = () => {
+            btn.disabled = true;
+            fetch(`/workflow/item/${itemId}/toggle-operator`, {
+                method: 'POST',
+                headers: { 'X-CSRF-TOKEN': csrfToken }
+            })
+            .then(res => res.json())
+            .then(data => {
+                if(data.success) {
+                    refreshItemCard(itemId);
+                } else {
+                    btn.disabled = false;
+                }
+            });
+        };
+
+        if (hasOperator) {
+            Swal.fire({
+                title: '{{ __("Change Operator?") }}',
+                text: '{{ __("Are you sure you want to change or remove the operator?") }}',
+                icon: 'question',
+                showCancelButton: true,
+                confirmButtonText: '{{ __("Yes, Change") }}',
+                confirmButtonColor: '#0d6efd',
+                cancelButtonText: '{{ __("Cancel") }}'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    performToggle();
+                }
+            });
+        } else {
+            performToggle();
+        }
     }
 
     // --- Daily Check ---

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -107,11 +107,11 @@
 
     <div class="card {{ $cardClass }} w-100 position-relative">
 
-    {{-- Operator Badge (Top Right) --}}
-    <div class="position-absolute top-0 end-0 m-2 z-index-10">
+    {{-- Operator Badge (Bottom Right) --}}
+    <div class="position-absolute bottom-0 end-0 m-2 z-index-10">
         <button class="btn btn-sm {{ $operatorId ? ($isMe ? 'btn-primary' : 'btn-secondary') : 'btn-outline-secondary' }} rounded-pill shadow-sm py-0 px-2"
                 style="font-size: 0.75rem; border-width: 1px;"
-                onclick="window.toggleOperator ? window.toggleOperator({{ $item->id }}, this) : console.error('toggleOperator not defined')"
+                onclick="window.toggleOperator ? window.toggleOperator({{ $item->id }}, this, {{ $operatorId ? 'true' : 'false' }}) : console.error('toggleOperator not defined')"
                 title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Claim' }}">
             <i class="bi bi-person-badge-fill"></i>
             @if($operatorName)


### PR DESCRIPTION
- Moved the Operator button from top-right to bottom-right in `_item_card.blade.php` and `_employee_card.blade.php` to prevent overlap with action buttons.
- Updated `window.toggleOperator` JS function in Production, Workflow, Registration, and Renewal index views to accept a `hasOperator` argument.
- Implemented SweetAlert2 confirmation popup when changing/removing an assigned operator.
- Updated `onclick` handlers in Blade templates to pass the operator state.