### PR TITLE
Fix operator filter and operator assignment functionality

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -169,8 +169,17 @@ class RegistrationController extends Controller
         }
         $cancelledEmployersCount = $cancelledEmployersQuery->count();
 
-        // Users for Filter
-        $users = User::orderBy('name')->get(['id', 'name']);
+        // Active Operators for Filter
+        $operatorIds = (clone $statsQuery)
+            ->whereIn('status', ['registration_pending', 'registration_completed'])
+            ->whereNotNull('operator_id')
+            ->distinct()
+            ->pluck('operator_id');
+
+        $activeOperators = User::whereIn('id', $operatorIds)->orderBy('name')->get(['id', 'name']);
+
+        // All Users for Assignment
+        $allUsers = User::orderBy('name')->get(['id', 'name']);
 
         // --- 3. Process Visible Employers ---
         // OPTIMIZATION: Removed heavy hydration and PHP loops.
@@ -209,7 +218,8 @@ class RegistrationController extends Controller
             'lastStepId',
             'addressOptions',
             'notificationSetting',
-            'users'
+            'activeOperators',
+            'allUsers'
         ));
     }
 
@@ -1956,16 +1966,39 @@ class RegistrationController extends Controller
     public function toggleOperator(Request $request, $employeeId)
     {
         $employee = Employee::findOrFail($employeeId);
-        $userId = auth()->id();
 
-        if ($employee->operator_id === $userId) {
-            $employee->update(['operator_id' => null]);
-            $message = 'Operator unassigned.';
+        // Check for specific user assignment
+        if ($request->has('operator_id')) {
+            $userId = $request->input('operator_id');
+            // If explicit null or empty, remove operator
+            if (empty($userId)) {
+                $employee->update(['operator_id' => null]);
+                $message = 'Operator unassigned.';
+            } else {
+                $user = User::find($userId);
+                if ($user) {
+                    $employee->update(['operator_id' => $user->id]);
+                    $message = 'Operator assigned to ' . $user->name;
+                } else {
+                     return response()->json(['success' => false, 'message' => 'User not found'], 404);
+                }
+            }
         } else {
-            $employee->update(['operator_id' => $userId]);
-            $message = 'Operator assigned to ' . auth()->user()->name;
+            // Legacy Toggle Behavior (Toggle Me)
+            $userId = auth()->id();
+            if ($employee->operator_id === $userId) {
+                $employee->update(['operator_id' => null]);
+                $message = 'Operator unassigned.';
+            } else {
+                $employee->update(['operator_id' => $userId]);
+                $message = 'Operator assigned to ' . auth()->user()->name;
+            }
         }
 
-        return response()->json(['success' => true, 'message' => $message]);
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+            'html' => $this->getEmployeeCardHtml($employee)
+        ]);
     }
 }

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -39,7 +39,7 @@ class RenewalController extends Controller
         // --- 2. Global Employee Query (Lightweight) ---
         $employeeQuery = Employee::query()
             ->whereIn('status', ['renewal_pending', 'renewal_completed', 'renewal_cancelled'])
-            ->select('id', 'employer_id', 'status', 'employeeNameTh', 'employeeNameEn', 'employeeTitleTh', 'employeeTitleEn', 'employeePhoto', 'employeeNationality');
+            ->select('id', 'employer_id', 'status', 'employeeNameTh', 'employeeNameEn', 'employeeTitleTh', 'employeeTitleEn', 'employeePhoto', 'employeeNationality', 'operator_id');
 
         if (auth()->user()->can('manage-tickets')) {
             $employeeQuery->withoutGlobalScope('employerTenancy');
@@ -152,8 +152,17 @@ class RenewalController extends Controller
                 $q->where('status', 'renewal_resolution_cancelled');
             })->count();
 
-        // Users for Filter
-        $users = User::orderBy('name')->get(['id', 'name']);
+        // Active Operators for Filter
+        $operatorIds = (clone $employeeQuery) // Reusing the global query which has operators
+            ->whereIn('status', ['renewal_pending', 'renewal_completed'])
+            ->whereNotNull('operator_id')
+            ->distinct()
+            ->pluck('operator_id');
+
+        $activeOperators = User::whereIn('id', $operatorIds)->orderBy('name')->get(['id', 'name']);
+
+        // All Users for Assignment
+        $allUsers = User::orderBy('name')->get(['id', 'name']);
 
         $perPage = $request->input('per_page', 20);
         if (!in_array($perPage, [20, 50, 100])) {
@@ -262,7 +271,8 @@ class RenewalController extends Controller
             'stepStats',
             'lastStepId',
             'addressOptions',
-            'users'
+            'activeOperators',
+            'allUsers'
         ));
     }
 
@@ -1031,16 +1041,36 @@ class RenewalController extends Controller
     public function toggleOperator(Request $request, $employeeId)
     {
         $employee = Employee::findOrFail($employeeId);
-        $userId = auth()->id();
 
-        if ($employee->operator_id === $userId) {
-            $employee->update(['operator_id' => null]);
-            $message = 'Operator unassigned.';
+        if ($request->has('operator_id')) {
+            $userId = $request->input('operator_id');
+            if (empty($userId)) {
+                $employee->update(['operator_id' => null]);
+                $message = 'Operator unassigned.';
+            } else {
+                $user = User::find($userId);
+                if ($user) {
+                    $employee->update(['operator_id' => $user->id]);
+                    $message = 'Operator assigned to ' . $user->name;
+                } else {
+                     return response()->json(['success' => false, 'message' => 'User not found'], 404);
+                }
+            }
         } else {
-            $employee->update(['operator_id' => $userId]);
-            $message = 'Operator assigned to ' . auth()->user()->name;
+            $userId = auth()->id();
+            if ($employee->operator_id === $userId) {
+                $employee->update(['operator_id' => null]);
+                $message = 'Operator unassigned.';
+            } else {
+                $employee->update(['operator_id' => $userId]);
+                $message = 'Operator assigned to ' . auth()->user()->name;
+            }
         }
 
-        return response()->json(['success' => true, 'message' => $message]);
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+            'html' => $this->getEmployeeCardHtml($employee)
+        ]);
     }
 }

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -50,10 +50,15 @@
 
     {{-- Operator Badge (Bottom Right) --}}
     <div class="position-absolute bottom-0 end-0 m-2 z-index-10">
+        @php
+            $toggleUrl = request()->is('production/renewal*')
+                ? route('production.renewal.toggle_operator', $employee->id)
+                : route('production.registration.toggle_operator', $employee->id);
+        @endphp
         <button class="btn btn-sm {{ $operatorId ? ($isMe ? 'btn-primary' : 'btn-secondary') : 'btn-outline-secondary' }} rounded-pill shadow-sm py-0 px-2"
                 style="font-size: 0.75rem; border-width: 1px;"
-                onclick="window.toggleOperator ? window.toggleOperator({{ $employee->id }}, this, {{ $operatorId ? 'true' : 'false' }}) : console.error('toggleOperator not defined')"
-                title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Claim' }}">
+                onclick="window.toggleOperator ? window.toggleOperator({{ $employee->id }}, this, '{{ $operatorId ?? '' }}', '{{ $toggleUrl }}') : console.error('toggleOperator not defined')"
+                title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Assign' }}">
             <i class="bi bi-person-badge-fill"></i>
             @if($operatorName)
                 <span class="ms-1 fw-bold">{{ $operatorName }}</span>

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -257,12 +257,12 @@
                 <div class="dropdown">
                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i class="bi bi-person-fill me-1"></i>
-                        {{ request('operator_filter') ? ($users->firstWhere('id', request('operator_filter'))->name ?? __('Operator')) : __('Operator') }}
+                        {{ request('operator_filter') ? ($activeOperators->firstWhere('id', request('operator_filter'))->name ?? __('Operator')) : __('Operator') }}
                     </button>
                     <ul class="dropdown-menu" style="max-height: 300px; overflow-y: auto;">
                         <li><a class="dropdown-item" href="{{ route('production.registration.index', array_merge(request()->query(), ['operator_filter' => null])) }}">{{ __('All Operators') }}</a></li>
                         <li><hr class="dropdown-divider"></li>
-                        @foreach($users as $user)
+                        @foreach($activeOperators as $user)
                             <li><a class="dropdown-item {{ request('operator_filter') == $user->id ? 'active' : '' }}" href="{{ route('production.registration.index', array_merge(request()->query(), ['operator_filter' => $user->id])) }}">{{ $user->name }}</a></li>
                         @endforeach
                     </ul>
@@ -901,6 +901,7 @@
     const currentStepFilter = @json(request('filter'));
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     const lastStepId = @json($lastStepId);
+    window.allUsers = @json($allUsers);
 
     // --- Notification Settings ---
     window.saveNotificationSettings = function() {
@@ -1251,39 +1252,57 @@
     }
 
     // --- Operator Toggle ---
-    window.toggleOperator = function(employeeId, btn, hasOperator) {
-        const performToggle = () => {
-            btn.disabled = true;
-            fetch(`/production/registration/${employeeId}/toggle-operator`, {
-                method: 'POST',
-                headers: { 'X-CSRF-TOKEN': csrfToken }
-            })
-            .then(res => res.json())
-            .then(data => {
+    window.toggleOperator = function(employeeId, btn, currentOperatorId, url) {
+        let options = {};
+        options[''] = '{{ __("No Operator") }}';
+        if (window.allUsers) {
+            window.allUsers.forEach(u => {
+                options[u.id] = u.name;
+            });
+        }
+
+        Swal.fire({
+            title: '{{ __("Assign Operator") }}',
+            input: 'select',
+            inputOptions: options,
+            inputValue: currentOperatorId || '',
+            showCancelButton: true,
+            confirmButtonText: '{{ __("Save") }}',
+            showLoaderOnConfirm: true,
+            preConfirm: (value) => {
+                const fetchUrl = url || `/production/registration/${employeeId}/toggle-operator`;
+                return fetch(fetchUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': csrfToken
+                    },
+                    body: JSON.stringify({ operator_id: value })
+                })
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(response.statusText)
+                    }
+                    return response.json()
+                })
+                .catch(error => {
+                    Swal.showValidationMessage(
+                        `Request failed: ${error}`
+                    )
+                })
+            },
+            allowOutsideClick: () => !Swal.isLoading()
+        }).then((result) => {
+            if (result.isConfirmed) {
+                const data = result.value;
                 if(data.success) {
                     if(data.html) updateCardHTML(employeeId, data.html);
+                    Swal.fire('{{ __("Success") }}', data.message, 'success');
+                } else {
+                     Swal.fire('{{ __("Error") }}', data.message, 'error');
                 }
-                btn.disabled = false;
-            });
-        };
-
-        if (hasOperator) {
-            Swal.fire({
-                title: '{{ __("Change Operator?") }}',
-                text: '{{ __("Are you sure you want to change or remove the operator?") }}',
-                icon: 'question',
-                showCancelButton: true,
-                confirmButtonText: '{{ __("Yes, Change") }}',
-                confirmButtonColor: '#0d6efd',
-                cancelButtonText: '{{ __("Cancel") }}'
-            }).then((result) => {
-                if (result.isConfirmed) {
-                    performToggle();
-                }
-            });
-        } else {
-            performToggle();
-        }
+            }
+        });
     }
 
     // --- Resolution Status & Note Functions ---

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -227,12 +227,12 @@
                 <div class="dropdown">
                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i class="bi bi-person-fill me-1"></i>
-                        {{ request('operator_filter') ? ($users->firstWhere('id', request('operator_filter'))->name ?? __('Operator')) : __('Operator') }}
+                        {{ request('operator_filter') ? ($activeOperators->firstWhere('id', request('operator_filter'))->name ?? __('Operator')) : __('Operator') }}
                     </button>
                     <ul class="dropdown-menu" style="max-height: 300px; overflow-y: auto;">
                         <li><a class="dropdown-item" href="{{ route('production.renewal.index', array_merge(request()->query(), ['operator_filter' => null])) }}">{{ __('All Operators') }}</a></li>
                         <li><hr class="dropdown-divider"></li>
-                        @foreach($users as $user)
+                        @foreach($activeOperators as $user)
                             <li><a class="dropdown-item {{ request('operator_filter') == $user->id ? 'active' : '' }}" href="{{ route('production.renewal.index', array_merge(request()->query(), ['operator_filter' => $user->id])) }}">{{ $user->name }}</a></li>
                         @endforeach
                     </ul>
@@ -815,6 +815,7 @@
     const currentStepFilter = @json(request('filter'));
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
     const lastStepId = @json($lastStepId);
+    window.allUsers = @json($allUsers);
 
     // --- Lazy Loading Logic ---
     window.loadedEmployers = {};
@@ -887,39 +888,57 @@
     });
 
     // --- Operator Toggle ---
-    window.toggleOperator = function(employeeId, btn, hasOperator) {
-        const performToggle = () => {
-            btn.disabled = true;
-            fetch(`/production/renewal/${employeeId}/toggle-operator`, {
-                method: 'POST',
-                headers: { 'X-CSRF-TOKEN': csrfToken }
-            })
-            .then(res => res.json())
-            .then(data => {
+    window.toggleOperator = function(employeeId, btn, currentOperatorId, url) {
+        let options = {};
+        options[''] = '{{ __("No Operator") }}';
+        if (window.allUsers) {
+            window.allUsers.forEach(u => {
+                options[u.id] = u.name;
+            });
+        }
+
+        Swal.fire({
+            title: '{{ __("Assign Operator") }}',
+            input: 'select',
+            inputOptions: options,
+            inputValue: currentOperatorId || '',
+            showCancelButton: true,
+            confirmButtonText: '{{ __("Save") }}',
+            showLoaderOnConfirm: true,
+            preConfirm: (value) => {
+                const fetchUrl = url || `/production/renewal/${employeeId}/toggle-operator`;
+                return fetch(fetchUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': csrfToken
+                    },
+                    body: JSON.stringify({ operator_id: value })
+                })
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(response.statusText)
+                    }
+                    return response.json()
+                })
+                .catch(error => {
+                    Swal.showValidationMessage(
+                        `Request failed: ${error}`
+                    )
+                })
+            },
+            allowOutsideClick: () => !Swal.isLoading()
+        }).then((result) => {
+            if (result.isConfirmed) {
+                const data = result.value;
                 if(data.success) {
                     if(data.html) updateCardHTML(employeeId, data.html);
+                    Swal.fire('{{ __("Success") }}', data.message, 'success');
+                } else {
+                     Swal.fire('{{ __("Error") }}', data.message, 'error');
                 }
-                btn.disabled = false;
-            });
-        };
-
-        if (hasOperator) {
-            Swal.fire({
-                title: '{{ __("Change Operator?") }}',
-                text: '{{ __("Are you sure you want to change or remove the operator?") }}',
-                icon: 'question',
-                showCancelButton: true,
-                confirmButtonText: '{{ __("Yes, Change") }}',
-                confirmButtonColor: '#0d6efd',
-                cancelButtonText: '{{ __("Cancel") }}'
-            }).then((result) => {
-                if (result.isConfirmed) {
-                    performToggle();
-                }
-            });
-        } else {
-            performToggle();
-        }
+            }
+        });
     }
 
     // --- Resolution Status & Note Functions ---


### PR DESCRIPTION
- Updated `RegistrationController` and `RenewalController` to fetch active operators for the filter dropdown, ensuring only relevant users are shown.
- Updated `toggleOperator` logic in controllers to handle explicit operator assignment (via `operator_id`) and return updated card HTML.
- Updated `_employee_card.blade.php` to calculate correct toggle URL and pass current operator ID.
- Updated `index.blade.php` for both Registration and Renewal to:
    - Use `$activeOperators` for the filter dropdown.
    - Inject `$allUsers` globally for the assignment modal.
    - Update `toggleOperator` JS function to use SweetAlert2 with a select input for user assignment.