### PR TITLE
Fix ReferenceError in address dropdown initialization

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1170,7 +1170,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const addressForm = document.getElementById('addressForm');
     const saveBtn = document.getElementById('saveAddressBtn');
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-    await fetchThaiAddressData();
+
     // --- Form Fields ---
     const fields = {
         id: document.getElementById('address_id'),
@@ -1193,6 +1193,8 @@ document.addEventListener('DOMContentLoaded', function () {
         addrSubDistrictEn: document.getElementById('addrSubDistrictEn'),
         addrZipCode: document.getElementById('addrZipCode')
     };
+
+    await fetchThaiAddressData();
 
     // --- Data Loading ---
     async function fetchThaiAddressData() {


### PR DESCRIPTION
Moved the `fields` constant definition before the `await fetchThaiAddressData()` call in `resources/views/layouts/app.blade.php`. This ensures that the DOM elements are mapped and available when `populateProvinces` is executed, preventing the "Cannot access 'fields' before initialization" error that was blocking address data from loading.