### PR TITLE
Fix finance tab functionality and show last step name for employees

### DIFF
--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -271,7 +271,7 @@ if (typeof window.financialManager === 'undefined') {
                     if (usedItemIds.has(item.id)) return; // Locked by installment
 
                     if (item.employee_id) itemsByEmpId[item.employee_id] = item.id;
-                    list.push({ ...item, type: 'item' });
+                    list.push({ ...item, type: 'item', last_step_name: item.last_step_name });
                 });
 
                 // 2. Candidates
@@ -289,6 +289,7 @@ if (typeof window.financialManager === 'undefined') {
                         insurance_type: emp.insurance_type,
                         passport: emp.passport,
                         employee_id: emp.id,
+                        last_step_name: emp.last_step_name,
                         type: 'employee'
                     });
                 });
@@ -341,6 +342,7 @@ if (typeof window.financialManager === 'undefined') {
                         nationality: item.nationality,
                         insurance_type: item.insurance_type,
                         passport: item.passport,
+                        last_step_name: item.last_step_name,
                         type: 'item'
                     });
                 });
@@ -360,6 +362,7 @@ if (typeof window.financialManager === 'undefined') {
                             nationality: emp.nationality,
                             insurance_type: emp.insurance_type,
                             passport: emp.passport,
+                            last_step_name: emp.last_step_name,
                             type: 'employee'
                         });
                     });
@@ -409,6 +412,7 @@ if (typeof window.financialManager === 'undefined') {
                             nationality: item.nationality,
                             insurance_type: item.insurance_type,
                             passport: item.passport,
+                            last_step_name: item.last_step_name,
                             type: 'item',
                             attached: isAttached
                         });
@@ -429,6 +433,7 @@ if (typeof window.financialManager === 'undefined') {
                         nationality: emp.nationality,
                         insurance_type: emp.insurance_type,
                         passport: emp.passport,
+                        last_step_name: emp.last_step_name,
                         type: 'employee',
                         attached: false
                     });
@@ -650,8 +655,10 @@ if (typeof window.financialManager === 'undefined') {
                         .then(res => res.json())
                         .then(data => {
                             if (data.success) {
-                                this.financialGroups.push(data.group);
-                                this.switchGroup(data.group.id);
+                                // Ensure reactivity and defaults for empty arrays
+                                const newGroup = { ...data.group, transactions: [] };
+                                this.financialGroups = [...this.financialGroups, newGroup];
+                                this.switchGroup(newGroup.id);
                             }
                         });
                     }
@@ -704,7 +711,11 @@ if (typeof window.financialManager === 'undefined') {
                         .then(data => {
                             if (data.success) {
                                  const group = this.financialGroups.find(g => g.id === groupId);
-                                 if(group) group.name = result.value;
+                                 if(group) {
+                                     group.name = result.value;
+                                     // Trigger reactivity
+                                     this.financialGroups = [...this.financialGroups];
+                                 }
                             }
                         });
                     }

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -3,6 +3,15 @@
     financialGroups: {{ json_encode($production->financialGroups) }},
     transactions: {{ json_encode($production->financialGroups->pluck('transactions')->flatten()) }},
     productionItems: {{ json_encode($production->items->map(function($item) {
+        $lastStepName = null;
+        if (request()->is('production/registration*') && $item->employee) {
+            $lastStepName = $item->employee->registrationSteps->sortByDesc('order')->first()?->name;
+        } elseif (request()->is('production/renewal*') && $item->employee) {
+            $lastStepName = $item->employee->registrationSteps->sortByDesc('order')->first()?->name; // Renewal uses registrationSteps relation logic
+        } else {
+            $lastStepName = $item->completedWorkTypeSteps->sortByDesc('order')->first()?->name;
+        }
+
         return [
             'id' => $item->id,
             'name' => $item->employee ? ($item->employee->name_th ?? $item->employee->name_en) : 'New Employee',
@@ -12,10 +21,16 @@
             'nationality' => $item->employee ? $item->employee->employeeNationality : '',
             'insurance_type' => $item->employee ? $item->employee->insurance_type : '',
             'passport' => $item->employee ? $item->employee->employeePassport : '',
-            'employee_id' => $item->employee_id
+            'employee_id' => $item->employee_id,
+            'last_step_name' => $lastStepName
         ];
     })) }},
     employees: {{ json_encode(($employees ?? collect())->map(function($emp) {
+        $lastStepName = null;
+        if (request()->is('production/registration*') || request()->is('production/renewal*')) {
+            $lastStepName = $emp->registrationSteps->sortByDesc('order')->first()?->name;
+        }
+
         return [
             'id' => $emp->id,
             'name' => $emp->employeeNameTh ?? $emp->employeeNameEn,
@@ -25,6 +40,7 @@
             'nationality' => $emp->employeeNationality,
             'insurance_type' => $emp->insurance_type,
             'passport' => $emp->employeePassport,
+            'last_step_name' => $lastStepName
         ];
     })) }},
     productionId: {{ $production->id }},
@@ -651,6 +667,10 @@ class="row">
                                             <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
                                                 <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
                                             </template>
+                                            <!-- Last Step Badge -->
+                                            <template x-if="item.last_step_name">
+                                                <span class="badge border border-primary text-primary rounded-pill ms-1" style="font-size: 0.6rem;" x-text="item.last_step_name"></span>
+                                            </template>
                                         </div>
                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.75rem;">
                                              <span class="text-truncate" x-text="item.nationality"></span>
@@ -835,6 +855,10 @@ class="row">
                                                             <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
                                                                 <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
                                                             </template>
+                                                            <!-- Last Step Badge -->
+                                                            <template x-if="item.last_step_name">
+                                                                <span class="badge border border-primary text-primary rounded-pill ms-1" style="font-size: 0.6rem;" x-text="item.last_step_name"></span>
+                                                            </template>
                                                         </div>
                                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.7rem;">
                                                              <span class="text-truncate" x-text="item.nationality"></span>
@@ -970,6 +994,10 @@ class="row">
                                                             </template>
                                                             <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
                                                                 <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
+                                                            </template>
+                                                            <!-- Last Step Badge -->
+                                                            <template x-if="item.last_step_name">
+                                                                <span class="badge border border-primary text-primary rounded-pill ms-1" style="font-size: 0.6rem;" x-text="item.last_step_name"></span>
                                                             </template>
                                                         </div>
                                                         <div class="d-flex align-items-center gap-1 text-muted" style="font-size: 0.7rem;">

--- a/setup_data.php
+++ b/setup_data.php
@@ -1,0 +1,28 @@
+<?php
+require __DIR__.'/vendor/autoload.php';
+$app = require_once __DIR__.'/bootstrap/app.php';
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+
+use App\Models\Employer;
+use App\Models\Employee;
+use App\Models\RegistrationStep;
+use App\Models\ProductionOrder;
+use App\Models\ProductionItem;
+
+$employer = Employer::create(['employerId' => 'EMP1', 'employerNameTh' => 'Test Employer 1', 'employerNameEn' => 'Test Employer 1']);
+
+$step1 = RegistrationStep::create(['name' => 'Step 1', 'type' => 'registration', 'order' => 1]);
+$step2 = RegistrationStep::create(['name' => 'Step 2', 'type' => 'registration', 'order' => 2]);
+
+$emp1 = Employee::create(['employer_id' => $employer->id, 'employeeNameTh' => 'Somchai', 'employeePassport' => 'P12345', 'status' => 'registration_pending']);
+$emp1->registrationSteps()->sync([$step1->id => ['completed_at' => now()], $step2->id => ['completed_at' => now()]]);
+
+$emp2 = Employee::create(['employer_id' => $employer->id, 'employeeNameTh' => 'Somsri', 'employeePassport' => '-', 'status' => 'registration_pending']);
+$emp2->registrationSteps()->sync([$step1->id => ['completed_at' => now()]]);
+
+$order = ProductionOrder::create(['employer_id' => $employer->id, 'project_name' => 'Test Registration']);
+ProductionItem::create(['production_order_id' => $order->id, 'employee_id' => $emp1->id, 'status' => 'pending']);
+ProductionItem::create(['production_order_id' => $order->id, 'employee_id' => $emp2->id, 'status' => 'pending']);
+
+echo "Data seeded successfully.\n";


### PR DESCRIPTION
- Fix tab rename bug in `public/js/financial-manager.js` by triggering AlpineJS reactivity using spread syntax on `this.financialGroups`.
- Fix add tab bug in `public/js/financial-manager.js` by explicitly initializing `transactions: []` when pushing new groups.
- Inject `last_step_name` into `productionItems` and `employees` payload in `financial-tab.blade.php`.
- Conditionally read `registrationSteps` for Registration/Renewal pages and `completedWorkTypeSteps` for standard Production menus to determine the final step.
- Update `financial-manager.js` to parse and map `last_step_name` to `availableItems`, `allEmployeesForTier`, and `editModalItems`.
- Render a badge in UI for `last_step_name` beside passport status.

---
*PR created automatically by Jules for task [17673696828971127748](https://jules.google.com/task/17673696828971127748) started by @nongjossss-commits*