### PR TITLE
feat: enhance chat access and drag-n-drop gps navigation

### DIFF
--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -207,15 +207,22 @@
 
                                     <!-- Employee Card -->
                                     <template x-if="msg.context_data.type === 'employee'">
-                                        <div class="d-flex align-items-center p-2 rounded bg-white border">
+                                        <div class="d-flex align-items-center p-2 rounded bg-white border shadow-sm" style="min-width: 200px;">
                                             <div class="me-2">
-                                                <i class="bi bi-person-circle fs-3 text-secondary"></i>
+                                                <template x-if="msg.context_data.photo">
+                                                    <img :src="msg.context_data.photo" class="rounded-circle border object-fit-cover" width="40" height="40">
+                                                </template>
+                                                <template x-if="!msg.context_data.photo">
+                                                    <div class="rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;">
+                                                        <i class="bi bi-person-fill"></i>
+                                                    </div>
+                                                </template>
                                             </div>
                                             <div class="flex-grow-1 lh-1">
                                                 <a :href="msg.context_data.url" class="fw-bold text-decoration-none text-dark d-block text-truncate" style="max-width: 150px;" x-text="msg.context_data.name"></a>
                                                 <small class="text-muted d-block text-truncate" style="max-width: 150px;" x-text="msg.context_data.subtitle || 'Employee'"></small>
                                             </div>
-                                            <button type="button" class="btn btn-sm btn-outline-info btn-preview ms-2" :data-model-type="'employee'" :data-model-id="msg.context_data.id">
+                                            <button type="button" class="btn btn-sm btn-outline-info btn-preview ms-2 rounded-circle" :data-model-type="'employee'" :data-model-id="msg.context_data.id" title="Preview">
                                                 <i class="bi bi-search"></i>
                                             </button>
                                         </div>
@@ -223,15 +230,17 @@
 
                                     <!-- Employer Card -->
                                     <template x-if="msg.context_data.type === 'employer'">
-                                        <div class="d-flex align-items-center p-2 rounded bg-white border">
+                                        <div class="d-flex align-items-center p-2 rounded bg-white border shadow-sm" style="min-width: 200px;">
                                             <div class="me-2">
-                                                <i class="bi bi-building fs-3 text-secondary"></i>
+                                                <div class="rounded-circle bg-light border d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;">
+                                                    <i class="bi bi-building-fill text-primary fs-5"></i>
+                                                </div>
                                             </div>
                                             <div class="flex-grow-1 lh-1">
                                                 <a :href="msg.context_data.url" class="fw-bold text-decoration-none text-dark d-block text-truncate" style="max-width: 150px;" x-text="msg.context_data.name"></a>
                                                 <small class="text-muted d-block text-truncate" style="max-width: 150px;" x-text="msg.context_data.subtitle || 'Employer'"></small>
                                             </div>
-                                            <button type="button" class="btn btn-sm btn-outline-info btn-preview ms-2" :data-model-type="'employer'" :data-model-id="msg.context_data.id">
+                                            <button type="button" class="btn btn-sm btn-outline-info btn-preview ms-2 rounded-circle" :data-model-type="'employer'" :data-model-id="msg.context_data.id" title="Preview">
                                                 <i class="bi bi-search"></i>
                                             </button>
                                         </div>
@@ -579,7 +588,7 @@
         Alpine.data('chatManager', () => ({
             // --- State ---
             currentUserId: {{ auth()->id() }},
-            isAdminOrStaff: {{ auth()->user()->hasRole(['admin', 'staff']) ? 'true' : 'false' }},
+            isAdminOrStaff: {{ auth()->user()->hasRole(['admin', 'staff', 'super-admin']) ? 'true' : 'false' }},
             contacts: [], // Mixed array of users and groups
             searchQuery: '',
             openChats: [], // { uniqueKey: 'user-1' | 'group-5', id, type, name, messages, ... }
@@ -1418,10 +1427,10 @@
 
                      if (data.type === 'employee') {
                          contextType = 'employee';
-                         contextUrl = `/employees/${data.id}/locate`;
+                         contextUrl = data.url || `/employees/${data.id}/locate`;
                      } else if (data.type === 'employer') {
                          contextType = 'employer';
-                         contextUrl = `/employers/${data.id}/locate`;
+                         contextUrl = data.url || `/employers/${data.id}/locate`;
                      }
                      // ... other types ...
 
@@ -1431,7 +1440,8 @@
                          url: contextUrl,
                          text: `[${data.type.toUpperCase()}] ${data.title}`,
                          name: attachmentName,
-                         subtitle: subtitle
+                         subtitle: subtitle,
+                         photo: data.photo || null
                     };
                     this.bringToFront(chat.uniqueKey);
                 }

--- a/resources/views/employers/index.blade.php
+++ b/resources/views/employers/index.blade.php
@@ -60,7 +60,7 @@
                                ondragstart="window.startDragGlobal(event, 'employer', {
                                    id: {{ $employer->id }},
                                    name: '{{ addslashes($employer->employerNameTh) }}',
-                                   code: '{{ $employer->employerId }}',
+                                   subtitle: '{{ addslashes($employer->employerNameEn) }}',
                                    url: '{{ route('employers.edit', $employer->id) }}'
                                })"
                                title="{{ __('Drag') }}">

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -41,7 +41,15 @@
      data-is-not-started="{{ $isNotStarted ? 'true' : 'false' }}"
      data-employer-id="{{ $employee->employer_id }}"
      data-biometrics-collected="{{ $employee->biometrics_collected_at ? 'true' : 'false' }}"
-     style="transition: all 0.3s ease; {{ $isCancelled ? 'filter: grayscale(100%);' : '' }}">
+     style="transition: all 0.3s ease; {{ $isCancelled ? 'filter: grayscale(100%);' : '' }}"
+     draggable="true"
+     ondragstart="startDragGlobal(event, 'employee', {
+        id: {{ $employee->id }},
+        name: '{{ addslashes($employee->employeeNameEn ?? $employee->employeeNameTh) }}',
+        photo: '{{ $employee->employeePhoto ? Storage::disk('public')->url($employee->employeePhoto) : '' }}',
+        subtitle: '{{ $employee->employer->employerNameTh ?? '' }}',
+        url: '{{ route('production.registration.index', ['highlight_employer_id' => $employee->employer_id, 'highlight_employee_id' => $employee->id]) }}'
+     })">
 
     {{-- Sequence Number (Outside Card) --}}
     <div class="employee-sequence-number me-2 fs-5 fw-bold text-muted opacity-50 text-end" style="min-width: 30px;"></div>

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -358,7 +358,15 @@
                 {{-- Sequence Number (CSS Counter will handle number) --}}
                 <div class="employer-sequence-number me-3 pt-2"></div>
 
-                <div class="card flex-grow-1 shadow-sm overflow-visible {{ $employerCardClass }}" style="position: relative;">
+                <div class="card flex-grow-1 shadow-sm overflow-visible {{ $employerCardClass }}"
+                     style="position: relative;"
+                     draggable="true"
+                     ondragstart="startDragGlobal(event, 'employer', {
+                        id: {{ $employer->id }},
+                        name: '{{ addslashes($employer->employerNameTh) }}',
+                        subtitle: '{{ addslashes($employer->employerNameEn) }}',
+                        url: '{{ route('employers.show', $employer->id) }}'
+                     })">
                     {{-- Status/Note Tab/Drawer --}}
                     <div class="position-absolute d-flex align-items-center gap-1 shadow-sm border border-secondary border-bottom-0 rounded-top bg-white px-2 py-1"
                          style="top: -34px; right: 20px; z-index: 5; height: 34px;">

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -100,7 +100,15 @@
 <div class="d-flex align-items-center item-card-outer mb-3"
      id="item-card-{{ $item->id }}"
      data-status="{{ $status }}"
-     style="transition: all 0.3s ease; {{ $isCancelled ? 'filter: grayscale(100%);' : '' }}">
+     style="transition: all 0.3s ease; {{ $isCancelled ? 'filter: grayscale(100%);' : '' }}"
+     draggable="true"
+     ondragstart="startDragGlobal(event, 'employee', {
+        id: {{ $item->employee_id ?? 0 }},
+        name: '{{ addslashes($empNameEn) }}',
+        photo: '{{ $empPhoto }}',
+        subtitle: '{{ addslashes($order->project_name ?? '') }}',
+        url: '{{ route('workflow.index', ['order' => $order->id, 'item' => $item->id]) }}'
+     })">
 
     {{-- Sequence Number (CSS Counter can handle this if parent has counter-reset) --}}
     <div class="item-sequence-number me-2 fs-5 fw-bold text-muted opacity-50 text-end" style="min-width: 30px;"></div>


### PR DESCRIPTION
- Enable chat access for super-admin role.
- Update drag payload in Employee and Employer cards to include photo, name, and specific source URL.
- Implement GPS navigation: clicking dragged cards in chat now navigates to the specific menu (Production, Workflow, Employer) and highlights the item.
- Update Chat Widget UI to display rich cards with photos/icons for dropped items.