### PR TITLE
feat: Add download original template button and delete confirmation t…

### DIFF
--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -199,7 +199,10 @@ class PdfTemplateController extends Controller
             'employer_id' => $request->type === 'employer' ? $request->employer_id : null,
             'created_by' => Auth::id(),
             'field_mapping' => [], // Initialize empty
-            'meta_data' => ['auto_prefix_titles' => false], // Default setting
+            'meta_data' => [
+                'auto_prefix_titles' => false,
+                'original_filename' => $file->getClientOriginalName(),
+            ],
         ]);
 
         return redirect()->route('admin.pdf-templates.builder', $template)
@@ -245,7 +248,7 @@ class PdfTemplateController extends Controller
             ->with('success', 'Template deleted successfully.');
     }
 
-    public function file(PdfTemplate $pdf_template)
+    public function file(Request $request, PdfTemplate $pdf_template)
     {
         $this->authorize('view-pdf-templates');
 
@@ -253,6 +256,14 @@ class PdfTemplateController extends Controller
 
         if (!Storage::disk('public')->exists($path)) {
             abort(404);
+        }
+
+        if ($request->query('download')) {
+            $filename = $pdf_template->meta_data['original_filename'] ?? ($pdf_template->name . '.pdf');
+            if (!str_ends_with($filename, '.pdf')) {
+                $filename .= '.pdf';
+            }
+            return response()->download(Storage::disk('public')->path($path), $filename);
         }
 
         return response()->file(Storage::disk('public')->path($path));

--- a/resources/views/pdf_templates/index.blade.php
+++ b/resources/views/pdf_templates/index.blade.php
@@ -176,6 +176,10 @@
                                     <i class="bi bi-pencil-square"></i> Builder
                                 </a>
 
+                                <a href="{{ route('admin.pdf-templates.file', ['pdf_template' => $template->id, 'download' => 1]) }}" class="btn btn-sm btn-outline-secondary me-2" title="Download Original">
+                                    <i class="bi bi-download"></i>
+                                </a>
+
                                 @can('delete-pdf-templates', $template)
                                 <form action="{{ route('admin.pdf-templates.destroy', $template) }}" method="POST" class="d-inline delete-form">
                                     @csrf
@@ -207,4 +211,33 @@
         @endif
     </div>
 </div>
+
+@push('scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('.btn-submit-swal').forEach(button => {
+            button.addEventListener('click', function(e) {
+                e.preventDefault();
+                const form = this.closest('form');
+                const title = this.dataset.swalTitle || 'Are you sure?';
+                const text = this.dataset.swalText || '';
+
+                Swal.fire({
+                    title: title,
+                    text: text,
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonColor: '#d33',
+                    cancelButtonColor: '#6c757d',
+                    confirmButtonText: 'Yes, delete it!'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        form.submit();
+                    }
+                });
+            });
+        });
+    });
+</script>
+@endpush
 @endsection

--- a/tests/Feature/PdfTemplateTest.php
+++ b/tests/Feature/PdfTemplateTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\PdfTemplate;
+use Spatie\Permission\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PdfTemplateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Create role if not exists
+        Role::firstOrCreate(['name' => 'super-admin']);
+    }
+
+    public function test_store_template_saves_original_filename()
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+        $user->assignRole('super-admin');
+
+        // Generate a real valid PDF using FPDF
+        $fpdf = new \setasign\Fpdi\Fpdi();
+        $fpdf->AddPage();
+        $fpdf->SetFont('Arial', 'B', 16);
+        $fpdf->Cell(40, 10, 'Hello World!');
+        $pdfContent = $fpdf->Output('S');
+
+        $file = UploadedFile::fake()->createWithContent('my-original-template.pdf', $pdfContent);
+
+        $response = $this->actingAs($user)->post(route('admin.pdf-templates.store'), [
+            'name' => 'My Template',
+            'type' => 'global',
+            'file' => $file,
+        ]);
+
+        if (session('errors')) {
+            dump(session('errors')->all());
+        }
+
+        $response->assertRedirect();
+
+        $template = PdfTemplate::first();
+        $this->assertNotNull($template);
+        $this->assertEquals('My Template', $template->name);
+        $this->assertEquals('my-original-template.pdf', $template->meta_data['original_filename']);
+    }
+
+    public function test_download_template_uses_original_filename()
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+        $user->assignRole('super-admin');
+
+        $file = UploadedFile::fake()->create('test-template.pdf', 100, 'application/pdf');
+        $path = $file->store('pdf_templates', 'public');
+
+        $template = PdfTemplate::create([
+            'name' => 'Download Test',
+            'file_path' => $path,
+            'type' => 'global',
+            'created_by' => $user->id,
+            'meta_data' => [
+                'original_filename' => 'original-file.pdf'
+            ]
+        ]);
+
+        $response = $this->actingAs($user)->get(route('admin.pdf-templates.file', [
+            'pdf_template' => $template->id,
+            'download' => 1
+        ]));
+
+        $response->assertOk();
+        $response->assertHeader('content-disposition', 'attachment; filename=original-file.pdf');
+    }
+
+    public function test_download_template_fallback_filename()
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+        $user->assignRole('super-admin');
+
+        $file = UploadedFile::fake()->create('test-template.pdf', 100, 'application/pdf');
+        $path = $file->store('pdf_templates', 'public');
+
+        $template = PdfTemplate::create([
+            'name' => 'Fallback Test',
+            'file_path' => $path,
+            'type' => 'global',
+            'created_by' => $user->id,
+            // No meta_data['original_filename']
+        ]);
+
+        $response = $this->actingAs($user)->get(route('admin.pdf-templates.file', [
+            'pdf_template' => $template->id,
+            'download' => 1
+        ]));
+
+        $response->assertOk();
+        $header = $response->headers->get('content-disposition');
+        $this->assertTrue(
+            $header === 'attachment; filename="Fallback Test.pdf"' ||
+            $header === 'attachment; filename=Fallback Test.pdf'
+        );
+    }
+}


### PR DESCRIPTION
…o PDF Templates

- Updated `PdfTemplateController` to store `original_filename` in `meta_data` upon upload.
- Added logic to `PdfTemplateController::file` to handle `download=1` parameter for downloading the file with its original name.
- Updated `resources/views/pdf_templates/index.blade.php` to include a "Download Original" button.
- Added JavaScript handler for `.btn-submit-swal` in `index.blade.php` to show SweetAlert2 confirmation before deletion.
- Added `PdfTemplateTest` to verify store and download functionality.