### PR TITLE
Add dynamic inline Remarks field to production and workflow employee cards

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -307,6 +307,19 @@ class WorkflowController extends Controller
     }
 
     /**
+     * Update Remarks for a ProductionItem via AJAX.
+     */
+    public function updateRemarks(Request $request, $itemId)
+    {
+        $request->validate(['remarks' => 'nullable|string']);
+
+        $item = ProductionItem::findOrFail($itemId);
+        $item->update(['remarks' => $request->remarks]);
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
      * Dashboard Landing Page Logic
      */
     private function dashboard($tabs)

--- a/app/Models/ProductionItem.php
+++ b/app/Models/ProductionItem.php
@@ -23,6 +23,7 @@ class ProductionItem extends Model
         'completed_at', // NEW: Workflow finished
         'new_employee_data', // JSON for temp employees
         'operator_id', // NEW: Assigned Operator
+        'remarks', // Added remarks
     ];
 
     protected $casts = [

--- a/database/migrations/2026_02_28_155809_add_remarks_to_production_items_table.php
+++ b/database/migrations/2026_02_28_155809_add_remarks_to_production_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('production_items', function (Blueprint $table) {
+            $table->text('remarks')->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('production_items', function (Blueprint $table) {
+            $table->dropColumn('remarks');
+        });
+    }
+};

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -513,6 +513,64 @@
                     <input x-show="isEditing" type="text" class="form-control form-control-sm" x-model="refId" placeholder="Ref ID">
                 </div>
             </div>
+
+            {{-- Remarks Field (Separate Row, Independent Edit) --}}
+            <div class="d-flex align-items-end gap-2 mt-2" x-data="{
+                isEditingRemark: false,
+                remarkText: {{ json_encode($item->remarks ?? '') }},
+                saving: false,
+                saveRemark() {
+                    if(this.saving) return;
+                    this.saving = true;
+                    fetch('/workflow/item/{{ $item->id }}/remarks', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content,
+                            'Accept': 'application/json'
+                        },
+                        body: JSON.stringify({ remarks: this.remarkText })
+                    })
+                    .then(res => res.json())
+                    .then(data => {
+                        this.saving = false;
+                        if(data.success) {
+                            this.isEditingRemark = false;
+                            showToast('บันทึกหมายเหตุสำเร็จ', 'success');
+                        } else {
+                            showToast('เกิดข้อผิดพลาดในการบันทึก', 'danger');
+                        }
+                    })
+                    .catch(err => {
+                        this.saving = false;
+                        console.error(err);
+                        showToast('เกิดข้อผิดพลาดในการเชื่อมต่อ', 'danger');
+                    });
+                }
+            }">
+                <div class="flex-grow-1" style="max-width: 440px;">
+                    <small class="text-muted d-block" style="font-size: 0.7rem;">หมายเหตุ</small>
+                    <div x-show="!isEditingRemark" class="small text-dark border rounded px-2 py-1 bg-light text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word;">
+                        <span x-text="remarkText || '-'"></span>
+                    </div>
+                    <textarea x-show="isEditingRemark" class="form-control form-control-sm" x-model="remarkText" placeholder="กรอกข้อความหมายเหตุ" rows="2" style="resize: none;"></textarea>
+                </div>
+
+                {{-- Remark Action Buttons --}}
+                <div class="d-flex gap-1 mb-1">
+                    <button x-show="!isEditingRemark" @click="isEditingRemark = true" class="btn btn-sm btn-outline-secondary rounded-circle" title="แก้ไขหมายเหตุ">
+                        <i class="bi bi-pencil-fill"></i>
+                    </button>
+                    <button x-show="isEditingRemark" @click="saveRemark()" class="btn btn-sm btn-success rounded-circle" title="บันทึกหมายเหตุ" :disabled="saving">
+                        <i class="bi bi-check-lg" x-show="!saving"></i>
+                        <span class="spinner-border spinner-border-sm" x-show="saving" role="status" aria-hidden="true"></span>
+                    </button>
+                    <button x-show="isEditingRemark" @click="isEditingRemark = false" class="btn btn-sm btn-outline-danger rounded-circle" title="ยกเลิก" :disabled="saving">
+                        <i class="bi bi-x-lg"></i>
+                    </button>
+                </div>
+            </div>
+
             </div>
 
             {{-- Actions --}}

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -413,6 +413,77 @@
                         </div>
                     </div>
                 </div>
+
+                {{-- REMARKS SECTION --}}
+                <div class="ms-md-4" x-data="{
+                    isEditingRemark: false,
+                    remarkText: {{ json_encode($item->remarks ?? '') }},
+                    saving: false,
+                    saveRemark() {
+                        if(this.saving) return;
+                        this.saving = true;
+                        fetch('/workflow/item/{{ $item->id }}/remarks', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content,
+                                'Accept': 'application/json'
+                            },
+                            body: JSON.stringify({ remarks: this.remarkText })
+                        })
+                        .then(res => res.json())
+                        .then(data => {
+                            this.saving = false;
+                            if(data.success) {
+                                this.isEditingRemark = false;
+                                Swal.fire({
+                                    toast: true,
+                                    position: 'top-end',
+                                    icon: 'success',
+                                    title: 'บันทึกหมายเหตุสำเร็จ',
+                                    showConfirmButton: false,
+                                    timer: 1500
+                                });
+                            } else {
+                                Swal.fire('Error', 'เกิดข้อผิดพลาดในการบันทึก', 'error');
+                            }
+                        })
+                        .catch(err => {
+                            this.saving = false;
+                            console.error(err);
+                            Swal.fire('Error', 'เกิดข้อผิดพลาดในการเชื่อมต่อ', 'error');
+                        });
+                    }
+                }">
+                    <div style="min-width: 140px; max-width: 250px;">
+                        <small class="text-muted d-block fw-bold" style="font-size: 0.7rem;">หมายเหตุ</small>
+
+                        {{-- Display Mode --}}
+                        <div x-show="!isEditingRemark" class="d-flex align-items-start gap-1">
+                            <div class="text-dark small border rounded px-2 py-1 bg-light flex-grow-1 text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word;">
+                                <span x-text="remarkText || '-'"></span>
+                            </div>
+                            <button @click="isEditingRemark = true" class="btn btn-sm btn-outline-secondary rounded-circle" style="padding: 2px 6px;" title="แก้ไขหมายเหตุ">
+                                <i class="bi bi-pencil-fill" style="font-size: 0.75rem;"></i>
+                            </button>
+                        </div>
+
+                        {{-- Edit Mode --}}
+                        <div x-show="isEditingRemark" class="mt-1 d-flex gap-1 align-items-end">
+                            <textarea class="form-control form-control-sm" x-model="remarkText" placeholder="กรอกข้อความหมายเหตุ" rows="2" style="resize: none;"></textarea>
+                            <div class="d-flex flex-column gap-1">
+                                <button @click="saveRemark()" class="btn btn-sm btn-success rounded-circle" style="padding: 2px 6px;" title="บันทึก" :disabled="saving">
+                                    <i class="bi bi-check-lg" x-show="!saving" style="font-size: 0.75rem;"></i>
+                                    <span class="spinner-border spinner-border-sm" x-show="saving" role="status" aria-hidden="true" style="width: 12px; height: 12px;"></span>
+                                </button>
+                                <button @click="isEditingRemark = false" class="btn btn-sm btn-outline-danger rounded-circle" style="padding: 2px 6px;" title="ยกเลิก" :disabled="saving">
+                                    <i class="bi bi-x-lg" style="font-size: 0.75rem;"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
             </div>
 
             {{-- Actions --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -387,6 +387,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('workflow/item/{item}/appointment-complete', [\App\Http\Controllers\WorkflowController::class, 'toggleAppointmentComplete'])->name('workflow.item.appointment_complete');
     Route::post('workflow/appointments/export', [\App\Http\Controllers\WorkflowController::class, 'exportAppointments'])->name('workflow.appointments.export');
     Route::post('workflow/item/{item}/check-daily', [\App\Http\Controllers\WorkflowController::class, 'checkDaily'])->name('workflow.item.check_daily');
+    Route::post('workflow/item/{item}/remarks', [\App\Http\Controllers\WorkflowController::class, 'updateRemarks'])->name('workflow.item.remarks');
     Route::post('workflow/item/{item}/group', [\App\Http\Controllers\WorkflowController::class, 'updateGroup'])->name('workflow.item.group');
     Route::post('workflow/item/{item}/finalize', [\App\Http\Controllers\WorkflowController::class, 'finalizeItem'])->name('workflow.item.finalize');
     Route::post('workflow/item/{item}/cancel', [\App\Http\Controllers\WorkflowController::class, 'cancelItem'])->name('workflow.item.cancel');


### PR DESCRIPTION
This PR adds a new independent "Remarks" (หมายเหตุ) field to employee cards within the Pre-Production, Workflow, Registration, and Renewal menus. The field allows users to add or edit remarks dynamically via AJAX without reloading the page. Remarks are tied specifically to the individual workflow/production items (using the `production_items` table), ensuring they are kept correctly separate between different jobs/menus, as requested. The UI includes an inline edit button specifically for this field and displays a Toast notification upon successful saving.

---
*PR created automatically by Jules for task [14197009811218418115](https://jules.google.com/task/14197009811218418115) started by @nongjossss-commits*