### PR TITLE
Fix insurance update error and add passport badges to finance

### DIFF
--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -39,7 +39,7 @@ class RenewalController extends Controller
         // --- 2. Global Employee Query (Lightweight) ---
         $employeeQuery = Employee::query()
             ->whereIn('status', ['renewal_pending', 'renewal_completed', 'renewal_cancelled'])
-            ->select('id', 'employer_id', 'status', 'employeeNameTh', 'employeeNameEn', 'employeeTitleTh', 'employeeTitleEn', 'employeePhoto', 'employeeNationality', 'operator_id');
+            ->select('id', 'employer_id', 'status', 'employeeNameTh', 'employeeNameEn', 'employeeTitleTh', 'employeeTitleEn', 'employeePhoto', 'employeeNationality', 'operator_id', 'employeePassport', 'insurance_type');
 
         if (auth()->user()->can('manage-tickets')) {
             $employeeQuery->withoutGlobalScope('employerTenancy');
@@ -1150,17 +1150,13 @@ class RenewalController extends Controller
             // Clear others
             $updateData['insurance_detail_private'] = null;
             $updateData['insurance_detail_hospital'] = null;
-            // Also sync to legacy fields if necessary (based on store method)
-            $updateData['hospital_name'] = $validated['insurance_detail_social'] ?? null;
         } elseif ($validated['insurance_type'] === 'ประกันเอกชน') {
              $updateData['insurance_detail_private'] = $validated['insurance_detail_private'] ?? null;
              // Clear others
              $updateData['insurance_detail_social'] = null;
              $updateData['insurance_detail_hospital'] = null;
-             $updateData['hospital_name'] = null;
         } elseif ($validated['insurance_type'] === 'ประกันโรงพยาบาล') {
              $updateData['insurance_detail_hospital'] = $validated['insurance_detail_hospital'] ?? null;
-             $updateData['hospital_name'] = $validated['insurance_detail_hospital'] ?? null;
              // Clear others
              $updateData['insurance_detail_social'] = null;
              $updateData['insurance_detail_private'] = null;
@@ -1169,7 +1165,6 @@ class RenewalController extends Controller
             $updateData['insurance_detail_social'] = null;
             $updateData['insurance_detail_private'] = null;
             $updateData['insurance_detail_hospital'] = null;
-            $updateData['hospital_name'] = null;
         }
 
         $employee->update($updateData);

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -11,6 +11,7 @@
             'photo' => $item->employee ? $item->employee->photo_url : '',
             'nationality' => $item->employee ? $item->employee->employeeNationality : '',
             'insurance_type' => $item->employee ? $item->employee->insurance_type : '',
+            'passport' => $item->employee ? $item->employee->employeePassport : '',
             'employee_id' => $item->employee_id
         ];
     })) }},
@@ -23,6 +24,7 @@
             'photo' => $emp->photo_url,
             'nationality' => $emp->employeeNationality,
             'insurance_type' => $emp->insurance_type,
+            'passport' => $emp->employeePassport,
         ];
     })) }},
     productionId: {{ $production->id }},


### PR DESCRIPTION
- Fix: Remove assignment to non-existent 'hospital_name' column in RenewalController.
- Feature: Add 'employeePassport' and 'insurance_type' to employee query in RenewalController.
- Feature: Pass passport data to financial-manager.js via financial-tab.blade.php.
- Feature: Display "Has Passport" / "No Passport" badges in Finance > Add Installment / Manage Employees modals.
- Fix: Ensure `passport` and `insurance_type` are preserved when merging employee lists in financial-manager.js.