### PR TITLE
feat: Add option to include employee list in financial documents

### DIFF
--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -121,9 +121,60 @@ class ProductionDocumentController extends Controller
         $employerName = $production->employer->employerNameTh ?: ($production->employer->employerNameEn ?: 'Unknown_Employer');
         $pageTitle = "{$title}_{$employerName}_PROD-{$production->id}";
 
+        // --- Employee List Data Logic ---
+        $includeEmployeeList = $request->query('include_employee_list') == 1;
+        $employeeList = [];
+
+        if ($includeEmployeeList) {
+            // Get all items/employees for this production order
+            $items = $production->items;
+            $pricingMode = $financialData['pricing_mode'] ?? 'per_head';
+            $pricingTiers = collect($financialData['pricing_tiers'] ?? []);
+
+            $index = 1;
+            foreach ($items as $item) {
+                if ($item->employee) {
+                    $emp = $item->employee;
+
+                    // Determine Price
+                    $price = 0;
+                    if ($pricingMode === 'per_head') {
+                        // Find the tier this item belongs to
+                        $tier = $pricingTiers->first(function ($t) use ($item) {
+                            return in_array($item->id, $t['item_ids'] ?? []);
+                        });
+
+                        if ($tier) {
+                            $price = $tier['price'] ?? 0;
+                        } else {
+                            // If no explicit tier is matched, maybe it's in a default tier
+                            $defaultTier = $pricingTiers->first(function ($t) {
+                                return empty($t['item_ids']);
+                            });
+                            if ($defaultTier) {
+                                $price = $defaultTier['price'] ?? 0;
+                            }
+                        }
+                    }
+
+                    $employeeList[] = [
+                        'index' => $index++,
+                        'image' => $emp->image,
+                        'prefix' => $emp->titleTh,
+                        'name' => trim($emp->employeeNameTh ?: $emp->employeeNameEn),
+                        'nationality' => $emp->nationality,
+                        'price' => $price,
+                        'employee_id' => $emp->employee_id_number,
+                    ];
+                }
+            }
+        }
+
         // Prepare data for the view
         $data = [
             'production' => $production,
+            'includeEmployeeList' => $includeEmployeeList,
+            'employeeList' => $employeeList,
             'profile' => $companyProfile, // Fix: layout expects 'profile'
             'company' => $companyProfile, // Keep for backward compat if any
             'billTo' => $billTo,

--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -64,6 +64,7 @@ if (typeof window.financialManager === 'undefined') {
 
             selectedTransactionIds: [],
             documentTypeToGenerate: '',
+            includeEmployeeList: false,
 
             // Context
             productionId: initialData.productionId,
@@ -947,6 +948,7 @@ if (typeof window.financialManager === 'undefined') {
             openSelectionModal(type) {
                 this.documentTypeToGenerate = type;
                 this.selectedTransactionIds = [];
+                this.includeEmployeeList = false;
                 bootstrap.Modal.getOrCreateInstance(this.$refs.docSelectionModal).show();
             },
             generateSelectedDocument() {
@@ -956,10 +958,10 @@ if (typeof window.financialManager === 'undefined') {
                 if (this.documentTypeToGenerate === 'advance_receipt') {
                     mode = 'advance_only';
                 }
-                this.openDocument(this.documentTypeToGenerate, ids, mode);
+                this.openDocument(this.documentTypeToGenerate, ids, mode, this.includeEmployeeList);
                 bootstrap.Modal.getInstance(this.$refs.docSelectionModal).hide();
             },
-            openDocument(type, transactionIds = null, mode = null) {
+            openDocument(type, transactionIds = null, mode = null, includeEmployeeList = false) {
                 let url = `/production/${this.productionId}/documents/${type}?profile_id=${this.selectedProfileId}`;
                 if (this.activeGroupId) {
                     url += `&group_id=${this.activeGroupId}`;
@@ -969,6 +971,9 @@ if (typeof window.financialManager === 'undefined') {
                 }
                 if (mode) {
                     url += `&mode=${mode}`;
+                }
+                if (includeEmployeeList) {
+                    url += `&include_employee_list=1`;
                 }
                 window.open(url, '_blank');
             },

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -542,5 +542,41 @@
             Please check the correctness of this document.
         </div>
     </div>
+
+    @if(!empty($includeEmployeeList) && $includeEmployeeList)
+    <div class="page" style="page-break-before: always; margin-top: 20px;">
+        <h2 style="text-align: center; margin-bottom: 20px; font-size: 18px;">ตารางรายชื่อพนักงาน / Employee List</h2>
+        <table class="items-table" style="font-size: 12px;">
+            <thead>
+                <tr>
+                    <th style="width: 5%; text-align: center;">ลำดับ<br><span class="en-label">No.</span></th>
+                    <th style="width: 15%; text-align: center;">รูปถ่าย<br><span class="en-label">Photo</span></th>
+                    <th style="width: 15%;">รหัสลูกจ้าง<br><span class="en-label">Employee ID</span></th>
+                    <th style="width: 35%;">ชื่อ-นามสกุล<br><span class="en-label">Name</span></th>
+                    <th style="width: 15%; text-align: center;">สัญชาติ<br><span class="en-label">Nationality</span></th>
+                    <th style="width: 15%; text-align: right;">ราคาต่อหัว<br><span class="en-label">Price</span></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($employeeList as $emp)
+                <tr>
+                    <td style="text-align: center; vertical-align: middle;">{{ $emp['index'] }}</td>
+                    <td style="text-align: center; vertical-align: middle;">
+                        @if(!empty($emp['image']))
+                            <img src="{{ asset('storage/' . $emp['image']) }}" alt="Photo" style="width: 50px; height: 50px; object-fit: cover; border-radius: 4px;">
+                        @else
+                            <div style="width: 50px; height: 50px; background-color: #f3f4f6; border-radius: 4px; display: inline-block; line-height: 50px; color: #9ca3af; font-size: 10px;">No Image</div>
+                        @endif
+                    </td>
+                    <td style="vertical-align: middle;">{{ $emp['employee_id'] ?: '-' }}</td>
+                    <td style="vertical-align: middle;">{{ $emp['prefix'] }} {{ $emp['name'] }}</td>
+                    <td style="text-align: center; vertical-align: middle;">{{ $emp['nationality'] ?: '-' }}</td>
+                    <td style="text-align: right; vertical-align: middle;">{{ number_format($emp['price'], 2) }}</td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+    @endif
 </body>
 </html>

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -999,6 +999,14 @@ class="row">
                             No transactions available for this type.
                         </div>
                     </div>
+
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" :id="'includeEmployeeList-' + productionId" x-model="includeEmployeeList">
+                        <label class="form-check-label small fw-bold" :for="'includeEmployeeList-' + productionId">
+                            แนบตารางรายชื่อพนักงาน / Include Employee List
+                        </label>
+                    </div>
+
                     <button class="btn btn-primary btn-sm w-100" @click="generateSelectedDocument()" :disabled="selectedTransactionIds.length === 0">
                         Generate
                     </button>


### PR DESCRIPTION
This PR implements the user-requested feature to optionally include an "Employee List" table when generating financial documents (Invoices, Receipts, Quotations, etc.).

When the user selects documents to generate from the financial dashboard, a new checkbox is presented: "แนบตารางรายชื่อพนักงาน / Include Employee List". 

If selected, the system fetches all employees associated with the production order's items, calculates the correct "price per head" based on the current pricing tier rules, and appends a cleanly formatted table as a new page at the end of the generated PDF document.

---
*PR created automatically by Jules for task [3117775358104803595](https://jules.google.com/task/3117775358104803595) started by @nongjossss-commits*