### PR TITLE
feat: standardize PDF filenames across the application

### DIFF
--- a/app/Helpers/PdfHelper.php
+++ b/app/Helpers/PdfHelper.php
@@ -15,11 +15,19 @@ class PdfHelper
      * @param string $disposition 'attachment' or 'inline'
      * @return \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public static function streamFile($disk, $filePath, $disposition = 'attachment')
+    public static function streamFile($disk, $filePath, $disposition = 'attachment', $customFilename = null)
     {
         if (!Storage::disk($disk)->exists($filePath)) {
             abort(404, 'File not found.');
         }
+
+        $filename = $customFilename ?: basename($filePath);
+        // Ensure extension
+        if (!str_ends_with(strtolower($filename), '.pdf')) {
+             $filename .= '.pdf';
+        }
+        // Sanitize (allow Thai characters, remove system reserved chars)
+        $filename = preg_replace('/[\\\\/:*?"<>|]/', '_', $filename);
 
         $mimeType = Storage::disk($disk)->mimeType($filePath);
 
@@ -28,10 +36,10 @@ class PdfHelper
             if ($disposition === 'inline') {
                 return response()->file(Storage::disk($disk)->path($filePath), [
                     'Content-Type' => 'application/pdf',
-                    'Content-Disposition' => 'inline; filename="' . basename($filePath) . '"'
+                    'Content-Disposition' => 'inline; filename="' . $filename . '"'
                 ]);
             }
-            return Storage::disk($disk)->download($filePath);
+            return Storage::disk($disk)->download($filePath, $filename);
         }
 
         // If it's an image, convert to PDF
@@ -68,13 +76,13 @@ class PdfHelper
 
             $pdf->Image($fullPath, $margin, $margin, $finalW, $finalH);
 
-            return response($pdf->Output('S', basename($filePath) . '.pdf'))
+            return response($pdf->Output('S', $filename))
                 ->header('Content-Type', 'application/pdf')
-                ->header('Content-Disposition', $disposition . '; filename="' . basename($filePath) . '.pdf"');
+                ->header('Content-Disposition', $disposition . '; filename="' . $filename . '"');
         }
 
         // Fallback
-        return Storage::disk($disk)->download($filePath);
+        return Storage::disk($disk)->download($filePath, $filename);
     }
 
     /**

--- a/app/Http/Controllers/CustomFieldController.php
+++ b/app/Http/Controllers/CustomFieldController.php
@@ -30,10 +30,35 @@ class CustomFieldController extends Controller
             abort(404, 'File not found or not a file field.');
         }
 
+        $fieldName = $field->field_name ?? 'Custom_Field';
+        $ownerName = 'Unknown';
+        $ownerId = '';
+
+        if ($type === 'employee') {
+            $owner = $field->employee;
+            $ownerName = $owner->employeeNameTh ?: ($owner->employeeNameEn ?: 'Unknown_Employee');
+            $ownerId = $owner->employer_employee_id ?: $owner->id;
+        } else {
+            // ProductionCustomField (Polymorphic)
+            $owner = $field->model;
+            if ($owner instanceof \App\Models\Employer) {
+                $ownerName = $owner->employerNameTh ?: ($owner->employerNameEn ?: 'Unknown_Employer');
+                $ownerId = $owner->employerId;
+            } elseif ($owner instanceof \App\Models\Employee) {
+                $ownerName = $owner->employeeNameTh ?: ($owner->employeeNameEn ?: 'Unknown_Employee');
+                $ownerId = $owner->employer_employee_id ?: $owner->id;
+            } else {
+                 $ownerName = $owner ? (class_basename($owner) . '_' . $owner->id) : 'Unknown_Owner';
+                 $ownerId = $owner ? $owner->id : '';
+            }
+        }
+
+        $filename = "{$fieldName}_{$ownerName}_{$ownerId}.pdf";
+
         $filePath = $field->file_path;
         $disk = 'public';
         $disposition = $request->input('disposition', 'inline');
 
-        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
+        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition, $filename);
     }
 }

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -1090,7 +1090,39 @@ public function create(Request $request) // เพิ่ม Request $request เ
 
         $disposition = $request->input('disposition', 'inline');
 
-        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
+        // Map field to readable name
+        $fieldMapping = [
+            'employee_doc_1' => 'Passport',
+            'employee_doc_2' => 'Visa',
+            'employee_doc_3' => 'Work_Permit',
+            'employee_doc_4' => 'Pink_Card',
+            'insurance_document_path' => 'Social_Security_Insurance',
+            'insurance_document_path_private' => 'Private_Insurance',
+            'medical_certificate_path' => 'Medical_Certificate',
+            // Legacy
+            'passport_file_path' => 'Passport',
+            'visa_file_path' => 'Visa',
+            'work_permit_file_path' => 'Work_Permit',
+            'pink_card_file_path' => 'Pink_Card',
+        ];
+
+        $docName = $fieldMapping[$field] ?? $field;
+
+        // Handle generic doc 5-18
+        if (str_starts_with($field, 'employee_doc_')) {
+            $num = (int)str_replace('employee_doc_', '', $field);
+            if ($num >= 5) {
+                 $docName = "Other_Document_{$num}";
+            }
+        }
+
+        $employeeName = $employee->employeeNameTh ?: ($employee->employeeNameEn ?: 'Unknown_Employee');
+        $empId = $employee->employer_employee_id ?: $employee->id;
+
+        // Construct filename: [DocName]_[EmployeeName]_[ID].pdf
+        $filename = "{$docName}_{$employeeName}_{$empId}.pdf";
+
+        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition, $filename);
     }
 
     /**

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -680,8 +680,23 @@ class EmployerController extends Controller
             abort(404, 'File not found.');
         }
 
+        // Map field to readable name
+        $fieldMapping = [
+            'employer_doc_company' => 'Company_Registration',
+            'employer_doc_lease' => 'Lease_Agreement',
+            'employer_doc_construction' => 'Construction_Contract',
+            'employer_doc_other_1' => 'Other_1',
+            'employer_doc_other_2' => 'Other_2',
+            'employer_doc_other_3' => 'Other_3',
+        ];
+
+        $docName = $fieldMapping[$field] ?? $field;
+        $employerName = $employer->employerNameTh ?: ($employer->employerNameEn ?: 'Unknown_Employer');
+        // Construct filename: [DocType]_[EmployerName]_[EmployerID].pdf
+        $filename = "{$docName}_{$employerName}_{$employer->employerId}.pdf";
+
         $disposition = $request->input('disposition', 'inline');
 
-        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition);
+        return \App\Helpers\PdfHelper::streamFile($disk, $filePath, $disposition, $filename);
     }
 }

--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -116,6 +116,11 @@ class ProductionDocumentController extends Controller
 
         $title = $titles[$type] ?? ucfirst($type);
 
+        // Construct descriptive filename for browser "Save as PDF"
+        // [Document Type]_[Employer Name]_[Production ID]
+        $employerName = $production->employer->employerNameTh ?: ($production->employer->employerNameEn ?: 'Unknown_Employer');
+        $pageTitle = "{$title}_{$employerName}_PROD-{$production->id}";
+
         // Prepare data for the view
         $data = [
             'production' => $production,
@@ -124,6 +129,7 @@ class ProductionDocumentController extends Controller
             'billTo' => $billTo,
             'type' => $type,
             'title' => $title, // Explicitly pass the title
+            'page_title' => $pageTitle, // For <title> tag
             'date' => now(),
             'transactions' => $transactions,
             'financial' => $financialData,

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -698,7 +698,15 @@ class PdfGeneratorService
 
     public function generateFilename(PdfTemplate $template, Employee $employee)
     {
-        // Fixed: Append Employee ID to ensure uniqueness for duplicate names
-        return Str::slug($template->name . '-' . $employee->employeeNameEn . '-' . $employee->id) . '.pdf';
+        // Use Thai name if available
+        $employeeName = $employee->employeeNameTh ?: ($employee->employeeNameEn ?: 'Unknown');
+
+        // Construct descriptive filename: [TemplateName]_[EmployeeName]_[EmployeeID].pdf
+        $filename = "{$template->name}_{$employeeName}_{$employee->id}.pdf";
+
+        // Sanitize (allow Thai characters, remove system reserved chars)
+        $filename = preg_replace('/[\\\\/:*?"<>|]/', '_', $filename);
+
+        return $filename;
     }
 }

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -2,7 +2,7 @@
 <html lang="th">
 <head>
     <meta charset="UTF-8">
-    <title>{{ $title ?? ucfirst($type) }}</title>
+    <title>{{ $page_title ?? $title ?? ucfirst($type) }}</title>
     <!-- Google Fonts for Sarabun -->
     <link href="https://fonts.googleapis.com/css2?family=Sarabun:wght@400;500;700&display=swap" rel="stylesheet">
     <style>


### PR DESCRIPTION
- Updated `PdfHelper::streamFile` to accept a custom filename and sanitize it, preserving Thai characters.
- Updated `EmployerController::downloadDocumentAsPdf` to use a descriptive filename: `[DocType]_[EmployerName]_[EmployerID].pdf`.
- Updated `EmployeeController::downloadDocumentAsPdf` to use a descriptive filename: `[DocType]_[EmployeeName]_[EmployeeID].pdf`.
- Updated `CustomFieldController::downloadCustomFieldPdf` to use a descriptive filename based on the field owner.
- Updated `ProductionDocumentController::show` to set a custom `<title>` tag for the view: `[DocType]_[EmployerName]_PROD-[ID]`.
- Updated `resources/views/documents/layout.blade.php` to respect the `$page_title` variable.
- Updated `PdfGeneratorService::generateFilename` to use the Thai name if available and sanitize the filename properly.