### PR TITLE
Fix employee list data mapping in financial docs

### DIFF
--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -159,10 +159,10 @@ class ProductionDocumentController extends Controller
 
                     $employeeList[] = [
                         'index' => $index++,
-                        'image' => $emp->image,
+                        'image' => $emp->employeePhoto,
                         'prefix' => $emp->employeeTitleEn ?: $emp->titleTh,
                         'name' => trim($emp->employeeNameEn ?: $emp->employeeNameTh),
-                        'nationality' => $emp->nationality,
+                        'nationality' => $emp->employeeNationality,
                         'price' => $price,
                         'employee_id' => 'EMP' . str_pad($emp->id, 5, '0', STR_PAD_LEFT),
                     ];


### PR DESCRIPTION
Fix employee photo and nationality mapping in financial documents.

In the employee list array mapping inside `ProductionDocumentController.php`:
- Changed `$emp->image` to `$emp->employeePhoto`
- Changed `$emp->nationality` to `$emp->employeeNationality`

This ensures that the correct fields from the `Employee` model are used to populate the table when generating PDFs like invoices and receipts.

---
*PR created automatically by Jules for task [13148843006278944756](https://jules.google.com/task/13148843006278944756) started by @nongjossss-commits*