### PR TITLE
Fix syntax error in Registration index script to restore pagination l…

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2401,6 +2401,7 @@
         });
     }
 
+    document.addEventListener('DOMContentLoaded', function() {
         // --- Restore UI State on Load (After Reload) ---
         const urlParams = new URLSearchParams(window.location.search);
         const restoreEmployerId = sessionStorage.getItem('registration_restore_employer_id') || urlParams.get('highlight_employer_id');


### PR DESCRIPTION
…istener

- Fixed a syntax error in `resources/views/production/registration/index.blade.php` where an orphaned code block had a closing brace `});` without a matching opening `document.addEventListener`.
- Wrapped the orphaned UI state restoration logic in a `DOMContentLoaded` listener.
- This fix ensures the entire script block executes, which is critical for registering the Trash modal pagination event listener (`trashBody.addEventListener('click')`). Without this fix, the listener was not attached, causing pagination links to trigger full page reloads instead of AJAX updates, breaking the UI.