### PR TITLE
Fix: Workflow Dashboard Overview stats include soft-deleted employer …

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -242,11 +242,23 @@ class WorkflowController extends Controller
      */
     private function dashboard($tabs)
     {
-        // 1. Global Scoreboard Stats
-        $itemsQuery = ProductionItem::whereHas('order', fn($q) => $q->where('status', '!=', 'pre_production'));
+        // 1. Get Valid WorkType IDs (to match the displayed tabs)
+        $validWorkTypeIds = $tabs->pluck('id');
 
+        // 2. Base Query for Items that should be counted
+        // Must belong to a valid WorkType (Tab) AND have a valid Employer (same as index query)
+        $itemsQuery = ProductionItem::whereHas('order', function($q) use ($validWorkTypeIds) {
+            $q->where('status', '!=', 'pre_production')
+              ->whereIn('work_type_id', $validWorkTypeIds)
+              ->whereHas('employer');
+        });
+
+        // 3. Global Scoreboard Stats
         $stats = [
-            'total_projects' => ProductionOrder::where('status', '!=', 'pre_production')->count(),
+            'total_projects' => ProductionOrder::where('status', '!=', 'pre_production')
+                                    ->whereIn('work_type_id', $validWorkTypeIds)
+                                    ->whereHas('employer')
+                                    ->count(),
             'total_employees' => (clone $itemsQuery)->count(),
             'not_started' => (clone $itemsQuery)->where('status', 'pending')
                                            ->whereHas('order', fn($q) => $q->where('status', '!=', 'cancelled'))

--- a/tests/Feature/WorkflowScoreboardTest.php
+++ b/tests/Feature/WorkflowScoreboardTest.php
@@ -138,3 +138,48 @@ test('tab stats exclude items from cancelled orders', function () {
     expect($stats['not_started'])->toBe(1)
         ->and($stats['cancelled'])->toBe(1);
 });
+
+test('dashboard stats exclude orders from deleted employers', function () {
+    $workType = WorkType::where('slug', 'notify_in')->first();
+
+    // Active Employer
+    $activeOrder = ProductionOrder::create([
+        'employer_id' => $this->employer->id,
+        'work_type_id' => $workType->id,
+        'status' => 'active',
+        'type' => 'employer',
+        'project_name' => 'Active Project',
+        'created_by' => $this->user->id,
+    ]);
+    ProductionItem::create([
+        'production_order_id' => $activeOrder->id,
+        'status' => 'pending',
+    ]);
+
+    // Deleted Employer
+    $deletedEmployer = Employer::create([
+        'employerNameTh' => 'Deleted Employer',
+        'employerId' => 'EMP-002',
+    ]);
+    $deletedOrder = ProductionOrder::create([
+        'employer_id' => $deletedEmployer->id,
+        'work_type_id' => $workType->id,
+        'status' => 'active',
+        'type' => 'employer',
+        'project_name' => 'Deleted Project',
+        'created_by' => $this->user->id,
+    ]);
+    ProductionItem::create([
+        'production_order_id' => $deletedOrder->id,
+        'status' => 'pending',
+    ]);
+
+    $deletedEmployer->delete();
+
+    $response = $this->get(route('workflow.index'));
+    $stats = $response->viewData('stats');
+
+    // Expect: Not Started = 1 (Active only)
+    expect($stats['not_started'])->toBe(1)
+        ->and($stats['total_employees'])->toBe(1);
+});


### PR DESCRIPTION
…orders

This commit fixes a discrepancy between the Workflow "Overview" stats and the individual "Tab" stats. Previously, the "Overview" dashboard counted all ProductionItems linked to any ProductionOrder, regardless of whether the employer was soft-deleted or if the order belonged to a hidden/invalid WorkType. The "Tab" views, however, correctly filtered out orders with soft-deleted employers and only displayed active WorkTypes.

Changes:
- Updated `WorkflowController::dashboard` to:
    - Filter items by valid `work_type_id` (derived from active tabs).
    - Filter items by `whereHas('employer')` to exclude orders from soft-deleted employers.
- Added a regression test case in `tests/Feature/WorkflowScoreboardTest.php` to verify that orders from deleted employers are excluded from the "Not Started" count.