### PR TITLE
Fix Chat Widget JS Crash affecting other features

### DIFF
--- a/resources/views/components/chat-widget.blade.php
+++ b/resources/views/components/chat-widget.blade.php
@@ -88,7 +88,7 @@
                             :class="{'bg-light': item.type === 'group'}">
                             <div class="position-relative">
                                 <img :src="item.avatar_url" class="rounded-circle object-fit-cover border" width="40" height="40"
-                                     onerror="this.src='https://ui-avatars.com/api/?name=' + item.name + '&color=7F9CF5&background=EBF4FF'">
+                                     :onerror="`this.src='https://ui-avatars.com/api/?name=${item.name}&color=7F9CF5&background=EBF4FF'`">
                                 <span x-show="item.type === 'user' && item.is_online" class="position-absolute bottom-0 end-0 p-1 bg-success border border-white rounded-circle"></span>
                             </div>
                             <div class="flex-grow-1 lh-sm overflow-hidden">
@@ -146,7 +146,7 @@
                     </button>
 
                     <img :src="chat.avatar_url" class="rounded-circle object-fit-cover" width="32" height="32"
-                         onerror="this.src='https://ui-avatars.com/api/?name=' + chat.name + '&color=7F9CF5&background=EBF4FF'">
+                         :onerror="`this.src='https://ui-avatars.com/api/?name=${chat.name}&color=7F9CF5&background=EBF4FF'`">
                     <div class="lh-1">
                         <div class="fw-bold text-truncate" style="max-width: 150px;" x-text="chat.name"></div>
                         <small class="text-success" style="font-size: 0.7rem;" x-show="chat.type === 'user' && chat.is_online">{{ __('Online') }}</small>
@@ -339,7 +339,7 @@
                  @drop.prevent="handleDrop($event, 'chat_window', chat.uniqueKey)"
                  :title="chat.name">
                 <img :src="chat.avatar_url" class="w-100 h-100 object-fit-cover rounded-circle"
-                     onerror="this.src='https://ui-avatars.com/api/?name=' + chat.name + '&color=7F9CF5&background=EBF4FF'">
+                     :onerror="`this.src='https://ui-avatars.com/api/?name=${chat.name}&color=7F9CF5&background=EBF4FF'`">
                 <span x-show="chat.unreadCount > 0"
                       class="position-absolute top-0 end-0 translate-middle badge rounded-pill bg-danger border border-white"
                       style="font-size: 0.7rem; padding: 0.25em 0.5em !important; transform: translate(25%, -25%) !important;"
@@ -447,7 +447,7 @@
                             <div class="d-flex justify-content-between align-items-center mb-2 pb-1 border-bottom">
                                 <div class="d-flex align-items-center gap-2">
                                     <img :src="member.avatar_url" class="rounded-circle" width="30" height="30"
-                                         onerror="this.src='https://ui-avatars.com/api/?name=' + member.name">
+                                         :onerror="`this.src='https://ui-avatars.com/api/?name=${member.name}'`">
                                     <div class="lh-1">
                                         <div class="small fw-bold" x-text="member.name"></div>
                                         <div class="text-muted" style="font-size: 0.7rem;" x-text="member.role === 'admin' ? 'Admin' : 'Member'"></div>


### PR DESCRIPTION
Fixes an issue where clicking "AI Enhance" in the image cropper hangs on "Segmenting person...".
The issue was caused by a `ReferenceError` inside the global chat widget's image `onerror` callback, which crashed the whole page's JS execution context. Fixed the variable scopes in Alpine bindings within `chat-widget.blade.php`.

---
*PR created automatically by Jules for task [16225653033525565671](https://jules.google.com/task/16225653033525565671) started by @nongjossss-commits*