### PR TITLE
Fix PDF Document VAT rate overriding and missing tier prices

### DIFF
--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -147,9 +147,21 @@ class ProductionDocumentController extends Controller
                             // or stores integers. Ensure we match against string representations of IDs.
                             // FinancialHubController@storeManual creates tiers like [ 'item_ids' => [1, 2, 3] ]
                             // where these integers correspond to production_items.id
-                            return in_array(strval($item->id), $itemIds, true) ||
-                                   in_array('emp_' . $item->employee_id, $itemIds, true) ||
-                                   in_array(strval($item->employee_id), $itemIds, true);
+
+                            // Also handle array of objects if frontend saved it incorrectly
+                            $flatIds = [];
+                            foreach ($t['item_ids'] ?? [] as $idVal) {
+                                if (is_array($idVal) && isset($idVal['id'])) {
+                                    $flatIds[] = strval($idVal['id']);
+                                } else {
+                                    $flatIds[] = strval($idVal);
+                                }
+                            }
+
+                            return in_array(strval($item->id), $flatIds, true) ||
+                                   in_array('emp_' . $item->employee_id, $flatIds, true) ||
+                                   in_array(strval($item->employee_id), $flatIds, true) ||
+                                   in_array('item_' . $item->id, $flatIds, true);
                         });
 
                         if ($tier) {

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -280,10 +280,18 @@
             $getTierForItem = function($item, $tiers) {
                 // Returns the entire tier object or null
                 foreach ($tiers as $tier) {
-                    $itemIds = array_map('strval', $tier['item_ids'] ?? []);
-                    if (in_array(strval($item->id), $itemIds, true) ||
-                        in_array('emp_' . $item->employee_id, $itemIds, true) ||
-                        in_array(strval($item->employee_id), $itemIds, true)) {
+                    $flatIds = [];
+                    foreach ($tier['item_ids'] ?? [] as $idVal) {
+                        if (is_array($idVal) && isset($idVal['id'])) {
+                            $flatIds[] = strval($idVal['id']);
+                        } else {
+                            $flatIds[] = strval($idVal);
+                        }
+                    }
+                    if (in_array(strval($item->id), $flatIds, true) ||
+                        in_array('emp_' . $item->employee_id, $flatIds, true) ||
+                        in_array(strval($item->employee_id), $flatIds, true) ||
+                        in_array('item_' . $item->id, $flatIds, true)) {
                         return $tier;
                     }
                 }
@@ -295,10 +303,18 @@
             // Since tiers don't have IDs, we use the tier object itself (or its properties)
             $getTierKey = function($item, $tiers) {
                 foreach ($tiers as $idx => $tier) {
-                    $itemIds = array_map('strval', $tier['item_ids'] ?? []);
-                    if (in_array(strval($item->id), $itemIds, true) ||
-                        in_array('emp_' . $item->employee_id, $itemIds, true) ||
-                        in_array(strval($item->employee_id), $itemIds, true)) {
+                    $flatIds = [];
+                    foreach ($tier['item_ids'] ?? [] as $idVal) {
+                        if (is_array($idVal) && isset($idVal['id'])) {
+                            $flatIds[] = strval($idVal['id']);
+                        } else {
+                            $flatIds[] = strval($idVal);
+                        }
+                    }
+                    if (in_array(strval($item->id), $flatIds, true) ||
+                        in_array('emp_' . $item->employee_id, $flatIds, true) ||
+                        in_array(strval($item->employee_id), $flatIds, true) ||
+                        in_array('item_' . $item->id, $flatIds, true)) {
                         return $idx; // Use Index as Key
                     }
                 }

--- a/resources/views/production/documents/credit_note.blade.php
+++ b/resources/views/production/documents/credit_note.blade.php
@@ -24,7 +24,7 @@
             $refundAmount = request('refund_amount', 0);
 
             // VAT Logic
-            $vatRate = isset($production->financial_data['vat_rate']) ? (float)$production->financial_data['vat_rate'] : 7;
+            $vatRate = isset($production->financial_data['vat_rate']) && $production->financial_data['vat_rate'] !== '' ? (float)$production->financial_data['vat_rate'] : 7;
             $vatIncluded = $production->financial_data['vat_included'] ?? false;
 
             // Calculate Paid Heads (reverse engineer)

--- a/resources/views/production/documents/invoice.blade.php
+++ b/resources/views/production/documents/invoice.blade.php
@@ -23,7 +23,7 @@
         @php
             $grandTotal = 0;
             // Config
-            $vatRate = isset($financial['vat_rate']) ? (float)$financial['vat_rate'] : 7;
+            $vatRate = isset($financial['vat_rate']) && $financial['vat_rate'] !== '' ? (float)$financial['vat_rate'] : 7;
             $vatIncluded = $financial['vat_included'] ?? false;
             $whtEnabled = $financial['wht_enabled'] ?? false;
             $whtRate = isset($financial['wht_rate']) ? (float)$financial['wht_rate'] : 3;

--- a/resources/views/production/documents/quotation.blade.php
+++ b/resources/views/production/documents/quotation.blade.php
@@ -22,7 +22,7 @@
             $fixedTotal = $financial['fixed_base_amount'] ?? ($financial['total_amount'] ?? 0);
 
             // Tax Settings
-            $vatRate = isset($financial['vat_rate']) ? (float)$financial['vat_rate'] : 7;
+            $vatRate = isset($financial['vat_rate']) && $financial['vat_rate'] !== '' ? (float)$financial['vat_rate'] : 7;
             $vatIncluded = $financial['vat_included'] ?? false;
             $whtEnabled = $financial['wht_enabled'] ?? false;
             $whtRate = isset($financial['wht_rate']) ? (float)$financial['wht_rate'] : 3;

--- a/resources/views/production/documents/receipt.blade.php
+++ b/resources/views/production/documents/receipt.blade.php
@@ -18,7 +18,7 @@
             $grandTotal = 0;
 
             // Tax Config
-            $vatRate = isset($financial['vat_rate']) ? (float)$financial['vat_rate'] : 7;
+            $vatRate = isset($financial['vat_rate']) && $financial['vat_rate'] !== '' ? (float)$financial['vat_rate'] : 7;
             $vatIncluded = $financial['vat_included'] ?? false;
             $whtEnabled = $financial['wht_enabled'] ?? false;
             $whtRate = isset($financial['wht_rate']) ? (float)$financial['wht_rate'] : 3;


### PR DESCRIPTION
Fixes two key issues in Manual Billing documents:
1. **VAT 0% issue**: Replaces ternary checks on `vat_rate` with explicit checks against empty strings to correctly retain `0` without falling back to `7`.
2. **Missing Tier Prices in Employee List**: Modifies the search logic for matching `employee_id`/`item_id` to pricing tiers. Extends logic to handle scenarios where `$tier['item_ids']` are saved as arrays of objects (from the frontend payload issue in `FinancialHubController`) ensuring employee per-head prices correctly display.

---
*PR created automatically by Jules for task [15330513865885446605](https://jules.google.com/task/15330513865885446605) started by @nongjossss-commits*