### PR TITLE
feat: enhance 'view selected' feature with card grid and removal logic

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -952,6 +952,7 @@
 
     @include('components.download-modals')
     @include('partials.background-removal-scripts')
+    @include('partials.view_selected_modal')
     @stack('scripts')
 
 <!-- Universal Preview Modal -->
@@ -1475,6 +1476,10 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }
 
+        // Update View Selected Button Count (Global Badge)
+        const viewSelectedBadge = document.getElementById('view-selected-count');
+        if (viewSelectedBadge) viewSelectedBadge.textContent = count;
+
         // Sync individual checkboxes
         if (employeeCheckboxes) {
             employeeCheckboxes.forEach(cb => {
@@ -1504,6 +1509,9 @@ document.addEventListener('DOMContentLoaded', function () {
             employer_id: cb.dataset.employerId || '',
             name_th: cb.dataset.nameTh || '',
             name_en: cb.dataset.nameEn || '',
+            title_th: cb.dataset.titleTh || '',
+            title_en: cb.dataset.titleEn || '',
+            nationality: cb.dataset.nationality || '',
             photo: cb.dataset.photo || '',
             employer_name: cb.dataset.employerName || ''
         };
@@ -1559,6 +1567,117 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
     }
+
+    // --- New Feature: View Selected Modal Logic ---
+    window.openViewSelectedModal = function() {
+        const data = window.getGlobalSelectedData();
+        const container = document.getElementById('selected-items-container');
+        const countBadge = document.getElementById('modal-selected-count');
+        const modalEl = document.getElementById('viewSelectedModal');
+
+        if (!container || !modalEl) {
+            console.error('Modal elements not found');
+            return;
+        }
+
+        if (countBadge) countBadge.textContent = data.length;
+
+        container.innerHTML = ''; // Clear
+
+        if (data.length === 0) {
+            container.innerHTML = `
+                <div class="col-12 text-center py-5 text-muted w-100">
+                    <i class="bi bi-check2-circle display-1 opacity-25"></i>
+                    <p class="mt-3">{{ __('No employees selected') }}</p>
+                </div>
+            `;
+        } else {
+            data.forEach(item => {
+                const titleTh = item.title_th || '';
+                const nameTh = item.name_th || '-';
+                const fullNameTh = titleTh + ' ' + nameTh;
+
+                const titleEn = item.title_en || '';
+                const nameEn = item.name_en || '-';
+                const fullNameEn = titleEn + ' ' + nameEn;
+
+                const nationality = item.nationality || '-';
+                const employer = item.employer_name || '-';
+                const photo = item.photo || 'https://placehold.co/50x50/e2e8f0/6c757d?text=PIC';
+
+                const cardHtml = `
+                    <div class="col" id="modal-item-${item.id}">
+                        <div class="card h-100 shadow-sm border position-relative hover-shadow transition-all">
+                            <button type="button" class="btn btn-sm btn-outline-danger position-absolute top-0 end-0 m-2 rounded-circle shadow-sm bg-white"
+                                    onclick="window.removeSelectedItemFromModal('${item.id}')"
+                                    title="{{ __('Remove') }}" style="width: 28px; height: 28px; padding: 0; z-index: 5;">
+                                <i class="bi bi-x-lg"></i>
+                            </button>
+                            <div class="card-body d-flex align-items-center gap-3 p-3">
+                                <div class="flex-shrink-0">
+                                    <img src="${photo}" class="rounded-circle shadow-sm border" width="60" height="60" style="object-fit: cover;">
+                                </div>
+                                <div class="flex-grow-1 overflow-hidden">
+                                    <div class="fw-bold text-dark text-truncate" title="${fullNameEn}">${fullNameEn}</div>
+                                    <div class="text-muted small text-truncate" title="${fullNameTh}">${fullNameTh}</div>
+                                    <div class="d-flex align-items-center gap-2 mt-1">
+                                        <span class="badge bg-light text-dark border"><i class="bi bi-flag me-1"></i>${nationality}</span>
+                                    </div>
+                                    <div class="small text-primary mt-1 text-truncate" title="${employer}">
+                                        <i class="bi bi-building me-1"></i>${employer}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                `;
+                container.innerHTML += cardHtml;
+            });
+        }
+
+        const modal = new bootstrap.Modal(modalEl);
+        modal.show();
+    };
+
+    window.removeSelectedItemFromModal = function(id) {
+        // removeItemsByIds is defined inside DOMContentLoaded scope previously, so it's not global.
+        // We need to access the logic. But wait, `removeItemsByIds` was defined inside the closure.
+        // We need to expose it or reimplement it.
+        // Let's reimplement a simple version here relying on `getGlobalSelectedData` and `setGlobalSelectedData` which ARE global.
+
+        const current = window.getGlobalSelectedData();
+        const filtered = current.filter(item => String(item.id) !== String(id));
+        window.setGlobalSelectedData(filtered);
+
+        // Sync main UI (Checkboxes)
+        if(window.refreshGlobalSelectionUI) {
+            window.refreshGlobalSelectionUI();
+        }
+
+        // Remove from DOM immediately
+        const el = document.getElementById(`modal-item-${id}`);
+        if(el) {
+            el.remove();
+        }
+
+        // Update Modal Count
+        const countBadge = document.getElementById('modal-selected-count');
+        if (countBadge) countBadge.textContent = filtered.length;
+
+        // If empty, show empty state
+        if (filtered.length === 0) {
+            const container = document.getElementById('selected-items-container');
+            if (container) {
+                container.innerHTML = `
+                    <div class="col-12 text-center py-5 text-muted w-100">
+                        <i class="bi bi-check2-circle display-1 opacity-25"></i>
+                        <p class="mt-3">{{ __('No employees selected') }}</p>
+                    </div>
+                `;
+            }
+            // Optional: Close modal if empty? No, user might want to see it cleared.
+        }
+    };
 });
 </script>
 

--- a/resources/views/partials/view_selected_modal.blade.php
+++ b/resources/views/partials/view_selected_modal.blade.php
@@ -1,0 +1,28 @@
+<div class="modal fade" id="viewSelectedModal" tabindex="-1" aria-labelledby="viewSelectedModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content border-0 shadow-lg">
+            <div class="modal-header bg-info text-white">
+                <h5 class="modal-title fw-bold" id="viewSelectedModalLabel">
+                    <i class="bi bi-check-circle-fill me-2"></i>{{ __('Selected Employees') }}
+                    <span class="badge bg-white text-info ms-2" id="modal-selected-count">0</span>
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body bg-light p-4">
+                <div id="selected-items-container" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+                    <!-- Items will be populated here via JS -->
+                    <div class="col-12 text-center py-5 text-muted">
+                        <i class="bi bi-check2-circle display-1 opacity-25"></i>
+                        <p class="mt-3">{{ __('No employees selected') }}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer bg-white">
+                <button type="button" class="btn btn-outline-danger me-auto" onclick="window.clearGlobalSelection(); bootstrap.Modal.getInstance(document.getElementById('viewSelectedModal')).hide();">
+                    <i class="bi bi-trash me-1"></i> {{ __('Clear All Selection') }}
+                </button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Close') }}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -83,6 +83,9 @@
                            data-status="{{ $employee->status }}"
                            data-name-th="{{ $employee->employeeNameTh }}"
                            data-name-en="{{ $employee->employeeNameEn }}"
+                           data-title-th="{{ $employee->employeeTitleTh }}"
+                           data-title-en="{{ $employee->employeeTitleEn }}"
+                           data-nationality="{{ $employee->employeeNationality }}"
                            data-photo="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}"
                            data-employer-name="{{ $employee->employer->employerNameTh ?? 'N/A' }}">
                 </div>

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -334,8 +334,9 @@
                 </div>
 
                 <button class="btn btn-sm btn-outline-danger ms-2" onclick="window.clearGlobalSelection();">{{ __('Clear Selection') }}</button>
-                <button class="btn btn-sm btn-info text-white" id="btn-view-selected">
+                <button class="btn btn-sm btn-info text-white" id="btn-view-selected" onclick="window.openViewSelectedModal()">
                     <i class="bi bi-eye me-1"></i> {{ __('View Selected') }}
+                    <span class="badge bg-white text-info ms-1" id="view-selected-count">0</span>
                 </button>
                 <div class="ms-auto text-muted small d-none d-md-block">
                     <i class="bi bi-arrows-move me-1"></i> {{ __('Drag to Chat') }}
@@ -645,26 +646,6 @@
 {{-- Include Advanced Export & Target Employer Modals (reused from Employees) --}}
 @include('employees.modals.advanced_export')
 @include('employees.modals.select_target_employer_modal')
-
-{{-- View Selected Items Modal --}}
-<div class="modal fade" id="viewSelectedModal" tabindex="-1" aria-labelledby="viewSelectedModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="viewSelectedModalLabel">{{ __('Selected Employees') }}</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body p-0">
-                <div id="selected-list-container" class="list-group list-group-flush">
-                    <!-- Items will be populated here -->
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Close') }}</button>
-            </div>
-        </div>
-    </div>
-</div>
 
 {{-- Edit Employee Modal --}}
 <div class="modal fade" id="editEmployeeModal" tabindex="-1" aria-labelledby="editEmployeeModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
@@ -2077,59 +2058,6 @@
 
     // --- Bulk Action Handlers (Advanced Features) ---
     document.addEventListener('DOMContentLoaded', function() {
-        const viewSelectedBtn = document.getElementById('btn-view-selected');
-        const container = document.getElementById('selected-list-container');
-        const modalEl = document.getElementById('viewSelectedModal');
-        const modal = new bootstrap.Modal(modalEl);
-
-        if (viewSelectedBtn) {
-            viewSelectedBtn.addEventListener('click', function() {
-                const data = window.getGlobalSelectedData();
-                if (data.length === 0) {
-                    showToast('{{ __('No employees selected') }}', 'danger');
-                    return;
-                }
-
-                container.innerHTML = '';
-                data.forEach(item => {
-                    // Populate modal list (Copied logic from employees.index)
-                    const li = document.createElement('div');
-                    li.className = 'list-group-item d-flex align-items-center justify-content-between';
-                    li.id = `selected-item-${item.id}`;
-
-                    li.innerHTML = `
-                        <div class="d-flex align-items-center">
-                            <img src="${item.photo}" class="rounded-circle me-3" style="width: 40px; height: 40px; object-fit: cover;">
-                            <div>
-                                <div class="fw-bold">${item.name_en || 'N/A'}</div>
-                                <div class="text-muted small">${item.name_th || 'N/A'}</div>
-                                <div class="text-muted small"><i class="bi bi-building me-1"></i>${item.employer_name || 'N/A'}</div>
-                            </div>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-danger btn-remove-selected" data-id="${item.id}">
-                            <i class="bi bi-trash"></i>
-                        </button>
-                    `;
-                    container.appendChild(li);
-                });
-
-                // Re-attach remove listeners inside modal
-                container.querySelectorAll('.btn-remove-selected').forEach(btn => {
-                    btn.addEventListener('click', function() {
-                        const id = this.dataset.id;
-                        window.removeItemsByIds ? window.removeItemsByIds([id]) : console.error('removeItemsByIds not found');
-                        // Update UI inside modal manually or let global listener handle page,
-                        // but modal needs manual removal from list
-                         const itemEl = document.getElementById(`selected-item-${id}`);
-                        if (itemEl) itemEl.remove();
-                        if (container.children.length === 0) modal.hide();
-                    });
-                });
-
-                modal.show();
-            });
-        }
-
         // Handle Bulk Generate PDF
         const bulkGeneratePdfBtn = document.getElementById('bulk-generate-pdf-btn');
         if (bulkGeneratePdfBtn) {

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -311,8 +311,9 @@
                 </div>
 
                 <button class="btn btn-sm btn-outline-danger ms-2" onclick="window.clearGlobalSelection();">{{ __('Clear Selection') }}</button>
-                <button class="btn btn-sm btn-info text-white" id="btn-view-selected">
+                <button class="btn btn-sm btn-info text-white" id="btn-view-selected" onclick="window.openViewSelectedModal()">
                     <i class="bi bi-eye me-1"></i> {{ __('View Selected') }}
+                    <span class="badge bg-white text-info ms-1" id="view-selected-count">0</span>
                 </button>
                 <div class="ms-auto text-muted small d-none d-md-block">
                     <i class="bi bi-arrows-move me-1"></i> {{ __('Drag to Chat') }}
@@ -646,26 +647,6 @@
 {{-- Include Advanced Export & Target Employer Modals (reused from Employees) --}}
 @include('employees.modals.advanced_export')
 @include('employees.modals.select_target_employer_modal')
-
-{{-- View Selected Items Modal --}}
-<div class="modal fade" id="viewSelectedModal" tabindex="-1" aria-labelledby="viewSelectedModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="viewSelectedModalLabel">{{ __('Selected Employees') }}</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body p-0">
-                <div id="selected-list-container" class="list-group list-group-flush">
-                    <!-- Items will be populated here -->
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('Close') }}</button>
-            </div>
-        </div>
-    </div>
-</div>
 
 {{-- Edit Employee Modal --}}
 <div class="modal fade" id="editEmployeeModal" tabindex="-1" aria-labelledby="editEmployeeModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
@@ -1718,59 +1699,6 @@
 
     // --- Bulk Action Handlers (Advanced Features) ---
     document.addEventListener('DOMContentLoaded', function() {
-        const viewSelectedBtn = document.getElementById('btn-view-selected');
-        const container = document.getElementById('selected-list-container');
-        const modalEl = document.getElementById('viewSelectedModal');
-        const modal = new bootstrap.Modal(modalEl);
-
-        if (viewSelectedBtn) {
-            viewSelectedBtn.addEventListener('click', function() {
-                const data = window.getGlobalSelectedData();
-                if (data.length === 0) {
-                    showToast('{{ __('No employees selected') }}', 'danger');
-                    return;
-                }
-
-                container.innerHTML = '';
-                data.forEach(item => {
-                    // Populate modal list (Copied logic from employees.index)
-                    const li = document.createElement('div');
-                    li.className = 'list-group-item d-flex align-items-center justify-content-between';
-                    li.id = `selected-item-${item.id}`;
-
-                    li.innerHTML = `
-                        <div class="d-flex align-items-center">
-                            <img src="${item.photo}" class="rounded-circle me-3" style="width: 40px; height: 40px; object-fit: cover;">
-                            <div>
-                                <div class="fw-bold">${item.name_en || 'N/A'}</div>
-                                <div class="text-muted small">${item.name_th || 'N/A'}</div>
-                                <div class="text-muted small"><i class="bi bi-building me-1"></i>${item.employer_name || 'N/A'}</div>
-                            </div>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-danger btn-remove-selected" data-id="${item.id}">
-                            <i class="bi bi-trash"></i>
-                        </button>
-                    `;
-                    container.appendChild(li);
-                });
-
-                // Re-attach remove listeners inside modal
-                container.querySelectorAll('.btn-remove-selected').forEach(btn => {
-                    btn.addEventListener('click', function() {
-                        const id = this.dataset.id;
-                        window.removeItemsByIds ? window.removeItemsByIds([id]) : console.error('removeItemsByIds not found');
-                        // Update UI inside modal manually or let global listener handle page,
-                        // but modal needs manual removal from list
-                         const itemEl = document.getElementById(`selected-item-${id}`);
-                        if (itemEl) itemEl.remove();
-                        if (container.children.length === 0) modal.hide();
-                    });
-                });
-
-                modal.show();
-            });
-        }
-
         // Handle Bulk Generate PDF
         const bulkGeneratePdfBtn = document.getElementById('bulk-generate-pdf-btn');
         if (bulkGeneratePdfBtn) {

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -247,6 +247,10 @@
             </ul>
         </div>
         <button class="btn btn-sm btn-outline-danger" onclick="window.clearGlobalSelection();">{{ __('Clear Selection') }}</button>
+        <button class="btn btn-sm btn-info text-white ms-2" id="btn-view-selected" onclick="window.openViewSelectedModal()">
+            <i class="bi bi-eye me-1"></i> {{ __('View Selected') }}
+            <span class="badge bg-white text-info ms-1" id="view-selected-count">0</span>
+        </button>
     </div>
 
     {{-- Accordion List --}}

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -134,6 +134,9 @@
                        data-employer-id="{{ $order->employer_id ?? '' }}"
                        data-name-th="{{ $item->employee->employeeNameTh ?? '' }}"
                        data-name-en="{{ $item->employee->employeeNameEn ?? '' }}"
+                       data-title-th="{{ $item->employee->employeeTitleTh ?? '' }}"
+                       data-title-en="{{ $item->employee->employeeTitleEn ?? '' }}"
+                       data-nationality="{{ $empNationality }}"
                        data-photo="{{ $empPhoto }}"
                        data-employer-name="{{ $order->employer->employerNameTh ?? 'N/A' }}"
                        {{ (!$item->employee_id || $isReadOnly) ? 'disabled' : '' }}>


### PR DESCRIPTION
- Added `resources/views/partials/view_selected_modal.blade.php` to display selected employees in a grid format with detailed cards (photo, title, names, nationality, employer).
- Updated `resources/views/layouts/app.blade.php` to include the global modal and manage selection logic centrally using `sessionStorage`.
- Enhanced `getEmployeeData` to capture Title and Nationality fields from DOM data attributes.
- Added `window.openViewSelectedModal()` and `window.removeSelectedItemFromModal()` to handle modal interactions and sync UI (checkboxes) automatically.
- Updated `resources/views/production/registration/index.blade.php` and `resources/views/production/renewal/index.blade.php` to use the new global modal logic and display a selection count badge on the button.
- Added "View Selected" button to `resources/views/workflow/index.blade.php` for consistency.
- Updated `_employee_card.blade.php` and `_item_card.blade.php` to include necessary data attributes (`data-title-th`, `data-nationality`, etc.) for the selection logic.