### PR TITLE
Add Thai Address Data Generation Command and Restore Data File

### DIFF
--- a/app/Console/Commands/GenerateThaiAddressData.php
+++ b/app/Console/Commands/GenerateThaiAddressData.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+
+class GenerateThaiAddressData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'address:generate-data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Download and generate Thai address data JSON file from thailand-geography-json repository';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Downloading Thai address data...');
+
+        // URL for raw JSON data
+        $url = 'https://raw.githubusercontent.com/thailand-geography-data/thailand-geography-json/main/src/geography.json';
+
+        try {
+            // Fetch data
+            $items = Http::get($url)->json();
+
+            if (!$items) {
+                $this->error('Failed to download data file.');
+                return 1;
+            }
+
+            $this->info('Processing data...');
+
+            $result = [];
+
+            foreach ($items as $item) {
+                $result[] = [
+                    'province_th' => $item['provinceNameTh'],
+                    'province_en' => $item['provinceNameEn'],
+                    'district_th' => $item['districtNameTh'],
+                    'district_en' => $item['districtNameEn'],
+                    'subdistrict_th' => $item['subdistrictNameTh'],
+                    'subdistrict_en' => $item['subdistrictNameEn'],
+                    'zip_code' => (string) $item['postalCode'],
+                ];
+            }
+
+            // Path to save the file
+            $path = storage_path('app/public/data/thai-address-data.json');
+
+            // Ensure directory exists
+            $directory = dirname($path);
+            if (!File::exists($directory)) {
+                File::makeDirectory($directory, 0755, true);
+            }
+
+            // Save to file
+            File::put($path, json_encode($result, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+
+            $this->info("Successfully generated Thai address data at: {$path}");
+            $this->info('Total entries: ' . count($result));
+
+            return 0;
+
+        } catch (\Exception $e) {
+            $this->error('An error occurred: ' . $e->getMessage());
+            return 1;
+        }
+    }
+}

--- a/tests/Feature/AddressDataTest.php
+++ b/tests/Feature/AddressDataTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class AddressDataTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure the data file exists by running the command
+        // We can mock the Http facade to avoid external calls during test if preferred,
+        // but for now let's try to run it.
+        // If external calls are blocked in test environment, we might need to skip or mock.
+        // Given I could run it in bash session, it should work here too.
+
+        // Check if file exists, if not generate it.
+        $path = storage_path('app/public/data/thai-address-data.json');
+        if (!File::exists($path)) {
+             Artisan::call('address:generate-data');
+        }
+    }
+
+    /**
+     * Test that the Thai address data endpoint returns success.
+     */
+    public function test_thai_address_data_endpoint_returns_success()
+    {
+        $path = storage_path('app/public/data/thai-address-data.json');
+        if (!File::exists($path)) {
+            $this->markTestSkipped('Thai address data file could not be generated.');
+        }
+
+        $response = $this->get('/thai-addresses');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+
+        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\BinaryFileResponse::class, $response->baseResponse);
+
+        $filePath = $response->baseResponse->getFile()->getPathname();
+
+        $this->assertEquals(realpath($path), realpath($filePath));
+
+        $content = file_get_contents($filePath);
+        $data = json_decode($content, true);
+
+        $this->assertIsArray($data);
+        $this->assertNotEmpty($data);
+
+        $firstItem = $data[0];
+        $this->assertArrayHasKey('province_th', $firstItem);
+        $this->assertArrayHasKey('district_th', $firstItem);
+        $this->assertArrayHasKey('subdistrict_th', $firstItem);
+        $this->assertArrayHasKey('zip_code', $firstItem);
+    }
+}


### PR DESCRIPTION
- Created `GenerateThaiAddressData` command to fetch and format Thai geography data from `thailand-geography-json`.
- Restored missing `storage/app/public/data/thai-address-data.json` by running the command.
- Added feature test `AddressDataTest` to verify the `/thai-addresses` endpoint works and serves the data.
- Fixed the issue where "Add/Edit Address" modal had empty District/Sub-district dropdowns and displayed "Failed to load address data" error.