### PR TITLE
Fix Super Admin chat visibility and access

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -23,12 +23,12 @@ class ChatController extends Controller
         $currentUser = Auth::user();
 
         // 1. STRICT BLOCK: Employers cannot access chat at all
-        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
             return response()->json([], 403);
         }
 
         // Permission Check
-        if (!$currentUser->can('use-chat') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if (!$currentUser->can('use-chat') && !$currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
             return response()->json([], 403);
         }
 
@@ -37,11 +37,11 @@ class ChatController extends Controller
                      ->where('status', 'active');
 
         // --- User Access Control Logic ---
-        if ($currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if ($currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
             $userQuery->where(function($q) {
                 // Admin, Staff, Caretaker, Delegate see each other
                 $q->whereHas('roles', function($r) {
-                    $r->whereIn('name', ['admin', 'staff', 'caretaker', 'delegate']);
+                    $r->whereIn('name', ['super-admin', 'admin', 'staff', 'caretaker', 'delegate']);
                 });
             });
         } else {
@@ -102,7 +102,7 @@ class ChatController extends Controller
                     'is_online' => true,
                     'unread_count' => $group->unread_count, // Now accurate
                     'last_message_time' => null,
-                    'is_admin' => $currentUser->hasRole('admin') || $group->members()->where('user_id', $currentUser->id)->where('role', 'admin')->exists()
+                    'is_admin' => $currentUser->hasRole(['super-admin', 'admin']) || $group->members()->where('user_id', $currentUser->id)->where('role', 'admin')->exists()
                 ];
             });
 
@@ -123,7 +123,7 @@ class ChatController extends Controller
         $type = $request->query('type', 'user'); // Default to user for backward compatibility
 
         // Access Checks
-        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
             return response()->json(['error' => 'Access Denied'], 403);
         }
 
@@ -133,7 +133,7 @@ class ChatController extends Controller
 
             // Authorization
             if ($group->type !== 'community') {
-                if (!$group->members()->where('user_id', $currentUserId)->exists() && !$currentUser->hasRole(['admin'])) {
+                if (!$group->members()->where('user_id', $currentUserId)->exists() && !$currentUser->hasRole(['super-admin', 'admin'])) {
                      return response()->json(['error' => 'Not a member of this group'], 403);
                 }
             }
@@ -209,7 +209,7 @@ class ChatController extends Controller
         $currentUser = Auth::user();
 
         // Strict Access Check
-        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
              return response()->json(['error' => 'Access Denied'], 403);
         }
 
@@ -226,7 +226,7 @@ class ChatController extends Controller
             if (!$group) return response()->json(['error' => 'Group not found'], 404);
 
             // Check membership for private groups
-            if ($group->type !== 'community' && !$group->members()->where('user_id', Auth::id())->exists() && !$currentUser->hasRole('admin')) {
+            if ($group->type !== 'community' && !$group->members()->where('user_id', Auth::id())->exists() && !$currentUser->hasRole(['super-admin', 'admin'])) {
                 return response()->json(['error' => 'Not a member'], 403);
             }
 
@@ -262,7 +262,7 @@ class ChatController extends Controller
             if ($group->type === 'community') {
                 // Community is implicitly everyone with roles admin/staff/caretaker/delegate
                  $recipientIds = User::whereHas('roles', function($q) {
-                        $q->whereIn('name', ['admin', 'staff', 'caretaker', 'delegate']);
+                        $q->whereIn('name', ['super-admin', 'admin', 'staff', 'caretaker', 'delegate']);
                  })->where('id', '!=', Auth::id())->pluck('id')->toArray();
             } else {
                  $recipientIds = $group->members()->where('user_id', '!=', Auth::id())->pluck('user_id')->toArray();
@@ -491,8 +491,8 @@ class ChatController extends Controller
     {
         $currentUser = Auth::user();
 
-        // Access: Only Admin and Staff
-        if (!$currentUser->hasRole(['admin', 'staff'])) {
+        // Access: Only Super Admin, Admin and Staff
+        if (!$currentUser->hasRole(['super-admin', 'admin', 'staff'])) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -539,7 +539,7 @@ class ChatController extends Controller
 
         // Check permission (Admin role or Group Admin)
         $isGroupAdmin = $group->members()->where('user_id', $currentUser->id)->wherePivot('role', 'admin')->exists();
-        if (!$currentUser->hasRole('admin') && !$isGroupAdmin) {
+        if (!$currentUser->hasRole(['super-admin', 'admin']) && !$isGroupAdmin) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -599,7 +599,7 @@ class ChatController extends Controller
             $currentUser = Auth::user();
             if ($group && $group->type !== 'community') {
                 $isMember = $group->members()->where('user_id', $currentUser->id)->exists();
-                if (!$isMember && !$currentUser->hasRole('admin')) {
+                if (!$isMember && !$currentUser->hasRole(['super-admin', 'admin'])) {
                     return response()->json([], 403);
                 }
 
@@ -610,13 +610,13 @@ class ChatController extends Controller
                  // For Community or if group not specified, we search all staff/admin/etc.
                  // This matches the general contact list logic.
                  $usersQuery->whereHas('roles', function($r) {
-                    $r->whereIn('name', ['admin', 'staff', 'caretaker', 'delegate']);
+                    $r->whereIn('name', ['super-admin', 'admin', 'staff', 'caretaker', 'delegate']);
                 });
             }
         } else {
              // Fallback default search (Global Admin/Staff)
              $usersQuery->whereHas('roles', function($r) {
-                $r->whereIn('name', ['admin', 'staff', 'caretaker', 'delegate']);
+                $r->whereIn('name', ['super-admin', 'admin', 'staff', 'caretaker', 'delegate']);
             });
         }
 
@@ -650,7 +650,7 @@ class ChatController extends Controller
         // Group Owner check: Assuming 'created_by' or admin role in pivot
         $isGroupOwner = $group->created_by == $currentUser->id;
 
-        if (!$currentUser->hasRole(['admin', 'staff']) && !$isGroupOwner) {
+        if (!$currentUser->hasRole(['super-admin', 'admin', 'staff']) && !$isGroupOwner) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -671,7 +671,7 @@ class ChatController extends Controller
             $q->select('users.id', 'users.name', 'users.avatar_path', 'chat_group_members.role as group_role');
         }])->findOrFail($id);
 
-        if ($group->type !== 'community' && !$group->members()->where('user_id', $currentUser->id)->exists() && !$currentUser->hasRole('admin')) {
+        if ($group->type !== 'community' && !$group->members()->where('user_id', $currentUser->id)->exists() && !$currentUser->hasRole(['super-admin', 'admin'])) {
              return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -702,7 +702,7 @@ class ChatController extends Controller
 
         // Check permissions
         $isGroupAdmin = $group->members()->where('user_id', $currentUser->id)->wherePivot('role', 'admin')->exists();
-        if (!$currentUser->hasRole(['admin', 'staff']) && !$isGroupAdmin) {
+        if (!$currentUser->hasRole(['super-admin', 'admin', 'staff']) && !$isGroupAdmin) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -727,7 +727,7 @@ class ChatController extends Controller
         // Allow user to leave (remove themselves)
         $isSelf = $currentUser->id == $userId;
 
-        if (!$currentUser->hasRole(['admin', 'staff']) && !$isGroupAdmin && !$isSelf) {
+        if (!$currentUser->hasRole(['super-admin', 'admin', 'staff']) && !$isGroupAdmin && !$isSelf) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -112,4 +112,10 @@ class User extends Authenticatable
     {
         return $this->hasMany(ChatMessage::class, 'receiver_id');
     }
+
+    public function chatGroups(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    {
+        return $this->belongsToMany(ChatGroup::class, 'chat_group_members', 'user_id', 'chat_group_id')
+                    ->withPivot('role', 'joined_at');
+    }
 }


### PR DESCRIPTION
- Updated `ChatController` to include `super-admin` role in all relevant access checks and contact visibility queries.
- Added `chatGroups` relationship to `User` model to fix `searchUsers` method (and existing tests).
- Verified Super Admin can now see contacts, be seen by others, create groups, and send messages.