### PR TITLE
Fix passport and insurance type mappings in Finance Tab

### DIFF
--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -74,6 +74,13 @@ if (typeof window.financialManager === 'undefined') {
                 if (this.financialGroups.length > 0) {
                     this.switchGroup(this.financialGroups[0].id);
                 }
+
+                // Listen for insurance-updated event from _employee_card.blade.php
+                window.addEventListener('insurance-updated', (e) => {
+                    if (e.detail && e.detail.employeeId) {
+                        this.updateEmployeeInsurance(e.detail.employeeId, e.detail.insuranceType);
+                    }
+                });
             },
 
             switchGroup(groupId) {
@@ -279,6 +286,8 @@ if (typeof window.financialManager === 'undefined') {
                         title_en: emp.title_en,
                         photo: emp.photo,
                         nationality: emp.nationality,
+                        insurance_type: emp.insurance_type,
+                        passport: emp.passport,
                         employee_id: emp.id,
                         type: 'employee'
                     });
@@ -330,6 +339,8 @@ if (typeof window.financialManager === 'undefined') {
                         name_en: item.name_en,
                         title_en: item.title_en,
                         nationality: item.nationality,
+                        insurance_type: item.insurance_type,
+                        passport: item.passport,
                         type: 'item'
                     });
                 });
@@ -347,6 +358,8 @@ if (typeof window.financialManager === 'undefined') {
                             name_en: emp.name_en,
                             title_en: emp.title_en,
                             nationality: emp.nationality,
+                            insurance_type: emp.insurance_type,
+                            passport: emp.passport,
                             type: 'employee'
                         });
                     });
@@ -394,6 +407,8 @@ if (typeof window.financialManager === 'undefined') {
                             name_en: item.name_en,
                             title_en: item.title_en,
                             nationality: item.nationality,
+                            insurance_type: item.insurance_type,
+                            passport: item.passport,
                             type: 'item',
                             attached: isAttached
                         });
@@ -412,6 +427,8 @@ if (typeof window.financialManager === 'undefined') {
                         name_en: emp.name_en,
                         title_en: emp.title_en,
                         nationality: emp.nationality,
+                        insurance_type: emp.insurance_type,
+                        passport: emp.passport,
                         type: 'employee',
                         attached: false
                     });

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -179,6 +179,8 @@
                                    data-nationality="{{ $employee->employeeNationality }}"
                                    data-gender="{{ $employee->gender }}"
                                    data-country-code="{{ \App\Helpers\CountryHelper::getCountryCode($employee->employeeNationality) }}"
+                                   data-insurance-type="{{ $employee->insurance_type }}"
+                                   data-passport="{{ $employee->employeePassport }}"
                             ></td>
                         <td>
                             <i class="bi bi-grid-3x2-gap-fill text-muted cursor-grab"

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1560,7 +1560,9 @@ document.addEventListener('DOMContentLoaded', function () {
             title_en: cb.dataset.titleEn || '',
             nationality: cb.dataset.nationality || '',
             country_code: cb.dataset.countryCode || '',
-            gender: cb.dataset.gender || ''
+            gender: cb.dataset.gender || '',
+            insurance_type: cb.dataset.insuranceType || '',
+            passport: cb.dataset.passport || ''
         };
     }
 

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -826,6 +826,13 @@ class="row">
                                                             <template x-if="!item.insurance_type || item.insurance_type === '-' || item.insurance_type === 'No' || item.insurance_type === 'ไม่มี'">
                                                                 <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">None</span>
                                                             </template>
+                                                            <!-- Passport Badge -->
+                                                            <template x-if="item.passport && item.passport !== '-' && item.passport !== 'No' && item.passport !== 'ไม่มี'">
+                                                                <span class="badge bg-info text-dark rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('Passport') }}</span>
+                                                            </template>
+                                                            <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
+                                                                <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
+                                                            </template>
                                                         </div>
                                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.7rem;">
                                                              <span class="text-truncate" x-text="item.nationality"></span>
@@ -954,6 +961,13 @@ class="row">
                                                             </template>
                                                             <template x-if="!item.insurance_type || item.insurance_type === '-' || item.insurance_type === 'No' || item.insurance_type === 'ไม่มี'">
                                                                 <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">None</span>
+                                                            </template>
+                                                            <!-- Passport Badge -->
+                                                            <template x-if="item.passport && item.passport !== '-' && item.passport !== 'No' && item.passport !== 'ไม่มี'">
+                                                                <span class="badge bg-info text-dark rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('Passport') }}</span>
+                                                            </template>
+                                                            <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
+                                                                <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
                                                             </template>
                                                         </div>
                                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.7rem;">

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -87,7 +87,9 @@
                            data-title-en="{{ $employee->employeeTitleEn }}"
                            data-nationality="{{ $employee->employeeNationality }}"
                            data-photo="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}"
-                           data-employer-name="{{ $employee->employer->employerNameTh ?? 'N/A' }}">
+                           data-employer-name="{{ $employee->employer->employerNameTh ?? 'N/A' }}"
+                           data-insurance-type="{{ $employee->insurance_type }}"
+                           data-passport="{{ $employee->employeePassport }}">
                 </div>
                 @endcan
 

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -139,6 +139,8 @@
                        data-nationality="{{ $empNationality }}"
                        data-photo="{{ $empPhoto }}"
                        data-employer-name="{{ $order->employer->employerNameTh ?? 'N/A' }}"
+                       data-insurance-type="{{ $item->employee->insurance_type ?? '' }}"
+                       data-passport="{{ $empPassport }}"
                        {{ (!$item->employee_id || $isReadOnly) ? 'disabled' : '' }}>
                 </div>
 


### PR DESCRIPTION
This PR fixes a bug where `passport` and `insurance_type` properties were not correctly linked or mapped from the main employee models to the finance tab UI. It maps these missing properties in `public/js/financial-manager.js` and propagates the attributes from employee checkboxes across various modules (`_employee_card.blade.php`, `_item_card.blade.php`, and `employees/index.blade.php`). Additionally, it introduces real-time syncing so that when an insurance type is updated on an employee card, it immediately reflects within the finance dropdown options without requiring a page reload.

---
*PR created automatically by Jules for task [18249392458678606171](https://jules.google.com/task/18249392458678606171) started by @nongjossss-commits*