### PR TITLE
Fix: Correct preg_replace delimiter for PDF filename sanitization

### DIFF
--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -705,7 +705,7 @@ class PdfGeneratorService
         $filename = "{$template->name}_{$employeeName}_{$employee->id}.pdf";
 
         // Sanitize (allow Thai characters, remove system reserved chars)
-        $filename = preg_replace('/[\\\\/:*?"<>|]/', '_', $filename);
+        $filename = preg_replace('~[\\\\/:*?"<>|]~', '_', $filename);
 
         return $filename;
     }


### PR DESCRIPTION
This PR fixes a bug in the automated PDF printing and zipping feature where the process fails with a `preg_replace(): Unknown modifier ':'` error.

**Root cause:**
In `app/Services/PdfGeneratorService.php`, the regular expression intended to sanitize the filename (stripping reserved characters like `/`, `:`, etc.) was defined using the forward slash `/` as its delimiter:
```php
preg_replace('/[\\\\/:*?"<>|]/', '_', $filename);
```
Since the target pattern itself contained a forward slash `/` that was not escaped, PHP parsed the subsequent character `:` as an unknown regex modifier, resulting in a fatal error and stopping the document generation process.

**Fix:**
Changed the regex delimiter from `/` to `~` (tilde) so that the forward slash inside the pattern is correctly treated as a literal character to be matched:
```php
preg_replace('~[\\\\/:*?"<>|]~', '_', $filename);
```

This prevents the error and restores the functionality for generating automated PDFs and zip file downloads.

---
*PR created automatically by Jules for task [1918042451923235118](https://jules.google.com/task/1918042451923235118) started by @nongjossss-commits*