### PR TITLE
Update Automated PDF to redirect back to origin

### DIFF
--- a/app/Http/Controllers/Admin/PdfGenerationController.php
+++ b/app/Http/Controllers/Admin/PdfGenerationController.php
@@ -26,6 +26,7 @@ class PdfGenerationController extends Controller
         $this->authorize('view-pdf-templates');
 
         $employeeIds = $request->input('employees', []);
+        $redirectUrl = $request->input('redirect_url', url()->previous());
 
         if (empty($employeeIds)) {
             return redirect()->back()->with('error', 'No employees selected.');
@@ -62,7 +63,8 @@ class PdfGenerationController extends Controller
         return view('pdf_templates.generate_modal', [
             'employees' => $employeeIds,
             'templates' => $templates,
-            'employers' => $employers
+            'employers' => $employers,
+            'redirect_url' => $redirectUrl
         ]);
     }
 
@@ -89,13 +91,18 @@ class PdfGenerationController extends Controller
         $outputType = $request->output_type;
         $slotName = $request->slot_name;
         $targetEmployerId = $request->input('target_employer_id');
+        $redirectUrl = $request->input('redirect_url', route('employees.index'));
 
         // Force Synchronous Processing for ALL counts
-        return $this->processSynchronously($employeeIds, $templateId, $outputType, $slotName, $targetEmployerId);
+        return $this->processSynchronously($employeeIds, $templateId, $outputType, $slotName, $targetEmployerId, $redirectUrl);
     }
 
-    protected function processSynchronously($employeeIds, $templateId, $outputType, $slotName, $targetEmployerId = null)
+    protected function processSynchronously($employeeIds, $templateId, $outputType, $slotName, $targetEmployerId = null, $redirectUrl = null)
     {
+        if (!$redirectUrl) {
+            $redirectUrl = route('employees.index');
+        }
+
         // Increase limits for large batches (e.g. 500 records)
         set_time_limit(0);
         ini_set('memory_limit', '-1');
@@ -116,7 +123,7 @@ class PdfGenerationController extends Controller
                 if (request()->expectsJson() || request()->ajax()) {
                     return response()->json([], 200); // Empty result is valid but means nothing happened
                 }
-                return redirect()->route('employees.index')->with('warning', 'No valid employees found for generation.');
+                return redirect($redirectUrl)->with('warning', 'No valid employees found for generation.');
             }
 
             if ($outputType === 'save_to_slot') {
@@ -144,7 +151,7 @@ class PdfGenerationController extends Controller
                     $msg .= " (Failed: {$errorCount})";
                 }
 
-                return redirect()->route('employees.index')->with($errorCount > 0 ? 'warning' : 'success', $msg);
+                return redirect($redirectUrl)->with($errorCount > 0 ? 'warning' : 'success', $msg);
 
             } else {
                 // Download Mode: Stream content to ZIP to save memory
@@ -200,7 +207,7 @@ class PdfGenerationController extends Controller
                      if (!empty($errorLog)) {
                          $errorMessage .= " Details:\n" . $errorLog;
                      }
-                     return redirect()->route('employees.index')->with('danger', $errorMessage);
+                     return redirect($redirectUrl)->with('danger', $errorMessage);
                 }
 
                 return response()->download($zipPath)->deleteFileAfterSend(true);
@@ -215,7 +222,7 @@ class PdfGenerationController extends Controller
                  ], 500);
             }
 
-            return redirect()->route('employees.index')->with('danger', 'Generation Failed: ' . $e->getMessage());
+            return redirect($redirectUrl)->with('danger', 'Generation Failed: ' . $e->getMessage());
         }
     }
 }

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -606,6 +606,12 @@ document.addEventListener('DOMContentLoaded', function () {
             csrf.value = document.querySelector('meta[name="csrf-token"]').content;
             form.appendChild(csrf);
 
+            const redirectInput = document.createElement('input');
+            redirectInput.type = 'hidden';
+            redirectInput.name = 'redirect_url';
+            redirectInput.value = window.location.href;
+            form.appendChild(redirectInput);
+
             selected.forEach(id => {
                 const input = document.createElement('input');
                 input.type = 'hidden';

--- a/resources/views/pdf_templates/generate_modal.blade.php
+++ b/resources/views/pdf_templates/generate_modal.blade.php
@@ -17,6 +17,7 @@
 
                     <form action="{{ route('admin.pdf-templates.generate.process') }}" method="POST" id="generateForm" @submit.prevent="handleSubmit">
                         @csrf
+                        <input type="hidden" name="redirect_url" value="{{ $redirect_url }}">
 
                         <!-- Hidden Employee IDs (Used for Sync Download) -->
                         @foreach($employees as $id)
@@ -215,7 +216,7 @@
                         </div>
 
                         <div class="d-flex justify-content-end gap-2 pt-3 border-top">
-                            <a href="{{ url()->previous() }}" class="btn btn-light">Cancel</a>
+                            <a href="{{ $redirect_url }}" class="btn btn-light">Cancel</a>
                             <button type="submit" class="btn btn-primary" :disabled="isProcessing">
                                 <i class="bi bi-file-earmark-pdf me-2"></i>Generate Documents
                             </button>
@@ -273,6 +274,7 @@
             isLoadingTemplates: false,
             selectedEmployerId: 'global', // Filter
             targetEmployerId: '', // Target (for Data)
+            redirectUrl: @json($redirect_url),
 
             init() {
                 // Filter Listener
@@ -447,7 +449,7 @@
                     progressText.textContent = 'All documents generated successfully!';
                     progressBar.classList.add('bg-success');
                     setTimeout(() => {
-                        window.location.href = '{{ route("employees.index") }}';
+                        window.location.href = this.redirectUrl;
                     }, 1500);
                 }
             }

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -675,6 +675,12 @@
         csrf.value = document.querySelector('meta[name="csrf-token"]').content;
         form.appendChild(csrf);
 
+        const redirectInput = document.createElement('input');
+        redirectInput.type = 'hidden';
+        redirectInput.name = 'redirect_url';
+        redirectInput.value = window.location.href;
+        form.appendChild(redirectInput);
+
         selected.forEach(id => {
             const input = document.createElement('input');
             input.type = 'hidden';

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2154,6 +2154,12 @@
                 csrf.value = document.querySelector('meta[name="csrf-token"]').content;
                 form.appendChild(csrf);
 
+                const redirectInput = document.createElement('input');
+                redirectInput.type = 'hidden';
+                redirectInput.name = 'redirect_url';
+                redirectInput.value = window.location.href;
+                form.appendChild(redirectInput);
+
                 selected.forEach(id => {
                     const input = document.createElement('input');
                     input.type = 'hidden';

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -1795,6 +1795,12 @@
                 csrf.value = document.querySelector('meta[name="csrf-token"]').content;
                 form.appendChild(csrf);
 
+                const redirectInput = document.createElement('input');
+                redirectInput.type = 'hidden';
+                redirectInput.name = 'redirect_url';
+                redirectInput.value = window.location.href;
+                form.appendChild(redirectInput);
+
                 selected.forEach(id => {
                     const input = document.createElement('input');
                     input.type = 'hidden';

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -855,6 +855,12 @@
         csrf.value = document.querySelector('meta[name="csrf-token"]').content;
         form.appendChild(csrf);
 
+        const redirectInput = document.createElement('input');
+        redirectInput.type = 'hidden';
+        redirectInput.name = 'redirect_url';
+        redirectInput.value = window.location.href;
+        form.appendChild(redirectInput);
+
         selected.forEach(id => {
             const input = document.createElement('input');
             input.type = 'hidden';

--- a/tests/Feature/Pdf/PdfRedirectionTest.php
+++ b/tests/Feature/Pdf/PdfRedirectionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature\Pdf;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Employee;
+use App\Models\PdfTemplate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class PdfRedirectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup permissions
+        Permission::firstOrCreate(['name' => 'view-pdf-templates']);
+        Permission::firstOrCreate(['name' => 'manage-tickets']);
+        $role = Role::firstOrCreate(['name' => 'admin']);
+        $role->givePermissionTo(['view-pdf-templates', 'manage-tickets']);
+
+        $this->user = User::factory()->create();
+        $this->user->assignRole('admin');
+
+        $this->actingAs($this->user);
+    }
+
+    public function test_modal_receives_redirect_url()
+    {
+        $redirectUrl = 'http://example.com/previous-page';
+        $employee = Employee::factory()->create();
+
+        $response = $this->post(route('admin.pdf-templates.generate.modal'), [
+            'employees' => [$employee->id],
+            'redirect_url' => $redirectUrl
+        ]);
+
+        // If Vite fails, we catch it? No, it's a fatal error or exception.
+        // We will handle Vite in layout file.
+        $response->assertStatus(200);
+        $response->assertViewHas('redirect_url', $redirectUrl);
+    }
+
+    public function test_modal_defaults_to_previous_url_if_missing()
+    {
+        $employee = Employee::factory()->create();
+        $previousUrl = 'http://example.com/fallback';
+
+        $response = $this->from($previousUrl)->post(route('admin.pdf-templates.generate.modal'), [
+            'employees' => [$employee->id]
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertViewHas('redirect_url', $previousUrl);
+    }
+
+    public function test_process_save_to_slot_redirects_to_custom_url()
+    {
+        Storage::fake('public');
+
+        $employee = Employee::factory()->create();
+        $template = new PdfTemplate();
+        $template->name = 'Test Template';
+        $template->type = 'global';
+        $template->file_path = 'templates/dummy.pdf';
+        $template->save();
+
+        $redirectUrl = 'http://example.com/custom-redirect';
+
+        Storage::disk('public')->put($template->file_path, 'dummy content');
+
+        // Create a minimal valid PDF content to avoid Fpdi errors if service actually parses it
+        $pdfContent = "%PDF-1.4\n1 0 obj\n<<\n/Type /Catalog\n/Pages 2 0 R\n>>\nendobj\n2 0 obj\n<<\n/Type /Pages\n/Kids [3 0 R]\n/Count 1\n>>\nendobj\n3 0 obj\n<<\n/Type /Page\n/MediaBox [0 0 612 792]\n/Resources <<\n/Font <<\n/F1 4 0 R\n>>\n>>\n/Contents 5 0 R\n/Parent 2 0 R\n>>\nendobj\n4 0 obj\n<<\n/Type /Font\n/Subtype /Type1\n/BaseFont /Helvetica\n>>\nendobj\n5 0 obj\n<<\n/Length 44\n>>\nstream\nBT\n/F1 12 Tf\n72 712 Td\n(Hello World) Tj\nET\nendstream\nendobj\nxref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000060 00000 n \n0000000117 00000 n \n0000000244 00000 n \n0000000331 00000 n \ntrailer\n<<\n/Size 6\n/Root 1 0 R\n>>\nstartxref\n425\n%%EOF";
+        Storage::disk('public')->put($template->file_path, $pdfContent);
+
+        $response = $this->post(route('admin.pdf-templates.generate.process'), [
+            'employees' => [$employee->id],
+            'template_id' => $template->id,
+            'output_type' => 'save_to_slot',
+            'slot_name' => 'employee_doc_9',
+            'redirect_url' => $redirectUrl
+        ]);
+
+        $response->assertRedirect($redirectUrl);
+    }
+
+    public function test_process_error_redirects_to_custom_url()
+    {
+        $employee = Employee::factory()->create();
+        $template = new PdfTemplate();
+        $template->name = 'Test Template';
+        $template->type = 'global';
+        $template->file_path = 'templates/dummy_error.pdf'; // Valid path needed for DB constraint
+        $template->save();
+
+        $redirectUrl = 'http://example.com/failure-redirect';
+
+        // Mock PdfGeneratorService to throw exception
+        $this->mock(\App\Services\PdfGeneratorService::class, function ($mock) {
+            $mock->shouldReceive('generateSinglePdf')->andThrow(new \Exception('Mocked Failure'));
+            $mock->shouldReceive('generateFilename')->andReturn('test.pdf');
+        });
+
+        // Trigger download mode (which calls generateSinglePdf in loop)
+        $response = $this->post(route('admin.pdf-templates.generate.process'), [
+            'employees' => [$employee->id],
+            'template_id' => $template->id,
+            'output_type' => 'download',
+            'redirect_url' => $redirectUrl
+        ]);
+
+        $response->assertRedirect($redirectUrl);
+        $response->assertSessionHas('danger');
+    }
+}


### PR DESCRIPTION
This change updates the Automated PDF generation feature to preserve the user's context (e.g., search filters, pagination, active tab) by redirecting them back to the exact page they initiated the process from.

Changes:
- Modified `PdfGenerationController` to accept a `redirect_url` parameter and use it for redirection after processing.
- Updated `generate_modal.blade.php` to include `redirect_url` in the form, use it for the "Cancel" button, and handle client-side redirection in Alpine.js.
- Updated JavaScript in `production/index.blade.php`, `workflow/index.blade.php`, `employees/index.blade.php`, `production/renewal/index.blade.php`, and `production/registration/index.blade.php` to inject `window.location.href` as `redirect_url` when submitting the generation form.
- Added feature tests in `tests/Feature/Pdf/PdfRedirectionTest.php`.