### PR TITLE
UI: Move appointment updated by info below the date box

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -367,7 +367,7 @@
                         </div>
                     </div>
 
-                    <div x-show="!isEditing" class="d-flex align-items-center gap-2 cursor-pointer position-relative"
+                    <div x-show="!isEditing" class="cursor-pointer position-relative"
                          @click="isEditing = true; $nextTick(() => initFlatpickr())"
                          :class="{ 'opacity-50': isAppCompleted }">
 
@@ -383,7 +383,7 @@
                          </div>
 
                          <!-- Appt Updated By -->
-                         <div x-show="updatedByName" class="mt-1 text-end" style="font-size: 0.65rem;" x-cloak>
+                         <div x-show="updatedByName" class="mt-1 text-start" style="font-size: 0.65rem;" x-cloak>
                             <span class="text-muted"><i class="bi bi-clock"></i> <span x-text="updatedAtHuman"></span> โดย <span x-text="updatedByName"></span></span>
                          </div>
                     </div>


### PR DESCRIPTION
Moved the 'updated by' and timestamp information in the employee card from beside the appointment box to directly underneath it to save horizontal space and improve layout structure.

- Removed d-flex and align-items-center classes from the parent container
- Changed text alignment from end (right) to start (left)
- Allowed natural block flow for vertical stacking

---
*PR created automatically by Jules for task [9897708533930927952](https://jules.google.com/task/9897708533930927952) started by @nongjossss-commits*