### PR TITLE
Fix Finance Tab Badges and Update Financial PDF Output

### DIFF
--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -160,11 +160,11 @@ class ProductionDocumentController extends Controller
                     $employeeList[] = [
                         'index' => $index++,
                         'image' => $emp->image,
-                        'prefix' => $emp->titleTh,
-                        'name' => trim($emp->employeeNameTh ?: $emp->employeeNameEn),
+                        'prefix' => $emp->employeeTitleEn ?: $emp->titleTh,
+                        'name' => trim($emp->employeeNameEn ?: $emp->employeeNameTh),
                         'nationality' => $emp->nationality,
                         'price' => $price,
-                        'employee_id' => $emp->employee_id_number,
+                        'employee_id' => 'EMP' . str_pad($emp->id, 5, '0', STR_PAD_LEFT),
                     ];
                 }
             }

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -629,23 +629,24 @@ class="row">
                                         <div class="fw-bold text-truncate" style="font-size: 0.85rem;">
                                             <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
                                             <!-- Insurance Badge -->
-                                            <template x-if="item.insurance_type">
+                                            <template x-if="item.insurance_type && item.insurance_type !== '-' && item.insurance_type !== 'No' && item.insurance_type !== 'ไม่มี'">
                                                 <span class="badge rounded-pill ms-1" style="font-size: 0.6rem;"
                                                       :class="{
                                                           'bg-primary': item.insurance_type === 'ประกันสังคม',
                                                           'bg-warning text-dark': item.insurance_type === 'ประกันเอกชน',
-                                                          'bg-success': item.insurance_type === 'ประกันโรงพยาบาล'
+                                                          'bg-success': item.insurance_type === 'ประกันโรงพยาบาล',
+                                                          'bg-secondary': item.insurance_type !== 'ประกันสังคม' && item.insurance_type !== 'ประกันเอกชน' && item.insurance_type !== 'ประกันโรงพยาบาล'
                                                       }"
                                                       x-text="item.insurance_type"></span>
                                             </template>
-                                            <template x-if="!item.insurance_type">
+                                            <template x-if="!item.insurance_type || item.insurance_type === '-' || item.insurance_type === 'No' || item.insurance_type === 'ไม่มี'">
                                                 <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">None</span>
                                             </template>
                                             <!-- Passport Badge -->
-                                            <template x-if="item.passport && item.passport !== '-' && item.passport !== 'No'">
+                                            <template x-if="item.passport && item.passport !== '-' && item.passport !== 'No' && item.passport !== 'ไม่มี'">
                                                 <span class="badge bg-info text-dark rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('Passport') }}</span>
                                             </template>
-                                            <template x-if="!item.passport || item.passport === '-' || item.passport === 'No'">
+                                            <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
                                                 <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
                                             </template>
                                         </div>
@@ -812,16 +813,17 @@ class="row">
                                                     <div class="d-flex flex-column" style="line-height: 1.1; min-width: 0;">
                                                         <div class="fw-bold text-truncate">
                                                             <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
-                                                            <template x-if="item.insurance_type">
+                                                            <template x-if="item.insurance_type && item.insurance_type !== '-' && item.insurance_type !== 'No' && item.insurance_type !== 'ไม่มี'">
                                                                 <span class="badge rounded-pill ms-1" style="font-size: 0.6rem;"
                                                                     :class="{
                                                                         'bg-primary': item.insurance_type === 'ประกันสังคม',
                                                                         'bg-warning text-dark': item.insurance_type === 'ประกันเอกชน',
-                                                                        'bg-success': item.insurance_type === 'ประกันโรงพยาบาล'
+                                                                        'bg-success': item.insurance_type === 'ประกันโรงพยาบาล',
+                                                                        'bg-secondary': item.insurance_type !== 'ประกันสังคม' && item.insurance_type !== 'ประกันเอกชน' && item.insurance_type !== 'ประกันโรงพยาบาล'
                                                                     }"
                                                                     x-text="item.insurance_type"></span>
                                                             </template>
-                                                            <template x-if="!item.insurance_type">
+                                                            <template x-if="!item.insurance_type || item.insurance_type === '-' || item.insurance_type === 'No' || item.insurance_type === 'ไม่มี'">
                                                                 <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">None</span>
                                                             </template>
                                                         </div>
@@ -940,16 +942,17 @@ class="row">
                                                     <div class="d-flex flex-column" style="line-height: 1.1; min-width: 0;">
                                                         <div class="fw-bold text-truncate">
                                                             <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
-                                                            <template x-if="item.insurance_type">
+                                                            <template x-if="item.insurance_type && item.insurance_type !== '-' && item.insurance_type !== 'No' && item.insurance_type !== 'ไม่มี'">
                                                                 <span class="badge rounded-pill ms-1" style="font-size: 0.6rem;"
                                                                     :class="{
                                                                         'bg-primary': item.insurance_type === 'ประกันสังคม',
                                                                         'bg-warning text-dark': item.insurance_type === 'ประกันเอกชน',
-                                                                        'bg-success': item.insurance_type === 'ประกันโรงพยาบาล'
+                                                                        'bg-success': item.insurance_type === 'ประกันโรงพยาบาล',
+                                                                        'bg-secondary': item.insurance_type !== 'ประกันสังคม' && item.insurance_type !== 'ประกันเอกชน' && item.insurance_type !== 'ประกันโรงพยาบาล'
                                                                     }"
                                                                     x-text="item.insurance_type"></span>
                                                             </template>
-                                                            <template x-if="!item.insurance_type">
+                                                            <template x-if="!item.insurance_type || item.insurance_type === '-' || item.insurance_type === 'No' || item.insurance_type === 'ไม่มี'">
                                                                 <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">None</span>
                                                             </template>
                                                         </div>


### PR DESCRIPTION
This PR fixes several UI and data issues requested in the finance modules:
1. **Badges:** The "Passport" and "Insurance" badges in the financial tab previously incorrectly displayed as "Has Passport/Insurance" for employees whose fields contained the Thai string "ไม่มี" (None). Added explicit checks to ensure these render as empty/none correctly.
2. **Billing Names:** The financial PDF document generators have been updated to display the employee's English Title and English Name rather than defaulting to their Thai names.
3. **Billing ID:** To avoid duplication issues on invoices, the `Employee ID` displayed on the PDF is now generated internally from the employee's database ID (`$emp->id`), formatted with zero-padding (e.g., `EMP00012`).

---
*PR created automatically by Jules for task [10481846125695085515](https://jules.google.com/task/10481846125695085515) started by @nongjossss-commits*