### PR TITLE
Fix Filtering and Search Logic across Production Modules

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -108,14 +108,14 @@ class RegistrationController extends Controller
             $employerQuery->withoutGlobalScope('employerTenancy');
         }
 
+        // Always scope to employers who have relevant employees for this menu
+        $employerQuery->whereHas('employees', function($q) {
+             $q->whereIn('status', ['registration_pending', 'registration_completed', 'registration_cancelled']);
+        });
+
         // Apply Search to Employer Query
         if ($request->has('search') && $request->search) {
             $this->applyEmployerLevelSearch($employerQuery, $request->search);
-        } else {
-            // If no search, we only show employers who have relevant employees
-            $employerQuery->whereHas('employees', function($q) {
-                 $q->whereIn('status', ['registration_pending', 'registration_completed', 'registration_cancelled']);
-            });
         }
 
         // Apply Address Filters
@@ -258,20 +258,24 @@ class RegistrationController extends Controller
               ->orWhereRaw("REPLACE(employerNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
               ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
               // Job Owner
-              ->orWhereHas('jobOwner', function($q2) use ($search) {
-                  $q2->where('name', 'like', "%{$search}%");
+              ->orWhereHas('jobOwner', function($q2) use ($search, $cleanedSearch) {
+                  $q2->where('name', 'like', "%{$search}%")
+                     ->orWhereRaw("REPLACE(name, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
               })
               // Address
               ->orWhere(function($addrQ) use ($search) {
                   $addrQ->filterByAddress($search);
               })
-              // Employees (Robust Search)
+              // Employees (Robust Search) - Scoped to relevant statuses
               ->orWhereHas('employees', function($qEmp) use ($search, $cleanedSearch) {
-                  $qEmp->where('employeeNameTh', 'like', "%{$search}%")
-                       ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                       ->orWhere('employeePassport', 'like', "%{$search}%")
-                       ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                       ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                  $qEmp->whereIn('status', ['registration_pending', 'registration_completed', 'registration_cancelled'])
+                       ->where(function($sub) use ($search, $cleanedSearch) {
+                           $sub->where('employeeNameTh', 'like', "%{$search}%")
+                               ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                               ->orWhere('employeePassport', 'like', "%{$search}%")
+                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                       });
               });
         });
     }
@@ -305,6 +309,16 @@ class RegistrationController extends Controller
             } elseif ($filter === 'biometrics_not_collected') {
                  $q->where('status', '!=', 'registration_cancelled')
                    ->whereNull('biometrics_collected_at');
+            } elseif ($filter === 'total_appointments') {
+                 $q->whereIn('status', ['registration_pending', 'registration_completed'])
+                   ->whereNotNull('appointment_date');
+            } elseif ($filter === 'pending_daily_check') {
+                 $q->whereIn('status', ['registration_pending', 'registration_completed'])
+                   ->where('daily_check_enabled', true)
+                   ->where(function ($sub) {
+                       $sub->whereNull('last_daily_checked_at')
+                         ->orWhereDate('last_daily_checked_at', '<', now()->today());
+                   });
             } elseif (is_numeric($filter)) { // Step ID (Highest Step Logic approximation for filter)
                  // Strict Highest Step Filtering to match Employee List Logic
                  $q->where('status', '!=', 'registration_cancelled')
@@ -579,6 +593,16 @@ class RegistrationController extends Controller
             } elseif ($filter === 'biometrics_not_collected') {
                  $query->where('status', '!=', 'registration_cancelled')
                        ->whereNull('biometrics_collected_at');
+            } elseif ($filter === 'total_appointments') {
+                 $query->whereIn('status', ['registration_pending', 'registration_completed'])
+                       ->whereNotNull('appointment_date');
+            } elseif ($filter === 'pending_daily_check') {
+                 $query->whereIn('status', ['registration_pending', 'registration_completed'])
+                       ->where('daily_check_enabled', true)
+                       ->where(function ($sub) {
+                           $sub->whereNull('last_daily_checked_at')
+                             ->orWhereDate('last_daily_checked_at', '<', now()->today());
+                       });
             } elseif (is_numeric($filter)) { // Step ID
                  $query->where('status', '!=', 'registration_cancelled');
                  // We filter by highest step in PHP below
@@ -1712,8 +1736,9 @@ class RegistrationController extends Controller
                      ->orWhere('employerNameEn', 'like', "%{$search}%")
                      ->orWhereRaw("REPLACE(employerNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                      ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                     ->orWhereHas('jobOwner', function($q3) use ($search) {
-                         $q3->where('name', 'like', "%{$search}%");
+                     ->orWhereHas('jobOwner', function($q3) use ($search, $cleanedSearch) {
+                         $q3->where('name', 'like', "%{$search}%")
+                            ->orWhereRaw("REPLACE(name, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                      })
                      ->orWhere(function($addrQ) use ($search) {
                          $addrQ->filterByAddress($search);

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -123,6 +123,12 @@ class RenewalController extends Controller
                     });
                 }
 
+                if ($filter === 'pending_daily_check') {
+                    return $emps->contains(function($e) {
+                         return $e->status !== 'renewal_cancelled' && $e->is_daily_check_pending;
+                    });
+                }
+
                 // Step Filter
                 if (is_numeric($filter)) {
                     return $emps->contains(function($e) use ($filter) {
@@ -326,8 +332,14 @@ class RenewalController extends Controller
                        ->whereDoesntHave('registrationSteps', function($q) use ($stepOneId) {
                            $q->where('registration_steps.id', $stepOneId);
                        });
-            }
-            elseif (is_numeric($filter)) { // Step ID
+            } elseif ($filter === 'pending_daily_check') {
+                 $query->where('status', '!=', 'renewal_cancelled')
+                       ->where('daily_check_enabled', true)
+                       ->where(function ($sub) {
+                           $sub->whereNull('last_daily_checked_at')
+                             ->orWhereDate('last_daily_checked_at', '<', now()->today());
+                       });
+            } elseif (is_numeric($filter)) { // Step ID
                  $query->where('status', '!=', 'renewal_cancelled');
                  // We filter by highest step in PHP below
             }
@@ -925,15 +937,23 @@ class RenewalController extends Controller
     // --- Helpers ---
     private function applySearchToQuery($query, $search)
     {
-        return $query->where(function($q) use ($search) {
+        $search = trim($search);
+        $cleanedSearch = str_replace(' ', '', $search);
+
+        return $query->where(function($q) use ($search, $cleanedSearch) {
             $q->where('employeeNameTh', 'like', "%{$search}%")
               ->orWhere('employeeNameEn', 'like', "%{$search}%")
               ->orWhere('employeePassport', 'like', "%{$search}%")
-              ->orWhereHas('employer', function($q2) use ($search) {
+              ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+              ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+              ->orWhereHas('employer', function($q2) use ($search, $cleanedSearch) {
                   $q2->where('employerNameTh', 'like', "%{$search}%")
                      ->orWhere('employerNameEn', 'like', "%{$search}%")
-                     ->orWhereHas('jobOwner', function($q3) use ($search) {
-                         $q3->where('name', 'like', "%{$search}%");
+                     ->orWhereRaw("REPLACE(employerNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                     ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                     ->orWhereHas('jobOwner', function($q3) use ($search, $cleanedSearch) {
+                         $q3->where('name', 'like', "%{$search}%")
+                            ->orWhereRaw("REPLACE(name, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                      })
                      ->orWhere(function($addrQ) use ($search) {
                          $addrQ->filterByAddress($search);
@@ -944,9 +964,14 @@ class RenewalController extends Controller
 
     private function applyEmployerSearchToQuery($query, $employer, $search)
     {
+        $search = trim($search);
+        $cleanedSearch = str_replace(' ', '', $search);
+
         $employerMatches = false;
         if (stripos($employer->employerNameTh, $search) !== false ||
-            stripos($employer->employerNameEn, $search) !== false) {
+            stripos($employer->employerNameEn, $search) !== false ||
+            stripos(str_replace(' ', '', $employer->employerNameTh ?? ''), $cleanedSearch) !== false ||
+            stripos(str_replace(' ', '', $employer->employerNameEn ?? ''), $cleanedSearch) !== false) {
             $employerMatches = true;
         }
 
@@ -969,10 +994,12 @@ class RenewalController extends Controller
         if ($employerMatches) {
             return $query;
         } else {
-            return $query->where(function($q) use ($search) {
+            return $query->where(function($q) use ($search, $cleanedSearch) {
                 $q->where('employeeNameTh', 'like', "%{$search}%")
                   ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                  ->orWhere('employeePassport', 'like', "%{$search}%");
+                  ->orWhere('employeePassport', 'like', "%{$search}%")
+                  ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                  ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
             });
         }
     }

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -70,6 +70,11 @@ class ProductionController extends Controller
              $stats['not_started'] = (clone $baseItemsQuery)->where('status', 'pending')->doesntHave('completedWorkTypeSteps')->count();
              $stats['cancelled'] = (clone $baseItemsQuery)->where('status', 'cancelled')->count();
              $stats['completed'] = (clone $baseItemsQuery)->where('status', 'completed')->count();
+             $stats['pending_daily_check'] = (clone $baseItemsQuery)->whereNotIn('status', ['cancelled', 'completed'])
+                ->where(function($q) {
+                    $q->whereNull('last_checked_at')
+                      ->orWhereDate('last_checked_at', '<', now()->today());
+                })->count();
         } else {
             // 4. Active Tab Logic: Query Orders and Calculate Specific Stats
 
@@ -85,20 +90,26 @@ class ProductionController extends Controller
 
             // Search
             if ($request->has('search') && $request->search) {
-                $search = $request->search;
-                $query->where(function($q) use ($search) {
+                $search = trim($request->search);
+                $cleanedSearch = str_replace(' ', '', $search);
+                $query->where(function($q) use ($search, $cleanedSearch) {
                     $q->where('project_name', 'like', "%{$search}%")
-                      ->orWhereHas('employer', function($e) use ($search) {
+                      ->orWhereRaw("REPLACE(project_name, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                      ->orWhereHas('employer', function($e) use ($search, $cleanedSearch) {
                           $e->where('employerNameTh', 'like', "%{$search}%")
                             ->orWhere('employerNameEn', 'like', "%{$search}%")
+                            ->orWhereRaw("REPLACE(employerNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                            ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                             ->orWhere(function($addrQ) use ($search) {
                                 $addrQ->filterByAddress($search);
                             });
                       })
-                      ->orWhereHas('items.employee', function($emp) use ($search) {
+                      ->orWhereHas('items.employee', function($emp) use ($search, $cleanedSearch) {
                           $emp->where('employeeNameTh', 'like', "%{$search}%")
                               ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                              ->orWhere('employeePassport', 'like', "%{$search}%");
+                              ->orWhere('employeePassport', 'like', "%{$search}%")
+                              ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                              ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                       })
                       ->orWhereHas('creator', function($creator) use ($search) {
                           $creator->where('name', 'like', "%{$search}%");
@@ -122,11 +133,24 @@ class ProductionController extends Controller
                         $q->where('status', 'cancelled');
                     } elseif ($filter === 'completed') {
                         $q->where('status', 'completed');
+                    } elseif ($filter === 'pending_daily_check') {
+                        $q->where(function($sub) {
+                            $sub->whereNull('last_checked_at')
+                                ->orWhereDate('last_checked_at', '<', now()->today());
+                        })->whereNotIn('status', ['cancelled', 'completed']);
                     } elseif (is_numeric($filter)) {
                         $q->whereHas('completedWorkTypeSteps', function($s) use ($filter) {
                             $s->where('work_type_steps.id', $filter);
                         });
                     }
+                });
+            }
+
+            // Operator Filter
+            if ($request->has('operator_filter') && $request->operator_filter) {
+                $opFilter = $request->operator_filter;
+                $query->whereHas('items', function($q) use ($opFilter) {
+                    $q->where('operator_id', $opFilter);
                 });
             }
 
@@ -164,55 +188,65 @@ class ProductionController extends Controller
             // Init Step Stats
             $stats['step_stats'] = $steps->pluck('id')->mapWithKeys(fn($id) => [$id => 0])->toArray();
 
-            // Calculate Stats for Active Tab
-            if (!$request->has('search') && !$request->has('filter') && !$request->has('operator_filter')) {
-                 $baseItemsQuery = ProductionItem::whereHas('order', function($q) use ($activeTab) {
-                     $q->where('work_type_id', $activeTab->id)
-                       ->where('status', 'pre_production');
-                 });
-                 $stats['total_projects'] = ProductionOrder::where('work_type_id', $activeTab->id)->where('status', 'pre_production')->count();
-                 $stats['total_employees'] = (clone $baseItemsQuery)->count();
-                 $stats['not_started'] = (clone $baseItemsQuery)->where('status', 'pending')->doesntHave('completedWorkTypeSteps')->count();
-                 $stats['cancelled'] = (clone $baseItemsQuery)->where('status', 'cancelled')->count();
-                 $stats['completed'] = (clone $baseItemsQuery)->where('status', 'completed')->count();
+            // Stats should reflect search but NOT the state filter
+            $statsQuery = ProductionOrder::where('status', 'pre_production')
+                ->where('work_type_id', $activeTab->id);
 
-                 $allStepItems = (clone $baseItemsQuery)
-                     ->with('completedWorkTypeSteps:id,order')
-                     ->get();
+            if ($request->has('search') && $request->search) {
+                $search = trim($request->search);
+                $cleanedSearch = str_replace(' ', '', $search);
+                $statsQuery->where(function($q) use ($search, $cleanedSearch) {
+                    $q->where('project_name', 'like', "%{$search}%")
+                      ->orWhereRaw("REPLACE(project_name, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                      ->orWhereHas('employer', function($e) use ($search, $cleanedSearch) {
+                          $e->where('employerNameTh', 'like', "%{$search}%")
+                            ->orWhere('employerNameEn', 'like', "%{$search}%")
+                            ->orWhereRaw("REPLACE(employerNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                            ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                            ->orWhere(function($addrQ) use ($search) { $addrQ->filterByAddress($search); });
+                      })
+                      ->orWhereHas('items.employee', function($emp) use ($search, $cleanedSearch) {
+                          $emp->where('employeeNameTh', 'like', "%{$search}%")
+                              ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                              ->orWhere('employeePassport', 'like', "%{$search}%")
+                              ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                              ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                      })
+                      ->orWhereHas('employer.jobOwner', function($owner) use ($search) {
+                          $owner->where('name', 'like', "%{$search}%");
+                      });
+                });
+            }
 
-                 foreach ($allStepItems as $item) {
-                     if ($item->status === 'cancelled') continue;
+            if ($request->has('operator_filter') && $request->operator_filter) {
+                $opFilter = $request->operator_filter;
+                $statsQuery->whereHas('items', fn($q) => $q->where('operator_id', $opFilter));
+            }
+
+            $allMatchingOrders = $statsQuery->with(['items.completedWorkTypeSteps'])->get();
+            $stats['total_projects'] = $allMatchingOrders->count();
+
+            foreach ($allMatchingOrders as $order) {
+                foreach ($order->items as $item) {
+                     $stats['total_employees']++;
+                     if ($item->status === 'cancelled') {
+                         $stats['cancelled']++;
+                         continue;
+                     }
+                     if ($item->status === 'completed') {
+                         $stats['completed']++;
+                     }
+                     if ($item->status === 'pending' && $item->completedWorkTypeSteps->isEmpty()) {
+                         $stats['not_started']++;
+                     }
+                     if (!$item->is_checked_today && $item->status !== 'completed' && $item->status !== 'cancelled') {
+                         $stats['pending_daily_check']++;
+                     }
                      $highestStep = $item->completedWorkTypeSteps->sortByDesc('order')->first();
                      if ($highestStep && isset($stats['step_stats'][$highestStep->id])) {
                          $stats['step_stats'][$highestStep->id]++;
                      }
-                 }
-            } else {
-                 $allMatchingOrders = $query->get();
-                 $stats['total_projects'] = $allMatchingOrders->count();
-
-                 foreach ($allMatchingOrders as $order) {
-                     $order->load(['items.completedWorkTypeSteps']);
-                     foreach ($order->items as $item) {
-                         $stats['total_employees']++;
-
-                         if ($item->status === 'cancelled') {
-                             $stats['cancelled']++;
-                             continue;
-                         }
-                         if ($item->status === 'completed') {
-                             $stats['completed']++;
-                         }
-                         if ($item->status === 'pending' && $item->completedWorkTypeSteps->isEmpty()) {
-                             $stats['not_started']++;
-                         }
-
-                         $highestStep = $item->completedWorkTypeSteps->sortByDesc('order')->first();
-                         if ($highestStep && isset($stats['step_stats'][$highestStep->id])) {
-                             $stats['step_stats'][$highestStep->id]++;
-                         }
-                     }
-                 }
+                }
             }
 
             // Per Order Stats
@@ -252,14 +286,6 @@ class ProductionController extends Controller
                     'active_items_count' => $order->active_items_count
                 ];
             }
-        }
-
-        // Operator Filter
-        if ($request->has('operator_filter') && $request->operator_filter) {
-            $opFilter = $request->operator_filter;
-            $query->whereHas('items', function($q) use ($opFilter) {
-                $q->where('operator_id', $opFilter);
-            });
         }
 
         // Employers for Dropdown (Global Add Employee)

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -63,20 +63,26 @@ class WorkflowController extends Controller
 
         // Search
         if ($request->has('search') && $request->search) {
-            $search = $request->search;
-            $query->where(function($q) use ($search) {
+            $search = trim($request->search);
+            $cleanedSearch = str_replace(' ', '', $search);
+            $query->where(function($q) use ($search, $cleanedSearch) {
                 $q->where('project_name', 'like', "%{$search}%")
-                  ->orWhereHas('employer', function($e) use ($search) {
+                  ->orWhereRaw("REPLACE(project_name, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                  ->orWhereHas('employer', function($e) use ($search, $cleanedSearch) {
                       $e->where('employerNameTh', 'like', "%{$search}%")
                         ->orWhere('employerNameEn', 'like', "%{$search}%")
+                        ->orWhereRaw("REPLACE(employerNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                        ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                         ->orWhere(function($addrQ) use ($search) {
                             $addrQ->filterByAddress($search);
                         });
                   })
-                  ->orWhereHas('items.employee', function($emp) use ($search) {
+                  ->orWhereHas('items.employee', function($emp) use ($search, $cleanedSearch) {
                       $emp->where('employeeNameTh', 'like', "%{$search}%")
                           ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                          ->orWhere('employeePassport', 'like', "%{$search}%");
+                          ->orWhere('employeePassport', 'like', "%{$search}%")
+                          ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                          ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                   })
                   ->orWhereHas('creator', function($creator) use ($search) {
                       $creator->where('name', 'like', "%{$search}%");
@@ -101,12 +107,25 @@ class WorkflowController extends Controller
                     $q->where('status', 'cancelled');
                 } elseif ($filter === 'completed') {
                     $q->where('status', 'completed');
+                } elseif ($filter === 'pending_daily_check') {
+                    $q->where(function($sub) {
+                        $sub->whereNull('last_checked_at')
+                            ->orWhereDate('last_checked_at', '<', Carbon::today());
+                    })->whereNotIn('status', ['cancelled', 'completed']);
                 } elseif (is_numeric($filter)) {
                     // Highest Step ID match (approx for SQL: has this step)
                     $q->whereHas('completedWorkTypeSteps', function($s) use ($filter) {
                         $s->where('work_type_steps.id', $filter);
                     });
                 }
+            });
+        }
+
+        // Operator Filter
+        if ($request->has('operator_filter') && $request->operator_filter) {
+            $opFilter = $request->operator_filter;
+            $query->whereHas('items', function($q) use ($opFilter) {
+                $q->where('operator_id', $opFilter);
             });
         }
 
@@ -198,8 +217,42 @@ class WorkflowController extends Controller
         ];
 
         if ($activeTab) {
-            // Re-calculate stats based on current search/filter if present, or global for tab if not
-            $allMatchingOrders = $query->get(); // Re-run query without pagination
+            // Stats should reflect search but NOT the state filter
+            $statsQuery = ProductionOrder::where('status', '!=', 'pre_production')
+                ->where('work_type_id', $activeTab->id);
+
+            if ($request->has('search') && $request->search) {
+                $search = trim($request->search);
+                $cleanedSearch = str_replace(' ', '', $search);
+                $statsQuery->where(function($q) use ($search, $cleanedSearch) {
+                    $q->where('project_name', 'like', "%{$search}%")
+                      ->orWhereRaw("REPLACE(project_name, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                      ->orWhereHas('employer', function($e) use ($search, $cleanedSearch) {
+                          $e->where('employerNameTh', 'like', "%{$search}%")
+                            ->orWhere('employerNameEn', 'like', "%{$search}%")
+                            ->orWhereRaw("REPLACE(employerNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                            ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                            ->orWhere(function($addrQ) use ($search) { $addrQ->filterByAddress($search); });
+                      })
+                      ->orWhereHas('items.employee', function($emp) use ($search, $cleanedSearch) {
+                          $emp->where('employeeNameTh', 'like', "%{$search}%")
+                              ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                              ->orWhere('employeePassport', 'like', "%{$search}%")
+                              ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                              ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                      })
+                      ->orWhereHas('employer.jobOwner', function($owner) use ($search) {
+                          $owner->where('name', 'like', "%{$search}%");
+                      });
+                });
+            }
+
+            if ($request->has('operator_filter') && $request->operator_filter) {
+                $opFilter = $request->operator_filter;
+                $statsQuery->whereHas('items', fn($q) => $q->where('operator_id', $opFilter));
+            }
+
+            $allMatchingOrders = $statsQuery->with(['items.completedWorkTypeSteps'])->get();
             $stats['total_projects'] = $allMatchingOrders->count();
 
             foreach ($allMatchingOrders as $order) {
@@ -236,14 +289,6 @@ class WorkflowController extends Controller
                      }
                 }
             }
-        }
-
-        // Operator Filter
-        if ($request->has('operator_filter') && $request->operator_filter) {
-            $opFilter = $request->operator_filter;
-            $query->whereHas('items', function($q) use ($opFilter) {
-                $q->where('operator_id', $opFilter);
-            });
         }
 
         return view('workflow.index', compact('orders', 'tabs', 'activeTab', 'stats', 'steps', 'addressOptions', 'employers', 'users'));
@@ -619,26 +664,24 @@ class WorkflowController extends Controller
 
         // 3. Apply Search Filter
         if ($request->has('search') && $request->search) {
-            $search = $request->search;
+            $search = trim($request->search);
+            $cleanedSearch = str_replace(' ', '', $search);
 
             // Check if Order matches the search criteria (Project, Employer, etc.)
             // If it DOES match, we show ALL items (user found the order).
             // If it DOES NOT match, we assume the user found the order via a specific item/employee, so we show ONLY matching items.
             $orderMatches = ProductionOrder::where('id', $orderId)
-                ->where(function($q) use ($search) {
+                ->where(function($q) use ($search, $cleanedSearch) {
                     $q->where('project_name', 'like', "%{$search}%")
-                      ->orWhereHas('employer', function($e) use ($search) {
+                      ->orWhereRaw("REPLACE(project_name, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                      ->orWhereHas('employer', function($e) use ($search, $cleanedSearch) {
                           $e->where('employerNameTh', 'like', "%{$search}%")
                             ->orWhere('employerNameEn', 'like', "%{$search}%")
+                            ->orWhereRaw("REPLACE(employerNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                            ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                             ->orWhere(function($addrQ) use ($search) {
                                 $addrQ->filterByAddress($search);
                             });
-                      })
-                      ->orWhereHas('creator', function($creator) use ($search) {
-                          $creator->where('name', 'like', "%{$search}%");
-                      })
-                      ->orWhereHas('updater', function($updater) use ($search) {
-                          $updater->where('name', 'like', "%{$search}%");
                       })
                       ->orWhereHas('employer.jobOwner', function($owner) use ($search) {
                           $owner->where('name', 'like', "%{$search}%");
@@ -647,10 +690,12 @@ class WorkflowController extends Controller
                 ->exists();
 
             if (!$orderMatches) {
-                 $query->whereHas('employee', function($q) use ($search) {
+                 $query->whereHas('employee', function($q) use ($search, $cleanedSearch) {
                       $q->where('employeeNameTh', 'like', "%{$search}%")
                         ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                        ->orWhere('employeePassport', 'like', "%{$search}%");
+                        ->orWhere('employeePassport', 'like', "%{$search}%")
+                        ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                        ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                  });
             }
         }

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -119,7 +119,7 @@
     </div>
 
     {{-- Scoreboard --}}
-    <div class="row row-cols-1 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
+    <div class="row row-cols-1 row-cols-md-3 row-cols-xl-6 g-3 mb-4">
         {{-- Total Employees --}}
         <div class="col">
             <div class="card text-white h-100 shadow-sm border-0 cursor-pointer" onclick="window.location.href = '{{ route('production.index', ['tab' => $activeTab->slug ?? null]) }}';" style="background-color: #FBBF24;">
@@ -136,6 +136,16 @@
                 <div class="card-body text-center d-flex flex-column justify-content-center py-4">
                     <h1 class="display-4 fw-bold mb-0">{{ $stats['not_started'] ?? 0 }}</h1>
                     <p class="fs-5 fw-light mb-0">{{ __('Not Started') }}</p>
+                </div>
+            </div>
+        </div>
+
+        {{-- Daily Check (Reset at Midnight) --}}
+        <div class="col">
+            <div class="card text-white h-100 shadow-sm border-0 cursor-pointer filter-card" id="filter-daily-check" onclick="toggleFilter('pending_daily_check')" style="background-color: #F97316;">
+                <div class="card-body text-center d-flex flex-column justify-content-center py-4">
+                    <h1 class="display-4 fw-bold mb-0" id="stats-daily-check">{{ $stats['pending_daily_check'] ?? 0 }}</h1>
+                    <p class="fs-5 fw-light mb-0">{{ __('Daily Check') }}</p>
                 </div>
             </div>
         </div>
@@ -601,6 +611,7 @@
             if (currentStepFilter === 'not_started') document.getElementById('filter-not-started')?.classList.add('filter-active');
             else if (currentStepFilter === 'cancelled') document.getElementById('filter-cancelled')?.classList.add('filter-active');
             else if (currentStepFilter === 'completed') document.getElementById('filter-completed')?.classList.add('filter-active');
+            else if (currentStepFilter === 'pending_daily_check') document.getElementById('filter-daily-check')?.classList.add('filter-active');
             else {
                 const pill = document.getElementById(`filter-step-${currentStepFilter}`);
                 if (pill) pill.classList.add('filter-active');
@@ -1198,6 +1209,7 @@
         // Counters
         setHtml('stats-total-employees', stats.total_employees);
         setHtml('stats-total-projects', stats.total_projects);
+        setHtml('stats-daily-check', stats.pending_daily_check);
         setText('#filter-not-started h1', stats.not_started);
         setText('#filter-cancelled h1', stats.cancelled);
         setText('#filter-completed h1', stats.completed);

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -86,8 +86,9 @@
 
         {{-- Appointments (NEW) --}}
         <div class="col">
-            <div class="card text-white h-100 shadow-sm cursor-pointer"
-                 onclick="openCalendarModal()"
+            <div class="card text-white h-100 shadow-sm cursor-pointer filter-card"
+                 id="filter-total_appointments"
+                 onclick="toggleFilter('total_appointments')"
                  style="background-color: #8B5CF6; border: none; transition: transform 0.2s;"> {{-- Purple --}}
                 <div class="card-body text-center d-flex flex-column justify-content-center py-4">
                     <h1 class="display-4 fw-bold mb-0" id="global-appointments-count">{{ $totalAppointments ?? 0 }}</h1>
@@ -98,7 +99,9 @@
 
         {{-- Daily Check Pending (NEW) --}}
         <div class="col">
-            <div class="card text-white h-100 shadow-sm cursor-pointer"
+            <div class="card text-white h-100 shadow-sm cursor-pointer filter-card"
+                 id="filter-pending_daily_check"
+                 onclick="toggleFilter('pending_daily_check')"
                  style="background-color: #6366f1; border: none; transition: transform 0.2s;"> {{-- Indigo-500 --}}
                 <div class="card-body text-center d-flex flex-column justify-content-center py-4">
                     <h1 class="display-4 fw-bold mb-0" id="global-daily-check-pending-count">{{ $totalDailyCheckPending ?? 0 }}</h1>

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -86,7 +86,9 @@
 
         {{-- Daily Check Pending (NEW) --}}
         <div class="col">
-            <div class="card text-white h-100 shadow-sm cursor-pointer"
+            <div class="card text-white h-100 shadow-sm cursor-pointer filter-card"
+                 id="filter-pending_daily_check"
+                 onclick="toggleFilter('pending_daily_check')"
                  style="background-color: #6366f1; border: none; transition: transform 0.2s;"> {{-- Indigo-500 --}}
                 <div class="card-body text-center d-flex flex-column justify-content-center py-4">
                     <h1 class="display-4 fw-bold mb-0" id="global-daily-check-pending-count">{{ $totalDailyCheckPending ?? 0 }}</h1>


### PR DESCRIPTION
This pull request fixes several logic errors in the filtering and searching functionality of the Pre-Production, Workflow, Registration Resolution, and Renewal Resolution modules.

Key improvements:
1. **Search Scoping:** Fixed a bug where searching (e.g., by Job Owner) would bypass status constraints and pull in records from the entire database. Search results are now strictly limited to the current menu's scope.
2. **Robust Name Search:** Search fields now ignore spaces in names (using SQL REPLACE), allowing users to find "SA KK" by searching "SAKK" and vice-versa. This applies to Employer names, Employee names, and Job Owner names.
3. **Daily Check Logic:** Fully implemented the "Daily Check" filter across all menus. Clicking the Daily Check card on the scoreboard now correctly filters the employer list and ensures that opening a card shows only the employees requiring a check today.
4. **Drill-down Consistency:** Fixed the expanded card views (AJAX) to respect active filters and search terms, fulfilling the user's requirement to see only matching employees when a filter is active.
5. **Scoreboard Accuracy:** Refactored the statistics calculation to ensure that totals and state-specific counts correctly reflect active search terms and operator filters.
6. **UI Enhancements:** Added click handlers to missing scoreboard cards (like Daily Check) to trigger the appropriate filters.

---
*PR created automatically by Jules for task [18082295275419649356](https://jules.google.com/task/18082295275419649356) started by @nongjogame4-prog*