### PR TITLE
Fix VAT calculation and per-head pricing assignment in manual bills

### DIFF
--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -148,8 +148,8 @@ class ProductionDocumentController extends Controller
                             // FinancialHubController@storeManual creates tiers like [ 'item_ids' => [1, 2, 3] ]
                             // where these integers correspond to production_items.id
                             return in_array(strval($item->id), $itemIds, true) ||
-                                   in_array('emp_' . $item->employee_id, $itemIds, true) ||
-                                   in_array(strval($item->employee_id), $itemIds, true);
+                                   ($item->employee_id && in_array('emp_' . $item->employee_id, $itemIds, true)) ||
+                                   ($item->employee_id && in_array(strval($item->employee_id), $itemIds, true));
                         });
 
                         if ($tier) {

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -281,9 +281,16 @@
                 // Returns the entire tier object or null
                 foreach ($tiers as $tier) {
                     $itemIds = array_map('strval', $tier['item_ids'] ?? []);
+                    // Manual bills use $item->id without prefix. Standard bills use emp_{employee_id} or just employee_id
                     if (in_array(strval($item->id), $itemIds, true) ||
-                        in_array('emp_' . $item->employee_id, $itemIds, true) ||
-                        in_array(strval($item->employee_id), $itemIds, true)) {
+                        ($item->employee_id && in_array('emp_' . $item->employee_id, $itemIds, true)) ||
+                        ($item->employee_id && in_array(strval($item->employee_id), $itemIds, true))) {
+                        return $tier;
+                    }
+                }
+                // Fallback to default tier if empty or unnamed
+                foreach ($tiers as $tier) {
+                    if (empty($tier['item_ids']) || ($tier['name'] ?? '') === 'Default Tier') {
                         return $tier;
                     }
                 }
@@ -297,9 +304,15 @@
                 foreach ($tiers as $idx => $tier) {
                     $itemIds = array_map('strval', $tier['item_ids'] ?? []);
                     if (in_array(strval($item->id), $itemIds, true) ||
-                        in_array('emp_' . $item->employee_id, $itemIds, true) ||
-                        in_array(strval($item->employee_id), $itemIds, true)) {
+                        ($item->employee_id && in_array('emp_' . $item->employee_id, $itemIds, true)) ||
+                        ($item->employee_id && in_array(strval($item->employee_id), $itemIds, true))) {
                         return $idx; // Use Index as Key
+                    }
+                }
+                // Fallback index
+                foreach ($tiers as $idx => $tier) {
+                    if (empty($tier['item_ids']) || ($tier['name'] ?? '') === 'Default Tier') {
+                        return $idx;
                     }
                 }
                 return -1; // Not in tier

--- a/resources/views/production/documents/credit_note.blade.php
+++ b/resources/views/production/documents/credit_note.blade.php
@@ -24,7 +24,7 @@
             $refundAmount = request('refund_amount', 0);
 
             // VAT Logic
-            $vatRate = isset($production->financial_data['vat_rate']) ? (float)$production->financial_data['vat_rate'] : 7;
+            $vatRate = isset($production->financial_data['vat_rate']) && $production->financial_data['vat_rate'] !== '' ? (float)$production->financial_data['vat_rate'] : 7;
             $vatIncluded = $production->financial_data['vat_included'] ?? false;
 
             // Calculate Paid Heads (reverse engineer)

--- a/resources/views/production/documents/invoice.blade.php
+++ b/resources/views/production/documents/invoice.blade.php
@@ -23,7 +23,7 @@
         @php
             $grandTotal = 0;
             // Config
-            $vatRate = isset($financial['vat_rate']) ? (float)$financial['vat_rate'] : 7;
+            $vatRate = isset($financial['vat_rate']) && $financial['vat_rate'] !== '' ? (float)$financial['vat_rate'] : 7;
             $vatIncluded = $financial['vat_included'] ?? false;
             $whtEnabled = $financial['wht_enabled'] ?? false;
             $whtRate = isset($financial['wht_rate']) ? (float)$financial['wht_rate'] : 3;

--- a/resources/views/production/documents/quotation.blade.php
+++ b/resources/views/production/documents/quotation.blade.php
@@ -22,7 +22,7 @@
             $fixedTotal = $financial['fixed_base_amount'] ?? ($financial['total_amount'] ?? 0);
 
             // Tax Settings
-            $vatRate = isset($financial['vat_rate']) ? (float)$financial['vat_rate'] : 7;
+            $vatRate = isset($financial['vat_rate']) && $financial['vat_rate'] !== '' ? (float)$financial['vat_rate'] : 7;
             $vatIncluded = $financial['vat_included'] ?? false;
             $whtEnabled = $financial['wht_enabled'] ?? false;
             $whtRate = isset($financial['wht_rate']) ? (float)$financial['wht_rate'] : 3;

--- a/resources/views/production/documents/receipt.blade.php
+++ b/resources/views/production/documents/receipt.blade.php
@@ -18,7 +18,7 @@
             $grandTotal = 0;
 
             // Tax Config
-            $vatRate = isset($financial['vat_rate']) ? (float)$financial['vat_rate'] : 7;
+            $vatRate = isset($financial['vat_rate']) && $financial['vat_rate'] !== '' ? (float)$financial['vat_rate'] : 7;
             $vatIncluded = $financial['vat_included'] ?? false;
             $whtEnabled = $financial['wht_enabled'] ?? false;
             $whtRate = isset($financial['wht_rate']) ? (float)$financial['wht_rate'] : 3;


### PR DESCRIPTION
Fixes issues where manual bills incorrectly applied a 7% VAT despite being set to 0%, and failed to properly break down and assign per-head pricing due to unmapped pricing tiers.

---
*PR created automatically by Jules for task [16818686451426045128](https://jules.google.com/task/16818686451426045128) started by @nongjossss-commits*