### PR TITLE
Fix 'Not Started' filter in Registration Resolution to exclude comple…

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -61,7 +61,7 @@ class RegistrationController extends Controller
         $notStartedCount = 0;
         if ($stepOneId) {
             $notStartedCount = (clone $statsQuery)
-                ->whereIn('status', ['registration_pending', 'registration_completed'])
+                ->where('status', 'registration_pending')
                 ->whereDoesntHave('registrationSteps', function ($q) use ($stepOneId) {
                     $q->where('registration_steps.id', $stepOneId);
                 })->count();
@@ -296,7 +296,7 @@ class RegistrationController extends Controller
         // For other filters, we check if the employer has ANY employee matching the criteria
         $query->whereHas('employees', function($q) use ($filter, $stepOneId) {
             if ($filter === 'not_started') {
-                 $q->where('status', '!=', 'registration_cancelled')
+                 $q->where('status', 'registration_pending')
                    ->whereDoesntHave('registrationSteps', function($sq) use ($stepOneId) {
                        $sq->where('registration_steps.id', $stepOneId);
                    });
@@ -447,7 +447,7 @@ class RegistrationController extends Controller
                     $empSavedCount++;
                 }
 
-                if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                if ($stepOneId && $emp->status === 'registration_pending' && !$emp->registrationSteps->contains('id', $stepOneId)) {
                     $empNotStarted++;
                 }
 
@@ -581,7 +581,7 @@ class RegistrationController extends Controller
         if ($request->has('filter') && $request->filter) {
             $filter = $request->filter;
             if ($filter === 'not_started') {
-                 $query->where('status', '!=', 'registration_cancelled')
+                 $query->where('status', 'registration_pending')
                        ->whereDoesntHave('registrationSteps', function($q) use ($stepOneId) {
                            $q->where('registration_steps.id', $stepOneId);
                        });
@@ -1212,7 +1212,7 @@ class RegistrationController extends Controller
 
             foreach ($allEmployees as $emp) {
                 // Count Not Started
-                if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                if ($stepOneId && $emp->status === 'registration_pending' && !$emp->registrationSteps->contains('id', $stepOneId)) {
                     $globalNotStarted++;
                 }
 
@@ -1255,7 +1255,7 @@ class RegistrationController extends Controller
 
             foreach ($employerEmployees as $emp) {
                  // Count Not Started
-                 if ($stepOneId && !$emp->registrationSteps->contains('id', $stepOneId)) {
+                 if ($stepOneId && $emp->status === 'registration_pending' && !$emp->registrationSteps->contains('id', $stepOneId)) {
                      $employerNotStarted++;
                  }
 
@@ -1553,7 +1553,7 @@ class RegistrationController extends Controller
         $globalNotStarted = 0;
         if ($stepOneId) {
             $globalNotStarted = (clone $globalQuery)
-                ->whereIn('status', $activeStatuses)
+                ->where('status', 'registration_pending')
                 ->whereDoesntHave('registrationSteps', function ($q) use ($stepOneId) {
                     $q->where('registration_steps.id', $stepOneId);
                 })->count();
@@ -1616,7 +1616,7 @@ class RegistrationController extends Controller
             $empNotStarted = 0;
             if ($stepOneId) {
                 $empNotStarted = (clone $empQuery)
-                    ->whereIn('status', $activeStatuses)
+                    ->where('status', 'registration_pending')
                     ->whereDoesntHave('registrationSteps', function ($q) use ($stepOneId) {
                         $q->where('registration_steps.id', $stepOneId);
                     })->count();

--- a/tests/Feature/Production/RegistrationNotStartedFilterTest.php
+++ b/tests/Feature/Production/RegistrationNotStartedFilterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Production;
+
+use App\Models\User;
+use App\Models\Employee;
+use App\Models\Employer;
+use App\Models\RegistrationStep;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class RegistrationNotStartedFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $adminUser;
+    protected $steps;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup User & Permissions
+        $role = Role::firstOrCreate(['name' => 'admin']);
+        $role->givePermissionTo(Permission::firstOrCreate(['name' => 'view-finance']));
+        $role->givePermissionTo(Permission::firstOrCreate(['name' => 'edit-employees']));
+        $role->givePermissionTo(Permission::firstOrCreate(['name' => 'manage-tickets']));
+
+        $this->adminUser = User::factory()->create();
+        $this->adminUser->assignRole($role);
+
+        // Setup Steps
+        $this->steps = collect([
+            RegistrationStep::create(['name' => 'Step 1', 'order' => 1]),
+            RegistrationStep::create(['name' => 'Step 2', 'order' => 2]),
+        ]);
+    }
+
+    public function test_not_started_filter_excludes_completed_employees()
+    {
+        // Employer 1: Has PENDING employee with NO steps (Should be shown)
+        $employer1 = Employer::factory()->create(['employerNameTh' => 'Pending Employer']);
+        $emp1 = Employee::factory()->create([
+            'employer_id' => $employer1->id,
+            'status' => 'registration_pending'
+        ]);
+        // No steps attached
+
+        // Employer 2: Has COMPLETED employee with NO steps (Should be HIDDEN)
+        $employer2 = Employer::factory()->create(['employerNameTh' => 'Completed Employer']);
+        $emp2 = Employee::factory()->create([
+            'employer_id' => $employer2->id,
+            'status' => 'registration_completed'
+        ]);
+        // No steps attached
+
+        // Employer 3: Has PENDING employee WITH steps (Should be HIDDEN)
+        $employer3 = Employer::factory()->create(['employerNameTh' => 'Started Employer']);
+        $emp3 = Employee::factory()->create([
+            'employer_id' => $employer3->id,
+            'status' => 'registration_pending'
+        ]);
+        $emp3->registrationSteps()->attach($this->steps[0]->id, ['completed_at' => now()]);
+
+        // Act: Filter by 'not_started'
+        $response = $this->actingAs($this->adminUser)
+                         ->get(route('production.registration.index', ['filter' => 'not_started']));
+
+        $response->assertStatus(200);
+
+        // Assert:
+        // Employer 1 should be present
+        $response->assertSee('Pending Employer');
+
+        // Employer 2 should NOT be present (This validates the fix)
+        $response->assertDontSee('Completed Employer');
+
+        // Employer 3 should NOT be present
+        $response->assertDontSee('Started Employer');
+    }
+
+    public function test_not_started_count_is_correct()
+    {
+        // 1. Pending, No Steps (Counted)
+        $emp1 = Employee::factory()->create(['status' => 'registration_pending']);
+
+        // 2. Completed, No Steps (Not Counted - Fixed Logic)
+        $emp2 = Employee::factory()->create(['status' => 'registration_completed']);
+
+        // 3. Pending, Has Steps (Not Counted)
+        $started = Employee::factory()->create(['status' => 'registration_pending']);
+        $started->registrationSteps()->attach($this->steps[0]->id, ['completed_at' => now()]);
+
+        // Act
+        $response = $this->actingAs($this->adminUser)
+                         ->get(route('production.registration.index'));
+
+        // Assert
+        // We need to inspect the view data variable $notStartedCount
+        $notStartedCount = $response->viewData('notStartedCount');
+
+        $this->assertEquals(1, $notStartedCount);
+    }
+}


### PR DESCRIPTION
…ted employees

The 'Not Started' filter (Red Badge) was incorrectly including employees with `registration_completed` status if they had no registration steps recorded (which is common for employees directly finalized or imported). This caused the employer list to show employers who had only completed employees when filtered for 'Not Started', leading to confusion.

This commit updates the `not_started` logic across `RegistrationController` (index, filter, stats, progress) to strictly require `status = 'registration_pending'` in addition to having no steps. This ensures consistency between the server-side filter and the client-side (Blade) view logic.

* Modified `app/Http/Controllers/Production/RegistrationController.php`:
    - Updated `index`, `applyFilterToEmployerQuery`, `fetchEmployees`, `batchStats`, `updateProgress`, and `getStats` to use strict `status` check.
* Added Feature Test `tests/Feature/Production/RegistrationNotStartedFilterTest.php` to verify the fix.