### PR TITLE
Fix pagination bug in Registration Trash modal by implementing AJAX n…

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2241,15 +2241,11 @@
         // function updateSequenceNumbers() { ... }
 
     // --- Trash Feature ---
-    window.openTrashModal = function() {
-        const el = document.getElementById('trashModal');
-        const modal = new bootstrap.Modal(el);
-        modal.show();
-
+    window.loadTrashContent = function(url) {
         const body = document.getElementById('trashModalBody');
         body.innerHTML = '<div class="d-flex justify-content-center py-5"><div class="spinner-border text-danger" role="status"></div></div>';
 
-        fetch('{{ route("production.registration.trash") }}')
+        fetch(url || '{{ route("production.registration.trash") }}')
             .then(res => res.text())
             .then(html => {
                 body.innerHTML = html;
@@ -2257,6 +2253,13 @@
             .catch(err => {
                 body.innerHTML = '<div class="text-danger text-center p-4">Failed to load trash.</div>';
             });
+    }
+
+    window.openTrashModal = function() {
+        const el = document.getElementById('trashModal');
+        const modal = new bootstrap.Modal(el);
+        modal.show();
+        loadTrashContent();
     }
 
     window.restoreTrashItem = function(id) {
@@ -2276,11 +2279,7 @@
                 .then(data => {
                     if(data.success) {
                         // Refresh modal content
-                        fetch('{{ route("production.registration.trash") }}')
-                            .then(res => res.text())
-                            .then(html => {
-                                document.getElementById('trashModalBody').innerHTML = html;
-                            });
+                        loadTrashContent();
 
                         Swal.fire({
                             icon: 'success',
@@ -2296,6 +2295,21 @@
             }
         });
     }
+
+    // Intercept Pagination Clicks inside Trash Modal
+    document.addEventListener('DOMContentLoaded', function() {
+        const trashBody = document.getElementById('trashModalBody');
+        if (trashBody) {
+            trashBody.addEventListener('click', function(e) {
+                // Check if clicked element is pagination link or inside one
+                const link = e.target.closest('.pagination a, .page-link');
+                if (link && link.href) {
+                    e.preventDefault();
+                    loadTrashContent(link.href);
+                }
+            });
+        }
+    });
 
         // --- Restore UI State on Load (After Reload) ---
         const urlParams = new URLSearchParams(window.location.search);

--- a/tests/Feature/Production/RegistrationTrashTest.php
+++ b/tests/Feature/Production/RegistrationTrashTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Production;
+
+use App\Models\User;
+use App\Models\Employee;
+use App\Models\Employer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class RegistrationTrashTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $adminUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $role = Role::firstOrCreate(['name' => 'admin']);
+        $role->givePermissionTo(Permission::create(['name' => 'edit-employees']));
+
+        $this->adminUser = User::factory()->create();
+        $this->adminUser->assignRole($role);
+    }
+
+    public function test_can_fetch_trash_items()
+    {
+        // Create deleted employees (enough to trigger pagination)
+        Employee::factory()->count(15)->create([
+            'status' => 'registration_pending',
+            'deleted_at' => now()
+        ]);
+
+        $response = $this->actingAs($this->adminUser)
+                         ->get(route('production.registration.trash'));
+
+        $response->assertStatus(200);
+        // Ensure it returns the partial view
+        $response->assertViewIs('production.registration.partials.trash_list');
+        // Ensure pagination links are present (Bootstrap class)
+        $response->assertSee('pagination');
+    }
+
+    public function test_trash_pagination_returns_partial()
+    {
+        // Create 15 deleted employees (assuming pagination is 10)
+        Employee::factory()->count(15)->create([
+            'status' => 'registration_pending',
+            'deleted_at' => now()
+        ]);
+
+        // Request page 2
+        $response = $this->actingAs($this->adminUser)
+                         ->get(route('production.registration.trash', ['page' => 2]));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('production.registration.partials.trash_list');
+    }
+}


### PR DESCRIPTION
…avigation

- Intercept pagination link clicks in `#trashModalBody`.
- Load content via `fetch` instead of full page reload.
- Add `window.loadTrashContent` helper function.
- Add regression test `RegistrationTrashTest`.