### PR TITLE
Fix VAT, headcount price, and profile builder preview bugs

### DIFF
--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -102,9 +102,9 @@ if (typeof window.financialManager === 'undefined') {
                 this.advanceItems = group.advance_items || [];
 
                 this.vatIncluded = !!data.vat_included;
-                this.vatRate = data.vat_rate || 7;
+                this.vatRate = data.vat_rate !== undefined && data.vat_rate !== null ? data.vat_rate : 7;
                 this.whtEnabled = !!data.wht_enabled;
-                this.whtRate = data.wht_rate || 3;
+                this.whtRate = data.wht_rate !== undefined && data.wht_rate !== null ? data.wht_rate : 3;
 
                 this.useCustomHeader = !!data.custom_header;
                 this.customHeader = data.custom_header || { name:'', address:'', tax_id:'', phone:'', logo:'' };

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -277,10 +277,15 @@
             }
 
             // Helper to get Tier Object for an Item
-            $getTierForItem = function($itemId, $tiers) {
+            $getTierForItem = function($item, $tiers) {
                 // Returns the entire tier object or null
                 foreach ($tiers as $tier) {
-                    if (in_array($itemId, $tier['item_ids'] ?? [])) return $tier;
+                    $itemIds = array_map('strval', $tier['item_ids'] ?? []);
+                    if (in_array(strval($item->id), $itemIds, true) ||
+                        in_array('emp_' . $item->employee_id, $itemIds, true) ||
+                        in_array(strval($item->employee_id), $itemIds, true)) {
+                        return $tier;
+                    }
                 }
                 return null;
             };
@@ -288,17 +293,22 @@
             // Helper to generate a unique key for grouping (Price + Note)
             // Actually, we should group by Tier Index or Unique Content
             // Since tiers don't have IDs, we use the tier object itself (or its properties)
-            $getTierKey = function($itemId, $tiers) {
+            $getTierKey = function($item, $tiers) {
                 foreach ($tiers as $idx => $tier) {
-                    if (in_array($itemId, $tier['item_ids'] ?? [])) return $idx; // Use Index as Key
+                    $itemIds = array_map('strval', $tier['item_ids'] ?? []);
+                    if (in_array(strval($item->id), $itemIds, true) ||
+                        in_array('emp_' . $item->employee_id, $itemIds, true) ||
+                        in_array(strval($item->employee_id), $itemIds, true)) {
+                        return $idx; // Use Index as Key
+                    }
                 }
                 return -1; // Not in tier
             };
 
             $vatIncluded = $financial['vat_included'] ?? false;
-            $vatRate = isset($financial['vat_rate']) ? (float)$financial['vat_rate'] : 7;
+            $vatRate = isset($financial['vat_rate']) && $financial['vat_rate'] !== '' ? (float)$financial['vat_rate'] : 7;
             $whtEnabled = $financial['wht_enabled'] ?? false;
-            $whtRate = isset($financial['wht_rate']) ? (float)$financial['wht_rate'] : 3;
+            $whtRate = isset($financial['wht_rate']) && $financial['wht_rate'] !== '' ? (float)$financial['wht_rate'] : 3;
 
             if ($vatRate <= 0) {
                 $serviceBase = $serviceTotal;
@@ -349,7 +359,7 @@
                                 {{-- Group items by Tier Index to preserve Note grouping --}}
                                 @php
                                     $tierGroups = $items->groupBy(function($item) use ($getTierKey, $pricingTiers) {
-                                        return $getTierKey($item->id, $pricingTiers);
+                                        return $getTierKey($item, $pricingTiers);
                                     });
                                 @endphp
 

--- a/resources/views/finance/profiles/builder.blade.php
+++ b/resources/views/finance/profiles/builder.blade.php
@@ -183,11 +183,11 @@
 
                         <!-- Signature Draggable -->
                         <img x-show="formData.signature_url" :src="formData.signature_url" id="drag-signature" class="draggable-asset" data-type="signature"
-                             :style="getAssetStyle('signature')">
+                             :style="getAssetStyle('signature') + ' z-index: 10;'">
 
                         <!-- Stamp Draggable -->
                         <img x-show="formData.stamp_url" :src="formData.stamp_url" id="drag-stamp" class="draggable-asset" data-type="stamp"
-                             :style="getAssetStyle('stamp')">
+                             :style="getAssetStyle('stamp') + ' z-index: 10;'">
                     </div>
 
                 </div>


### PR DESCRIPTION
1. **VAT Calculation Bug:** Fixed an issue where setting `vat_rate` to `0` would fall back to the default `7%`. Updated `financial-manager.js` and `layout.blade.php` to use strict null/undefined/empty string checks instead of truthy evaluations (e.g. `|| 7` or `?: 7`).
2. **Employee Headcount Price for Manual Bills:** Updated `getTierKey` and `getTierForItem` logic in `ProductionDocumentController.php` to correctly match `$item` against the string representation of IDs.
3. **Profile Builder Asset Preview:** Added `z-index: 10` to signature and stamp preview images in `builder.blade.php` to prevent them from hiding behind other UI elements when uploaded.

---
*PR created automatically by Jules for task [3451255855318208135](https://jules.google.com/task/3451255855318208135) started by @nongjossss-commits*