### PR TITLE
Fix trash pagination broken UI in registration, renewal, and workflow

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2344,7 +2344,7 @@
         const trashBody = document.getElementById('trashModalBody');
         if (trashBody) {
             trashBody.addEventListener('click', function(e) {
-                const link = e.target.closest('.pagination a');
+                const link = e.target.closest('.pagination a, .page-link, a[href*="page="]');
                 if (link) {
                     e.preventDefault();
                     const url = link.href;

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -1977,7 +1977,7 @@
         const trashBody = document.getElementById('trashModalBody');
         if (trashBody) {
             trashBody.addEventListener('click', function(e) {
-                const link = e.target.closest('.pagination a');
+                const link = e.target.closest('.pagination a, .page-link, a[href*="page="]');
                 if (link) {
                     e.preventDefault();
                     const url = link.href;

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1522,7 +1522,7 @@
         const trashBody = document.getElementById('trashModalBody');
         if (trashBody) {
             trashBody.addEventListener('click', function(e) {
-                const link = e.target.closest('.pagination a');
+                const link = e.target.closest('.pagination a, .page-link, a[href*="page="]');
                 if (link) {
                     e.preventDefault();
                     const url = link.href;


### PR DESCRIPTION
- Updated JavaScript event listener selector for trash modal pagination interception
- Changed from `.pagination a` to `.pagination a, .page-link, a[href*="page="]` to support varied pagination markup (Bootstrap/Tailwind)
- Applied fix to Registration Resolution, Renewal Resolution, and Workflow modules
- Ensures pagination within the trash modal loads via AJAX instead of full page reload