### PR TITLE
Update search to include Request Number and Employer's Employee ID

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -114,6 +114,8 @@ public function reinstate(Employee $employee)
               ->orWhere('employeeWorkPermit', 'like', $searchTerm)
               ->orWhere('employee_id_number', 'like', $searchTerm)
               ->orWhere('name_list_number', 'like', $searchTerm)
+              ->orWhere('request_number', 'like', $searchTerm)
+              ->orWhere('employer_employee_id', 'like', $searchTerm)
               ->orWhereHas('employer', function ($employerQuery) use ($searchTerm) {
                   $employerQuery->where('employerNameTh', 'like', $searchTerm)
                                 ->orWhere('employerNameEn', 'like', $searchTerm)
@@ -832,6 +834,8 @@ public function create(Request $request) // เพิ่ม Request $request เ
                   ->orWhere('employeeWorkPermit', 'like', $searchTerm)
                   ->orWhere('employee_id_number', 'like', $searchTerm)
                   ->orWhere('name_list_number', 'like', $searchTerm)
+                  ->orWhere('request_number', 'like', $searchTerm)
+                  ->orWhere('employer_employee_id', 'like', $searchTerm)
                   ->orWhereHas('employer', function ($employerQuery) use ($searchTerm) {
                       $employerQuery->where('employerNameTh', 'like', $searchTerm)
                                     ->orWhere('employerNameEn', 'like', $searchTerm)
@@ -972,6 +976,8 @@ public function create(Request $request) // เพิ่ม Request $request เ
                   ->orWhere('employeeWorkPermit', 'like', $searchTerm)
                   ->orWhere('employee_id_number', 'like', $searchTerm)
                   ->orWhere('name_list_number', 'like', $searchTerm)
+              ->orWhere('request_number', 'like', $searchTerm)
+              ->orWhere('employer_employee_id', 'like', $searchTerm)
                   ->orWhereHas('employer', function ($employerQuery) use ($searchTerm) {
                       $employerQuery->where('employerNameTh', 'like', $searchTerm)
                                     ->orWhere('employerNameEn', 'like', $searchTerm)

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -174,6 +174,8 @@ class EmployerController extends Controller
                   ->orWhere('employeeWorkPermit', 'like', $searchTerm)
                   ->orWhere('employee_id_number', 'like', $searchTerm)
                   ->orWhere('name_list_number', 'like', $searchTerm)
+                  ->orWhere('request_number', 'like', $searchTerm)
+                  ->orWhere('employer_employee_id', 'like', $searchTerm)
                   ->orWhere('pinkCardNo', 'like', $searchTerm);
             });
         }
@@ -410,6 +412,8 @@ class EmployerController extends Controller
                   ->orWhere('employeeWorkPermit', 'like', $searchTerm)
                   ->orWhere('employee_id_number', 'like', $searchTerm)
                   ->orWhere('name_list_number', 'like', $searchTerm)
+                  ->orWhere('request_number', 'like', $searchTerm)
+                  ->orWhere('employer_employee_id', 'like', $searchTerm)
                   ->orWhere('pinkCardNo', 'like', $searchTerm);
             });
         }
@@ -459,6 +463,8 @@ class EmployerController extends Controller
                   ->orWhere('employeeWorkPermit', 'like', $searchTerm)
                   ->orWhere('employee_id_number', 'like', $searchTerm)
                   ->orWhere('name_list_number', 'like', $searchTerm)
+                  ->orWhere('request_number', 'like', $searchTerm)
+                  ->orWhere('employer_employee_id', 'like', $searchTerm)
                   ->orWhere('pinkCardNo', 'like', $searchTerm);
             });
         }

--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -278,6 +278,7 @@ class RegistrationController extends Controller
                                ->orWhere('name_list_number', 'like', "%{$search}%")
                                ->orWhere('pinkCardNo', 'like', "%{$search}%")
                                ->orWhere('request_number', 'like', "%{$search}%")
+                               ->orWhere('employer_employee_id', 'like', "%{$search}%")
                                ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                                ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                        });
@@ -424,6 +425,7 @@ class RegistrationController extends Controller
                                ->orWhere('name_list_number', 'like', "%{$trimmedSearch}%")
                                ->orWhere('pinkCardNo', 'like', "%{$trimmedSearch}%")
                                ->orWhere('request_number', 'like', "%{$trimmedSearch}%")
+                               ->orWhere('employer_employee_id', 'like', "%{$trimmedSearch}%")
                                ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                                ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                  });
@@ -1742,6 +1744,7 @@ class RegistrationController extends Controller
               ->orWhere('name_list_number', 'like', "%{$search}%")
               ->orWhere('pinkCardNo', 'like', "%{$search}%")
               ->orWhere('request_number', 'like', "%{$search}%")
+              ->orWhere('employer_employee_id', 'like', "%{$search}%")
               // Robust Name Search (Ignore Spaces)
               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
@@ -1814,6 +1817,7 @@ class RegistrationController extends Controller
                   ->orWhere('name_list_number', 'like', "%{$search}%")
                   ->orWhere('pinkCardNo', 'like', "%{$search}%")
                   ->orWhere('request_number', 'like', "%{$search}%")
+                  ->orWhere('employer_employee_id', 'like', "%{$search}%")
                   // Robust Name Search
                   ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                   ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
@@ -1964,6 +1968,7 @@ class RegistrationController extends Controller
                    ->orWhere('name_list_number', 'like', "%{$search}%")
                    ->orWhere('pinkCardNo', 'like', "%{$search}%")
                    ->orWhere('request_number', 'like', "%{$search}%")
+                   ->orWhere('employer_employee_id', 'like', "%{$search}%")
                    ->orWhereHas('employer', function($q2) use ($search) {
                        $q2->withTrashed()
                           ->where('employerNameTh', 'like', "%{$search}%")

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -971,6 +971,7 @@ class RenewalController extends Controller
               ->orWhere('name_list_number', 'like', "%{$search}%")
               ->orWhere('pinkCardNo', 'like', "%{$search}%")
               ->orWhere('request_number', 'like', "%{$search}%")
+              ->orWhere('employer_employee_id', 'like', "%{$search}%")
               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
               ->orWhereHas('employer', function($q2) use ($search, $cleanedSearch) {
@@ -1030,6 +1031,7 @@ class RenewalController extends Controller
                   ->orWhere('name_list_number', 'like', "%{$search}%")
                   ->orWhere('pinkCardNo', 'like', "%{$search}%")
                   ->orWhere('request_number', 'like', "%{$search}%")
+                  ->orWhere('employer_employee_id', 'like', "%{$search}%")
                   ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                   ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
             });
@@ -1058,6 +1060,7 @@ class RenewalController extends Controller
                    ->orWhere('name_list_number', 'like', "%{$search}%")
                    ->orWhere('pinkCardNo', 'like', "%{$search}%")
                    ->orWhere('request_number', 'like', "%{$search}%")
+                   ->orWhere('employer_employee_id', 'like', "%{$search}%")
                    ->orWhereHas('employer', function($q2) use ($search) {
                        $q2->withTrashed()
                           ->where('employerNameTh', 'like', "%{$search}%")

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -114,6 +114,7 @@ class ProductionController extends Controller
                               ->orWhere('name_list_number', 'like', "%{$search}%")
                               ->orWhere('pinkCardNo', 'like', "%{$search}%")
                               ->orWhere('request_number', 'like', "%{$search}%")
+                              ->orWhere('employer_employee_id', 'like', "%{$search}%")
                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                       })
@@ -220,6 +221,7 @@ class ProductionController extends Controller
                               ->orWhere('name_list_number', 'like', "%{$search}%")
                               ->orWhere('pinkCardNo', 'like', "%{$search}%")
                               ->orWhere('request_number', 'like', "%{$search}%")
+                              ->orWhere('employer_employee_id', 'like', "%{$search}%")
                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                       })

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -86,6 +86,7 @@ class WorkflowController extends Controller
                           ->orWhere('name_list_number', 'like', "%{$search}%")
                           ->orWhere('pinkCardNo', 'like', "%{$search}%")
                           ->orWhere('request_number', 'like', "%{$search}%")
+                              ->orWhere('employer_employee_id', 'like', "%{$search}%")
                           ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                           ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                   })
@@ -248,6 +249,7 @@ class WorkflowController extends Controller
                               ->orWhere('name_list_number', 'like', "%{$search}%")
                               ->orWhere('pinkCardNo', 'like', "%{$search}%")
                               ->orWhere('request_number', 'like', "%{$search}%")
+                              ->orWhere('employer_employee_id', 'like', "%{$search}%")
                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                       })
@@ -709,6 +711,7 @@ class WorkflowController extends Controller
                         ->orWhere('name_list_number', 'like', "%{$search}%")
                         ->orWhere('pinkCardNo', 'like', "%{$search}%")
                         ->orWhere('request_number', 'like', "%{$search}%")
+                        ->orWhere('employer_employee_id', 'like', "%{$search}%")
                         ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                         ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
                  });
@@ -977,6 +980,8 @@ class WorkflowController extends Controller
                   ->orWhere('employee_id_number', 'like', "%{$search}%")
                   ->orWhere('name_list_number', 'like', "%{$search}%")
                   ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                  ->orWhere('request_number', 'like', "%{$search}%")
+                  ->orWhere('employer_employee_id', 'like', "%{$search}%")
                   ->orWhereHas('employer', function($e) use ($search) {
                       $e->filterByAddress($search);
                   });
@@ -1007,6 +1012,8 @@ class WorkflowController extends Controller
                   ->orWhere('employee_id_number', 'like', "%{$search}%")
                   ->orWhere('name_list_number', 'like', "%{$search}%")
                   ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                  ->orWhere('request_number', 'like', "%{$search}%")
+                  ->orWhere('employer_employee_id', 'like', "%{$search}%")
                   ->orWhereHas('employer', function($e) use ($search) {
                       $e->filterByAddress($search);
                   });
@@ -1679,7 +1686,8 @@ class WorkflowController extends Controller
                       ->orWhere('employee_id_number', 'like', "%{$search}%")
                       ->orWhere('name_list_number', 'like', "%{$search}%")
                       ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                      ->orWhere('request_number', 'like', "%{$search}%");
+                      ->orWhere('request_number', 'like', "%{$search}%")
+                      ->orWhere('employer_employee_id', 'like', "%{$search}%");
                 })
                 ->orWhereHas('order', function($o) use ($search) {
                     $o->withTrashed()


### PR DESCRIPTION
- Updated `EmployeeController` (index, export, history) to search by `request_number` and `employer_employee_id`.
- Updated `EmployerController` (edit, filterHistory, exportEmployees) to search employees by `request_number` and `employer_employee_id`.
- Updated `ProductionController` (index) to search by `employer_employee_id` (already had `request_number`).
- Updated `WorkflowController` (index, fetchOrderItems, fetchTrash, searchResigned, searchGlobal) to search by `employer_employee_id` (and `request_number` where missing).
- Updated `RegistrationController` (all search methods) to search by `employer_employee_id` (already had `request_number`).
- Updated `RenewalController` (all search methods) to search by `employer_employee_id` (already had `request_number`).