### PR TITLE
Fix migration error: Unknown column 'insurance_detail_social'

### DIFF
--- a/database/migrations/2026_02_18_174627_add_sso_dates_to_employees_table.php
+++ b/database/migrations/2026_02_18_174627_add_sso_dates_to_employees_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('employees', function (Blueprint $table) {
-            $table->date('sso_issue_date')->nullable()->after('insurance_detail_social');
+            $table->date('sso_issue_date')->nullable()->after('social_security_number');
             $table->date('sso_expiry_date')->nullable()->after('sso_issue_date');
         });
     }


### PR DESCRIPTION
The migration `2026_02_18_174627_add_sso_dates_to_employees_table` was attempting to add `sso_issue_date` and `sso_expiry_date` after a non-existent column `insurance_detail_social`.

This change updates the migration to position these columns after `social_security_number`, which is the correct column for social security information and exists in the `employees` table.

Verified via `php artisan migrate --pretend` that the SQL is generated correctly.