### PR TITLE
feat(production): add insurance type management to Renewal

### DIFF
--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -152,6 +152,21 @@ class RenewalController extends Controller
             });
         }
 
+        // Insurance Filter (Server-Side)
+        if ($request->has('insurance_filter') && $request->insurance_filter) {
+            $insFilter = $request->insurance_filter;
+            $employerQuery->whereHas('employees', function($q) use ($insFilter) {
+                $q->whereIn('status', ['renewal_pending', 'renewal_completed']);
+                if ($insFilter === 'none') {
+                    $q->where(function($sub) {
+                        $sub->whereNull('insurance_type')->orWhere('insurance_type', '');
+                    });
+                } else {
+                    $q->where('insurance_type', $insFilter);
+                }
+            });
+        }
+
         // Calculate Cancelled Count (Global for these filtered IDs)
         $cancelledEmployersCount = Employer::whereIn('id', $filteredEmployerIds)
             ->whereHas('productionOrders', function($q) {
@@ -321,6 +336,17 @@ class RenewalController extends Controller
         // Operator Filter
         if ($request->has('operator_filter') && $request->operator_filter) {
             $query->where('operator_id', $request->operator_filter);
+        }
+
+        // Insurance Filter
+        if ($request->has('insurance_filter') && $request->insurance_filter) {
+            if ($request->insurance_filter === 'none') {
+                 $query->where(function($q) {
+                     $q->whereNull('insurance_type')->orWhere('insurance_type', '');
+                 });
+            } else {
+                 $query->where('insurance_type', $request->insurance_filter);
+            }
         }
 
         if ($request->has('filter') && $request->filter) {
@@ -1100,6 +1126,65 @@ class RenewalController extends Controller
         return response()->json([
             'success' => true,
             'message' => $message,
+            'html' => $this->getEmployeeCardHtml($employee)
+        ]);
+    }
+
+    public function updateInsurance(Request $request, $employeeId)
+    {
+        $employee = Employee::findOrFail($employeeId);
+
+        if (!auth()->user()->can('edit-employees')) {
+            return response()->json(['success' => false, 'message' => 'Permission denied'], 403);
+        }
+
+        $validated = $request->validate([
+            'insurance_type' => 'nullable|string',
+            'insurance_detail_social' => 'nullable|string',
+            'insurance_detail_private' => 'nullable|string',
+            'insurance_detail_hospital' => 'nullable|string',
+        ]);
+
+        $updateData = ['insurance_type' => $validated['insurance_type']];
+
+        // Conditional Logic based on Type (Clear others)
+        if ($validated['insurance_type'] === 'ประกันสังคม') {
+            $updateData['insurance_detail'] = $validated['insurance_detail_social'] ?? null; // Map to main detail column if needed or keep separate
+            $updateData['insurance_detail_social'] = $validated['insurance_detail_social'] ?? null;
+            // Clear others
+            $updateData['insurance_detail_private'] = null;
+            $updateData['insurance_detail_hospital'] = null;
+            // Also sync to legacy fields if necessary (based on store method)
+            $updateData['hospital_name'] = $validated['insurance_detail_social'] ?? null;
+            $updateData['insurance_company'] = null;
+        } elseif ($validated['insurance_type'] === 'ประกันเอกชน') {
+             $updateData['insurance_detail_private'] = $validated['insurance_detail_private'] ?? null;
+             $updateData['insurance_company'] = $validated['insurance_detail_private'] ?? null;
+             // Clear others
+             $updateData['insurance_detail_social'] = null;
+             $updateData['insurance_detail_hospital'] = null;
+             $updateData['hospital_name'] = null;
+        } elseif ($validated['insurance_type'] === 'ประกันโรงพยาบาล') {
+             $updateData['insurance_detail_hospital'] = $validated['insurance_detail_hospital'] ?? null;
+             $updateData['hospital_name'] = $validated['insurance_detail_hospital'] ?? null;
+             // Clear others
+             $updateData['insurance_detail_social'] = null;
+             $updateData['insurance_detail_private'] = null;
+             $updateData['insurance_company'] = null;
+        } else {
+            // None or cleared
+            $updateData['insurance_detail_social'] = null;
+            $updateData['insurance_detail_private'] = null;
+            $updateData['insurance_detail_hospital'] = null;
+            $updateData['hospital_name'] = null;
+            $updateData['insurance_company'] = null;
+        }
+
+        $employee->update($updateData);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Insurance updated.',
             'html' => $this->getEmployeeCardHtml($employee)
         ]);
     }

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -21,6 +21,7 @@
             'title_en' => $emp->employeeTitleEn,
             'photo' => $emp->photo_url,
             'nationality' => $emp->employeeNationality,
+            'insurance_type' => $emp->insurance_type,
         ];
     })) }},
     productionId: {{ $production->id }},
@@ -620,7 +621,19 @@
                                 <div class="d-flex align-items-center gap-2 overflow-hidden">
                                     <img :src="item.photo || 'https://ui-avatars.com/api/?name=User&background=random'" class="rounded-circle flex-shrink-0" style="width: 32px; height: 32px; object-fit: cover;">
                                     <div class="d-flex flex-column" style="line-height: 1.2; min-width: 0;">
-                                        <div class="fw-bold text-truncate" style="font-size: 0.85rem;" x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></div>
+                                        <div class="fw-bold text-truncate" style="font-size: 0.85rem;">
+                                            <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
+                                            <!-- Insurance Badge -->
+                                            <template x-if="item.insurance_type">
+                                                <span class="badge rounded-pill ms-1" style="font-size: 0.6rem;"
+                                                      :class="{
+                                                          'bg-primary': item.insurance_type === 'ประกันสังคม',
+                                                          'bg-warning text-dark': item.insurance_type === 'ประกันเอกชน',
+                                                          'bg-success': item.insurance_type === 'ประกันโรงพยาบาล'
+                                                      }"
+                                                      x-text="item.insurance_type"></span>
+                                            </template>
+                                        </div>
                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.75rem;">
                                              <span class="text-truncate" x-text="item.nationality"></span>
                                              <template x-if="item.nationality === 'Myanmar' || item.nationality === 'เมียนมา' || item.nationality === 'พม่า'"><span style="font-size: 1rem;">🇲🇲</span></template>

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -167,6 +167,98 @@
                 </div>
                 </div>
 
+            {{-- Insurance Type (Only for Renewal or general edit) --}}
+            @can('edit-employees')
+            <div class="ms-md-2" x-data="{
+                isEditing: false,
+                type: '{{ $employee->insurance_type }}',
+                hospital: '{{ $employee->hospital_name ?? $employee->insurance_detail }}',
+                company: '{{ $employee->insurance_company ?? $employee->insurance_detail_private }}',
+                saveInsurance() {
+                    let body = {
+                        insurance_type: this.type,
+                        _token: '{{ csrf_token() }}'
+                    };
+                    if (this.type === 'ประกันสังคม' || this.type === 'ประกันโรงพยาบาล') {
+                        body.insurance_detail_social = this.hospital; // Maps to hospital_name
+                        body.insurance_detail_hospital = this.hospital;
+                    } else if (this.type === 'ประกันเอกชน') {
+                        body.insurance_detail_private = this.company;
+                    }
+
+                    fetch('/production/renewal/{{ $employee->id }}/update-insurance', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest'
+                        },
+                        body: JSON.stringify(body)
+                    })
+                    .then(res => res.json())
+                    .then(data => {
+                        if(data.success) {
+                            if(data.html) updateCardHTML({{ $employee->id }}, data.html);
+                            showToast('{{ __('Insurance updated') }}', 'success');
+                        } else {
+                            showToast(data.message || '{{ __('Error saving') }}', 'danger');
+                        }
+                    })
+                    .catch(err => {
+                        console.error(err);
+                        showToast('{{ __('Error saving') }}', 'danger');
+                    });
+                }
+            }">
+                <div style="min-width: 140px;">
+                    <small class="text-muted d-block" style="font-size: 0.7rem;">{{ __('Insurance') }}</small>
+
+                    <div x-show="!isEditing" class="d-flex align-items-center gap-2 cursor-pointer position-relative"
+                         @click="isEditing = true">
+                         <div class="small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center w-100" style="min-height: 38px;">
+                            <div class="d-flex align-items-center justify-content-between">
+                                <span class="fw-bold text-primary" x-text="type || '-'"></span>
+                                <i class="bi bi-pencil-fill text-muted" style="font-size: 0.7rem;"></i>
+                            </div>
+                            <div x-show="type === 'ประกันสังคม' && hospital" class="text-muted text-truncate" style="font-size: 0.7rem; max-width: 130px;">
+                                <i class="bi bi-hospital me-1"></i><span x-text="hospital"></span>
+                            </div>
+                            <div x-show="type === 'ประกันโรงพยาบาล' && hospital" class="text-muted text-truncate" style="font-size: 0.7rem; max-width: 130px;">
+                                <i class="bi bi-hospital me-1"></i><span x-text="hospital"></span>
+                            </div>
+                            <div x-show="type === 'ประกันเอกชน' && company" class="text-muted text-truncate" style="font-size: 0.7rem; max-width: 130px;">
+                                <i class="bi bi-building me-1"></i><span x-text="company"></span>
+                            </div>
+                         </div>
+                    </div>
+
+                    <div x-show="isEditing" @click.outside="isEditing = false" class="flex-column gap-2 p-2 bg-white border rounded shadow-sm position-absolute" style="display: none; z-index: 1060; min-width: 220px;">
+                         <label class="small fw-bold">{{ __('Select Type') }}</label>
+                         <select class="form-select form-select-sm" x-model="type">
+                             <option value="">{{ __('None') }}</option>
+                             <option value="ประกันสังคม">{{ __('ประกันสังคม') }}</option>
+                             <option value="ประกันเอกชน">{{ __('ประกันเอกชน') }}</option>
+                             <option value="ประกันโรงพยาบาล">{{ __('ประกันโรงพยาบาล') }}</option>
+                         </select>
+
+                         <div x-show="type === 'ประกันสังคม' || type === 'ประกันโรงพยาบาล'">
+                             <label class="small fw-bold mt-1">{{ __('Hospital') }}</label>
+                             <input type="text" class="form-control form-control-sm" x-model="hospital" placeholder="Hospital Name">
+                         </div>
+
+                         <div x-show="type === 'ประกันเอกชน'">
+                             <label class="small fw-bold mt-1">{{ __('Company') }}</label>
+                             <input type="text" class="form-control form-control-sm" x-model="company" placeholder="Insurance Company">
+                         </div>
+
+                         <div class="d-flex gap-1 mt-2">
+                            <button @click="saveInsurance()" class="btn btn-sm btn-success flex-grow-1"><i class="bi bi-check-lg"></i> {{ __('Save') }}</button>
+                            <button @click="isEditing = false" class="btn btn-sm btn-outline-secondary"><i class="bi bi-x-lg"></i></button>
+                         </div>
+                    </div>
+                </div>
+            </div>
+            @endcan
+
             {{-- Appointment Date & Location (Copied from Workflow) --}}
             @php
                 $appDate = $employee->appointment_date;

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -240,6 +240,22 @@
                     </ul>
                 </div>
 
+                {{-- Insurance Filter --}}
+                <div class="dropdown">
+                    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <i class="bi bi-shield-check me-1"></i>
+                        {{ request('insurance_filter') ? (request('insurance_filter') === 'none' ? __('No Insurance') : request('insurance_filter')) : __('Insurance') }}
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li><a class="dropdown-item" href="{{ route('production.renewal.index', array_merge(request()->query(), ['insurance_filter' => null])) }}">{{ __('All Types') }}</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item" href="{{ route('production.renewal.index', array_merge(request()->query(), ['insurance_filter' => 'ประกันสังคม'])) }}">{{ __('ประกันสังคม') }}</a></li>
+                        <li><a class="dropdown-item" href="{{ route('production.renewal.index', array_merge(request()->query(), ['insurance_filter' => 'ประกันเอกชน'])) }}">{{ __('ประกันเอกชน') }}</a></li>
+                        <li><a class="dropdown-item" href="{{ route('production.renewal.index', array_merge(request()->query(), ['insurance_filter' => 'ประกันโรงพยาบาล'])) }}">{{ __('ประกันโรงพยาบาล') }}</a></li>
+                        <li><a class="dropdown-item text-muted" href="{{ route('production.renewal.index', array_merge(request()->query(), ['insurance_filter' => 'none'])) }}">{{ __('No Insurance') }}</a></li>
+                    </ul>
+                </div>
+
                 <div class="d-flex gap-2 flex-wrap justify-content-end">
                     @can('edit-employees')
                     <a href="{{ route('production.renewal.create') }}" class="btn btn-warning text-white fw-bold">

--- a/routes/web.php
+++ b/routes/web.php
@@ -316,6 +316,9 @@ Route::middleware(['auth'])->group(function () {
         // Operator
         Route::post('/{employee}/toggle-operator', [App\Http\Controllers\Production\RenewalController::class, 'toggleOperator'])->name('toggle_operator');
 
+        // Insurance
+        Route::post('/{employee}/update-insurance', [App\Http\Controllers\Production\RenewalController::class, 'updateInsurance'])->name('update_insurance');
+
         // Daily Check
         Route::post('/{employee}/check-daily', [App\Http\Controllers\Production\RenewalController::class, 'checkDaily'])->name('check_daily');
         Route::post('/{employee}/toggle-daily-check', [App\Http\Controllers\Production\RenewalController::class, 'toggleDailyCheck'])->name('toggle_daily_check');


### PR DESCRIPTION
- Added `updateInsurance` method to `RenewalController` and registered route.
- Updated `RenewalController` to support `insurance_filter` in index and fetchEmployees.
- Added Insurance Type filter dropdown to `resources/views/production/renewal/index.blade.php`.
- Added Insurance Type inline editor to `resources/views/production/registration/_employee_card.blade.php` using Alpine.js and AJAX.
- Updated `resources/views/production/partials/financial-tab.blade.php` to display insurance badges in the employee list.