### PR TITLE
Add request number search to Workflow, Production, Registration, and …

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -273,6 +273,7 @@ class RegistrationController extends Controller
                            $sub->where('employeeNameTh', 'like', "%{$search}%")
                                ->orWhere('employeeNameEn', 'like', "%{$search}%")
                                ->orWhere('employeePassport', 'like', "%{$search}%")
+                               ->orWhere('request_number', 'like', "%{$search}%")
                                ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                                ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                        });
@@ -414,6 +415,7 @@ class RegistrationController extends Controller
                         $q->where('employeeNameTh', 'like', "%{$trimmedSearch}%")
                                ->orWhere('employeeNameEn', 'like', "%{$trimmedSearch}%")
                                ->orWhere('employeePassport', 'like', "%{$trimmedSearch}%")
+                               ->orWhere('request_number', 'like', "%{$trimmedSearch}%")
                                ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                                ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                  });
@@ -1727,6 +1729,7 @@ class RegistrationController extends Controller
             $q->where('employeeNameTh', 'like', "%{$search}%")
               ->orWhere('employeeNameEn', 'like', "%{$search}%")
               ->orWhere('employeePassport', 'like', "%{$search}%")
+              ->orWhere('request_number', 'like', "%{$search}%")
               // Robust Name Search (Ignore Spaces)
               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
@@ -1794,6 +1797,7 @@ class RegistrationController extends Controller
                 $q->where('employeeNameTh', 'like', "%{$search}%")
                   ->orWhere('employeeNameEn', 'like', "%{$search}%")
                   ->orWhere('employeePassport', 'like', "%{$search}%")
+                  ->orWhere('request_number', 'like', "%{$search}%")
                   // Robust Name Search
                   ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                   ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
@@ -1939,6 +1943,7 @@ class RegistrationController extends Controller
                  $q->where('employeeNameTh', 'like', "%{$search}%")
                    ->orWhere('employeeNameEn', 'like', "%{$search}%")
                    ->orWhere('employeePassport', 'like', "%{$search}%")
+                   ->orWhere('request_number', 'like', "%{$search}%")
                    ->orWhereHas('employer', function($q2) use ($search) {
                        $q2->withTrashed()
                           ->where('employerNameTh', 'like', "%{$search}%")

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -966,6 +966,7 @@ class RenewalController extends Controller
             $q->where('employeeNameTh', 'like', "%{$search}%")
               ->orWhere('employeeNameEn', 'like', "%{$search}%")
               ->orWhere('employeePassport', 'like', "%{$search}%")
+              ->orWhere('request_number', 'like', "%{$search}%")
               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
               ->orWhereHas('employer', function($q2) use ($search, $cleanedSearch) {
@@ -1020,6 +1021,7 @@ class RenewalController extends Controller
                 $q->where('employeeNameTh', 'like', "%{$search}%")
                   ->orWhere('employeeNameEn', 'like', "%{$search}%")
                   ->orWhere('employeePassport', 'like', "%{$search}%")
+                  ->orWhere('request_number', 'like', "%{$search}%")
                   ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                   ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
             });
@@ -1043,6 +1045,7 @@ class RenewalController extends Controller
                  $q->where('employeeNameTh', 'like', "%{$search}%")
                    ->orWhere('employeeNameEn', 'like', "%{$search}%")
                    ->orWhere('employeePassport', 'like', "%{$search}%")
+                   ->orWhere('request_number', 'like', "%{$search}%")
                    ->orWhereHas('employer', function($q2) use ($search) {
                        $q2->withTrashed()
                           ->where('employerNameTh', 'like', "%{$search}%")

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -109,6 +109,7 @@ class ProductionController extends Controller
                           $emp->where('employeeNameTh', 'like', "%{$search}%")
                               ->orWhere('employeeNameEn', 'like', "%{$search}%")
                               ->orWhere('employeePassport', 'like', "%{$search}%")
+                              ->orWhere('request_number', 'like', "%{$search}%")
                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                       })
@@ -210,6 +211,7 @@ class ProductionController extends Controller
                           $emp->where('employeeNameTh', 'like', "%{$search}%")
                               ->orWhere('employeeNameEn', 'like', "%{$search}%")
                               ->orWhere('employeePassport', 'like', "%{$search}%")
+                              ->orWhere('request_number', 'like', "%{$search}%")
                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                       })

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -81,6 +81,7 @@ class WorkflowController extends Controller
                       $emp->where('employeeNameTh', 'like', "%{$search}%")
                           ->orWhere('employeeNameEn', 'like', "%{$search}%")
                           ->orWhere('employeePassport', 'like', "%{$search}%")
+                          ->orWhere('request_number', 'like', "%{$search}%")
                           ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                           ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                   })
@@ -694,6 +695,7 @@ class WorkflowController extends Controller
                       $q->where('employeeNameTh', 'like', "%{$search}%")
                         ->orWhere('employeeNameEn', 'like', "%{$search}%")
                         ->orWhere('employeePassport', 'like', "%{$search}%")
+                        ->orWhere('request_number', 'like', "%{$search}%")
                         ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                         ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                  });
@@ -958,6 +960,7 @@ class WorkflowController extends Controller
                 $q->where('employeeNameTh', 'like', "%{$search}%")
                   ->orWhere('employeeNameEn', 'like', "%{$search}%")
                   ->orWhere('employeePassport', 'like', "%{$search}%")
+                  ->orWhere('request_number', 'like', "%{$search}%")
                   ->orWhereHas('employer', function($e) use ($search) {
                       $e->filterByAddress($search);
                   });
@@ -984,6 +987,7 @@ class WorkflowController extends Controller
                 $q->where('employeeNameTh', 'like', "%{$search}%")
                   ->orWhere('employeeNameEn', 'like', "%{$search}%")
                   ->orWhere('employeePassport', 'like', "%{$search}%")
+                  ->orWhere('request_number', 'like', "%{$search}%")
                   ->orWhereHas('employer', function($e) use ($search) {
                       $e->filterByAddress($search);
                   });
@@ -1651,7 +1655,8 @@ class WorkflowController extends Controller
                     $e->withTrashed()
                       ->where('employeeNameTh', 'like', "%{$search}%")
                       ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                      ->orWhere('employeePassport', 'like', "%{$search}%");
+                      ->orWhere('employeePassport', 'like', "%{$search}%")
+                      ->orWhere('request_number', 'like', "%{$search}%");
                 })
                 ->orWhereHas('order', function($o) use ($search) {
                     $o->withTrashed()


### PR DESCRIPTION
…Renewal menus

This commit updates the search functionality in the Workflow, Pre-Production, Registration, and Renewal modules to include the `request_number` field. This allows users to search for employees by their request number across these different sections of the application.

Changes:
- Updated `WorkflowController` to include `request_number` in `index`, `fetchTrash`, `fetchOrderItems`, `searchResignedEmployees`, and `searchGlobalEmployees`.
- Updated `ProductionController` to include `request_number` in `index` search logic.
- Updated `RegistrationController` to include `request_number` in `applyEmployerLevelSearch`, `batchStats`, `applySearchToQuery`, `applyEmployerSearchToQuery`, and `fetchTrash`.
- Updated `RenewalController` to include `request_number` in `applySearchToQuery`, `applyEmployerSearchToQuery`, and `fetchTrash`.