### PR TITLE
Enhance Financial Profile Builder & PIN Protection

### DIFF
--- a/app/Http/Controllers/SuperAdmin/SettingsController.php
+++ b/app/Http/Controllers/SuperAdmin/SettingsController.php
@@ -20,6 +20,7 @@ class SettingsController extends Controller
         $menus = [
             'dashboard' => 'Dashboard',
             'finance' => 'Finance (การเงิน)',
+            'financial_profiles' => 'Financial Profiles (ข้อมูลผู้ตั้งบิล)',
             'activity_logs' => 'Activity Logs',
             'notifications' => 'Notifications',
             'incomplete_data' => 'Incomplete Data',

--- a/resources/views/finance/profiles/builder.blade.php
+++ b/resources/views/finance/profiles/builder.blade.php
@@ -165,7 +165,7 @@
                                 </tbody>
                             </table>
 
-                            <div class="row" style="margin-top: 100px;">
+                            <div class="row" style="position: absolute; bottom: 80px; left: 0; right: 0;">
                                 <div class="col-6 text-center">
                                     _______________________<br>
                                     Customer Signature
@@ -236,8 +236,8 @@ document.addEventListener('alpine:init', () => {
             logo_url: null,
             signature_url: null,
             stamp_url: null,
-            signature_position: { x: 400, y: 800, width: 150, height: 75, rotate: 0 },
-            stamp_position: { x: 500, y: 780, width: 100, height: 100, rotate: 0 },
+            signature_position: { x: 400, y: 950, width: 150, height: 75, rotate: 0 },
+            stamp_position: { x: 500, y: 930, width: 100, height: 100, rotate: 0 },
         },
 
         // Tracking items to remove on backend
@@ -269,8 +269,8 @@ document.addEventListener('alpine:init', () => {
                 type: this.currentType,
                 name: '', tax_id: '', branch: '', address: '', phone: '', email: '',
                 logo_url: null, signature_url: null, stamp_url: null,
-                signature_position: { x: 400, y: 800, width: 150, height: 75, rotate: 0 },
-                stamp_position: { x: 500, y: 780, width: 100, height: 100, rotate: 0 },
+                signature_position: { x: 400, y: 950, width: 150, height: 75, rotate: 0 },
+                stamp_position: { x: 500, y: 930, width: 100, height: 100, rotate: 0 },
             };
             this.removals = { logo: false, signature: false, stamp: false };
             this.currentMode = 'form';
@@ -290,8 +290,8 @@ document.addEventListener('alpine:init', () => {
                 logo_url: profile.logo_path ? `/storage/${profile.logo_path}` : null,
                 signature_url: profile.signature_path ? `/storage/${profile.signature_path}` : null,
                 stamp_url: profile.stamp_path ? `/storage/${profile.stamp_path}` : null,
-                signature_position: profile.signature_position || { x: 400, y: 800, width: 150, height: 75, rotate: 0 },
-                stamp_position: profile.stamp_position || { x: 500, y: 780, width: 100, height: 100, rotate: 0 },
+                signature_position: profile.signature_position || { x: 400, y: 950, width: 150, height: 75, rotate: 0 },
+                stamp_position: profile.stamp_position || { x: 500, y: 930, width: 100, height: 100, rotate: 0 },
             };
             this.removals = { logo: false, signature: false, stamp: false };
             this.currentMode = 'form';

--- a/resources/views/partials/sidebar-menu.blade.php
+++ b/resources/views/partials/sidebar-menu.blade.php
@@ -96,9 +96,11 @@
 <a href="{{ route('finance.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.index') || request()->routeIs('finance.create') ? 'active' : '' }}">
     <i class="bi bi-cash-coin me-2"></i>{{ __('Finance') }}
 </a>
+@if(\App\Facades\SuperAdmin::isVisible('financial_profiles'))
 <a href="{{ route('finance.profiles.builder') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.profiles.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
     <i class="bi bi-file-earmark-person me-2"></i>{{ __('Financial Profiles') }}
 </a>
+@endif
 @endhasanyrole
 @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -372,13 +372,15 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/', [App\Http\Controllers\FinancialHubController::class, 'index'])->name('index');
         Route::get('/create', [App\Http\Controllers\FinancialHubController::class, 'createManual'])->name('create');
         Route::post('/store', [App\Http\Controllers\FinancialHubController::class, 'storeManual'])->name('store');
+    });
 
-        // Profiles Builder & API
+    // Profiles Builder & API (Shares the same finance menu password, but can be controlled via its own visibility setting in Super Admin)
+    Route::middleware('menu:finance')->prefix('finance')->name('finance.')->group(function () {
         Route::get('/profiles', [App\Http\Controllers\FinancialProfileController::class, 'builder'])->name('profiles.builder');
         Route::get('/api/profiles', [App\Http\Controllers\FinancialProfileController::class, 'index']);
         Route::get('/api/profiles/{profile}', [App\Http\Controllers\FinancialProfileController::class, 'show']);
         Route::post('/api/profiles', [App\Http\Controllers\FinancialProfileController::class, 'store']);
-        Route::post('/api/profiles/{profile}', [App\Http\Controllers\FinancialProfileController::class, 'update']); // Use POST with _method=PUT for forms
+        Route::match(['put', 'post'], '/api/profiles/{profile}', [App\Http\Controllers\FinancialProfileController::class, 'update']); // Allow both to support FormData with spoofed _method=PUT
         Route::delete('/api/profiles/{profile}', [App\Http\Controllers\FinancialProfileController::class, 'destroy']);
     });
 


### PR DESCRIPTION
This submission fulfills the requirements to secure the Financial Profiles menu with the finance PIN, add its visibility toggle to the Super Admin settings, fix a `405 Method Not Allowed` / routing error when updating an existing profile via `FormData` using `_method=PUT`, and adjust the default positioning of stamps and signatures to the bottom of the document preview to better handle multiline bills.

---
*PR created automatically by Jules for task [14161604151437040482](https://jules.google.com/task/14161604151437040482) started by @nongjossss-commits*