### PR TITLE
Fix Renewal insurance update error and enhance Finance UI

### DIFF
--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -620,10 +620,8 @@ class RenewalController extends Controller
         if ($validated['insuranceType'] === 'ประกันสังคม') {
             $validated['socialSecurityNumber'] = $validated['social_security_number'] ?? null;
             $validated['hospitalName'] = $validated['insurance_detail_social'] ?? null;
-            $validated['insuranceCompany'] = null;
             $validated['insuranceExpiryDate'] = null;
         } elseif ($validated['insuranceType'] === 'ประกันเอกชน') {
-            $validated['insuranceCompany'] = $validated['insurance_detail_private'] ?? null;
             $validated['insuranceExpiryDate'] = $validated['insurance_expiry_date_private'] ?? null;
             $validated['socialSecurityNumber'] = null;
             $validated['hospitalName'] = null;
@@ -631,11 +629,9 @@ class RenewalController extends Controller
             $validated['hospitalName'] = $validated['insurance_detail_hospital'] ?? null;
             $validated['insuranceExpiryDate'] = $validated['insurance_expiry_date_hospital'] ?? null;
             $validated['socialSecurityNumber'] = null;
-            $validated['insuranceCompany'] = null;
         } else {
             $validated['socialSecurityNumber'] = null;
             $validated['hospitalName'] = null;
-            $validated['insuranceCompany'] = null;
             $validated['insuranceExpiryDate'] = null;
         }
 
@@ -1156,10 +1152,8 @@ class RenewalController extends Controller
             $updateData['insurance_detail_hospital'] = null;
             // Also sync to legacy fields if necessary (based on store method)
             $updateData['hospital_name'] = $validated['insurance_detail_social'] ?? null;
-            $updateData['insurance_company'] = null;
         } elseif ($validated['insurance_type'] === 'ประกันเอกชน') {
              $updateData['insurance_detail_private'] = $validated['insurance_detail_private'] ?? null;
-             $updateData['insurance_company'] = $validated['insurance_detail_private'] ?? null;
              // Clear others
              $updateData['insurance_detail_social'] = null;
              $updateData['insurance_detail_hospital'] = null;
@@ -1170,14 +1164,12 @@ class RenewalController extends Controller
              // Clear others
              $updateData['insurance_detail_social'] = null;
              $updateData['insurance_detail_private'] = null;
-             $updateData['insurance_company'] = null;
         } else {
             // None or cleared
             $updateData['insurance_detail_social'] = null;
             $updateData['insurance_detail_private'] = null;
             $updateData['insurance_detail_hospital'] = null;
             $updateData['hospital_name'] = null;
-            $updateData['insurance_company'] = null;
         }
 
         $employee->update($updateData);

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -10,6 +10,7 @@
             'title_en' => $item->employee ? $item->employee->employeeTitleEn : '',
             'photo' => $item->employee ? $item->employee->photo_url : '',
             'nationality' => $item->employee ? $item->employee->employeeNationality : '',
+            'insurance_type' => $item->employee ? $item->employee->insurance_type : '',
             'employee_id' => $item->employee_id
         ];
     })) }},
@@ -633,6 +634,9 @@
                                                       }"
                                                       x-text="item.insurance_type"></span>
                                             </template>
+                                            <template x-if="!item.insurance_type">
+                                                <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">None</span>
+                                            </template>
                                         </div>
                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.75rem;">
                                              <span class="text-truncate" x-text="item.nationality"></span>
@@ -795,7 +799,21 @@
                                                 <div class="d-flex align-items-center gap-2 overflow-hidden w-100">
                                                     <img :src="item.photo || 'https://ui-avatars.com/api/?name=User&background=random'" class="rounded-circle flex-shrink-0" style="width: 24px; height: 24px; object-fit: cover;">
                                                     <div class="d-flex flex-column" style="line-height: 1.1; min-width: 0;">
-                                                        <div class="fw-bold text-truncate" x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></div>
+                                                        <div class="fw-bold text-truncate">
+                                                            <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
+                                                            <template x-if="item.insurance_type">
+                                                                <span class="badge rounded-pill ms-1" style="font-size: 0.6rem;"
+                                                                    :class="{
+                                                                        'bg-primary': item.insurance_type === 'ประกันสังคม',
+                                                                        'bg-warning text-dark': item.insurance_type === 'ประกันเอกชน',
+                                                                        'bg-success': item.insurance_type === 'ประกันโรงพยาบาล'
+                                                                    }"
+                                                                    x-text="item.insurance_type"></span>
+                                                            </template>
+                                                            <template x-if="!item.insurance_type">
+                                                                <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">None</span>
+                                                            </template>
+                                                        </div>
                                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.7rem;">
                                                              <span class="text-truncate" x-text="item.nationality"></span>
                                                              <template x-if="item.nationality === 'Myanmar' || item.nationality === 'เมียนมา' || item.nationality === 'พม่า'"><span style="font-size: 0.8rem;">🇲🇲</span></template>
@@ -909,7 +927,21 @@
                                                 <div class="d-flex align-items-center gap-2 overflow-hidden w-100">
                                                     <img :src="item.photo || 'https://ui-avatars.com/api/?name=User&background=random'" class="rounded-circle flex-shrink-0" style="width: 24px; height: 24px; object-fit: cover;">
                                                     <div class="d-flex flex-column" style="line-height: 1.1; min-width: 0;">
-                                                        <div class="fw-bold text-truncate" x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></div>
+                                                        <div class="fw-bold text-truncate">
+                                                            <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
+                                                            <template x-if="item.insurance_type">
+                                                                <span class="badge rounded-pill ms-1" style="font-size: 0.6rem;"
+                                                                    :class="{
+                                                                        'bg-primary': item.insurance_type === 'ประกันสังคม',
+                                                                        'bg-warning text-dark': item.insurance_type === 'ประกันเอกชน',
+                                                                        'bg-success': item.insurance_type === 'ประกันโรงพยาบาล'
+                                                                    }"
+                                                                    x-text="item.insurance_type"></span>
+                                                            </template>
+                                                            <template x-if="!item.insurance_type">
+                                                                <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">None</span>
+                                                            </template>
+                                                        </div>
                                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.7rem;">
                                                              <span class="text-truncate" x-text="item.nationality"></span>
                                                              <template x-if="item.nationality === 'Myanmar' || item.nationality === 'เมียนมา' || item.nationality === 'พม่า'"><span style="font-size: 0.8rem;">🇲🇲</span></template>


### PR DESCRIPTION
- Fix `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'insurance_company'` in `RenewalController` by removing assignments to non-existent `insurance_company` column in `store` and `updateInsurance` methods.
- Enhance `financial-tab.blade.php`:
    - Add `insurance_type` to `productionItems` JSON payload.
    - Update "Manage Employees Modal" to display "None" badge when insurance type is missing.
    - Update "Add/Edit Transaction Modals" to display insurance badges next to employee names.