### PR TITLE
Fix AI Enhance CDN Error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "name": "pro-worker-app",
             "dependencies": {
+                "@mediapipe/tasks-vision": "^0.10.21",
                 "bootstrap": "^5.3.8",
                 "pdf-lib": "^1.17.1"
             },
@@ -557,6 +558,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@mediapipe/tasks-vision": {
+            "version": "0.10.21",
+            "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.21.tgz",
+            "integrity": "sha512-TuhKH+credq4zLksGbYrnvJ1aLIWMc5r0UHwzxzql4BHECJwIAoBR61ZrqwGOW6ZmSBIzU1t4VtKj8hbxFaKeA==",
+            "license": "Apache-2.0"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "vite": "^7.0.4"
     },
     "dependencies": {
+        "@mediapipe/tasks-vision": "^0.10.21",
         "bootstrap": "^5.3.8",
         "pdf-lib": "^1.17.1"
     }

--- a/resources/views/employees/partials/_edit_scripts.blade.php
+++ b/resources/views/employees/partials/_edit_scripts.blade.php
@@ -331,7 +331,7 @@
                          if (loadingText) loadingText.textContent = 'กำลังโหลด AI Models...';
                          try {
                              // Use native dynamic import
-                             const mediapipe = await import("https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/vision_bundle.js");
+                             const mediapipe = await import("https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.21/vision_bundle.mjs");
                              window.ImageSegmenter = mediapipe.ImageSegmenter;
                              window.FilesetResolver = mediapipe.FilesetResolver;
                          } catch (error) {
@@ -348,7 +348,7 @@
 
                     // 2. Initialize Segmenter
                     const vision = await window.FilesetResolver.forVisionTasks(
-                        "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/wasm"
+                        "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.21/wasm"
                     );
 
                     const segmenter = await window.ImageSegmenter.createFromOptions(vision, {


### PR DESCRIPTION
**Problem:**
The "AI Enhance" feature for employee profile pictures failed with a "CDN Error" because the jsdelivr CDN URL for `@mediapipe/tasks-vision@0.10.3/vision_bundle.js` was returning a 404 Not Found.

**Solution:**
- Updated the CDN version to `0.10.21`.
- Updated the file extension to `.mjs` (`vision_bundle.mjs`), as the `.js` file is not available in that version.
- Also updated the WASM binary path to version `0.10.21`.
- Ran a local verification script to ensure the new models are correctly imported without throwing errors.

---
*PR created automatically by Jules for task [9342552128725000636](https://jules.google.com/task/9342552128725000636) started by @nongjossss-commits*