### PR TITLE
Fix crash in Production sub-menus due to undefined array key

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -55,6 +55,7 @@ class ProductionController extends Controller
             'not_started' => 0,
             'cancelled' => 0,
             'completed' => 0,
+            'pending_daily_check' => 0,
             'step_stats' => [],
         ];
 


### PR DESCRIPTION
The ProductionController's `index` method calculates statistics for the dashboard. However, the `$stats` array was not initializing the `pending_daily_check` key for all code paths, specifically when a `tab` filter (like 'mou_renewal') was active. This caused a 500 error when the view or controller logic attempted to access this key.

This commit initializes `pending_daily_check` to 0 in the `$stats` array, ensuring consistent data structure regardless of the active tab.

Verified with a reproduction test case (`PreProductionCrashTest`) that confirmed the crash before the fix and the resolution after. Existing regression tests passed.