### PR TITLE
Restrict Super Admin creation to Super Admins only

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Employer;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rule;
 use Spatie\Permission\Models\Permission;
@@ -51,7 +52,13 @@ class UserController extends Controller
      */
     public function create()
     {
-        $roles = Role::all();
+        // Filter Roles: Only Super Admin can see/select 'super-admin'
+        if (Auth::user()->hasRole('super-admin')) {
+            $roles = Role::all();
+        } else {
+            $roles = Role::where('name', '!=', 'super-admin')->get();
+        }
+
         $employers = Employer::whereNull('user_id')->get();
         return view('admin.users.create', compact('roles', 'employers'));
     }
@@ -68,6 +75,11 @@ class UserController extends Controller
             'role_name' => ['required', 'string', Rule::exists('roles', 'name')],
             'employer_id' => ['nullable', 'required_if:role_name,employer', Rule::exists('employers', 'id')],
         ]);
+
+        // Security Check: Prevent non-SuperAdmin from creating SuperAdmin
+        if ($request->role_name === 'super-admin' && !Auth::user()->hasRole('super-admin')) {
+            abort(403, 'Unauthorized action. Only Super Admin can create another Super Admin.');
+        }
 
         // Create User
         $user = User::create([
@@ -104,7 +116,18 @@ class UserController extends Controller
      */
     public function edit(User $user)
     {
-        $roles = Role::all();
+        // Security Check: Prevent non-SuperAdmin from editing SuperAdmin
+        if ($user->hasRole('super-admin') && !Auth::user()->hasRole('super-admin')) {
+             abort(403, 'Unauthorized action. You cannot edit a Super Admin user.');
+        }
+
+        // Filter Roles: Only Super Admin can see/select 'super-admin'
+        if (Auth::user()->hasRole('super-admin')) {
+            $roles = Role::all();
+        } else {
+            $roles = Role::where('name', '!=', 'super-admin')->get();
+        }
+
         $allPermissions = Permission::all();
         $userPermissions = $user->permissions->pluck('name')->toArray();
 
@@ -124,6 +147,17 @@ class UserController extends Controller
     {
         // Check if this is a request from the full "Edit Form" (Feature D)
         if ($request->has('name')) {
+
+            // Security Check 1: Prevent non-SuperAdmin from updating SuperAdmin
+            if ($user->hasRole('super-admin') && !Auth::user()->hasRole('super-admin')) {
+                abort(403, 'Unauthorized action. You cannot update a Super Admin user.');
+            }
+
+            // Security Check 2: Prevent non-SuperAdmin from assigning SuperAdmin role
+            if ($request->role_name === 'super-admin' && !Auth::user()->hasRole('super-admin')) {
+                abort(403, 'Unauthorized action. Only Super Admin can assign the Super Admin role.');
+            }
+
             $request->validate([
                 'name' => ['required', 'string', 'max:255'],
                 'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
@@ -172,6 +206,12 @@ class UserController extends Controller
             return redirect()->route('admin.users.index')->with('success', 'User permissions and details updated.');
         } else {
             // This is a request from the "Status Toggle" (Feature C)
+
+            // Security Check: Prevent non-SuperAdmin from toggling status of SuperAdmin
+            if ($user->hasRole('super-admin') && !Auth::user()->hasRole('super-admin')) {
+                 abort(403, 'Unauthorized action. You cannot change status of a Super Admin user.');
+            }
+
             $newStatus = $user->status === 'active' ? 'inactive' : 'active';
             $user->update(['status' => $newStatus]);
             return redirect()->route('admin.users.index')->with('success', 'User status updated successfully.');

--- a/tests/Feature/Admin/UserCreationRestrictionTest.php
+++ b/tests/Feature/Admin/UserCreationRestrictionTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class UserCreationRestrictionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup Roles
+        Role::create(['name' => 'super-admin']);
+        Role::create(['name' => 'admin']);
+        Role::create(['name' => 'staff']);
+
+        // Assign permissions to admin so they can access users page
+        $adminRole = Role::findByName('admin');
+        // Admin needs permissions to view and manage users. Assuming these exist from seeder logic.
+        Permission::create(['name' => 'manage-users']);
+        Permission::create(['name' => 'manage-roles']);
+        $adminRole->givePermissionTo(['manage-users', 'manage-roles']);
+    }
+
+    /** @test */
+    public function admin_cannot_create_super_admin_user()
+    {
+        $admin = User::create([
+            'name' => 'Admin User',
+            'email' => 'admin@test.com',
+            'password' => Hash::make('password'),
+            'status' => 'active',
+        ]);
+        $admin->assignRole('admin');
+
+        $response = $this->actingAs($admin)->post(route('admin.users.store'), [
+            'name' => 'New Super Admin',
+            'email' => 'newsuper@test.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'role_name' => 'super-admin',
+        ]);
+
+        // Assert failure (currently might fail asserting 403 because it's not implemented, so I expect 302/200 if it passes validation)
+        // If the restriction IS implemented, it should return 403 or redirect back with error.
+        // Since I haven't implemented it yet, this test will FAIL if I assert 403.
+        // I will assert that the user was NOT created with super-admin role.
+
+        // However, standard Laravel authorization failure is 403.
+        // Or validation error 422.
+        // I'll check if the user exists.
+
+        $this->assertDatabaseMissing('users', [
+            'email' => 'newsuper@test.com',
+        ]);
+
+        // If the user was created despite the restriction, this test fails, confirming the bug/missing feature.
+    }
+
+    /** @test */
+    public function super_admin_can_create_super_admin_user()
+    {
+        $superAdmin = User::create([
+            'name' => 'Super Admin User',
+            'email' => 'super@test.com',
+            'password' => Hash::make('password'),
+            'status' => 'active',
+        ]);
+        $superAdmin->assignRole('super-admin');
+
+        $response = $this->actingAs($superAdmin)->post(route('admin.users.store'), [
+            'name' => 'Another Super Admin',
+            'email' => 'another@test.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'role_name' => 'super-admin',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertDatabaseHas('users', [
+            'email' => 'another@test.com',
+        ]);
+
+        $user = User::where('email', 'another@test.com')->first();
+        $this->assertTrue($user->hasRole('super-admin'));
+    }
+
+    /** @test */
+    public function admin_cannot_update_user_to_super_admin()
+    {
+        $admin = User::create([
+            'name' => 'Admin User',
+            'email' => 'admin@test.com',
+            'password' => Hash::make('password'),
+            'status' => 'active',
+        ]);
+        $admin->assignRole('admin');
+
+        $targetUser = User::create([
+            'name' => 'Target User',
+            'email' => 'target@test.com',
+            'password' => Hash::make('password'),
+            'status' => 'active',
+        ]);
+        $targetUser->assignRole('staff');
+
+        $response = $this->actingAs($admin)->put(route('admin.users.update', $targetUser), [
+            'name' => 'Target User Updated',
+            'email' => 'target@test.com',
+            'role_name' => 'super-admin', // Attempt to escalate privilege
+        ]);
+
+        // Expect failure
+        $targetUser->refresh();
+        $this->assertFalse($targetUser->hasRole('super-admin'));
+    }
+
+    /** @test */
+    public function admin_cannot_update_existing_super_admin()
+    {
+        $admin = User::create([
+            'name' => 'Admin User',
+            'email' => 'admin@test.com',
+            'password' => Hash::make('password'),
+            'status' => 'active',
+        ]);
+        $admin->assignRole('admin');
+
+        $superAdminTarget = User::create([
+            'name' => 'Super Admin Target',
+            'email' => 'targetsuper@test.com',
+            'password' => Hash::make('password'),
+            'status' => 'active',
+        ]);
+        $superAdminTarget->assignRole('super-admin');
+
+        $response = $this->actingAs($admin)->put(route('admin.users.update', $superAdminTarget), [
+            'name' => 'Hacked Name',
+            'email' => 'targetsuper@test.com',
+            'role_name' => 'staff', // Attempt to downgrade
+        ]);
+
+        // Expect failure
+        $superAdminTarget->refresh();
+        $this->assertEquals('Super Admin Target', $superAdminTarget->name);
+        $this->assertTrue($superAdminTarget->hasRole('super-admin'));
+    }
+}


### PR DESCRIPTION
- Modified `app/Http/Controllers/Admin/UserController.php` to restrict role selection and validation.
- Only authenticated users with `super-admin` role can create or update users with `super-admin` role.
- Prevents admins from elevating privileges or modifying existing super admins.
- Added `tests/Feature/Admin/UserCreationRestrictionTest.php` to verify the restrictions.