### PR TITLE
Fix Quotation Dropdown and Calculation Issues

### DIFF
--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -126,10 +126,24 @@ class ProductionDocumentController extends Controller
         $employeeList = [];
 
         if ($includeEmployeeList) {
-            // Get all items/employees for this production order
-            $items = $production->items;
             $pricingMode = $financialData['pricing_mode'] ?? 'per_head';
             $pricingTiers = collect($financialData['pricing_tiers'] ?? []);
+
+            // Start with all items
+            $items = $production->items;
+
+            // If specific transactions were requested, filter items to only include
+            // those attached to the selected transactions.
+            if ($request->has('transaction_ids')) {
+                // $transactions is already filtered by transaction_ids above
+                $transactionItemIds = $transactions->flatMap(function($t) {
+                    return $t->items->pluck('id');
+                })->unique();
+
+                $items = $items->filter(function($item) use ($transactionItemIds) {
+                    return $transactionItemIds->contains($item->id);
+                });
+            }
 
             $index = 1;
             foreach ($items as $item) {
@@ -138,15 +152,12 @@ class ProductionDocumentController extends Controller
 
                     // Determine Price
                     $price = 0;
+                    $isAssignedToTier = false;
+
                     if ($pricingMode === 'per_head') {
                         // Find the tier this item belongs to
-                        // The item_ids from frontend may be strings or integers, and in_array does strict check unless specified or we cast
                         $tier = $pricingTiers->first(function ($t) use ($item) {
                             $itemIds = array_map('strval', $t['item_ids'] ?? []);
-                            // In manual bills, frontend stores item->id directly without a prefix,
-                            // or stores integers. Ensure we match against string representations of IDs.
-                            // FinancialHubController@storeManual creates tiers like [ 'item_ids' => [1, 2, 3] ]
-                            // where these integers correspond to production_items.id
                             return in_array(strval($item->id), $itemIds, true) ||
                                    ($item->employee_id && in_array('emp_' . $item->employee_id, $itemIds, true)) ||
                                    ($item->employee_id && in_array(strval($item->employee_id), $itemIds, true));
@@ -154,16 +165,27 @@ class ProductionDocumentController extends Controller
 
                         if ($tier) {
                             $price = $tier['price'] ?? 0;
+                            $isAssignedToTier = true;
                         } else {
-                            // Default tier might be named 'Default Tier' by FinancialHubController
-                            // or might just have an empty item_ids array
+                            // Default tier fallback
                             $defaultTier = $pricingTiers->first(function ($t) {
                                 return empty($t['item_ids']) || ($t['name'] ?? '') === 'Default Tier';
                             });
                             if ($defaultTier) {
                                 $price = $defaultTier['price'] ?? 0;
+                                // We don't mark as explicitly assigned to a tier if they are just catching the default,
+                                // but we might want them to show up if the project relies on default tiers.
+                                // Typically, employees without explicit tier mapping in 'per_head' mode shouldn't show
+                                // up with 0 price unless it's genuinely free.
                             }
                         }
+                    }
+
+                    // For documents NOT filtered by transaction_ids, we only want to show employees
+                    // who actually have a price set (or are assigned to a tier).
+                    // This prevents printing all employees in the project when only a few have prices.
+                    if (!$request->has('transaction_ids') && $pricingMode === 'per_head' && $price <= 0) {
+                        continue; // Skip employees with 0 price in per-head full document lists
                     }
 
                     $employeeList[] = [

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -265,7 +265,24 @@
                     return $isReceiptContext ? ($t->paid_amount ?? 0) : $t->amount;
                 });
             } elseif ($showService) {
-                $serviceTotal = $financial['total_amount'] ?? 0;
+                // If it's a full document (like Quotation without transactions), we must calculate
+                // the total service fee correctly if in per_head mode.
+                $pricingMode = $financial['pricing_mode'] ?? 'per_head';
+                $pricingTiers = $financial['pricing_tiers'] ?? [];
+
+                if ($pricingMode === 'per_head') {
+                    $calculatedTotal = 0;
+                    foreach ($pricingTiers as $tier) {
+                        $count = count($tier['item_ids'] ?? []);
+                        $price = $tier['price'] ?? 0;
+                        $calculatedTotal += ($count * $price);
+                    }
+                    // Apply discount if any exists in financial data
+                    $discount = $financial['discount'] ?? 0;
+                    $serviceTotal = max(0, $calculatedTotal - $discount);
+                } else {
+                    $serviceTotal = $financial['total_amount'] ?? 0;
+                }
             }
 
             if ($advanceTransactions->isNotEmpty()) {

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -357,9 +357,18 @@ class="row">
                 </div>
 
                 <div class="d-grid gap-2">
-                    <button @click="openDocument('quotation')" class="btn btn-outline-secondary btn-sm text-start">
-                        <i class="bi bi-file-earmark-text me-2"></i>{{ __('Quotation (ใบเสนอราคา)') }}
-                    </button>
+                     <!-- Quotation Dropdown (Updated) -->
+                     <div class="btn-group">
+                        <button type="button" class="btn btn-outline-secondary btn-sm dropdown-toggle text-start" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-file-earmark-text me-2"></i>{{ __('Quotation (ใบเสนอราคา)') }}
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item" href="#" @click.prevent="openDocument('quotation', null, 'combined'); if(typeof bootstrap !== 'undefined') { bootstrap.Dropdown.getOrCreateInstance($el.closest('.btn-group').querySelector('.dropdown-toggle')).hide(); }">{{ __('Combined (Service + Advance)') }}</a></li>
+                            <li><a class="dropdown-item" href="#" @click.prevent="openDocument('quotation', null, 'service_only'); if(typeof bootstrap !== 'undefined') { bootstrap.Dropdown.getOrCreateInstance($el.closest('.btn-group').querySelector('.dropdown-toggle')).hide(); }">{{ __('Service Fee Only') }}</a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item" href="#" @click.prevent="openSelectionModal('quotation'); if(typeof bootstrap !== 'undefined') { bootstrap.Dropdown.getOrCreateInstance($el.closest('.btn-group').querySelector('.dropdown-toggle')).hide(); }">{{ __('Select Installment(s)...') }}</a></li>
+                        </ul>
+                    </div>
 
                      <!-- Invoice Dropdown (New) -->
                      <div class="btn-group">


### PR DESCRIPTION
This pull request addresses several issues with the Quotation functionality in the Finance tab.

Changes made:
1. **Quotation Dropdown:** Replaced the single Quotation button in the `financial-tab.blade.php` view with a dropdown menu, matching the functionality of the Invoice button. This allows users to generate a Quotation for the entire order, just the service fee, or specific installments.
2. **Employee List Filtering:** Updated the `generate` and `download` methods in `ProductionDocumentController` to correctly filter the list of employees included in the document based on the selected transactions. It now only includes employees associated with the selected `transaction_ids`. Furthermore, when generating a document for the full order, it now filters out employees who have a price of 0 in the `pricing_tiers`, ensuring only paying employees are listed.
3. **Quotation Total Calculation:** Fixed an issue in `layout.blade.php` where the grand total for Quotations was incorrectly calculating as 0. The view now properly calculates the `$serviceTotal` by summing up the quantities and prices from the `pricing_tiers` defined in the order's `financial_data` when the pricing mode is `per_head`.

---
*PR created automatically by Jules for task [4686901962659716924](https://jules.google.com/task/4686901962659716924) started by @nongjossss-commits*