### PR TITLE
Fix syntax error in layouts/app.blade.php blocking viewPDF

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1025,7 +1025,7 @@ window.viewPDF = function(url, title = 'PDF Preview') {
 };
 
 // Full-Featured Address Management Script
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', async function () {
     // --- Configuration & Global State ---
     const thaiDataUrl = "/thai-addresses"; // Hardcoded URL
     let thaiAddressData = [];


### PR DESCRIPTION
- Add `async` to DOMContentLoaded event listener to support `await fetchThaiAddressData()`
- Fixes critical bug where `viewPDF` was undefined due to script parsing failure
- Restores functionality for PDF Preview and Download buttons globally