### PR TITLE
Mobile Usability Fix: Screen Rotation and Modal-based PDF Viewing

### DIFF
--- a/app/Helpers/PdfHelper.php
+++ b/app/Helpers/PdfHelper.php
@@ -12,9 +12,10 @@ class PdfHelper
      *
      * @param string $disk
      * @param string $filePath
-     * @return \Illuminate\Http\Response
+     * @param string $disposition 'attachment' or 'inline'
+     * @return \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public static function streamFile($disk, $filePath)
+    public static function streamFile($disk, $filePath, $disposition = 'attachment')
     {
         if (!Storage::disk($disk)->exists($filePath)) {
             abort(404, 'File not found.');
@@ -22,8 +23,14 @@ class PdfHelper
 
         $mimeType = Storage::disk($disk)->mimeType($filePath);
 
-        // If it's already a PDF, download it directly
+        // If it's already a PDF
         if ($mimeType === 'application/pdf') {
+            if ($disposition === 'inline') {
+                return response()->file(Storage::disk($disk)->path($filePath), [
+                    'Content-Type' => 'application/pdf',
+                    'Content-Disposition' => 'inline; filename="' . basename($filePath) . '"'
+                ]);
+            }
             return Storage::disk($disk)->download($filePath);
         }
 
@@ -63,7 +70,7 @@ class PdfHelper
 
             return response($pdf->Output('S', basename($filePath) . '.pdf'))
                 ->header('Content-Type', 'application/pdf')
-                ->header('Content-Disposition', 'attachment; filename="' . basename($filePath) . '.pdf"');
+                ->header('Content-Disposition', $disposition . '; filename="' . basename($filePath) . '.pdf"');
         }
 
         // Fallback

--- a/app/Http/Controllers/CustomFieldController.php
+++ b/app/Http/Controllers/CustomFieldController.php
@@ -32,7 +32,8 @@ class CustomFieldController extends Controller
 
         $filePath = $field->file_path;
         $disk = 'public';
+        $disposition = $request->input('disposition', 'attachment');
 
-        return \App\Helpers\PdfHelper::streamFile($disk, $filePath);
+        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
     }
 }

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -65,7 +65,7 @@ class DownloadController extends Controller
         ]);
     }
 
-    public function download(DownloadTask $task)
+    public function download(Request $request, DownloadTask $task)
     {
         if ($task->user_id !== Auth::id()) {
             abort(403);
@@ -84,6 +84,15 @@ class DownloadController extends Controller
 
         if (!file_exists($fullPath)) {
             abort(404, 'File not found on server.');
+        }
+
+        $disposition = $request->input('disposition', 'attachment');
+
+        if ($disposition === 'inline') {
+            return response()->file($fullPath, [
+                'Content-Type' => mime_content_type($fullPath),
+                'Content-Disposition' => 'inline; filename="' . basename($fullPath) . '"'
+            ]);
         }
 
         return response()->download($fullPath);

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -1047,7 +1047,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
     /**
      * Download a document as PDF (converting images if necessary).
      */
-    public function downloadDocumentAsPdf(Employee $employee, $field)
+    public function downloadDocumentAsPdf(Request $request, Employee $employee, $field)
     {
         // Allowed fields (same as serveDocument, plus 'insurance_document_path')
         $allowedFields = [
@@ -1082,14 +1082,9 @@ public function create(Request $request) // เพิ่ม Request $request เ
             }
         }
 
-        $mimeType = Storage::disk($disk)->mimeType($filePath);
+        $disposition = $request->input('disposition', 'attachment');
 
-        // If it's already a PDF, download it directly
-        if ($mimeType === 'application/pdf') {
-            return Storage::disk($disk)->download($filePath);
-        }
-
-        return \App\Helpers\PdfHelper::streamFile($disk, $filePath);
+        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
     }
 
     /**

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -642,7 +642,7 @@ class EmployerController extends Controller
                          ->with('highlight_employer', $employer->id);
     }
 
-    public function downloadDocumentAsPdf(Employer $employer, $field)
+    public function downloadDocumentAsPdf(Request $request, Employer $employer, $field)
     {
         $allowedFields = [
             'employer_doc_company',
@@ -665,12 +665,8 @@ class EmployerController extends Controller
             abort(404, 'File not found.');
         }
 
-        $mimeType = Storage::disk($disk)->mimeType($filePath);
+        $disposition = $request->input('disposition', 'attachment');
 
-        if ($mimeType === 'application/pdf') {
-            return Storage::disk($disk)->download($filePath);
-        }
-
-        return \App\Helpers\PdfHelper::streamFile($disk, $filePath);
+        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
     }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,7 +5,7 @@
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#F97316",
-    "orientation": "portrait",
+    "orientation": "any",
     "icons": [
         {
             "src": "/images/icons/icon-192x192.png",

--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -197,10 +197,10 @@
 
                                     <!-- ... (Other context types same as before) ... -->
                                     <template x-if="msg.context_data.type === 'image'">
-                                        <a :href="msg.context_data.url" target="_blank"><img :src="msg.context_data.url" class="img-fluid rounded" style="max-height: 120px;"></a>
+                                        <a href="#" @click.prevent="viewPDF(msg.context_data.url, 'Image Attachment')"><img :src="msg.context_data.url" class="img-fluid rounded" style="max-height: 120px;"></a>
                                     </template>
                                      <template x-if="msg.context_data.type === 'file'">
-                                        <a :href="msg.context_data.url" target="_blank" class="d-flex align-items-center text-decoration-none small" :class="msg.sender_id == currentUserId ? 'text-white' : 'text-primary'">
+                                        <a href="#" @click.prevent="viewPDF(msg.context_data.url, msg.context_data.name || 'File')" class="d-flex align-items-center text-decoration-none small" :class="msg.sender_id == currentUserId ? 'text-white' : 'text-primary'">
                                             <i class="bi bi-file-earmark-text me-1"></i><span x-text="msg.context_data.name || 'File'"></span>
                                         </a>
                                     </template>

--- a/resources/views/components/download-modals.blade.php
+++ b/resources/views/components/download-modals.blade.php
@@ -237,14 +237,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 loadDownloadTasks();
                 downloadCenterModal.show();
 
-                // Auto download if ready (using iframe to avoid popup blockers/replacing page)
+                // Auto download if ready
                 if (data.download_url) {
-                    const iframe = document.createElement('iframe');
-                    iframe.style.display = 'none';
-                    iframe.src = data.download_url;
-                    document.body.appendChild(iframe);
-                    // Cleanup iframe after a bit
-                    setTimeout(() => document.body.removeChild(iframe), 60000);
+                    if (type === 'pdf') {
+                        viewPDF(data.download_url, 'Employee PDF');
+                    } else {
+                        // For ZIP, use iframe to avoid navigation and "back closes app" issue
+                        const iframe = document.createElement('iframe');
+                        iframe.style.display = 'none';
+                        iframe.src = data.download_url;
+                        document.body.appendChild(iframe);
+                        // Cleanup iframe after a bit
+                        setTimeout(() => document.body.removeChild(iframe), 60000);
+                    }
                 }
             } else {
                 showToast('Error starting download.', 'danger');
@@ -285,7 +290,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     let actionBtn = '';
                     if (task.status === 'completed') {
                         const url = '{{ route("admin.downloads.download", ":id") }}'.replace(':id', task.id);
-                        actionBtn = `<a href="${url}" class="btn btn-sm btn-success" target="_blank"><i class="bi bi-download"></i> Download</a>`;
+                        if (task.type === 'pdf') {
+                            actionBtn = `<button onclick="viewPDF('${url}', 'Download PDF')" class="btn btn-sm btn-success"><i class="bi bi-eye"></i> View PDF</button>`;
+                        } else {
+                            actionBtn = `<a href="${url}" class="btn btn-sm btn-success" target="_blank"><i class="bi bi-download"></i> Download</a>`;
+                        }
                     } else if (task.status === 'failed') {
                         actionBtn = `
                             <span class="text-danger fw-bold">Failed</span>

--- a/resources/views/components/file-input-group.blade.php
+++ b/resources/views/components/file-input-group.blade.php
@@ -19,12 +19,12 @@
 
     @if($value)
         <div class="mb-2 d-flex gap-1 flex-wrap">
-            <a href="{{ asset('storage/' . $value) }}" target="_blank" class="btn btn-success btn-sm text-white">
+            <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $value) }}', '{{ $label }}')" class="btn btn-success btn-sm text-white">
                 <i class="bi bi-eye-fill"></i> <span class="d-none d-sm-inline">{{ __('View') }}</span>
             </a>
 
             @if($pdfRoute)
-                <a href="{{ $pdfRoute }}" target="_blank" class="btn btn-danger btn-sm text-white">
+                <a href="#" onclick="event.preventDefault(); viewPDF('{{ $pdfRoute }}', '{{ $label }}')" class="btn btn-danger btn-sm text-white">
                     <i class="bi bi-file-earmark-pdf-fill"></i> PDF
                 </a>
             @endif

--- a/resources/views/financial/index.blade.php
+++ b/resources/views/financial/index.blade.php
@@ -167,7 +167,7 @@
                                     <i class="bi bi-eye"></i>
                                 </a>
                                 @if($txn->slip_path)
-                                    <a href="{{ asset('storage/' . $txn->slip_path) }}" target="_blank" class="btn btn-sm btn-outline-secondary" title="View Slip">
+                                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $txn->slip_path) }}', 'View Slip')" class="btn btn-sm btn-outline-secondary" title="View Slip">
                                         <i class="bi bi-receipt"></i>
                                     </a>
                                 @endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -954,6 +954,26 @@
     @include('partials.background-removal-scripts')
     @stack('scripts')
 
+<!-- PDF Preview Modal -->
+<div class="modal fade" id="pdfPreviewModal" tabindex="-1" aria-labelledby="pdfPreviewModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered" style="height: 90vh;">
+        <div class="modal-content h-100">
+            <div class="modal-header">
+                <h5 class="modal-title" id="pdfPreviewModalLabel">{{ __('PDF Preview') }}</h5>
+                <div class="d-flex gap-2">
+                    <a href="" id="pdfDownloadBtn" class="btn btn-sm btn-primary" download>
+                        <i class="bi bi-download"></i> {{ __('Download') }}
+                    </a>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+            </div>
+            <div class="modal-body p-0 h-100 overflow-hidden">
+                <iframe id="pdfPreviewFrame" src="" class="w-100 h-100" style="border: none;"></iframe>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Universal Preview Modal -->
 <div class="modal fade" id="universalPreviewModal" tabindex="-1" aria-labelledby="universalPreviewModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-xl modal-dialog-centered">
@@ -974,6 +994,24 @@
 </div>
 
 <script>
+window.viewPDF = function(url, title = 'PDF Preview') {
+    const modalEl = document.getElementById('pdfPreviewModal');
+    const iframe = document.getElementById('pdfPreviewFrame');
+    const downloadBtn = document.getElementById('pdfDownloadBtn');
+    const modalTitle = document.getElementById('pdfPreviewModalLabel');
+
+    // Add disposition=inline to URL if it's one of our routes
+    const pdfUrl = new URL(url, window.location.origin);
+    pdfUrl.searchParams.set('disposition', 'inline');
+
+    modalTitle.textContent = title;
+    downloadBtn.href = url; // Keep original for download
+    iframe.src = pdfUrl.toString();
+
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    modal.show();
+};
+
 // Full-Featured Address Management Script
 document.addEventListener('DOMContentLoaded', function () {
     // --- Configuration & Global State ---

--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -162,10 +162,10 @@
             <label class="form-label fw-bold">ใบรับรองแพทย์</label>
             @if($employee->medical_certificate_path)
                 <p class="form-control-plaintext">
-                    <a href="{{ Storage::disk('public')->url($employee->medical_certificate_path) }}" target="_blank" class="btn btn-success btn-sm text-white">
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ Storage::disk('public')->url($employee->medical_certificate_path) }}', 'ดูใบรับรองแพทย์')" class="btn btn-success btn-sm text-white">
                         <i class="bi bi-eye-fill"></i> ดูเอกสาร
                     </a>
-                    <a href="{{ route('employees.documents.pdf', ['employee' => $employee->id, 'field' => 'medical_certificate_path']) }}" target="_blank" class="btn btn-danger btn-sm text-white ms-1">
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employees.documents.pdf', ['employee' => $employee->id, 'field' => 'medical_certificate_path']) }}', 'ใบรับรองแพทย์')" class="btn btn-danger btn-sm text-white ms-1">
                         <i class="bi bi-file-earmark-pdf-fill"></i> PDF
                     </a>
                 </p>
@@ -226,10 +226,10 @@
             <label class="form-label fw-bold">ไฟล์แนบประกัน</label>
             @if($employee->insurance_document_path_private)
                 <p class="form-control-plaintext">
-                    <a href="{{ Storage::disk('public')->url($employee->insurance_document_path_private) }}" target="_blank" class="btn btn-success btn-sm text-white">
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ Storage::disk('public')->url($employee->insurance_document_path_private) }}', 'ดูประกัน')" class="btn btn-success btn-sm text-white">
                         <i class="bi bi-eye-fill"></i> ดูเอกสาร
                     </a>
-                    <a href="{{ route('employees.documents.pdf', ['employee' => $employee->id, 'field' => 'insurance_document_path_private']) }}" target="_blank" class="btn btn-danger btn-sm text-white ms-1">
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employees.documents.pdf', ['employee' => $employee->id, 'field' => 'insurance_document_path_private']) }}', 'ประกัน')" class="btn btn-danger btn-sm text-white ms-1">
                         <i class="bi bi-file-earmark-pdf-fill"></i> PDF
                     </a>
                 </p>
@@ -280,10 +280,10 @@
                 <label class="form-label fw-bold">{{ $label }}</label>
                 @if($employee->{$field})
                     <p class="form-control-plaintext">
-                        <a href="{{ $url }}" target="_blank" class="btn btn-success btn-sm text-white">
+                        <a href="#" onclick="event.preventDefault(); viewPDF('{{ $url }}', 'ดูเอกสาร')" class="btn btn-success btn-sm text-white">
                             <i class="bi bi-eye-fill"></i> ดูเอกสาร
                         </a>
-                        <a href="{{ $pdfUrl }}" target="_blank" class="btn btn-danger btn-sm text-white ms-1">
+                        <a href="#" onclick="event.preventDefault(); viewPDF('{{ $pdfUrl }}', '{{ $label }}')" class="btn btn-danger btn-sm text-white ms-1">
                             <i class="bi bi-file-earmark-pdf-fill"></i> PDF
                         </a>
                          @if($desc_field && $employee->{$desc_field})

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -130,8 +130,8 @@
             <label class="form-label fw-bold">1. หนังสือรับรองบริษัท / บัตรประชาชน</label>
             @if($employer->employer_doc_company)
                 <p class="form-control-plaintext">
-                    <a href="{{ asset('storage/' . $employer->employer_doc_company) }}" target="_blank" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_company']) }}" target="_blank" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_company) }}', 'ดูหนังสือรับรองบริษัท')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_company']) }}', 'หนังสือรับรองบริษัท')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
@@ -147,8 +147,8 @@
             <label class="form-label fw-bold">2. สัญญาเช่าบ้าน / ทะเบียนบ้าน</label>
              @if($employer->employer_doc_lease)
                 <p class="form-control-plaintext">
-                    <a href="{{ asset('storage/' . $employer->employer_doc_lease) }}" target="_blank" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_lease']) }}" target="_blank" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_lease) }}', 'ดูสัญญาเช่า')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_lease']) }}', 'สัญญาเช่า')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
@@ -158,8 +158,8 @@
             <label class="form-label fw-bold">3. สัญญาก่อสร้าง / แผนที่</label>
             @if($employer->employer_doc_construction)
                 <p class="form-control-plaintext">
-                    <a href="{{ asset('storage/' . $employer->employer_doc_construction) }}" target="_blank" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_construction']) }}" target="_blank" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_construction) }}', 'ดูใบอนุญาตก่อสร้าง')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_construction']) }}', 'ใบอนุญาตก่อสร้าง')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
@@ -171,8 +171,8 @@
             <label class="form-label fw-bold">4. เอกสารอื่นๆ 1</label>
             @if($employer->employer_doc_other_1)
                 <p class="form-control-plaintext">
-                    <a href="{{ asset('storage/' . $employer->employer_doc_other_1) }}" target="_blank" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_1']) }}" target="_blank" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_1) }}', '{{ $employer->employer_doc_other_1_desc ?? 'ดูเอกสารอื่นๆ 1' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_1']) }}', '{{ $employer->employer_doc_other_1_desc ?? 'เอกสารอื่นๆ 1' }}')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                     <br>({{ $employer->employer_doc_other_1_desc ?? 'N/A' }})
                 </p>
             @else
@@ -183,8 +183,8 @@
             <label class="form-label fw-bold">5. เอกสารอื่นๆ 2</label>
             @if($employer->employer_doc_other_2)
                 <p class="form-control-plaintext">
-                    <a href="{{ asset('storage/' . $employer->employer_doc_other_2) }}" target="_blank" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_2']) }}" target="_blank" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_2) }}', '{{ $employer->employer_doc_other_2_desc ?? 'ดูเอกสารอื่นๆ 2' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_2']) }}', '{{ $employer->employer_doc_other_2_desc ?? 'เอกสารอื่นๆ 2' }}')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                     <br>({{ $employer->employer_doc_other_2_desc ?? 'N/A' }})
                 </p>
             @else
@@ -195,8 +195,8 @@
             <label class="form-label fw-bold">6. เอกสารอื่นๆ 3</label>
             @if($employer->employer_doc_other_3)
                 <p class="form-control-plaintext">
-                    <a href="{{ asset('storage/' . $employer->employer_doc_other_3) }}" target="_blank" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_3']) }}" target="_blank" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_3) }}', '{{ $employer->employer_doc_other_3_desc ?? 'ดูเอกสารอื่นๆ 3' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
+                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_3']) }}', '{{ $employer->employer_doc_other_3_desc ?? 'เอกสารอื่นๆ 3' }}')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                     <br>({{ $employer->employer_doc_other_3_desc ?? 'N/A' }})
                 </p>
             @else

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -436,7 +436,7 @@
                                         <div class="fw-bold" x-text="formatType(t.type)"></div>
                                         <div class="small text-muted" x-text="t.notes || '-'"></div>
                                         <div x-show="t.slip_path" class="mt-1">
-                                            <a :href="'/storage/' + t.slip_path" target="_blank" class="badge bg-info text-decoration-none">View Slip</a>
+                                            <a href="#" @click.prevent="viewPDF('/storage/' + t.slip_path, 'View Slip')" class="badge bg-info text-decoration-none">View Slip</a>
                                         </div>
                                     </td>
                                     <td x-text="formatDate(t.due_date)"></td>
@@ -485,7 +485,7 @@
                                         <div class="fw-bold text-primary" x-text="formatType(t.type)"></div>
                                         <div class="small text-muted" x-text="t.notes || '-'"></div>
                                         <div x-show="t.slip_path" class="mt-1">
-                                            <a :href="'/storage/' + t.slip_path" target="_blank" class="badge bg-info text-decoration-none">View Slip</a>
+                                            <a href="#" @click.prevent="viewPDF('/storage/' + t.slip_path, 'View Slip')" class="badge bg-info text-decoration-none">View Slip</a>
                                         </div>
                                     </td>
                                     <td x-text="formatDate(t.due_date)"></td>
@@ -863,7 +863,7 @@
 
                                             <!-- View -->
                                             <template x-if="editingTransaction.slip_path">
-                                                <a :href="'/storage/' + editingTransaction.slip_path" target="_blank" class="btn btn-outline-secondary btn-sm" title="View">
+                                                <a href="#" @click.prevent="viewPDF('/storage/' + editingTransaction.slip_path, 'View Slip')" class="btn btn-outline-secondary btn-sm" title="View">
                                                     <i class="bi bi-eye"></i>
                                                 </a>
                                             </template>

--- a/resources/views/production/registration/partials/offcanvas_drawer.blade.php
+++ b/resources/views/production/registration/partials/offcanvas_drawer.blade.php
@@ -59,10 +59,10 @@
                             <span class="small text-secondary text-truncate" style="max-width: 150px;">Attachment</span>
                         </div>
                         <div class="d-flex gap-1">
-                            <a href="/storage/${field.file_path}" target="_blank" class="btn btn-sm btn-success text-white rounded-circle shadow-sm d-flex align-items-center justify-content-center flex-shrink-0" style="width: 32px; height: 32px;" title="View File">
+                            <a href="#" onclick="event.preventDefault(); viewPDF('/storage/${field.file_path}', '${field.field_name}')" class="btn btn-sm btn-success text-white rounded-circle shadow-sm d-flex align-items-center justify-content-center flex-shrink-0" style="width: 32px; height: 32px;" title="View File">
                                 <i class="bi bi-eye-fill"></i>
                             </a>
-                            <a href="/custom-fields/${field.id}/pdf?type=${context}" target="_blank" class="btn btn-sm btn-danger text-white rounded-circle shadow-sm d-flex align-items-center justify-content-center flex-shrink-0" style="width: 32px; height: 32px;" title="Download PDF">
+                            <a href="#" onclick="event.preventDefault(); viewPDF('/custom-fields/${field.id}/pdf?type=${context}', '${field.field_name}')" class="btn btn-sm btn-danger text-white rounded-circle shadow-sm d-flex align-items-center justify-content-center flex-shrink-0" style="width: 32px; height: 32px;" title="Download PDF">
                                 <i class="bi bi-file-earmark-pdf-fill"></i>
                             </a>
                         </div>

--- a/resources/views/production/workflow_item_timeline.blade.php
+++ b/resources/views/production/workflow_item_timeline.blade.php
@@ -71,7 +71,7 @@
                                                 <div class="flex-grow-1 text-truncate">
                                                     {{ $step->value_text ?? 'Attached File' }}
                                                 </div>
-                                                <a href="{{ Storage::url($step->file_path) }}" target="_blank" class="btn btn-sm btn-outline-primary">
+                                                <a href="#" onclick="event.preventDefault(); viewPDF('{{ Storage::url($step->file_path) }}', 'View Document')" class="btn btn-sm btn-outline-primary">
                                                     View
                                                 </a>
                                             </div>


### PR DESCRIPTION
This update addresses two critical mobile usability issues:
1. **Screen Rotation:** Changed the PWA manifest to allow rotation, enabling users to view the application in landscape mode.
2. **PWA State Preservation:** Replaced `target="_blank"` links for PDF and image viewing with a built-in modal viewer. This prevents the mobile app (when used as a PWA/Hybrid app on the home screen) from losing the current search/navigation state or closing entirely when the user navigates back from viewing a document.
3. **Enhanced PDF Streaming:** Updated the backend PDF helper and controllers to support inline streaming, which allows the modal to render the documents correctly.

---
*PR created automatically by Jules for task [10757769885232275628](https://jules.google.com/task/10757769885232275628) started by @nongjogame4-prog*