### PR TITLE
Fix: Remove invalid remarks code from employee card and refactor workflow remarks to use popup

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -514,63 +514,6 @@
                 </div>
             </div>
 
-            {{-- Remarks Field (Separate Row, Independent Edit) --}}
-            <div class="d-flex align-items-end gap-2 mt-2" x-data="{
-                isEditingRemark: false,
-                remarkText: {{ json_encode($item->remarks ?? '') }},
-                saving: false,
-                saveRemark() {
-                    if(this.saving) return;
-                    this.saving = true;
-                    fetch('/workflow/item/{{ $item->id }}/remarks', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content,
-                            'Accept': 'application/json'
-                        },
-                        body: JSON.stringify({ remarks: this.remarkText })
-                    })
-                    .then(res => res.json())
-                    .then(data => {
-                        this.saving = false;
-                        if(data.success) {
-                            this.isEditingRemark = false;
-                            showToast('บันทึกหมายเหตุสำเร็จ', 'success');
-                        } else {
-                            showToast('เกิดข้อผิดพลาดในการบันทึก', 'danger');
-                        }
-                    })
-                    .catch(err => {
-                        this.saving = false;
-                        console.error(err);
-                        showToast('เกิดข้อผิดพลาดในการเชื่อมต่อ', 'danger');
-                    });
-                }
-            }">
-                <div class="flex-grow-1" style="max-width: 440px;">
-                    <small class="text-muted d-block" style="font-size: 0.7rem;">หมายเหตุ</small>
-                    <div x-show="!isEditingRemark" class="small text-dark border rounded px-2 py-1 bg-light text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word;">
-                        <span x-text="remarkText || '-'"></span>
-                    </div>
-                    <textarea x-show="isEditingRemark" class="form-control form-control-sm" x-model="remarkText" placeholder="กรอกข้อความหมายเหตุ" rows="2" style="resize: none;"></textarea>
-                </div>
-
-                {{-- Remark Action Buttons --}}
-                <div class="d-flex gap-1 mb-1">
-                    <button x-show="!isEditingRemark" @click="isEditingRemark = true" class="btn btn-sm btn-outline-secondary rounded-circle" title="แก้ไขหมายเหตุ">
-                        <i class="bi bi-pencil-fill"></i>
-                    </button>
-                    <button x-show="isEditingRemark" @click="saveRemark()" class="btn btn-sm btn-success rounded-circle" title="บันทึกหมายเหตุ" :disabled="saving">
-                        <i class="bi bi-check-lg" x-show="!saving"></i>
-                        <span class="spinner-border spinner-border-sm" x-show="saving" role="status" aria-hidden="true"></span>
-                    </button>
-                    <button x-show="isEditingRemark" @click="isEditingRemark = false" class="btn btn-sm btn-outline-danger rounded-circle" title="ยกเลิก" :disabled="saving">
-                        <i class="bi bi-x-lg"></i>
-                    </button>
-                </div>
-            </div>
-
             </div>
 
             {{-- Actions --}}

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -416,26 +416,43 @@
 
                 {{-- REMARKS SECTION --}}
                 <div class="ms-md-4" x-data="{
-                    isEditingRemark: false,
                     remarkText: {{ json_encode($item->remarks ?? '') }},
-                    saving: false,
-                    saveRemark() {
-                        if(this.saving) return;
-                        this.saving = true;
-                        fetch('/workflow/item/{{ $item->id }}/remarks', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content,
-                                'Accept': 'application/json'
+                    openRemarkPopup() {
+                        Swal.fire({
+                            title: '{{ __("แก้ไขหมายเหตุ") }}',
+                            input: 'textarea',
+                            inputValue: this.remarkText,
+                            inputPlaceholder: 'กรอกข้อความหมายเหตุ...',
+                            showCancelButton: true,
+                            confirmButtonColor: '#3085d6',
+                            cancelButtonColor: '#d33',
+                            confirmButtonText: '{{ __("บันทึก") }}',
+                            cancelButtonText: '{{ __("ยกเลิก") }}',
+                            showLoaderOnConfirm: true,
+                            preConfirm: (text) => {
+                                return fetch('/workflow/item/{{ $item->id }}/remarks', {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/json',
+                                        'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content,
+                                        'Accept': 'application/json'
+                                    },
+                                    body: JSON.stringify({ remarks: text })
+                                })
+                                .then(response => {
+                                    if (!response.ok) {
+                                        throw new Error(response.statusText)
+                                    }
+                                    return response.json().then(data => ({ data, text }));
+                                })
+                                .catch(error => {
+                                    Swal.showValidationMessage(`เกิดข้อผิดพลาด: ${error}`);
+                                });
                             },
-                            body: JSON.stringify({ remarks: this.remarkText })
-                        })
-                        .then(res => res.json())
-                        .then(data => {
-                            this.saving = false;
-                            if(data.success) {
-                                this.isEditingRemark = false;
+                            allowOutsideClick: () => !Swal.isLoading()
+                        }).then((result) => {
+                            if (result.isConfirmed && result.value.data.success) {
+                                this.remarkText = result.value.data.remarks ?? result.value.text; // Update local text from response or input
                                 Swal.fire({
                                     toast: true,
                                     position: 'top-end',
@@ -444,42 +461,22 @@
                                     showConfirmButton: false,
                                     timer: 1500
                                 });
-                            } else {
+                            } else if (result.isConfirmed && !result.value.data.success) {
                                 Swal.fire('Error', 'เกิดข้อผิดพลาดในการบันทึก', 'error');
                             }
-                        })
-                        .catch(err => {
-                            this.saving = false;
-                            console.error(err);
-                            Swal.fire('Error', 'เกิดข้อผิดพลาดในการเชื่อมต่อ', 'error');
                         });
                     }
                 }">
                     <div style="min-width: 140px; max-width: 250px;">
                         <small class="text-muted d-block fw-bold" style="font-size: 0.7rem;">หมายเหตุ</small>
 
-                        {{-- Display Mode --}}
-                        <div x-show="!isEditingRemark" class="d-flex align-items-start gap-1">
+                        <div class="d-flex align-items-start gap-1">
                             <div class="text-dark small border rounded px-2 py-1 bg-light flex-grow-1 text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word;">
                                 <span x-text="remarkText || '-'"></span>
                             </div>
-                            <button @click="isEditingRemark = true" class="btn btn-sm btn-outline-secondary rounded-circle" style="padding: 2px 6px;" title="แก้ไขหมายเหตุ">
+                            <button @click="openRemarkPopup()" class="btn btn-sm btn-outline-secondary rounded-circle flex-shrink-0" style="padding: 2px 6px;" title="แก้ไขหมายเหตุ">
                                 <i class="bi bi-pencil-fill" style="font-size: 0.75rem;"></i>
                             </button>
-                        </div>
-
-                        {{-- Edit Mode --}}
-                        <div x-show="isEditingRemark" class="mt-1 d-flex gap-1 align-items-end">
-                            <textarea class="form-control form-control-sm" x-model="remarkText" placeholder="กรอกข้อความหมายเหตุ" rows="2" style="resize: none;"></textarea>
-                            <div class="d-flex flex-column gap-1">
-                                <button @click="saveRemark()" class="btn btn-sm btn-success rounded-circle" style="padding: 2px 6px;" title="บันทึก" :disabled="saving">
-                                    <i class="bi bi-check-lg" x-show="!saving" style="font-size: 0.75rem;"></i>
-                                    <span class="spinner-border spinner-border-sm" x-show="saving" role="status" aria-hidden="true" style="width: 12px; height: 12px;"></span>
-                                </button>
-                                <button @click="isEditingRemark = false" class="btn btn-sm btn-outline-danger rounded-circle" style="padding: 2px 6px;" title="ยกเลิก" :disabled="saving">
-                                    <i class="bi bi-x-lg" style="font-size: 0.75rem;"></i>
-                                </button>
-                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Removed the improperly copied 'remarks' code block from `resources/views/production/registration/_employee_card.blade.php` which was trying to access an undefined `$item` variable, causing a fatal error when opening the employer card.
- Updated `resources/views/workflow/partials/_item_card.blade.php` to replace the inline textarea edit form for 'remarks' with a SweetAlert popup input as requested by the user.
- Addressed code review feedback to handle cases where the API might not return the saved text, ensuring the frontend updates correctly.

---
*PR created automatically by Jules for task [11385376666779866231](https://jules.google.com/task/11385376666779866231) started by @nongjossss-commits*