### PR TITLE
Fix PDF preview z-index issue and update download buttons to direct d…

### DIFF
--- a/resources/views/components/download-modals.blade.php
+++ b/resources/views/components/download-modals.blade.php
@@ -246,17 +246,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
                     // Auto download if ready
                     if (data.download_url) {
-                        if (type === 'pdf') {
-                            viewPDF(data.download_url, 'Employee PDF');
-                        } else {
-                            // For ZIP, use iframe to avoid navigation and "back closes app" issue
-                            const iframe = document.createElement('iframe');
-                            iframe.style.display = 'none';
-                            iframe.src = data.download_url;
-                            document.body.appendChild(iframe);
-                            // Cleanup iframe after a bit
-                            setTimeout(() => document.body.removeChild(iframe), 60000);
-                        }
+                        // Direct Download for all types using iframe method to prevent page reload/navigation
+                        const iframe = document.createElement('iframe');
+                        iframe.style.display = 'none';
+                        iframe.src = data.download_url;
+                        document.body.appendChild(iframe);
+                        // Cleanup iframe after a bit
+                        setTimeout(() => document.body.removeChild(iframe), 60000);
                     }
                 } else {
                     showToast('Error starting download.', 'danger');
@@ -297,11 +293,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     let actionBtn = '';
                     if (task.status === 'completed') {
                         const url = '{{ route("admin.downloads.download", ":id") }}'.replace(':id', task.id);
-                        if (task.type === 'pdf') {
-                            actionBtn = `<button onclick="viewPDF('${url}', 'Download PDF')" class="btn btn-sm btn-success"><i class="bi bi-eye"></i> View PDF</button>`;
-                        } else {
-                            actionBtn = `<a href="${url}" class="btn btn-sm btn-success" target="_blank"><i class="bi bi-download"></i> Download</a>`;
-                        }
+                        actionBtn = `<a href="${url}" class="btn btn-sm btn-success" download><i class="bi bi-download"></i> Download</a>`;
                     } else if (task.status === 'failed') {
                         actionBtn = `
                             <span class="text-danger fw-bold">Failed</span>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -954,8 +954,27 @@
     @include('partials.background-removal-scripts')
     @stack('scripts')
 
+<!-- Universal Preview Modal -->
+<div class="modal fade" id="universalPreviewModal" tabindex="-1" aria-labelledby="universalPreviewModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="universalPreviewModalLabel">{{ __('Preview Data') }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="d-flex justify-content-center align-items-center" style="min-height: 200px;">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">{{ __('Loading...') }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- PDF Preview Modal -->
-<div class="modal fade" id="pdfPreviewModal" tabindex="-1" aria-labelledby="pdfPreviewModalLabel" aria-hidden="true">
+<div class="modal fade" id="pdfPreviewModal" tabindex="-1" aria-labelledby="pdfPreviewModalLabel" aria-hidden="true" style="z-index: 1060;">
     <div class="modal-dialog modal-xl modal-dialog-centered" style="height: 90vh;">
         <div class="modal-content h-100">
             <div class="modal-header">
@@ -983,25 +1002,6 @@
                         <span class="visually-hidden">Loading...</span>
                     </div>
                     <img id="imagePreview" src="" alt="Preview" class="m-auto" style="max-width: 100%; max-height: 100%; object-fit: contain; box-shadow: 0 0 20px rgba(0,0,0,0.5);">
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- Universal Preview Modal -->
-<div class="modal fade" id="universalPreviewModal" tabindex="-1" aria-labelledby="universalPreviewModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-xl modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="universalPreviewModalLabel">{{ __('Preview Data') }}</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="d-flex justify-content-center align-items-center" style="min-height: 200px;">
-                    <div class="spinner-border text-primary" role="status">
-                        <span class="visually-hidden">{{ __('Loading...') }}</span>
-                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -283,7 +283,7 @@
                         <a href="#" onclick="event.preventDefault(); viewPDF('{{ $url }}', 'ดูเอกสาร')" class="btn btn-success btn-sm text-white">
                             <i class="bi bi-eye-fill"></i> ดูเอกสาร
                         </a>
-                        <a href="#" onclick="event.preventDefault(); viewPDF('{{ $pdfUrl }}', '{{ $label }}')" class="btn btn-danger btn-sm text-white ms-1">
+                        <a href="{{ $pdfUrl }}" download class="btn btn-danger btn-sm text-white ms-1">
                             <i class="bi bi-file-earmark-pdf-fill"></i> PDF
                         </a>
                          @if($desc_field && $employee->{$desc_field})

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -131,7 +131,7 @@
             @if($employer->employer_doc_company)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_company) }}', 'ดูหนังสือรับรองบริษัท')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_company']) }}', 'หนังสือรับรองบริษัท')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_company']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
@@ -148,7 +148,7 @@
              @if($employer->employer_doc_lease)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_lease) }}', 'ดูสัญญาเช่า')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_lease']) }}', 'สัญญาเช่า')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_lease']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
@@ -159,7 +159,7 @@
             @if($employer->employer_doc_construction)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_construction) }}', 'ดูใบอนุญาตก่อสร้าง')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_construction']) }}', 'ใบอนุญาตก่อสร้าง')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_construction']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
@@ -172,7 +172,7 @@
             @if($employer->employer_doc_other_1)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_1) }}', '{{ $employer->employer_doc_other_1_desc ?? 'ดูเอกสารอื่นๆ 1' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_1']) }}', '{{ $employer->employer_doc_other_1_desc ?? 'เอกสารอื่นๆ 1' }}')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_1']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                     <br>({{ $employer->employer_doc_other_1_desc ?? 'N/A' }})
                 </p>
             @else
@@ -184,7 +184,7 @@
             @if($employer->employer_doc_other_2)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_2) }}', '{{ $employer->employer_doc_other_2_desc ?? 'ดูเอกสารอื่นๆ 2' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_2']) }}', '{{ $employer->employer_doc_other_2_desc ?? 'เอกสารอื่นๆ 2' }}')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_2']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                     <br>({{ $employer->employer_doc_other_2_desc ?? 'N/A' }})
                 </p>
             @else
@@ -196,7 +196,7 @@
             @if($employer->employer_doc_other_3)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_3) }}', '{{ $employer->employer_doc_other_3_desc ?? 'ดูเอกสารอื่นๆ 3' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
-                    <a href="#" onclick="event.preventDefault(); viewPDF('{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_3']) }}', '{{ $employer->employer_doc_other_3_desc ?? 'เอกสารอื่นๆ 3' }}')" class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
+                    <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_3']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
                     <br>({{ $employer->employer_doc_other_3_desc ?? 'N/A' }})
                 </p>
             @else

--- a/resources/views/production/registration/partials/offcanvas_drawer.blade.php
+++ b/resources/views/production/registration/partials/offcanvas_drawer.blade.php
@@ -62,7 +62,7 @@
                             <a href="#" onclick="event.preventDefault(); viewPDF('/storage/${field.file_path}', '${field.field_name}')" class="btn btn-sm btn-success text-white rounded-circle shadow-sm d-flex align-items-center justify-content-center flex-shrink-0" style="width: 32px; height: 32px;" title="View File">
                                 <i class="bi bi-eye-fill"></i>
                             </a>
-                            <a href="#" onclick="event.preventDefault(); viewPDF('/custom-fields/${field.id}/pdf?type=${context}', '${field.field_name}')" class="btn btn-sm btn-danger text-white rounded-circle shadow-sm d-flex align-items-center justify-content-center flex-shrink-0" style="width: 32px; height: 32px;" title="Download PDF">
+                            <a href="/custom-fields/${field.id}/pdf?type=${context}" download class="btn btn-sm btn-danger text-white rounded-circle shadow-sm d-flex align-items-center justify-content-center flex-shrink-0" style="width: 32px; height: 32px;" title="Download PDF">
                                 <i class="bi bi-file-earmark-pdf-fill"></i>
                             </a>
                         </div>


### PR DESCRIPTION
…ownload

- Swap modal order in `app.blade.php` and add z-index 1060 to `pdfPreviewModal` to ensure it appears on top of `universalPreviewModal`.
- Update "Download PDF" buttons in `_employer_data.blade.php` and `_employee_data.blade.php` to use direct download links.
- Update "Download PDF" button in `offcanvas_drawer.blade.php` to use direct download.
- Update `download-modals.blade.php` to perform direct download (via iframe) instead of opening preview for PDFs.