### PR TITLE
Add Medical Certificate option to Bulk Download

### DIFF
--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -34,6 +34,7 @@ class ProcessDownload implements ShouldQueue
         'work_permit' => ['work_permit_file_path', 'employee_doc_3'],
         'pink_card' => ['pink_card_file_path', 'employee_doc_4'],
         'tor_ror_38' => 'employee_doc_5',
+        'medical_certificate' => 'medical_certificate_path',
         'report_90_day' => 'employee_doc_6',
         'residence_notification' => 'employee_doc_7',
         'hometown_doc' => 'employee_doc_8',

--- a/resources/views/components/download-modals.blade.php
+++ b/resources/views/components/download-modals.blade.php
@@ -68,6 +68,10 @@
                                     <input class="form-check-input" type="checkbox" name="files[]" value="tor_ror_38" id="chkTorRor38">
                                     <label class="form-check-label" for="chkTorRor38">5. ทร. 38</label>
                                 </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="files[]" value="medical_certificate" id="chkMedicalCertificate" checked>
+                                    <label class="form-check-label" for="chkMedicalCertificate">ใบรับรองแพทย์ (Medical Certificate)</label>
+                                </div>
                             </div>
                             <!-- Column 2 -->
                             <div class="col-6">


### PR DESCRIPTION
Added the missing option to include the Medical Certificate (ใบรับรองแพทย์) in the bulk file download and PDF export functionality for employees.

---
*PR created automatically by Jules for task [909493611222980608](https://jules.google.com/task/909493611222980608) started by @nongjossss-commits*