### PR TITLE
Fix PDF download failures by enforcing ASCII filenames

### DIFF
--- a/app/Helpers/PdfHelper.php
+++ b/app/Helpers/PdfHelper.php
@@ -26,10 +26,15 @@ class PdfHelper
         if (!str_ends_with(strtolower($filename), '.pdf')) {
              $filename .= '.pdf';
         }
-        // Sanitize (allow Thai characters, remove system reserved chars)
-        // Note: Using a stricter regex or relying on Laravel's download method handling is safer.
-        // We do basic sanitization here but rely on response->download() for encoding headers.
-        $filename = preg_replace('/[\\\\/:*?"<>|]/', '_', $filename);
+        // Sanitize filename to ensure ASCII compatibility as requested by user.
+        // This prevents header encoding issues in some browsers/servers.
+        // Also fix regex delimiter issue.
+        $filename = preg_replace('/[^\x20-\x7E]/', '', $filename); // Remove non-ASCII
+        $filename = preg_replace('/[\\\\\/:\*\?"<>\|]/', '_', $filename); // Remove reserved chars
+        $filename = trim($filename);
+        if (empty($filename) || $filename === '.pdf') {
+            $filename = 'document_' . time() . '.pdf';
+        }
 
         $mimeType = Storage::disk($disk)->mimeType($filePath);
 
@@ -82,9 +87,13 @@ class PdfHelper
 
             $pdf->Image($fullPath, $margin, $margin, $finalW, $finalH);
 
-            return response($pdf->Output('S', $filename))
-                ->header('Content-Type', 'application/pdf')
-                ->setContentDisposition($disposition, $filename, 'document.pdf');
+            $response = response($pdf->Output('S', $filename))
+                ->header('Content-Type', 'application/pdf');
+
+            // Manually set Content-Disposition for standard Response object (Image converted to PDF)
+            // Use safe ASCII filename
+            $headerValue = $disposition . '; filename="' . $filename . '"';
+            return $response->header('Content-Disposition', $headerValue);
         }
 
         // Fallback

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -1122,8 +1122,13 @@ public function create(Request $request) // เพิ่ม Request $request เ
             }
         }
 
-        $employeeName = $employee->employeeNameTh ?: ($employee->employeeNameEn ?: 'Unknown_Employee');
+        // Use English name for filename compatibility
+        $employeeName = $employee->employeeNameEn ?: 'Employee_' . $employee->id;
+        // Sanitize name to be safe (remove non-alphanumeric except hyphen and underscore)
+        $employeeName = preg_replace('/[^A-Za-z0-9\-\_]/', '_', $employeeName);
+
         $empId = $employee->employer_employee_id ?: $employee->id;
+        $empId = preg_replace('/[^A-Za-z0-9\-\_]/', '_', (string)$empId);
 
         // Construct filename: [DocName]_[EmployeeName]_[ID].pdf
         $filename = "{$docName}_{$employeeName}_{$empId}.pdf";

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -697,9 +697,15 @@ class EmployerController extends Controller
         ];
 
         $docName = $fieldMapping[$field] ?? $field;
-        $employerName = $employer->employerNameTh ?: ($employer->employerNameEn ?: 'Unknown_Employer');
+        // Use English name for filename compatibility
+        $employerName = $employer->employerNameEn ?: 'Employer_' . $employer->employerId;
+        // Sanitize name to be safe
+        $employerName = preg_replace('/[^A-Za-z0-9\-\_]/', '_', $employerName);
+
+        $employerId = preg_replace('/[^A-Za-z0-9\-\_]/', '_', (string)$employer->employerId);
+
         // Construct filename: [DocType]_[EmployerName]_[EmployerID].pdf
-        $filename = "{$docName}_{$employerName}_{$employer->employerId}.pdf";
+        $filename = "{$docName}_{$employerName}_{$employerId}.pdf";
 
         $disposition = $request->input('disposition', 'inline');
 

--- a/tests/Feature/Pdf/DocumentDownloadTest.php
+++ b/tests/Feature/Pdf/DocumentDownloadTest.php
@@ -51,10 +51,10 @@ class DocumentDownloadTest extends TestCase
         $response->assertStatus(200);
 
         // Expected Content-Disposition header
-        $filename = basename($path);
-
+        // It uses constructed filename, not stored filename.
         $this->assertStringContainsString('inline', $response->headers->get('Content-Disposition'));
-        $this->assertStringContainsString($filename, $response->headers->get('Content-Disposition'));
+        // Check for constructed name part (Passport)
+        $this->assertStringContainsString('Passport', $response->headers->get('Content-Disposition'));
     }
 
     public function test_employer_document_download_disposition_inline()
@@ -83,8 +83,9 @@ class DocumentDownloadTest extends TestCase
 
         $response->assertStatus(200);
 
-        $filename = basename($path);
+        // It uses constructed filename, not stored filename.
         $this->assertStringContainsString('inline', $response->headers->get('Content-Disposition'));
-        $this->assertStringContainsString($filename, $response->headers->get('Content-Disposition'));
+        // Check for constructed name part (Company_Registration)
+        $this->assertStringContainsString('Company_Registration', $response->headers->get('Content-Disposition'));
     }
 }

--- a/tests/Feature/Pdf/PdfHelperTest.php
+++ b/tests/Feature/Pdf/PdfHelperTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Pdf;
+
+use App\Helpers\PdfHelper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PdfHelperTest extends TestCase
+{
+    public function test_stream_file_converts_image_to_pdf_and_returns_response()
+    {
+        Storage::fake('public');
+
+        // Create a dummy image
+        $image = UploadedFile::fake()->image('test.jpg', 100, 100);
+        $path = $image->store('test_files', 'public');
+
+        // This call should NOT throw "Call to undefined method"
+        try {
+            $response = PdfHelper::streamFile('public', $path, 'inline', 'test_image.pdf');
+
+            // If we reach here, check status
+            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
+        } catch (\Error $e) {
+            $this->fail("Caught Error: " . $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail("Caught Exception: " . $e->getMessage());
+        }
+    }
+
+    public function test_stream_file_with_thai_filename_pdf()
+    {
+        Storage::fake('public');
+
+        // Create a dummy PDF (fake content)
+        $pdfContent = '%PDF-1.4 header dummy content';
+        $path = 'test_files/thai_test.pdf';
+        Storage::disk('public')->put($path, $pdfContent);
+
+        $thaiFilename = 'ทดสอบ_123.pdf';
+
+        $response = PdfHelper::streamFile('public', $path, 'attachment', $thaiFilename);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Verify Content-Disposition header handles sanitization (strict ASCII)
+        $disposition = $response->headers->get('Content-Disposition');
+
+        // Should contain sanitized filename "_123.pdf"
+        // Note: Laravel's BinaryFileResponse might wrap it in quotes.
+        $this->assertStringContainsString('_123.pdf', $disposition);
+        $this->assertStringNotContainsString('ทดสอบ', $disposition);
+    }
+}


### PR DESCRIPTION
- Fixed a critical regex bug in `PdfHelper.php` that caused a 500 error during downloads.
- Updated `PdfHelper::streamFile` to strip non-ASCII characters from filenames and manually handle `Content-Disposition` headers for image-to-PDF conversions, resolving "Call to undefined method" errors.
- Modified `EmployeeController` and `EmployerController` to generate filenames using English names (`employeeNameEn`/`employerNameEn`) and sanitized alphanumeric strings, ensuring cross-browser compatibility.
- Added `PdfHelperTest` to verify filename sanitization and crash prevention.
- Updated `DocumentDownloadTest` to align with the new filename format.