### PR TITLE
Fix manual bill per head pricing issue in documents

### DIFF
--- a/app/Http/Controllers/FinancialHubController.php
+++ b/app/Http/Controllers/FinancialHubController.php
@@ -147,6 +147,27 @@ class FinancialHubController extends Controller
 
                 if (!empty($itemsToInsert)) {
                     \App\Models\ProductionItem::insert($itemsToInsert);
+
+                    // Fetch the newly created items to get their IDs
+                    $insertedItems = \App\Models\ProductionItem::where('production_order_id', $order->id)->pluck('id')->toArray();
+
+                    // Update the group and order's financial_data to include these items in the default pricing tier
+                    if (!empty($insertedItems)) {
+                        $financialData = [
+                            'pricing_mode' => 'per_head', // Default to per head if there are employees
+                            'pricing_tiers' => [
+                                [
+                                    'id' => 'tier_' . time(),
+                                    'name' => 'Default Tier',
+                                    'price' => 0,
+                                    'item_ids' => $insertedItems
+                                ]
+                            ]
+                        ];
+
+                        $group->update(['financial_data' => $financialData]);
+                        $order->update(['financial_data' => $financialData]);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes an issue where manual bills created with employees did not properly assign those employees to a pricing tier, causing the "Price" (ราคาต่อหัว) column in PDF documents to show 0.00. This update ensures that if employees are selected during manual bill creation, they are grouped into a default tier and the pricing mode is set to "per_head" in the initial `financial_data`.

---
*PR created automatically by Jules for task [3497914127665798930](https://jules.google.com/task/3497914127665798930) started by @nongjossss-commits*