### PR TITLE
Fix cascading address dropdowns and English auto-fill logic

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1225,6 +1225,9 @@ document.addEventListener('DOMContentLoaded', function () {
     function populateDistricts(province) {
         fields.addrDistrict.innerHTML = '<option value="">{{ __('Select District') }}</option>';
         fields.addrSubDistrict.innerHTML = '<option value="">{{ __('Select Sub-district') }}</option>'; // Reset sub-districts
+        fields.addrDistrict.disabled = true;
+        fields.addrSubDistrict.disabled = true;
+
         if (!province) return;
 
         const districts = [...new Set(thaiAddressData.filter(d => d.province_th === province).map(d => d.district_th))];
@@ -1233,10 +1236,16 @@ document.addEventListener('DOMContentLoaded', function () {
             const option = new Option(district, district);
             fields.addrDistrict.add(option);
         });
+
+        if (districts.length > 0) {
+            fields.addrDistrict.disabled = false;
+        }
     }
 
     function populateSubDistricts(province, district) {
         fields.addrSubDistrict.innerHTML = '<option value="">{{ __('Select Sub-district') }}</option>';
+        fields.addrSubDistrict.disabled = true;
+
         if (!province || !district) return;
 
         const subDistricts = thaiAddressData.filter(d => d.province_th === province && d.district_th === district);
@@ -1245,6 +1254,10 @@ document.addEventListener('DOMContentLoaded', function () {
             const option = new Option(sub.subdistrict_th, sub.subdistrict_th);
             fields.addrSubDistrict.add(option);
         });
+
+        if (subDistricts.length > 0) {
+            fields.addrSubDistrict.disabled = false;
+        }
     }
 
     // --- Event Listeners for Dropdowns ---


### PR DESCRIPTION
The District and Sub-district dropdowns in the Address Management modal were remaining disabled even after options were populated, preventing user interaction. This also blocked the cascading English address auto-fill logic which relies on the 'change' event of these dropdowns.

This commit updates `populateDistricts` and `populateSubDistricts` in `resources/views/layouts/app.blade.php` to explicitly enable the select elements (`disabled = false`) after successfully adding options. This change is detected by the Alpine.js `searchableSelect` component (via MutationObserver), which then updates its UI state to allow interaction.

This restores:
1. The ability to select Districts and Sub-districts.
2. The automatic filling of English address fields upon selection.