### PR TITLE
Disable document scanner for Employer Custom Fields to fix large file…

### DIFF
--- a/resources/views/production/registration/partials/modals/add_custom_field.blade.php
+++ b/resources/views/production/registration/partials/modals/add_custom_field.blade.php
@@ -37,7 +37,7 @@
 
                     <div class="mb-3 input-group-file-type d-none">
                         <label class="form-label">Select File</label>
-                        <input type="file" name="field_file" class="form-control" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
+                        <input type="file" name="field_file" class="form-control" multiple>
                         <div class="mt-2">
                             <label class="form-label small">Description (Optional)</label>
                             <input type="text" name="field_value_desc" class="form-control form-control-sm" placeholder="File description...">

--- a/resources/views/production/registration/partials/offcanvas_drawer.blade.php
+++ b/resources/views/production/registration/partials/offcanvas_drawer.blade.php
@@ -91,7 +91,7 @@
             // For file type editing, we need to allow re-upload
             if (field.field_type === 'file') {
                  // Append file input to editInputHtml
-                 editInputHtml += `<input type="file" name="field_file" class="form-control form-control-sm mb-2" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">`;
+                 editInputHtml += `<input type="file" name="field_file" class="form-control form-control-sm mb-2" multiple>`;
             }
 
             return `


### PR DESCRIPTION
… crashes

- Removed `onchange="window.interceptFileSelect"` from `add_custom_field.blade.php`
- Removed `onchange="window.interceptFileSelect"` from `offcanvas_drawer.blade.php`
- Enables direct upload of large files (up to server limit) without client-side WASM processing overhead.