### PR TITLE
Fix trash pagination broken UI and sorting order.

### DIFF
--- a/app/Http/Controllers/Admin/TrashController.php
+++ b/app/Http/Controllers/Admin/TrashController.php
@@ -42,7 +42,7 @@ class TrashController extends Controller
         }
 
         foreach ($models as $modelName => $modelClass) {
-            $query = $modelClass::onlyTrashed();
+            $query = $modelClass::onlyTrashed()->latest('deleted_at');
 
             // V2.5.5 Fix: Ensure Admin sees all trashed items by ignoring global scopes (tenancy)
             if ($modelName === 'employees' || $modelName === 'employers') {

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -1257,6 +1257,30 @@
             });
     }
 
+    // Fix Trash Pagination
+    document.addEventListener('DOMContentLoaded', function() {
+        const trashBody = document.getElementById('trashModalBody');
+        if (trashBody) {
+            trashBody.addEventListener('click', function(e) {
+                const link = e.target.closest('.pagination a');
+                if (link) {
+                    e.preventDefault();
+                    const url = link.href;
+                    trashBody.innerHTML = '<div class="d-flex justify-content-center py-5"><div class="spinner-border text-danger" role="status"></div></div>';
+                    fetch(url)
+                        .then(res => res.text())
+                        .then(html => {
+                            trashBody.innerHTML = html;
+                        })
+                        .catch(err => {
+                            console.error(err);
+                            trashBody.innerHTML = '<div class="text-danger text-center p-4">Failed to load page.</div>';
+                        });
+                }
+            });
+        }
+    });
+
     window.restoreTrashItem = function(id) {
         Swal.fire({
             title: '{{ __("Restore Item?") }}',

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2339,6 +2339,30 @@
             });
     }
 
+    // Fix Trash Pagination
+    document.addEventListener('DOMContentLoaded', function() {
+        const trashBody = document.getElementById('trashModalBody');
+        if (trashBody) {
+            trashBody.addEventListener('click', function(e) {
+                const link = e.target.closest('.pagination a');
+                if (link) {
+                    e.preventDefault();
+                    const url = link.href;
+                    trashBody.innerHTML = '<div class="d-flex justify-content-center py-5"><div class="spinner-border text-danger" role="status"></div></div>';
+                    fetch(url)
+                        .then(res => res.text())
+                        .then(html => {
+                            trashBody.innerHTML = html;
+                        })
+                        .catch(err => {
+                            console.error(err);
+                            trashBody.innerHTML = '<div class="text-danger text-center p-4">Failed to load page.</div>';
+                        });
+                }
+            });
+        }
+    });
+
     window.restoreTrashItem = function(id) {
         Swal.fire({
             title: '{{ __("Restore Item?") }}',

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -1972,6 +1972,30 @@
             });
     }
 
+    // Fix Trash Pagination
+    document.addEventListener('DOMContentLoaded', function() {
+        const trashBody = document.getElementById('trashModalBody');
+        if (trashBody) {
+            trashBody.addEventListener('click', function(e) {
+                const link = e.target.closest('.pagination a');
+                if (link) {
+                    e.preventDefault();
+                    const url = link.href;
+                    trashBody.innerHTML = '<div class="d-flex justify-content-center py-5"><div class="spinner-border text-danger" role="status"></div></div>';
+                    fetch(url)
+                        .then(res => res.text())
+                        .then(html => {
+                            trashBody.innerHTML = html;
+                        })
+                        .catch(err => {
+                            console.error(err);
+                            trashBody.innerHTML = '<div class="text-danger text-center p-4">Failed to load page.</div>';
+                        });
+                }
+            });
+        }
+    });
+
     window.restoreTrashItem = function(id) {
         Swal.fire({
             title: '{{ __("Restore Item?") }}',

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1517,6 +1517,30 @@
             });
     }
 
+    // Fix Trash Pagination
+    document.addEventListener('DOMContentLoaded', function() {
+        const trashBody = document.getElementById('trashModalBody');
+        if (trashBody) {
+            trashBody.addEventListener('click', function(e) {
+                const link = e.target.closest('.pagination a');
+                if (link) {
+                    e.preventDefault();
+                    const url = link.href;
+                    trashBody.innerHTML = '<div class="d-flex justify-content-center py-5"><div class="spinner-border text-danger" role="status"></div></div>';
+                    fetch(url)
+                        .then(res => res.text())
+                        .then(html => {
+                            trashBody.innerHTML = html;
+                        })
+                        .catch(err => {
+                            console.error(err);
+                            trashBody.innerHTML = '<div class="text-danger text-center p-4">Failed to load page.</div>';
+                        });
+                }
+            });
+        }
+    });
+
     window.restoreTrashItem = function(id) {
         Swal.fire({
             title: '{{ __("Restore Item?") }}',


### PR DESCRIPTION
- Modified `TrashController.php` to sort Central Trash items by `deleted_at` descending.
- Updated `production/registration/index.blade.php`, `production/renewal/index.blade.php`, `workflow/index.blade.php`, and `production/index.blade.php` to handle trash pagination clicks via AJAX to prevent full page reloads that break the UI.
- Implemented event delegation for `#trashModalBody` to intercept pagination links.