### PR TITLE
Fix manual bill VAT saving and zero per-head price calculation

### DIFF
--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -102,7 +102,7 @@ if (typeof window.financialManager === 'undefined') {
                 this.advanceItems = group.advance_items || [];
 
                 this.vatIncluded = !!data.vat_included;
-                this.vatRate = data.vat_rate !== undefined && data.vat_rate !== null ? data.vat_rate : 7;
+                this.vatRate = data.vat_rate !== undefined && data.vat_rate !== null && data.vat_rate !== '' ? parseFloat(data.vat_rate) : 7;
                 this.whtEnabled = !!data.wht_enabled;
                 this.whtRate = data.wht_rate !== undefined && data.wht_rate !== null ? data.wht_rate : 3;
 
@@ -857,7 +857,7 @@ if (typeof window.financialManager === 'undefined') {
                     pricing_tiers: this.pricingTiers,
                     discount: this.discount,
                     vat_included: this.vatIncluded,
-                    vat_rate: this.vatRate,
+                    vat_rate: parseFloat(this.vatRate),
                     wht_enabled: this.whtEnabled,
                     wht_rate: this.whtRate,
                     advance_items: this.advanceItems,

--- a/resources/js/financial-manager.js
+++ b/resources/js/financial-manager.js
@@ -94,7 +94,7 @@ if (typeof window.financialManager === 'undefined') {
                 this.advanceItems = group.advance_items || [];
 
                 this.vatIncluded = !!data.vat_included;
-                this.vatRate = data.vat_rate || 7;
+                this.vatRate = data.vat_rate !== undefined && data.vat_rate !== null && data.vat_rate !== '' ? parseFloat(data.vat_rate) : 7;
                 this.whtEnabled = !!data.wht_enabled;
                 this.whtRate = data.wht_rate || 3;
 
@@ -825,7 +825,7 @@ if (typeof window.financialManager === 'undefined') {
                     pricing_tiers: this.pricingTiers,
                     discount: this.discount,
                     vat_included: this.vatIncluded,
-                    vat_rate: this.vatRate,
+                    vat_rate: parseFloat(this.vatRate),
                     wht_enabled: this.whtEnabled,
                     wht_rate: this.whtRate,
                     advance_items: this.advanceItems,

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -309,7 +309,8 @@
                         return $idx; // Use Index as Key
                     }
                 }
-                // Fallback index
+
+                // Fallback: If not found but default tier exists, return default tier index
                 foreach ($tiers as $idx => $tier) {
                     if (empty($tier['item_ids']) || ($tier['name'] ?? '') === 'Default Tier') {
                         return $idx;
@@ -381,10 +382,19 @@
                                         $count = $groupedItems->count();
                                         // Get tier data
                                         $tier = ($tierIdx >= 0 && isset($pricingTiers[$tierIdx])) ? $pricingTiers[$tierIdx] : null;
-                                        $price = $tier ? ($tier['price'] ?? 0) : 0; // Fallback price? Or should we calc from transaction?
 
-                                        // Wait, the transaction amount is fixed. We are just "breaking it down".
-                                        // If transaction has partial items from a tier, we show partial count.
+                                        // The transaction amount is fixed for the installment, meaning if the installment
+                                        // spans multiple employees, we should distribute the total transaction amount
+                                        // by proportional tier price if available, or flat average per head if no tiers
+                                        $totalEmployeesInTransaction = $items->count();
+                                        if ($totalEmployeesInTransaction > 0) {
+                                            // Simple average: transaction amount / total employees.
+                                            // We assign the same average price to every item within this transaction grouping.
+                                            $price = $amount / $totalEmployeesInTransaction;
+                                        } else {
+                                            $price = 0;
+                                        }
+
                                         $subtotal = $price * $count;
 
                                         $desc = $t->notes ?: ucfirst(str_replace('_', ' ', $t->type));


### PR DESCRIPTION
- Fixes an issue in the Financial Manager frontend where inputting '0' as the VAT rate would revert to '7' due to a JS truthy fallback. 
- Fixes an issue where Manual Bills attached with employees showed '0.00' for the per-head price on the generated invoice, by calculating the average rate manually using the total amount and employee count.

---
*PR created automatically by Jules for task [12198851470120198081](https://jules.google.com/task/12198851470120198081) started by @nongjossss-commits*