### PR TITLE
Add 5 MB max file size hint to employer document fields

### DIFF
--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -243,7 +243,7 @@
         <h5>{{ __('Employer Attachments') }}</h5>
         <div class="row mb-3">
             <div class="col-md-6">
-                <label for="employer_doc_company" class="form-label">1. {{ __('Company Certificate / ID Card') }}</label>
+                <label for="employer_doc_company" class="form-label">1. {{ __('Company Certificate / ID Card') }} <span class="text-muted small">(รองรับไฟล์สูงสุด 5 MB)</span></label>
                 <div class="input-group input-group-sm">
                     <input type="file" class="form-control form-control-sm @error('employer_doc_company') is-invalid @enderror" id="employer_doc_company" name="employer_doc_company" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_company' } }))">
@@ -264,7 +264,7 @@
         </div>
         <div class="row mb-3">
             <div class="col-md-6">
-                <label for="employer_doc_lease" class="form-label">2. {{ __('Lease Agreement / House Registration') }}</label>
+                <label for="employer_doc_lease" class="form-label">2. {{ __('Lease Agreement / House Registration') }} <span class="text-muted small">(รองรับไฟล์สูงสุด 5 MB)</span></label>
                 <div class="input-group input-group-sm">
                     <input type="file" class="form-control form-control-sm @error('employer_doc_lease') is-invalid @enderror" id="employer_doc_lease" name="employer_doc_lease" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_lease' } }))">
@@ -276,7 +276,7 @@
                 @enderror
             </div>
             <div class="col-md-6">
-                <label for="employer_doc_construction" class="form-label">3. {{ __('Construction Contract / Map') }}</label>
+                <label for="employer_doc_construction" class="form-label">3. {{ __('Construction Contract / Map') }} <span class="text-muted small">(รองรับไฟล์สูงสุด 5 MB)</span></label>
                 <div class="input-group input-group-sm">
                     <input type="file" class="form-control form-control-sm @error('employer_doc_construction') is-invalid @enderror" id="employer_doc_construction" name="employer_doc_construction" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_construction' } }))">
@@ -290,7 +290,7 @@
         </div>
         <div class="row mb-3">
             <div class="col-md-4">
-                <label for="employer_doc_other_1" class="form-label">4. {{ __('Other Document') }} 1</label>
+                <label for="employer_doc_other_1" class="form-label">4. {{ __('Other Document') }} 1 <span class="text-muted small">(รองรับไฟล์สูงสุด 5 MB)</span></label>
                 <div class="input-group input-group-sm">
                     <input type="file" class="form-control form-control-sm @error('employer_doc_other_1') is-invalid @enderror" id="employer_doc_other_1" name="employer_doc_other_1" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_other_1' } }))">
@@ -303,7 +303,7 @@
                 @enderror
             </div>
             <div class="col-md-4">
-                <label for="employer_doc_other_2" class="form-label">5. {{ __('Other Document') }} 2</label>
+                <label for="employer_doc_other_2" class="form-label">5. {{ __('Other Document') }} 2 <span class="text-muted small">(รองรับไฟล์สูงสุด 5 MB)</span></label>
                 <div class="input-group input-group-sm">
                     <input type="file" class="form-control form-control-sm @error('employer_doc_other_2') is-invalid @enderror" id="employer_doc_other_2" name="employer_doc_other_2" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_other_2' } }))">
@@ -316,7 +316,7 @@
                 @enderror
             </div>
             <div class="col-md-4">
-                <label for="employer_doc_other_3" class="form-label">6. {{ __('Other Document') }} 3</label>
+                <label for="employer_doc_other_3" class="form-label">6. {{ __('Other Document') }} 3 <span class="text-muted small">(รองรับไฟล์สูงสุด 5 MB)</span></label>
                 <div class="input-group input-group-sm">
                     <input type="file" class="form-control form-control-sm @error('employer_doc_other_3') is-invalid @enderror" id="employer_doc_other_3" name="employer_doc_other_3" multiple onchange="if(window.interceptFileSelect) window.interceptFileSelect(event)">
                     <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'employer_doc_other_3' } }))">

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -311,7 +311,7 @@
                 <x-file-input-group
                     id="employer_doc_company"
                     name="employer_doc_company"
-                    label="1. {{ __('Company Certificate / ID Card') }}"
+                    label="1. {{ __('Company Certificate / ID Card') }} <span class='text-muted small'>(รองรับไฟล์สูงสุด 5 MB)</span>"
                     :value="$employer->employer_doc_company"
                     :pdfRoute="route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_company'])"
                 />
@@ -329,7 +329,7 @@
                 <x-file-input-group
                     id="employer_doc_lease"
                     name="employer_doc_lease"
-                    label="2. {{ __('Lease Agreement / House Registration') }}"
+                    label="2. {{ __('Lease Agreement / House Registration') }} <span class='text-muted small'>(รองรับไฟล์สูงสุด 5 MB)</span>"
                     :value="$employer->employer_doc_lease"
                     :pdfRoute="route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_lease'])"
                 />
@@ -338,7 +338,7 @@
                 <x-file-input-group
                     id="employer_doc_construction"
                     name="employer_doc_construction"
-                    label="3. {{ __('Construction Contract / Map') }}"
+                    label="3. {{ __('Construction Contract / Map') }} <span class='text-muted small'>(รองรับไฟล์สูงสุด 5 MB)</span>"
                     :value="$employer->employer_doc_construction"
                     :pdfRoute="route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_construction'])"
                 />
@@ -349,7 +349,7 @@
                 <x-file-input-group
                     id="employer_doc_other_1"
                     name="employer_doc_other_1"
-                    label="4. {{ __('Other Document') }} 1"
+                    label="4. {{ __('Other Document') }} 1 <span class='text-muted small'>(รองรับไฟล์สูงสุด 5 MB)</span>"
                     :value="$employer->employer_doc_other_1"
                     :pdfRoute="route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_1'])"
                     description="employer_doc_other_1_desc"
@@ -360,7 +360,7 @@
                 <x-file-input-group
                     id="employer_doc_other_2"
                     name="employer_doc_other_2"
-                    label="5. {{ __('Other Document') }} 2"
+                    label="5. {{ __('Other Document') }} 2 <span class='text-muted small'>(รองรับไฟล์สูงสุด 5 MB)</span>"
                     :value="$employer->employer_doc_other_2"
                     :pdfRoute="route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_2'])"
                     description="employer_doc_other_2_desc"
@@ -371,7 +371,7 @@
                 <x-file-input-group
                     id="employer_doc_other_3"
                     name="employer_doc_other_3"
-                    label="6. {{ __('Other Document') }} 3"
+                    label="6. {{ __('Other Document') }} 3 <span class='text-muted small'>(รองรับไฟล์สูงสุด 5 MB)</span>"
                     :value="$employer->employer_doc_other_3"
                     :pdfRoute="route('employers.documents.pdf', ['employer' => $employer->id, 'field' => 'employer_doc_other_3'])"
                     description="employer_doc_other_3_desc"


### PR DESCRIPTION
The user reported an issue with a 500 KB limit and requested updating the UI for all 6 document upload points on the employer pages to display that they support up to 5 MB per file.

Investigated the backend logic (`EmployerController`) and confirmed that the upload validation (`max:5120`) is correctly configured for 5 MB. Added the requested text hints `(รองรับไฟล์สูงสุด 5 MB)` to the `create.blade.php` and `edit.blade.php` views for the Employer module. Verified the changes locally via Playwright visually confirming the UI displays correctly.

---
*PR created automatically by Jules for task [14114581698812483989](https://jules.google.com/task/14114581698812483989) started by @nongjossss-commits*