### PR TITLE
Add direct Finance generation from employee bulk actions

### DIFF
--- a/app/Http/Controllers/FinancialHubController.php
+++ b/app/Http/Controllers/FinancialHubController.php
@@ -69,7 +69,7 @@ class FinancialHubController extends Controller
     /**
      * Show the form for creating a manual bill.
      */
-    public function createManual()
+    public function createManual(Request $request)
     {
         // For the employer dropdown. In a real scenario with thousands of employers,
         // we should use an AJAX search (like select2).
@@ -81,7 +81,15 @@ class FinancialHubController extends Controller
             ->limit(500) // Safety limit
             ->get();
 
-        return view('financial.create_manual', compact('employers'));
+        $selectedEmployees = collect();
+        $employeeIds = $request->input('employee_ids', old('employee_ids'));
+        if ($employeeIds && is_array($employeeIds)) {
+            $selectedEmployees = \App\Models\Employee::whereIn('id', $employeeIds)
+                ->select('id', 'employeeNameTh', 'employeeNameEn', 'employer_employee_id')
+                ->get();
+        }
+
+        return view('financial.create_manual', compact('employers', 'selectedEmployees'));
     }
 
     /**
@@ -94,6 +102,8 @@ class FinancialHubController extends Controller
             'description' => 'nullable|string|max:255',
             'amount' => 'nullable|numeric|min:0',
             'bill_date' => 'nullable|date',
+            'employee_ids' => 'nullable|array',
+            'employee_ids.*' => 'exists:employees,id',
         ]);
 
         DB::beginTransaction();
@@ -121,7 +131,26 @@ class FinancialHubController extends Controller
                 'production_order_id' => $order->id,
             ]);
 
-            // 3. (Optional) Create Initial Transaction
+            // 3. Attach Employees to the Order
+            if ($request->has('employee_ids') && is_array($request->employee_ids)) {
+                $employeeIds = $request->employee_ids;
+                $itemsToInsert = [];
+                foreach ($employeeIds as $empId) {
+                    $itemsToInsert[] = [
+                        'production_order_id' => $order->id,
+                        'employee_id' => $empId,
+                        'status' => 'pending',
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+                }
+
+                if (!empty($itemsToInsert)) {
+                    \App\Models\ProductionItem::insert($itemsToInsert);
+                }
+            }
+
+            // 4. (Optional) Create Initial Transaction
             if ($request->filled('amount') && $request->amount > 0) {
                 FinancialTransaction::create([
                     'production_order_id' => $order->id,

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -125,6 +125,10 @@
             @can('manage-tickets')
             <li><a class="dropdown-item" href="#" id="bulk-generate-pdf-btn"><i class="bi bi-file-earmark-pdf me-2"></i>{{ __('Automated PDF') }}</a></li>
             @endcan
+            <li><hr class="dropdown-divider"></li>
+            @can('view-finance')
+            <li><a class="dropdown-item text-primary" href="#" id="bulk-finance-btn"><i class="bi bi-cash-stack me-2"></i>{{ __('การเงิน (Finance)') }}</a></li>
+            @endcan
         </ul>
     </div>
     <button class="btn btn-sm btn-outline-danger" onclick="window.clearGlobalSelection();">{{ __('Clear Selection') }}</button>
@@ -413,6 +417,41 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Handle Bulk Send to Production
+    const bulkFinanceBtn = document.getElementById('bulk-finance-btn');
+    if (bulkFinanceBtn) {
+        bulkFinanceBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            const selectedData = window.getGlobalSelectedData();
+            const selectedIds = selectedData.map(item => item.id);
+
+            if (selectedIds.length === 0) {
+                showToast('{{ __('Please select employees first.') }}', 'danger');
+                return;
+            }
+
+            if (typeof window.FinancialSecurity !== 'undefined') {
+                window.FinancialSecurity.checkAndRun(function() {
+                    const form = document.createElement('form');
+                    form.method = 'GET';
+                    form.action = '{{ route("finance.create") }}';
+
+                    selectedIds.forEach(id => {
+                        const input = document.createElement('input');
+                        input.type = 'hidden';
+                        input.name = 'employee_ids[]';
+                        input.value = id;
+                        form.appendChild(input);
+                    });
+
+                    document.body.appendChild(form);
+                    form.submit();
+                });
+            } else {
+                console.error('FinancialSecurity module not loaded');
+            }
+        });
+    }
+
     const bulkSendProductionBtn = document.getElementById('bulk-send-production-btn');
     if (bulkSendProductionBtn) {
         bulkSendProductionBtn.addEventListener('click', function(e) {

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -588,6 +588,10 @@
         <li><a class="dropdown-item" href="#" id="employer-bulk-download-btn"><i class="bi bi-download me-2"></i>{{ __('Download Files') }}</a></li>
         <li><a class="dropdown-item" href="#" id="employer-bulk-send-data-btn"><i class="bi bi-send me-2"></i>{{ __('Send Data') }}</a></li>
         <li><a class="dropdown-item" href="#" id="employer-bulk-send-production-btn"><i class="bi bi-diagram-3 me-2"></i>{{ __('Send to P Production') }}</a></li>
+        <li><hr class="dropdown-divider"></li>
+        @can('view-finance')
+        <li><a class="dropdown-item text-primary" href="#" id="employer-bulk-finance-btn"><i class="bi bi-cash-stack me-2"></i>{{ __('การเงิน (Finance)') }}</a></li>
+        @endcan
     </x-bulk-action-bar>
 
     <div id="employeeList">
@@ -1333,6 +1337,47 @@
                 const modalEl = document.getElementById('selectTargetEmployerModal');
                 const modal = new bootstrap.Modal(modalEl);
                 modal.show();
+            });
+        }
+
+        const bulkFinanceBtn = document.getElementById('employer-bulk-finance-btn');
+        if (bulkFinanceBtn) {
+            bulkFinanceBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = Array.from(document.querySelectorAll('.employee-checkbox:checked')).map(cb => cb.value);
+
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                if (typeof window.FinancialSecurity !== 'undefined') {
+                    window.FinancialSecurity.checkAndRun(function() {
+                        const form = document.createElement('form');
+                        form.method = 'GET';
+                        form.action = '{{ route("finance.create") }}';
+
+                        // Pass employer_id if we have one
+                        const empInput = document.createElement('input');
+                        empInput.type = 'hidden';
+                        empInput.name = 'employer_id';
+                        empInput.value = '{{ $employer->id }}';
+                        form.appendChild(empInput);
+
+                        selected.forEach(id => {
+                            const input = document.createElement('input');
+                            input.type = 'hidden';
+                            input.name = 'employee_ids[]';
+                            input.value = id;
+                            form.appendChild(input);
+                        });
+
+                        document.body.appendChild(form);
+                        form.submit();
+                    });
+                } else {
+                    console.error('FinancialSecurity module not loaded');
+                }
             });
         }
 

--- a/resources/views/financial/create_manual.blade.php
+++ b/resources/views/financial/create_manual.blade.php
@@ -17,7 +17,7 @@
                             <select name="employer_id" id="employer_id" class="form-select" required>
                                 <option value="">-- {{ __('Select Employer') }} --</option>
                                 @foreach($employers as $emp)
-                                    <option value="{{ $emp->id }}" {{ old('employer_id') == $emp->id ? 'selected' : '' }}>
+                                    <option value="{{ $emp->id }}" {{ old('employer_id', request('employer_id')) == $emp->id ? 'selected' : '' }}>
                                         {{ $emp->employerNameTh }} {{ $emp->employerNameEn ? '('.$emp->employerNameEn.')' : '' }}
                                     </option>
                                 @endforeach
@@ -45,6 +45,27 @@
                                 <div class="form-text">{{ __('If entered, a pending transaction will be created immediately.') }}</div>
                             </div>
                         </div>
+
+                        @if(isset($selectedEmployees) && $selectedEmployees->count() > 0)
+                        <div class="mb-3">
+                            <label class="form-label">{{ __('Selected Employees') }} <span class="badge bg-info text-white">{{ $selectedEmployees->count() }}</span></label>
+                            <div class="border rounded p-3 bg-light" style="max-height: 200px; overflow-y: auto;">
+                                <ul class="list-unstyled mb-0">
+                                    @foreach($selectedEmployees as $emp)
+                                        <li class="mb-1">
+                                            <i class="bi bi-person me-2 text-secondary"></i>
+                                            {{ $emp->employeeNameTh ?? $emp->employeeNameEn }}
+                                            @if($emp->employer_employee_id)
+                                                <span class="text-muted small">({{ $emp->employer_employee_id }})</span>
+                                            @endif
+                                            <input type="hidden" name="employee_ids[]" value="{{ $emp->id }}">
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                            <div class="form-text text-success"><i class="bi bi-info-circle me-1"></i>{{ __('These employees will be automatically added to the bill.') }}</div>
+                        </div>
+                        @endif
 
                         <div class="d-flex justify-content-between mt-4">
                             <a href="{{ route('finance.index') }}" class="btn btn-secondary">{{ __('Cancel') }}</a>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -117,6 +117,10 @@
                 @can('manage-tickets')
                 <li><a class="dropdown-item" href="#" id="notification-bulk-generate-pdf-btn"><i class="bi bi-file-earmark-pdf me-2"></i>{{ __('Automated PDF') }}</a></li>
                 @endcan
+                <li><hr class="dropdown-divider"></li>
+                @can('view-finance')
+                <li><a class="dropdown-item text-primary" href="#" id="notification-bulk-finance-btn"><i class="bi bi-cash-stack me-2"></i>{{ __('การเงิน (Finance)') }}</a></li>
+                @endcan
             </ul>
         </div>
         <div class="d-flex gap-2">
@@ -402,6 +406,44 @@
                 const modalEl = document.getElementById('selectTargetEmployerModal');
                 const modal = new bootstrap.Modal(modalEl);
                 modal.show();
+            });
+        }
+
+        const bulkFinanceBtn = document.getElementById('notification-bulk-finance-btn');
+        if (bulkFinanceBtn) {
+            bulkFinanceBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const activePane = document.querySelector('.tab-content .tab-pane.active');
+                if (!activePane) return;
+
+                const checkboxes = activePane.querySelectorAll('.bulk-action-checkbox:checked');
+                const selected = Array.from(checkboxes).map(cb => cb.value);
+
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                if (typeof window.FinancialSecurity !== 'undefined') {
+                    window.FinancialSecurity.checkAndRun(function() {
+                        const form = document.createElement('form');
+                        form.method = 'GET';
+                        form.action = '{{ route("finance.create") }}';
+
+                        selected.forEach(id => {
+                            const input = document.createElement('input');
+                            input.type = 'hidden';
+                            input.name = 'employee_ids[]';
+                            input.value = id;
+                            form.appendChild(input);
+                        });
+
+                        document.body.appendChild(form);
+                        form.submit();
+                    });
+                } else {
+                    console.error('FinancialSecurity module not loaded');
+                }
             });
         }
 


### PR DESCRIPTION
Implement a new feature allowing users to initiate a financial bill directly from the employee lists in Employer Edit, Employee Index, and Notifications modules. Selected employees are passed via a GET form to the manual bill creation route `/finance/create` after validating the security PIN. The controller stores the new bill and attaches these employees as `ProductionItem`s, enabling quick, non-workflow billing.

---
*PR created automatically by Jules for task [14162880634527108755](https://jules.google.com/task/14162880634527108755) started by @nongjossss-commits*