### PR TITLE
Allow compatible PDF 1.7 uploads by using parser-based validation ins…

### DIFF
--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -144,9 +144,18 @@ class PdfTemplateController extends Controller
         $file = $request->file('file');
         $filePath = $file->getRealPath();
 
-        // Validate PDF Version (Must be <= 1.4 for FPDI compatibility)
-        // If not compatible, try to normalize immediately
-        if (!PdfHelper::isCompatible($filePath, 1.4)) {
+        // Validate compatibility by attempting to parse with FPDI
+        // This allows compatible 1.7 PDFs (without compressed streams) to pass
+        $isCompatible = false;
+        try {
+            $pdf = new \setasign\Fpdi\Fpdi();
+            $pdf->setSourceFile($filePath);
+            $isCompatible = true;
+        } catch (\Exception $e) {
+            $isCompatible = false;
+        }
+
+        if (!$isCompatible) {
             try {
                 // Attempt to normalize the temp file directly
                 $normalizedPath = $pdfService->tryNormalizePdf($filePath);


### PR DESCRIPTION
…tead of strict version check

The existing logic strictly rejected any PDF with version > 1.4 using `PdfHelper::isCompatible`. This prevented users from uploading perfectly valid PDF 1.7 files (created by modern software) even if they did not use incompatible features like compressed object streams.

This change modifies `PdfTemplateController` to attempt to parse the file using `setasign\Fpdi\Fpdi`. If the parser accepts it, the file is allowed regardless of the version header. If parsing fails, it falls back to the existing normalization logic (which may still fail if external tools like Node/GS are missing, but this change reduces the need for them).

Test Plan:
- Validated with `reproduce_issue.php` that `PdfHelper::isCompatible` incorrectly rejects 1.7 files that FPDI can read.
- Validated with `verify_fix.php` that the new logic accepts these files.
- Validated with `verify_failure.php` that corrupted files are still correctly rejected/handled.