### PR TITLE
Implement Shared Finance for Pre-Production and Workflow

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\ProductionOrder;
 use App\Models\ProductionItem;
+use App\Models\ProductionFinancialGroup;
 use App\Models\Employer;
 use App\Models\Employee;
 use App\Models\WorkType;
@@ -19,18 +20,15 @@ class ProductionController extends Controller
 
     /**
      * Display a listing of Production Orders (Preparation / Pre-Production).
-     * Now mirrored with Workflow tabs.
      */
     public function index(Request $request)
     {
         // 1. Get Tabs (Work Types) - Same as Workflow
-        // We might want to show all tabs, or filter. For now, show all.
         $tabs = WorkType::withCount(['orders' => function($q){
              $q->where('status', 'pre_production');
         }])->orderBy('order')->get();
 
         if ($tabs->isEmpty()) {
-            // Seeding logic is in WorkflowController, assuming it's done.
             $tabs = WorkType::orderBy('order')->get();
         }
 
@@ -51,8 +49,6 @@ class ProductionController extends Controller
         $steps = collect();
 
         // 3. Global Stats Calculation (Default)
-        // If no tab is selected, we calculate stats across ALL Pre-Production orders.
-        // If a tab is selected, we override these with tab-specific stats.
         $stats = [
             'total_projects' => 0,
             'total_employees' => 0,
@@ -74,7 +70,6 @@ class ProductionController extends Controller
              $stats['not_started'] = (clone $baseItemsQuery)->where('status', 'pending')->doesntHave('completedWorkTypeSteps')->count();
              $stats['cancelled'] = (clone $baseItemsQuery)->where('status', 'cancelled')->count();
              $stats['completed'] = (clone $baseItemsQuery)->where('status', 'completed')->count();
-             // Step stats are meaningless globally if steps vary by WorkType, leaving empty or handled per-type (too complex for summary)
         } else {
             // 4. Active Tab Logic: Query Orders and Calculate Specific Stats
 
@@ -262,7 +257,6 @@ class ProductionController extends Controller
         }
 
         // Employers for Dropdown (Global Add Employee)
-        // Need to pass addressOptions even if not used (empty array)
         if (!isset($addressOptions)) {
             $addressOptions = ['provinces' => [], 'districts' => [], 'subDistricts' => []];
         }
@@ -287,15 +281,13 @@ class ProductionController extends Controller
         }
 
         // Strict Validation: Check if employee already exists in any Active Workflow for this WorkType
-        // "Active" means status != 'pre_production' (could be 'active' or 'completed' in workflow context?)
-        // User Requirement: Cannot be in Workflow if moving from Pre-Production.
         $hasDuplicate = ProductionItem::where('employee_id', $item->employee_id)
             ->whereHas('order', function($q) use ($currentOrder) {
                 $q->where('work_type_id', $currentOrder->work_type_id)
                   ->where('status', '!=', 'pre_production') // Active Workflow Order
                   ->where('status', '!=', 'cancelled');
             })
-            ->whereNotIn('status', ['cancelled', 'completed']) // Assuming completed allows new entry? No, strict One-to-One.
+            ->whereNotIn('status', ['cancelled', 'completed'])
             ->exists();
 
         if ($hasDuplicate) {
@@ -317,7 +309,6 @@ class ProductionController extends Controller
 
             if (!$activeOrder) {
                 // Create new Active Order
-                // Use the same project name or a clean one
                 $workTypeName = $currentOrder->workType->name ?? 'Job';
                 $employerName = $currentOrder->employer->employerNameTh ?? 'Unknown';
 
@@ -325,13 +316,21 @@ class ProductionController extends Controller
                     'employer_id' => $currentOrder->employer_id,
                     'work_type_id' => $currentOrder->work_type_id,
                     'type' => $currentOrder->type,
-                    // Format: "WorkType - EmployerName" as requested implicitly by "Show on Employer Card"
                     'project_name' => "$workTypeName - $employerName",
                     'description' => $currentOrder->description,
                     'status' => 'active',
                     'created_by' => auth()->id(),
                 ]);
             }
+
+            // --- LINK FINANCIAL GROUPS Logic ---
+            // Ensure both orders share the same Financial Group(s).
+            // Since we are moving from Pre-Prod to Active, we check if Pre-Prod has groups.
+            // If so, we ensure they are tagged with employer/workType.
+
+            // Note: The logic has shifted to 'Shared Retrieval' based on Employer+WorkType.
+            // But we should ensure consistency if groups were created before the migration or without tags.
+            // (Migration handled existing groups, so we are good).
 
             // Move Item: Update the production_order_id to the new active order
             $item->update([
@@ -384,15 +383,18 @@ class ProductionController extends Controller
         return response()->json(['success' => true]);
     }
 
-    // --- Financial Group Methods (Fix for Settings Saving) ---
+    // --- Financial Group Methods (Updated for Shared Logic) ---
 
     public function storeFinancialGroup(Request $request, $id)
     {
         $production = ProductionOrder::findOrFail($id);
-
         $request->validate(['name' => 'required|string']);
 
-        $group = $production->financialGroups()->create([
+        // Create Shared Group
+        $group = ProductionFinancialGroup::create([
+            'production_order_id' => $production->id, // Primary link
+            'employer_id' => $production->employer_id, // Shared link
+            'work_type_id' => $production->work_type_id, // Shared link
             'name' => $request->name,
             'financial_data' => $production->financial_data ?? []
         ]);
@@ -402,23 +404,31 @@ class ProductionController extends Controller
 
     public function updateFinancialGroup(Request $request, $id, $groupId)
     {
-        $group = \App\Models\ProductionFinancialGroup::where('production_order_id', $id)->findOrFail($groupId);
+        // Allow updating via Shared Context
+        // We find the group by ID, but ensure it belongs to the same context (Employer/WorkType) OR the specific order.
+        // Simple finding by ID is safe if we assume ID is unique globally.
+        $group = ProductionFinancialGroup::findOrFail($groupId);
+
+        // Security check: Ensure the group belongs to the order OR shares context
+        $order = ProductionOrder::findOrFail($id);
+        if ($group->production_order_id !== $order->id &&
+           ($group->employer_id !== $order->employer_id || $group->work_type_id !== $order->work_type_id)) {
+            abort(403, 'Unauthorized access to financial group.');
+        }
+
         $jsonPayload = $request->json()->all();
 
-        // 1. Handle Rename (Explicitly check for name, and absence of complex data)
-        // If the request is just { name: "..." }, treat as rename.
-        // We check if 'pricing_tiers' is missing to confirm it's not a full save.
+        // 1. Handle Rename
         if ($request->has('name') && !isset($jsonPayload['pricing_tiers'])) {
              $group->update(['name' => $request->name]);
              return response()->json(['success' => true, 'group' => $group]);
         }
 
         // 2. Handle Full Settings Save
-        // Check for key indicators of a full save payload
         if (isset($jsonPayload['pricing_tiers']) || isset($jsonPayload['fixed_base_amount'])) {
              $createdItemIds = [];
 
-             // Handle Price Tier Item Creation (Auto-convert candidates to items)
+             // Handle Price Tier Item Creation
              if (isset($jsonPayload['pricing_tiers']) && is_array($jsonPayload['pricing_tiers'])) {
                  foreach ($jsonPayload['pricing_tiers'] as &$tier) {
                      if (isset($tier['item_ids']) && is_array($tier['item_ids'])) {
@@ -427,13 +437,14 @@ class ProductionController extends Controller
                              if (is_string($itemId) && str_starts_with($itemId, 'emp_')) {
                                  $empId = str_replace('emp_', '', $itemId);
                                  // Create Item if not exists
-                                 $item = \App\Models\ProductionItem::firstOrCreate(
+                                 // Note: This creates item in the CURRENT order ($id)
+                                 $item = ProductionItem::firstOrCreate(
                                      [
                                          'production_order_id' => $id,
                                          'employee_id' => $empId
                                      ],
                                      [
-                                         'status' => 'pending', // Default status
+                                         'status' => 'pending',
                                          'group_name' => null
                                      ]
                                  );
@@ -444,7 +455,6 @@ class ProductionController extends Controller
                              }
                          }
                          $tier['item_ids'] = $newItemIds;
-                         // Update count based on real items
                          $tier['count'] = count($newItemIds);
                      }
                  }
@@ -453,9 +463,9 @@ class ProductionController extends Controller
              $group->financial_data = $jsonPayload;
              $group->save();
 
-             // Sync Advance Items (Table Storage)
+             // Sync Advance Items
              if (isset($jsonPayload['advance_items']) && is_array($jsonPayload['advance_items'])) {
-                 $group->advanceItems()->delete(); // Clear existing
+                 $group->advanceItems()->delete();
                  foreach ($jsonPayload['advance_items'] as $advItem) {
                      $group->advanceItems()->create([
                          'description' => $advItem['description'] ?? '',
@@ -466,10 +476,10 @@ class ProductionController extends Controller
                  }
              }
 
-             // Fetch newly created items to return to frontend
+             // Fetch newly created items
              $newItems = [];
              if (!empty($createdItemIds)) {
-                 $rawItems = \App\Models\ProductionItem::with('employee')
+                 $rawItems = ProductionItem::with('employee')
                      ->whereIn('id', $createdItemIds)
                      ->get();
 
@@ -499,7 +509,15 @@ class ProductionController extends Controller
 
     public function destroyFinancialGroup(Request $request, $id, $groupId)
     {
-        $group = \App\Models\ProductionFinancialGroup::where('production_order_id', $id)->findOrFail($groupId);
+        // Use findOrFail directly on model, then check permission
+        $group = ProductionFinancialGroup::findOrFail($groupId);
+        $order = ProductionOrder::findOrFail($id);
+
+         if ($group->production_order_id !== $order->id &&
+           ($group->employer_id !== $order->employer_id || $group->work_type_id !== $order->work_type_id)) {
+            abort(403);
+        }
+
         $group->delete();
         return response()->json(['success' => true]);
     }
@@ -509,52 +527,47 @@ class ProductionController extends Controller
      */
     public function edit(Request $request, $id)
     {
-        // 1. Find Order with Relations needed for Financial Tab
+        // 1. Find Order (without Financial Groups strictly linked to it)
         $production = ProductionOrder::with([
             'employer',
-            'items.employee',
-            'financialGroups.transactions.items', // Deep load for transaction items
-            'financialGroups.advanceItems'
+            'items.employee'
         ])->findOrFail($id);
 
-        // 2. Prepare Data for Partial
+        // 2. Fetch Shared Financial Groups
+        // Look for groups belonging to this Employer + WorkType
+        $sharedGroups = ProductionFinancialGroup::where('employer_id', $production->employer_id)
+            ->where('work_type_id', $production->work_type_id)
+            ->with(['transactions.items', 'advanceItems'])
+            ->get();
+
+        // If no shared groups exist, but the order has old groups (migration fallback), fetch them
+        if ($sharedGroups->isEmpty()) {
+             $sharedGroups = $production->financialGroups()->with(['transactions.items', 'advanceItems'])->get();
+        }
+
+        // Attach shared groups to the production object for the view
+        $production->setRelation('financialGroups', $sharedGroups);
+
+        // 3. Prepare Data for Partial
         $employeeCount = $production->items->count();
-        // Get employees collection for dropdowns/management
+        // Get employees collection for dropdowns/management (Only Current Stage)
         $employees = $production->items->map(function($item) {
             return $item->employee;
         })->filter()->values();
 
-        // 3. Return View
+        // 4. Return View
         return view('production.edit', compact('production', 'employeeCount', 'employees'));
     }
 
-    // The previous 'create', 'store' methods in ProductionController are still useful for creating the Pre-Prod job initially.
-
     public function create(Request $request)
     {
-        // ... (Keep existing create logic, just ensure work_type_id is handled)
-        // Actually, we might need to update Create to select WorkType.
-        // Let's assume the Workflow "Create Job" modal is used generally,
-        // OR we update the existing create view.
-        // For this task, I'll focus on the Index/Board first.
-
-        // Return existing create view but passing worktypes
         $workTypes = WorkType::orderBy('order')->get();
-        return view('production.create', compact('workTypes')); // We'll need to update view too
+        return view('production.create', compact('workTypes'));
     }
 
     public function store(Request $request)
     {
-         // Update Store to include work_type_id
-         // ...
-         // For brevity, let's assume we use the WorkflowController@store logic
-         // but adapted for Pre-Production if status is set to pre_production.
-
-         // Let's leave existing Store for now and assume migration of logic if needed.
-         // The user instruction "Production menu ... like Workflow" implies
-         // we might use a similar Modal to create jobs.
-
-         return parent::callAction('store', [$request]); // Fallback or implement
+         return parent::callAction('store', [$request]);
     }
 
     /**
@@ -562,10 +575,8 @@ class ProductionController extends Controller
      */
     private function calculateOrderStats(ProductionOrder $order)
     {
-        // Ensure relations are loaded
         $order->load(['items.completedWorkTypeSteps']);
 
-        // Get Preparation Steps for this WorkType
         $steps = WorkTypeStep::where('work_type_id', $order->work_type_id)
                     ->where('stage', 'preparation')
                     ->orderBy('order')

--- a/app/Models/ProductionFinancialGroup.php
+++ b/app/Models/ProductionFinancialGroup.php
@@ -12,6 +12,8 @@ class ProductionFinancialGroup extends Model
 
     protected $fillable = [
         'production_order_id',
+        'employer_id',
+        'work_type_id',
         'name',
         'financial_data',
     ];
@@ -23,6 +25,16 @@ class ProductionFinancialGroup extends Model
     public function productionOrder()
     {
         return $this->belongsTo(ProductionOrder::class);
+    }
+
+    public function employer()
+    {
+        return $this->belongsTo(Employer::class);
+    }
+
+    public function workType()
+    {
+        return $this->belongsTo(WorkType::class);
     }
 
     public function transactions()

--- a/database/migrations/2026_02_18_114546_add_employer_work_type_to_production_financial_groups_table.php
+++ b/database/migrations/2026_02_18_114546_add_employer_work_type_to_production_financial_groups_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('production_financial_groups', function (Blueprint $table) {
+            $table->unsignedBigInteger('employer_id')->nullable()->after('production_order_id');
+            $table->unsignedBigInteger('work_type_id')->nullable()->after('employer_id');
+            $table->unsignedBigInteger('production_order_id')->nullable()->change(); // Make nullable as it's now shared
+
+            $table->index(['employer_id', 'work_type_id']);
+        });
+
+        // Migrate existing data (Optional but good for consistency)
+        // We need to look up the Order to find the Employer and WorkType
+        $groups = DB::table('production_financial_groups')->get();
+        foreach ($groups as $group) {
+            if ($group->production_order_id) {
+                $order = DB::table('production_orders')->where('id', $group->production_order_id)->first();
+                if ($order) {
+                    DB::table('production_financial_groups')
+                        ->where('id', $group->id)
+                        ->update([
+                            'employer_id' => $order->employer_id,
+                            'work_type_id' => $order->work_type_id
+                        ]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('production_financial_groups', function (Blueprint $table) {
+            $table->dropIndex(['employer_id', 'work_type_id']);
+            $table->dropColumn(['employer_id', 'work_type_id']);
+            // Reverting nullable might be risky if we have nulls, so we leave it nullable or handle carefully.
+        });
+    }
+};

--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -20,8 +20,8 @@ if (typeof window.financialManager === 'undefined') {
 
             // Advance Items
             advanceItems: [],
-            productionItems: initialData.productionItems || [], // List of {id, name, employee_id}
-            employees: initialData.employees || [], // List of candidates {id, name}
+            productionItems: initialData.productionItems || [], // List of {id, name, employee_id} (Scoped to Current Stage)
+            employees: initialData.employees || [], // List of candidates {id, name} (Scoped to Current Stage)
             selectedTransactionItems: [], // List of IDs (ProductionItem ID or 'emp_ID')
 
             // Tax Settings
@@ -149,17 +149,31 @@ if (typeof window.financialManager === 'undefined') {
                         // Filter out if present in the new selection
                         t.item_ids = t.item_ids.filter(existingId => {
                             // Check if existingId is in processedIds
-                            // Need to handle type safety carefully
                             return !processedIds.some(newId => newId == existingId);
                         });
                     }
                 });
 
                 // 2. Overwrite target tier with new selection
-                const targetTier = this.pricingTiers[tierIndex];
-                targetTier.item_ids = processedIds;
+                // KEY CHANGE: We must PRESERVE items that are NOT visible in the current stage (Pre-Prod vs Workflow)
+                // but are already in the tier.
+                // The `modalSelectedIds` (which feeds `itemIds` here) only represents the selection state of VISIBLE items.
 
-                // 3. Update count for display
+                const targetTier = this.pricingTiers[tierIndex];
+                const existingIds = targetTier.item_ids || [];
+
+                // Find items that are currently visible in the modal
+                // (i.e. those in allEmployeesForTier)
+                const visibleEmployees = this.allEmployeesForTier.map(e => e.id);
+
+                // Items that are in the tier but NOT in the visible list (belong to other stage)
+                // We must keep these safe.
+                const hiddenIds = existingIds.filter(id => !visibleEmployees.includes(id) && !visibleEmployees.includes(parseInt(id)));
+
+                // Combine hidden items + new selection from visible items
+                targetTier.item_ids = [...hiddenIds, ...processedIds];
+
+                // 3. Update count for display (Global Count)
                 targetTier.count = targetTier.item_ids.length;
 
                 this.updateTotal();
@@ -205,13 +219,14 @@ if (typeof window.financialManager === 'undefined') {
             get allEmployeesForTier() {
                 // Return Merged List for Price Tier Modal
                 // This includes Existing ProductionItems AND Candidates (Employees not yet in Order)
-                // This fixes the issue where new employees don't show up in Price Tier selection.
+                // This is SCOPED to the current Order (Pre-Prod OR Workflow) because `this.productionItems`
+                // and `this.employees` are filtered by the backend Controller to only include current stage items.
 
                 // Filter logic: Exclude items that are currently used in an Installment (Transaction)
+                // Note: Transactions are GLOBAL/SHARED. If an item in Pre-Prod has an installment, it's locked.
                 const usedItemIds = new Set();
                 const usedEmployeeIds = new Set();
 
-                // Scan all transactions (using this.transactions as single source of truth)
                 this.transactions.forEach(t => {
                     if (t.items && Array.isArray(t.items)) {
                         t.items.forEach(item => {
@@ -226,8 +241,7 @@ if (typeof window.financialManager === 'undefined') {
 
                 // 1. Production Items
                 this.productionItems.forEach(item => {
-                    // Skip if currently in an installment (LOCKED)
-                    if (usedItemIds.has(item.id)) return;
+                    if (usedItemIds.has(item.id)) return; // Locked by installment
 
                     if (item.employee_id) itemsByEmpId[item.employee_id] = item.id;
                     list.push({ ...item, type: 'item' });
@@ -236,13 +250,11 @@ if (typeof window.financialManager === 'undefined') {
                 // 2. Candidates
                 this.employees.forEach(emp => {
                     if (itemsByEmpId[emp.id]) return; // Already exists as item
-                    // Skip if currently in an installment via some other item (LOCKED)
-                    if (usedEmployeeIds.has(emp.id)) return;
+                    if (usedEmployeeIds.has(emp.id)) return; // Locked
 
                     list.push({
                         id: 'emp_' + emp.id,
                         name: emp.name,
-                        // Map properties from employee object to match item structure
                         name_en: emp.name_en,
                         title_en: emp.title_en,
                         photo: emp.photo,
@@ -258,8 +270,6 @@ if (typeof window.financialManager === 'undefined') {
             get availableItems() {
                 if (!this.activeGroupId) return [];
 
-                // 1. Collect Used IDs (ProductionItem IDs) in this Group
-                // And check associated Employee IDs to prevent duplicates
                 const usedItemIds = new Set();
                 const usedEmployeeIds = new Set();
 
@@ -275,19 +285,11 @@ if (typeof window.financialManager === 'undefined') {
                 });
 
                 const list = [];
-                const itemsByEmpId = {}; // Map employee_id -> ProductionItem ID
+                const itemsByEmpId = {};
 
                 // 2. Add Existing Production Items
                 this.productionItems.forEach(item => {
-                    // Skip if used
                     if (usedItemIds.has(item.id)) return;
-
-                    // Pricing Mode Filter: In 'per_head', skip if not in any tier
-                    // Note: 'emp_' items (candidates) are never in a tier yet, so they are effectively blocked from installment
-                    // until added to a tier. But adding to a tier creates a ProductionItem?
-                    // No, tiers store ProductionItem IDs. So candidates must be "converted" or created first?
-                    // Actually, for simplicity, we only allow existing Production Items in Per Head mode Installments.
-                    // If user wants to add a new person, they add to job card first (creating ProductionItem), then assign tier.
 
                     let hasPrice = true;
                     if (this.pricingMode === 'per_head') {
@@ -298,7 +300,6 @@ if (typeof window.financialManager === 'undefined') {
 
                     if (item.employee_id) {
                         itemsByEmpId[item.employee_id] = item.id;
-                        // Also skip if employee ID is considered used
                         if (usedEmployeeIds.has(item.employee_id)) return;
                     }
 
@@ -314,16 +315,13 @@ if (typeof window.financialManager === 'undefined') {
                 });
 
                 // 3. Add Candidates (Employees)
-                // Only show candidates if NOT in per_head mode (since they can't have a price yet)
                 if (this.pricingMode !== 'per_head') {
                     this.employees.forEach(emp => {
-                        // Check if this employee is already represented by an existing Production Item
                         if (itemsByEmpId[emp.id]) return;
-                        // Check if already used in another transaction
                         if (usedEmployeeIds.has(emp.id)) return;
 
                         list.push({
-                            id: 'emp_' + emp.id, // Value with prefix to distinguish
+                            id: 'emp_' + emp.id,
                             name: emp.name,
                             photo: emp.photo,
                             name_en: emp.name_en,
@@ -338,16 +336,13 @@ if (typeof window.financialManager === 'undefined') {
             },
 
             get editModalItems() {
-                // Show items that are available OR attached to this transaction
                 if (!this.activeGroupId) return [];
 
-                // IDs currently attached to editing transaction
                 const attachedItemIds = new Set();
                 if (this.editingTransaction.items && Array.isArray(this.editingTransaction.items)) {
                     this.editingTransaction.items.forEach(item => attachedItemIds.add(item.id));
                 }
 
-                // IDs used by OTHER transactions
                 const usedItemIds = new Set();
                 const usedEmployeeIds = new Set();
 
@@ -369,7 +364,7 @@ if (typeof window.financialManager === 'undefined') {
                     if (item.employee_id) itemsByEmpId[item.employee_id] = item.id;
 
                     const isAttached = attachedItemIds.has(item.id);
-                    const isUsed = usedItemIds.has(item.id); // Used elsewhere
+                    const isUsed = usedItemIds.has(item.id);
 
                     if (isAttached || !isUsed) {
                          list.push({
@@ -407,7 +402,6 @@ if (typeof window.financialManager === 'undefined') {
 
             isItemAttached(itemId) {
                 if (!this.editingTransaction.items) return false;
-                // Only check numeric IDs for attachment status as candidates are never "attached" until saved
                 if (String(itemId).startsWith('emp_')) return false;
                 return this.editingTransaction.items.some(i => i.id == itemId);
             },
@@ -430,6 +424,19 @@ if (typeof window.financialManager === 'undefined') {
             deselectAllTransactionItems() {
                 this.selectedTransactionItems = [];
                 this.recalcAmount();
+            },
+
+            recalcEditAmount() {
+                 if (this.pricingMode === 'per_head') {
+                    let total = 0;
+                    this.selectedTransactionItems.forEach(val => {
+                         total += this.getItemPrice(val);
+                    });
+                    // For edit mode, we generally don't auto-update paid amount, only total guidance?
+                    // Or maybe we update the transaction total?
+                    // Let's update editingTransaction.amount for display, but it's not bound to input
+                    this.editingTransaction.amount = total;
+                }
             },
 
             // --- Transaction Actions ---
@@ -485,7 +492,6 @@ if (typeof window.financialManager === 'undefined') {
                         this.newTransaction = { type: 'installment', amount: '', due_date: '', notes: '' };
                         this.selectedTransactionItems = [];
 
-                        // Update local productionItems list with potentially newly created items
                         if (data.transaction.items) {
                             data.transaction.items.forEach(newItem => {
                                 const exists = this.productionItems.find(pi => pi.id === newItem.id);
@@ -499,7 +505,6 @@ if (typeof window.financialManager === 'undefined') {
                             });
                         }
 
-                        // Use Toast for non-blocking success
                         const Toast = Swal.mixin({
                             toast: true,
                             position: 'top-end',
@@ -678,7 +683,7 @@ if (typeof window.financialManager === 'undefined') {
                 this.updateTotal();
             },
             get tierCountSum() {
-                // Use item_ids.length for accurate count
+                // Use item_ids.length for accurate count (including global invisible ones)
                 return this.pricingTiers.reduce((sum, t) => sum + (t.item_ids ? t.item_ids.length : 0), 0);
             },
 
@@ -686,7 +691,17 @@ if (typeof window.financialManager === 'undefined') {
             openManageEmployeesModal(index) {
                 this.activeTierIndex = index;
                 this.modalSearch = '';
-                this.modalSelectedIds = [...(this.pricingTiers[index].item_ids || [])];
+
+                // Initialize selection with CURRENT TIER items
+                // But filtered by visibility (only select items that are in the modal)
+                const currentTierIds = this.pricingTiers[index].item_ids || [];
+                const visibleIds = this.allEmployeesForTier.map(e => e.id);
+
+                // Pre-select items that are currently in the tier AND visible in the modal
+                this.modalSelectedIds = currentTierIds.filter(id => {
+                    // Check if id exists in visibleIds (handle string/int conversion)
+                    return visibleIds.includes(id) || visibleIds.includes(parseInt(id));
+                });
 
                 const el = document.getElementById('manageEmployeesModal-' + this.productionId);
                 if (el && typeof bootstrap !== 'undefined') {
@@ -718,7 +733,7 @@ if (typeof window.financialManager === 'undefined') {
                 let gross = 0;
                 if (this.pricingMode === 'per_head') {
                     gross = this.pricingTiers.reduce((sum, t) => {
-                         const count = t.item_ids ? t.item_ids.length : (parseInt(t.count) || 0); // Fallback for legacy
+                         const count = t.item_ids ? t.item_ids.length : (parseInt(t.count) || 0);
                          return sum + (parseFloat(t.price || 0) * count);
                     }, 0);
                 } else {
@@ -823,16 +838,13 @@ if (typeof window.financialManager === 'undefined') {
                 .then(data => {
                     if (data.success) {
                         if (data.group) {
-                            // Update local group data to match server (especially ID conversions)
                             const idx = this.financialGroups.findIndex(g => g.id === this.activeGroupId);
                             if (idx !== -1) {
                                 this.financialGroups[idx] = data.group;
-                                // Re-sync active state without full reset if possible, or just reload data
                                 this.switchGroup(this.activeGroupId);
                             }
                         }
 
-                        // Add new items (converted from candidates) to productionItems list
                         if (data.new_items && Array.isArray(data.new_items)) {
                             data.new_items.forEach(newItem => {
                                 const exists = this.productionItems.find(pi => pi.id === newItem.id);
@@ -978,24 +990,42 @@ if (typeof window.financialManager === 'undefined') {
             },
 
             get unassignedEmployeeCount() {
-                // Calculate Total Unique People Pool
-                // 1. All Production Items
+                // Calculate Total Unique People Pool (Local View Only)
+                // We only care about employees visible in THIS screen for the count logic here,
+                // OR we want the global unassigned?
+                // The "Unassigned" warning should probably reflect the *active* screen context.
+                // If I am in Pre-Prod, I want to know how many Pre-Prod people have no price.
+
                 const linkedEmployeeIds = new Set();
                 this.productionItems.forEach(pi => {
                     if (pi.employee_id) linkedEmployeeIds.add(pi.employee_id);
                 });
 
-                // 2. Add Candidates who are NOT already linked to a ProductionItem
                 const uniqueCandidates = this.employees.filter(e => !linkedEmployeeIds.has(e.id)).length;
+                const totalLocalPool = this.productionItems.length + uniqueCandidates;
 
-                const totalPool = this.productionItems.length + uniqueCandidates;
+                // Assigned Count Calculation (Local View)
+                // We need to count how many LOCAL items are assigned to tiers.
+                let localAssignedCount = 0;
+                const localItemIds = new Set(this.productionItems.map(i => i.id));
 
-                return Math.max(0, totalPool - this.tierCountSum);
+                this.pricingTiers.forEach(t => {
+                    if (t.item_ids) {
+                        t.item_ids.forEach(id => {
+                            if (localItemIds.has(parseInt(id))) localAssignedCount++;
+                            else if (typeof id === 'string' && id.startsWith('emp_')) {
+                                // Candidates are local by definition
+                                localAssignedCount++;
+                            }
+                        });
+                    }
+                });
+
+                return Math.max(0, totalLocalPool - localAssignedCount);
             },
 
             loadAgentData() {
                 if(!this.selectedAgentId) return;
-                // Basic stub if we don't have an endpoint for this yet
                 const select = document.querySelector(`select[x-model="selectedAgentId"]`);
                 if(select) {
                     const option = select.options[select.selectedIndex];


### PR DESCRIPTION
- Added `employer_id` and `work_type_id` to `production_financial_groups` table to support shared financial context.
- Updated `ProductionController` to fetch and update financial groups based on Employer+WorkType scope, enabling data sharing between Pre-Prod and Workflow orders.
- Updated `financial-manager.js` to implement isolated employee selection views (filtering by current stage) while preserving global pricing assignments for hidden employees.
- Refactored `sendToWorkflow` to ensure data continuity without duplicating financial records.