### PR TITLE
Fix preview and download buttons for employee and employer documents

### DIFF
--- a/app/Http/Controllers/CustomFieldController.php
+++ b/app/Http/Controllers/CustomFieldController.php
@@ -32,7 +32,7 @@ class CustomFieldController extends Controller
 
         $filePath = $field->file_path;
         $disk = 'public';
-        $disposition = $request->input('disposition', 'attachment');
+        $disposition = $request->input('disposition', 'inline');
 
         return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
     }

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -1082,7 +1082,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
             }
         }
 
-        $disposition = $request->input('disposition', 'attachment');
+        $disposition = $request->input('disposition', 'inline');
 
         return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
     }

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -665,7 +665,7 @@ class EmployerController extends Controller
             abort(404, 'File not found.');
         }
 
-        $disposition = $request->input('disposition', 'attachment');
+        $disposition = $request->input('disposition', 'inline');
 
         return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
     }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1013,12 +1013,26 @@ let imageZoomLevel = 1.0;
 let isImageFitToScreen = true;
 
 window.viewPDF = function(url, title = 'PDF Preview') {
+    // Check if URL is valid
+    if (!url) {
+        console.error('viewPDF called with empty URL');
+        return;
+    }
+
+    // Fallback if bootstrap is not loaded yet
     if (typeof bootstrap === 'undefined') {
-        alert('{{ __("System is loading components... please try again in a moment.") }}');
+        console.warn('Bootstrap not loaded, opening in new tab');
+        window.open(url, '_blank');
         return;
     }
 
     const modalEl = document.getElementById('pdfPreviewModal');
+    if (!modalEl) {
+        console.error('PDF Preview Modal element not found');
+        window.open(url, '_blank');
+        return;
+    }
+
     const iframe = document.getElementById('pdfPreviewFrame');
     const imageContainer = document.getElementById('imagePreviewContainer');
     const imagePreview = document.getElementById('imagePreview');
@@ -1028,59 +1042,67 @@ window.viewPDF = function(url, title = 'PDF Preview') {
     const modalTitle = document.getElementById('pdfPreviewModalLabel');
 
     try {
-        // Add disposition=inline only if it's a local URL (to avoid breaking S3 signatures)
+        // Construct URL object to parse parts
+        // Use window.location.origin as base for relative URLs
         const pdfUrl = new URL(url, window.location.origin);
-        if (pdfUrl.origin === window.location.origin) {
-            pdfUrl.searchParams.set('disposition', 'inline');
+
+        // Add disposition=inline for local URLs or routes
+        // We check if hostname matches to allow protocol mismatches (http vs https behind proxy)
+        if (pdfUrl.hostname === window.location.hostname) {
+             pdfUrl.searchParams.set('disposition', 'inline');
         }
 
-        modalTitle.textContent = title;
-        downloadBtn.href = url; // Keep original for download
+        if(modalTitle) modalTitle.textContent = title;
+        if(downloadBtn) downloadBtn.href = url; // Keep original URL for download button
 
-        // Detect if file is an image
+        // Detect if file is an image based on extension
         const pathname = pdfUrl.pathname.toLowerCase();
         const isImage = /\.(jpg|jpeg|png|gif|webp|bmp)$/i.test(pathname);
 
         if (isImage) {
             // Image Mode
-            iframe.style.display = 'none';
-            imageContainer.classList.remove('d-none');
+            if(iframe) iframe.style.display = 'none';
+            if(imageContainer) imageContainer.classList.remove('d-none');
             if (zoomControls) zoomControls.classList.remove('d-none');
 
             // Reset Zoom
             isImageFitToScreen = true;
             imageZoomLevel = 1.0;
-            updateImageStyle();
+            if (typeof updateImageStyle === 'function') updateImageStyle();
 
             // Load Image
-            imageSpinner.classList.remove('d-none');
-            imagePreview.style.opacity = '0.5';
-            imagePreview.src = pdfUrl.toString();
+            if(imageSpinner) imageSpinner.classList.remove('d-none');
+            if(imagePreview) {
+                imagePreview.style.opacity = '0.5';
+                imagePreview.src = pdfUrl.toString();
 
-            imagePreview.onload = function() {
-                imageSpinner.classList.add('d-none');
-                imagePreview.style.opacity = '1';
-            };
-            imagePreview.onerror = function() {
-                imageSpinner.classList.add('d-none');
-                // Don't alert immediately, sometimes it's just a flicker, but if persistent it's an issue.
-                // Fallback to iframe if image fails? No, keep it simple.
-            };
+                imagePreview.onload = function() {
+                    if(imageSpinner) imageSpinner.classList.add('d-none');
+                    imagePreview.style.opacity = '1';
+                };
+                imagePreview.onerror = function() {
+                    if(imageSpinner) imageSpinner.classList.add('d-none');
+                    console.error('Image failed to load');
+                };
+            }
 
         } else {
             // PDF / Other Mode
-            iframe.style.display = 'block';
-            imageContainer.classList.add('d-none');
+            if(iframe) {
+                iframe.style.display = 'block';
+                iframe.src = pdfUrl.toString();
+            }
+            if(imageContainer) imageContainer.classList.add('d-none');
             if (zoomControls) zoomControls.classList.add('d-none');
-
-            iframe.src = pdfUrl.toString();
         }
 
         const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
         modal.show();
+
     } catch (e) {
         console.error('Error opening preview:', e);
-        alert('{{ __("Could not open preview. Please try downloading the file directly.") }}');
+        // Fallback to new tab
+        window.open(url, '_blank');
     }
 };
 

--- a/tests/Feature/Pdf/DocumentDownloadTest.php
+++ b/tests/Feature/Pdf/DocumentDownloadTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Pdf;
+
+use App\Models\Employee;
+use App\Models\Employer;
+use App\Models\JobOwner;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use Spatie\Permission\Models\Permission;
+
+class DocumentDownloadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Seed permissions
+        $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+        // Ensure manage-tickets exists if not seeded
+        if (!Permission::where('name', 'manage-tickets')->exists()) {
+             Permission::create(['name' => 'manage-tickets']);
+        }
+    }
+
+    public function test_employee_document_download_disposition_inline()
+    {
+        Storage::fake('public');
+        $file = UploadedFile::fake()->create('document.pdf', 100);
+        $path = $file->store('employee_files', 'public');
+
+        $jobOwner = JobOwner::factory()->create();
+        $employer = Employer::factory()->create(['job_owner_id' => $jobOwner->id]);
+        $employee = Employee::factory()->create([
+            'employer_id' => $employer->id,
+            'employee_doc_1' => $path,
+        ]);
+
+        $user = User::factory()->create();
+        $user->givePermissionTo(['view-employees', 'manage-tickets']);
+
+        $response = $this->actingAs($user)->get(route('employees.documents.pdf', [
+            'employee' => $employee->id,
+            'field' => 'employee_doc_1'
+        ]));
+
+        $response->assertStatus(200);
+
+        // Expected Content-Disposition header
+        $filename = basename($path);
+
+        $this->assertStringContainsString('inline', $response->headers->get('Content-Disposition'));
+        $this->assertStringContainsString($filename, $response->headers->get('Content-Disposition'));
+    }
+
+    public function test_employer_document_download_disposition_inline()
+    {
+        Storage::fake('public');
+        $file = UploadedFile::fake()->create('company.pdf', 100);
+        $path = $file->store('employer_documents', 'public');
+
+        $jobOwner = JobOwner::factory()->create();
+        $employer = Employer::factory()->create([
+            'job_owner_id' => $jobOwner->id,
+            'employer_doc_company' => $path,
+        ]);
+
+        $user = User::factory()->create();
+        // Assuming EmployerPolicy might also check manage-tickets or ownership
+        // Let's check EmployerPolicy logic if needed. Usually view-employers is enough for middleware, but policy?
+        // EmployerPolicy not checked previously, but likely similar.
+        // Giving manage-tickets is safer.
+        $user->givePermissionTo(['view-employers', 'manage-tickets']);
+
+        $response = $this->actingAs($user)->get(route('employers.documents.pdf', [
+            'employer' => $employer->id,
+            'field' => 'employer_doc_company'
+        ]));
+
+        $response->assertStatus(200);
+
+        $filename = basename($path);
+        $this->assertStringContainsString('inline', $response->headers->get('Content-Disposition'));
+        $this->assertStringContainsString($filename, $response->headers->get('Content-Disposition'));
+    }
+}


### PR DESCRIPTION
- Modified `EmployeeController`, `EmployerController`, and `CustomFieldController` to return `Content-Disposition: inline` by default for document downloads, fixing the issue where PDFs were downloaded instead of previewed in the modal.
- Updated `viewPDF` function in `resources/views/layouts/app.blade.php` to robustly handle relative URLs and routes, ensuring the `disposition=inline` query parameter is added where appropriate, and providing better error handling and fallbacks for image/PDF previews.
- Added `tests/Feature/Pdf/DocumentDownloadTest.php` to verify the disposition header fix.