### PR TITLE
Isolate Employee Request Numbers by Menu Context

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -105,18 +105,20 @@ class ProductionController extends Controller
                                 $addrQ->filterByAddress($search);
                             });
                       })
-                      ->orWhereHas('items.employee', function($emp) use ($search, $cleanedSearch) {
-                          $emp->where('employeeNameTh', 'like', "%{$search}%")
-                              ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                              ->orWhere('employeePassport', 'like', "%{$search}%")
-                              ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
-                              ->orWhere('employee_id_number', 'like', "%{$search}%")
-                              ->orWhere('name_list_number', 'like', "%{$search}%")
-                              ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                              ->orWhere('request_number', 'like', "%{$search}%")
-                              ->orWhere('employer_employee_id', 'like', "%{$search}%")
-                              ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                              ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                      ->orWhereHas('items', function($itemQuery) use ($search, $cleanedSearch) {
+                          $itemQuery->where('request_number', 'like', "%{$search}%")
+                              ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
+                                  $emp->where('employeeNameTh', 'like', "%{$search}%")
+                                      ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                                      ->orWhere('employeePassport', 'like', "%{$search}%")
+                                      ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
+                                      ->orWhere('employee_id_number', 'like', "%{$search}%")
+                                      ->orWhere('name_list_number', 'like', "%{$search}%")
+                                      ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                                      ->orWhere('employer_employee_id', 'like', "%{$search}%")
+                                      ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                                      ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                              });
                       })
                       ->orWhereHas('creator', function($creator) use ($search) {
                           $creator->where('name', 'like', "%{$search}%");
@@ -212,18 +214,20 @@ class ProductionController extends Controller
                             ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                             ->orWhere(function($addrQ) use ($search) { $addrQ->filterByAddress($search); });
                       })
-                      ->orWhereHas('items.employee', function($emp) use ($search, $cleanedSearch) {
-                          $emp->where('employeeNameTh', 'like', "%{$search}%")
-                              ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                              ->orWhere('employeePassport', 'like', "%{$search}%")
-                              ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
-                              ->orWhere('employee_id_number', 'like', "%{$search}%")
-                              ->orWhere('name_list_number', 'like', "%{$search}%")
-                              ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                              ->orWhere('request_number', 'like', "%{$search}%")
-                              ->orWhere('employer_employee_id', 'like', "%{$search}%")
-                              ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                              ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                      ->orWhereHas('items', function($itemQuery) use ($search, $cleanedSearch) {
+                          $itemQuery->where('request_number', 'like', "%{$search}%")
+                              ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
+                                  $emp->where('employeeNameTh', 'like', "%{$search}%")
+                                      ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                                      ->orWhere('employeePassport', 'like', "%{$search}%")
+                                      ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
+                                      ->orWhere('employee_id_number', 'like', "%{$search}%")
+                                      ->orWhere('name_list_number', 'like', "%{$search}%")
+                                      ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                                      ->orWhere('employer_employee_id', 'like', "%{$search}%")
+                                      ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                                      ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                              });
                       })
                       ->orWhereHas('employer.jobOwner', function($owner) use ($search) {
                           $owner->where('name', 'like', "%{$search}%");

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -77,18 +77,20 @@ class WorkflowController extends Controller
                             $addrQ->filterByAddress($search);
                         });
                   })
-                  ->orWhereHas('items.employee', function($emp) use ($search, $cleanedSearch) {
-                      $emp->where('employeeNameTh', 'like', "%{$search}%")
-                          ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                          ->orWhere('employeePassport', 'like', "%{$search}%")
-                          ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
-                          ->orWhere('employee_id_number', 'like', "%{$search}%")
-                          ->orWhere('name_list_number', 'like', "%{$search}%")
-                          ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                          ->orWhere('request_number', 'like', "%{$search}%")
-                              ->orWhere('employer_employee_id', 'like', "%{$search}%")
-                          ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                          ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                  ->orWhereHas('items', function($itemQuery) use ($search, $cleanedSearch) {
+                      $itemQuery->where('request_number', 'like', "%{$search}%")
+                          ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
+                              $emp->where('employeeNameTh', 'like', "%{$search}%")
+                                  ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                                  ->orWhere('employeePassport', 'like', "%{$search}%")
+                                  ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
+                                  ->orWhere('employee_id_number', 'like', "%{$search}%")
+                                  ->orWhere('name_list_number', 'like', "%{$search}%")
+                                  ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                                  ->orWhere('employer_employee_id', 'like', "%{$search}%")
+                                  ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                                  ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                          });
                   })
                   ->orWhereHas('creator', function($creator) use ($search) {
                       $creator->where('name', 'like', "%{$search}%");


### PR DESCRIPTION
This change ensures that `request_number` values are isolated for an employee across different application menus (Pre Production / Workflow, Registration Resolution, Renewal Resolution). This solves the issue where updating a request number in one menu would overwrite and mess up the request number shown in other menus for the same employee. We achieved this by making the `request_number` context-aware (either tied to the `production_item` for workflow tasks, or using dedicated columns on the `employees` table for resolution statuses), while keeping the original `request_number` field intact for general profile use.

---
*PR created automatically by Jules for task [10958708993331881907](https://jules.google.com/task/10958708993331881907) started by @nongjossss-commits*