### PR TITLE
fix: Change migration column type from string to text to avoid Row size too large error

### DIFF
--- a/database/migrations/2026_03_03_004838_add_menu_request_numbers_to_employees_table.php
+++ b/database/migrations/2026_03_03_004838_add_menu_request_numbers_to_employees_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('employees', function (Blueprint $table) {
-            $table->string('registration_request_number')->nullable()->after('request_number');
-            $table->string('renewal_request_number')->nullable()->after('registration_request_number');
+            $table->text('registration_request_number')->nullable()->after('request_number');
+            $table->text('renewal_request_number')->nullable()->after('registration_request_number');
         });
 
         // Backfill data from main request_number


### PR DESCRIPTION
Change the new column types in the `employees` migration from `VARCHAR` (`string()`) to `TEXT` (`text()`) to resolve the "Row size too large" error encountered during `php artisan migrate`.

---
*PR created automatically by Jules for task [5567108513240079477](https://jules.google.com/task/5567108513240079477) started by @nongjossss-commits*