### PR TITLE
Fix super-admin and admin role access parity

### DIFF
--- a/app/Http/Controllers/Admin/TicketController.php
+++ b/app/Http/Controllers/Admin/TicketController.php
@@ -31,7 +31,7 @@ class TicketController extends Controller
         // Admin and Staff can see ALL tickets.
         // Other roles (like 'caretaker') are restricted to assigned employers.
         $currentUser = Auth::user();
-        $canViewAllTickets = $currentUser->hasRole(['admin', 'staff']);
+        $canViewAllTickets = $currentUser->hasRole(['super-admin', 'admin', 'staff']);
 
         if ($employerId) {
             // Show tickets list for a specific employer
@@ -128,7 +128,7 @@ class TicketController extends Controller
         // Authorization Check for Caretakers
         // Admin/Staff can view all. Caretakers can only view if assigned to the employer.
         $currentUser = Auth::user();
-        $canViewAllTickets = $currentUser->hasRole(['admin', 'staff']);
+        $canViewAllTickets = $currentUser->hasRole(['super-admin', 'admin', 'staff']);
 
         if (!$canViewAllTickets) {
             // Check assignment

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -23,12 +23,12 @@ class ChatController extends Controller
         $currentUser = Auth::user();
 
         // 1. STRICT BLOCK: Employers cannot access chat at all
-        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
             return response()->json([], 403);
         }
 
         // Permission Check
-        if (!$currentUser->can('use-chat') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if (!$currentUser->can('use-chat') && !$currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
             return response()->json([], 403);
         }
 
@@ -37,7 +37,7 @@ class ChatController extends Controller
                      ->where('status', 'active');
 
         // --- User Access Control Logic ---
-        if ($currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if ($currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
             $userQuery->where(function($q) {
                 // Admin, Staff, Caretaker, Delegate see each other
                 $q->whereHas('roles', function($r) {
@@ -102,7 +102,7 @@ class ChatController extends Controller
                     'is_online' => true,
                     'unread_count' => $group->unread_count, // Now accurate
                     'last_message_time' => null,
-                    'is_admin' => $currentUser->hasRole('admin') || $group->members()->where('user_id', $currentUser->id)->where('role', 'admin')->exists()
+                    'is_admin' => $currentUser->hasAnyRole(['admin', 'super-admin']) || $group->members()->where('user_id', $currentUser->id)->where('role', 'admin')->exists()
                 ];
             });
 
@@ -123,7 +123,7 @@ class ChatController extends Controller
         $type = $request->query('type', 'user'); // Default to user for backward compatibility
 
         // Access Checks
-        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
             return response()->json(['error' => 'Access Denied'], 403);
         }
 
@@ -133,7 +133,7 @@ class ChatController extends Controller
 
             // Authorization
             if ($group->type !== 'community') {
-                if (!$group->members()->where('user_id', $currentUserId)->exists() && !$currentUser->hasRole(['admin'])) {
+                if (!$group->members()->where('user_id', $currentUserId)->exists() && !$currentUser->hasRole(['super-admin', 'admin'])) {
                      return response()->json(['error' => 'Not a member of this group'], 403);
                 }
             }
@@ -209,7 +209,7 @@ class ChatController extends Controller
         $currentUser = Auth::user();
 
         // Strict Access Check
-        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['admin', 'staff', 'caretaker', 'delegate'])) {
+        if ($currentUser->hasRole('employer') && !$currentUser->hasRole(['super-admin', 'admin', 'staff', 'caretaker', 'delegate'])) {
              return response()->json(['error' => 'Access Denied'], 403);
         }
 
@@ -226,7 +226,7 @@ class ChatController extends Controller
             if (!$group) return response()->json(['error' => 'Group not found'], 404);
 
             // Check membership for private groups
-            if ($group->type !== 'community' && !$group->members()->where('user_id', Auth::id())->exists() && !$currentUser->hasRole('admin')) {
+            if ($group->type !== 'community' && !$group->members()->where('user_id', Auth::id())->exists() && !$currentUser->hasAnyRole(['admin', 'super-admin'])) {
                 return response()->json(['error' => 'Not a member'], 403);
             }
 
@@ -492,7 +492,7 @@ class ChatController extends Controller
         $currentUser = Auth::user();
 
         // Access: Only Admin and Staff
-        if (!$currentUser->hasRole(['admin', 'staff'])) {
+        if (!$currentUser->hasRole(['super-admin', 'admin', 'staff'])) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -539,7 +539,7 @@ class ChatController extends Controller
 
         // Check permission (Admin role or Group Admin)
         $isGroupAdmin = $group->members()->where('user_id', $currentUser->id)->wherePivot('role', 'admin')->exists();
-        if (!$currentUser->hasRole('admin') && !$isGroupAdmin) {
+        if (!$currentUser->hasAnyRole(['admin', 'super-admin']) && !$isGroupAdmin) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -599,7 +599,7 @@ class ChatController extends Controller
             $currentUser = Auth::user();
             if ($group && $group->type !== 'community') {
                 $isMember = $group->members()->where('user_id', $currentUser->id)->exists();
-                if (!$isMember && !$currentUser->hasRole('admin')) {
+                if (!$isMember && !$currentUser->hasAnyRole(['admin', 'super-admin'])) {
                     return response()->json([], 403);
                 }
 
@@ -650,7 +650,7 @@ class ChatController extends Controller
         // Group Owner check: Assuming 'created_by' or admin role in pivot
         $isGroupOwner = $group->created_by == $currentUser->id;
 
-        if (!$currentUser->hasRole(['admin', 'staff']) && !$isGroupOwner) {
+        if (!$currentUser->hasRole(['super-admin', 'admin', 'staff']) && !$isGroupOwner) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -671,7 +671,7 @@ class ChatController extends Controller
             $q->select('users.id', 'users.name', 'users.avatar_path', 'chat_group_members.role as group_role');
         }])->findOrFail($id);
 
-        if ($group->type !== 'community' && !$group->members()->where('user_id', $currentUser->id)->exists() && !$currentUser->hasRole('admin')) {
+        if ($group->type !== 'community' && !$group->members()->where('user_id', $currentUser->id)->exists() && !$currentUser->hasAnyRole(['admin', 'super-admin'])) {
              return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -702,7 +702,7 @@ class ChatController extends Controller
 
         // Check permissions
         $isGroupAdmin = $group->members()->where('user_id', $currentUser->id)->wherePivot('role', 'admin')->exists();
-        if (!$currentUser->hasRole(['admin', 'staff']) && !$isGroupAdmin) {
+        if (!$currentUser->hasRole(['super-admin', 'admin', 'staff']) && !$isGroupAdmin) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 
@@ -727,7 +727,7 @@ class ChatController extends Controller
         // Allow user to leave (remove themselves)
         $isSelf = $currentUser->id == $userId;
 
-        if (!$currentUser->hasRole(['admin', 'staff']) && !$isGroupAdmin && !$isSelf) {
+        if (!$currentUser->hasRole(['super-admin', 'admin', 'staff']) && !$isGroupAdmin && !$isSelf) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
 

--- a/app/Http/Controllers/FinancialController.php
+++ b/app/Http/Controllers/FinancialController.php
@@ -19,7 +19,7 @@ class FinancialController extends Controller
     public function storeTransaction(Request $request, $productionId)
     {
         // Permission check
-        if (!auth()->user()->can('manage-finance') && !auth()->user()->hasRole('admin')) {
+        if (!auth()->user()->can('manage-finance') && !auth()->user()->hasAnyRole(['admin', 'super-admin'])) {
              return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
         }
 
@@ -92,7 +92,7 @@ class FinancialController extends Controller
      */
     public function updateTransaction(Request $request, $id)
     {
-         if (!auth()->user()->can('manage-finance') && !auth()->user()->hasRole('admin')) {
+         if (!auth()->user()->can('manage-finance') && !auth()->user()->hasAnyRole(['admin', 'super-admin'])) {
              return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
         }
 
@@ -248,7 +248,7 @@ class FinancialController extends Controller
      */
     public function destroyTransaction($id)
     {
-        if (!auth()->user()->can('manage-finance') && !auth()->user()->hasRole('admin')) {
+        if (!auth()->user()->can('manage-finance') && !auth()->user()->hasAnyRole(['admin', 'super-admin'])) {
              return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
         }
 

--- a/app/Policies/PdfTemplatePolicy.php
+++ b/app/Policies/PdfTemplatePolicy.php
@@ -15,7 +15,7 @@ class PdfTemplatePolicy
 
     public function view(User $user, PdfTemplate $pdfTemplate): bool
     {
-        if ($user->hasRole('admin') || $user->hasRole('staff')) {
+        if ($user->hasAnyRole(['admin', 'super-admin']) || $user->hasRole('staff')) {
             return true;
         }
 
@@ -38,7 +38,7 @@ class PdfTemplatePolicy
     public function update(User $user, PdfTemplate $pdfTemplate): bool
     {
         if ($user->hasPermissionTo('edit-pdf-templates')) {
-             if ($user->hasRole('admin') || $user->hasRole('staff')) {
+             if ($user->hasAnyRole(['admin', 'super-admin']) || $user->hasRole('staff')) {
                  return true;
              }
              if ($user->hasRole('employer') && $pdfTemplate->employer_id === $user->employer->id) {
@@ -51,7 +51,7 @@ class PdfTemplatePolicy
     public function delete(User $user, PdfTemplate $pdfTemplate): bool
     {
         if ($user->hasPermissionTo('delete-pdf-templates')) {
-             if ($user->hasRole('admin') || $user->hasRole('staff')) {
+             if ($user->hasAnyRole(['admin', 'super-admin']) || $user->hasRole('staff')) {
                  return true;
              }
              if ($user->hasRole('employer') && $pdfTemplate->employer_id === $user->employer->id) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -55,7 +55,7 @@ class AppServiceProvider extends ServiceProvider
 
                     // Logic update: "adminTicketUnreadCount" should respect visibility scope.
                     $currentUser = auth()->user();
-                    $canViewAllTickets = $currentUser->hasRole(['admin', 'staff']);
+                    $canViewAllTickets = $currentUser->hasRole(['super-admin', 'admin', 'staff']);
 
                     $unreadQuery = JobTicket::query();
 

--- a/resources/views/admin/incomplete_employees/index.blade.php
+++ b/resources/views/admin/incomplete_employees/index.blade.php
@@ -8,11 +8,11 @@
             <p class="text-muted">{{ __('Employees with missing mandatory information.') }}</p>
         </div>
         <div>
-            @role('admin')
+            @hasanyrole('admin|super-admin')
             <a href="{{ route('admin.settings.completeness.index') }}" class="btn btn-outline-primary">
                 <i class="bi bi-gear-fill me-1"></i> {{ __('Configure Settings') }}
             </a>
-            @endrole
+            @endhasanyrole
         </div>
     </div>
 

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -105,7 +105,7 @@
                     <select class="form-select" id="business_type_select">
                         <option value="">{{ __('Select...') }}</option>
                     </select>
-                    @if(auth()->user()->hasRole('admin'))
+                    @if(auth()->user()->hasAnyRole(['admin', 'super-admin']))
                     <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#manageBusinessTypeModal">
                         <i class="bi bi-gear"></i> {{ __('Manage') }}
                     </button>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -122,7 +122,7 @@
                     <select class="form-select" id="business_type_select">
                         <option value="">{{ __('Select...') }}</option>
                     </select>
-                    @if(auth()->user()->hasRole('admin'))
+                    @if(auth()->user()->hasAnyRole(['admin', 'super-admin']))
                     <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#manageBusinessTypeModal">
                         <i class="bi bi-gear"></i> {{ __('Manage') }}
                     </button>

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -77,7 +77,7 @@
     $isEmployer = $user->hasRole('employer');
     $canManage = $user->can('manage-own-workflow');
     $isReadOnly = $isEmployer && !$canManage;
-    $canDelete = $user->hasRole('admin');
+    $canDelete = $user->hasAnyRole(['admin', 'super-admin']);
 
     // Restore Logic
     $canRestore = false;


### PR DESCRIPTION
This pull request ensures that the `super-admin` role correctly inherits all operational capabilities of the `admin` role across the system. Specifically, UI buttons related to configuration (like Completeness Settings in Incomplete Data view), manage operations in employers forms, item deletions in workflows, and backend authorizations across controllers and policies now correctly evaluate for `super-admin` alongside `admin`.

The `super-admin` role was missing from multiple explicit `hasRole('admin')` checks, which resulted in `super-admin` users being locked out of administrative tasks they should logically have access to. All strict `admin` role checks have been expanded to `['admin', 'super-admin']`.

---
*PR created automatically by Jules for task [387982430205868620](https://jules.google.com/task/387982430205868620) started by @nongjossss-commits*