### PR TITLE
Update custom document descriptions in preview modals

### DIFF
--- a/resources/views/previews/_employee_data.blade.php
+++ b/resources/views/previews/_employee_data.blade.php
@@ -271,8 +271,10 @@
         @foreach($attachmentFields as $key => $file)
             @php
                 $field = $file['field'];
-                $label = $file['label'];
                 $desc_field = $file['desc_field'] ?? null;
+                $description = ($desc_field && $employee->{$desc_field}) ? $employee->{$desc_field} : null;
+                $label = $description ? $file['label'] . ' - ' . $description : $file['label'];
+
                 $url = $employee->{$field} ? Storage::disk('public')->url($employee->{$field}) : '#';
                 $pdfUrl = $employee->{$field} ? route('employees.documents.pdf', ['employee' => $employee->id, 'field' => $field]) : '#';
             @endphp
@@ -286,12 +288,7 @@
                         <a href="{{ $pdfUrl }}" download class="btn btn-danger btn-sm text-white ms-1">
                             <i class="bi bi-file-earmark-pdf-fill"></i> PDF
                         </a>
-                         @if($desc_field && $employee->{$desc_field})
-                            <span class="text-muted d-block" style="font-size: 0.875em;">({{ $employee->{$desc_field} }})</span>
-                        @endif
                     </p>
-                @elseif($desc_field && $employee->{$desc_field})
-                    <p class="form-control-plaintext text-muted" style="color: #6c757d !important;">{{ $employee->{$desc_field} }}</p>
                 @else
                     <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
                 @endif

--- a/resources/views/previews/_employer_data.blade.php
+++ b/resources/views/previews/_employer_data.blade.php
@@ -168,36 +168,33 @@
     </div>
     <div class="row mb-3">
         <div class="col-md-4">
-            <label class="form-label fw-bold">4. เอกสารอื่นๆ 1</label>
+            <label class="form-label fw-bold">4. เอกสารอื่นๆ 1{{ $employer->employer_doc_other_1_desc ? ' - ' . $employer->employer_doc_other_1_desc : '' }}</label>
             @if($employer->employer_doc_other_1)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_1) }}', '{{ $employer->employer_doc_other_1_desc ?? 'ดูเอกสารอื่นๆ 1' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
                     <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_1']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
-                    <br>({{ $employer->employer_doc_other_1_desc ?? 'N/A' }})
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
             @endif
         </div>
         <div class="col-md-4">
-            <label class="form-label fw-bold">5. เอกสารอื่นๆ 2</label>
+            <label class="form-label fw-bold">5. เอกสารอื่นๆ 2{{ $employer->employer_doc_other_2_desc ? ' - ' . $employer->employer_doc_other_2_desc : '' }}</label>
             @if($employer->employer_doc_other_2)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_2) }}', '{{ $employer->employer_doc_other_2_desc ?? 'ดูเอกสารอื่นๆ 2' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
                     <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_2']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
-                    <br>({{ $employer->employer_doc_other_2_desc ?? 'N/A' }})
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>
             @endif
         </div>
         <div class="col-md-4">
-            <label class="form-label fw-bold">6. เอกสารอื่นๆ 3</label>
+            <label class="form-label fw-bold">6. เอกสารอื่นๆ 3{{ $employer->employer_doc_other_3_desc ? ' - ' . $employer->employer_doc_other_3_desc : '' }}</label>
             @if($employer->employer_doc_other_3)
                 <p class="form-control-plaintext">
                     <a href="#" onclick="event.preventDefault(); viewPDF('{{ asset('storage/' . $employer->employer_doc_other_3) }}', '{{ $employer->employer_doc_other_3_desc ?? 'ดูเอกสารอื่นๆ 3' }}')" class="btn btn-success btn-sm text-white"><i class="bi bi-eye-fill"></i> ดูไฟล์</a>
                     <a href="{{ route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_3']) }}" download class="btn btn-danger btn-sm text-white"><i class="bi bi-file-earmark-pdf-fill"></i> PDF</a>
-                    <br>({{ $employer->employer_doc_other_3_desc ?? 'N/A' }})
                 </p>
             @else
                 <p class="form-control-plaintext text-muted">ไม่มีเอกสาร</p>


### PR DESCRIPTION
**Changes Made**
- Modified Employee preview view to include dynamically populated custom document labels for 'Other Documents 1-10'.
- Modified Employer preview view to include dynamically populated custom document labels for 'Other Documents 1-3'.
- Removed duplicate descriptions previously rendered underneath file download links for both models.

**Why**
The user requested that the specific text entered to describe an "other document" be reflected in the document label itself on the preview modal instead of being displayed separately underneath the download button. This makes it much clearer to the user what document they are viewing when they upload general files.

---
*PR created automatically by Jules for task [13777256607236489470](https://jules.google.com/task/13777256607236489470) started by @nongjossss-commits*