### PR TITLE
Fix Flatpickr UI sync on Bulk Edit Master Apply

### DIFF
--- a/resources/views/employees/bulk_edit_form.blade.php
+++ b/resources/views/employees/bulk_edit_form.blade.php
@@ -345,11 +345,20 @@
                     if (masterInput.type !== 'file') {
                         const value = masterInput.value;
                         individualInputs.forEach(input => {
-                            input.value = value;
-                            input.dispatchEvent(new Event('change'));
+                            if (input._flatpickr) {
+                                // If input is managed by Flatpickr, use its setDate method
+                                input._flatpickr.setDate(value, true);
+                            } else {
+                                // Standard input
+                                input.value = value;
+                                input.dispatchEvent(new Event('change'));
+                            }
+
                             // Visual highlight
-                            input.classList.add('bg-success-subtle');
-                            setTimeout(() => input.classList.remove('bg-success-subtle'), 1000);
+                            // Check if Flatpickr created an alt input for styling
+                            const inputToHighlight = input._flatpickr && input._flatpickr.altInput ? input._flatpickr.altInput : input;
+                            inputToHighlight.classList.add('bg-success-subtle');
+                            setTimeout(() => inputToHighlight.classList.remove('bg-success-subtle'), 1000);
                         });
                     }
 


### PR DESCRIPTION
This PR fixes a bug in the Advanced Edit (Bulk Edit) form where clicking "Apply to All" for date fields would update the underlying hidden `<input>` but fail to update the visible Flatpickr UI.

### Changes:
- Modified `resources/views/employees/bulk_edit_form.blade.php`.
- Added a check for `input._flatpickr` within the Master Field Sync logic.
- Implemented `input._flatpickr.setDate(value, true)` to properly notify the Flatpickr UI of programmatic changes.
- Added logic to apply the success visual highlight (`bg-success-subtle`) to the `altInput` generated by Flatpickr, so users get visual feedback when dates are auto-applied.

### Notes:
- Verified that the document scanner UI (`open-document-scanner`) correctly exists next to standard file inputs, fulfilling the user's requirement without forcing heavy photo manipulation tools (like background removal) onto regular document attachments.

---
*PR created automatically by Jules for task [9556862269879364203](https://jules.google.com/task/9556862269879364203) started by @nongjossss-commits*