### PR TITLE
Fix PDF downloads failing with Thai filenames

### DIFF
--- a/app/Helpers/PdfHelper.php
+++ b/app/Helpers/PdfHelper.php
@@ -27,19 +27,25 @@ class PdfHelper
              $filename .= '.pdf';
         }
         // Sanitize (allow Thai characters, remove system reserved chars)
+        // Note: Using a stricter regex or relying on Laravel's download method handling is safer.
+        // We do basic sanitization here but rely on response->download() for encoding headers.
         $filename = preg_replace('/[\\\\/:*?"<>|]/', '_', $filename);
 
         $mimeType = Storage::disk($disk)->mimeType($filePath);
 
         // If it's already a PDF
         if ($mimeType === 'application/pdf') {
+            $path = Storage::disk($disk)->path($filePath);
+
             if ($disposition === 'inline') {
-                return response()->file(Storage::disk($disk)->path($filePath), [
-                    'Content-Type' => 'application/pdf',
-                    'Content-Disposition' => 'inline; filename="' . $filename . '"'
-                ]);
+                return response()->file($path, [
+                    'Content-Type' => 'application/pdf'
+                ])->setContentDisposition('inline', $filename, 'document.pdf');
             }
-            return Storage::disk($disk)->download($filePath, $filename);
+
+            // Use response()->download() instead of Storage::download() to explicitly control header encoding if needed,
+            // but Storage::download() generally handles it. The issue is likely in custom headers or manual overrides.
+            return response()->download($path, $filename);
         }
 
         // If it's an image, convert to PDF
@@ -78,11 +84,11 @@ class PdfHelper
 
             return response($pdf->Output('S', $filename))
                 ->header('Content-Type', 'application/pdf')
-                ->header('Content-Disposition', $disposition . '; filename="' . $filename . '"');
+                ->setContentDisposition($disposition, $filename, 'document.pdf');
         }
 
         // Fallback
-        return Storage::disk($disk)->download($filePath, $filename);
+        return response()->download(Storage::disk($disk)->path($filePath), $filename);
     }
 
     /**

--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -90,12 +90,11 @@ class DownloadController extends Controller
 
         if ($disposition === 'inline') {
             return response()->file($fullPath, [
-                'Content-Type' => mime_content_type($fullPath),
-                'Content-Disposition' => 'inline; filename="' . basename($fullPath) . '"'
-            ]);
+                'Content-Type' => mime_content_type($fullPath)
+            ])->setContentDisposition('inline', basename($fullPath), 'download_file');
         }
 
-        return response()->download($fullPath);
+        return response()->download($fullPath, basename($fullPath));
     }
 
     // Helper to clean up old files (optional, can be scheduled)


### PR DESCRIPTION
This commit addresses an issue where downloading files with Thai characters in their names would result in a failed download or a file named 'pdf.htm' containing an HTML error page. This was caused by manual construction of the 'Content-Disposition' header, which does not support non-ASCII characters directly.

The fix involves:
1.  Updating `app/Helpers/PdfHelper.php` to use `response()->download()` and `setContentDisposition()` which correctly encodes Unicode filenames using RFC 6266 standards.
2.  Updating `app/Http/Controllers/DownloadController.php` to similarly use Laravel's response helpers for serving files, ensuring consistent behavior for bulk downloads and other file types.

This ensures compatibility with browsers like Chrome that require proper encoding for non-ASCII filenames.