### PR TITLE
Fix MySQL row size limit on employees table migration

### DIFF
--- a/database/migrations/2026_03_03_004838_add_menu_request_numbers_to_employees_table.php
+++ b/database/migrations/2026_03_03_004838_add_menu_request_numbers_to_employees_table.php
@@ -12,6 +12,22 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Convert large VARCHAR columns to TEXT to save row space
+        Schema::table('employees', function (Blueprint $table) {
+            $columnsToConvert = [
+                'employee_doc_1', 'employee_doc_2', 'employee_doc_3', 'employee_doc_4',
+                'employee_doc_5', 'employee_doc_6', 'employee_doc_7', 'employee_doc_8',
+                'employee_doc_9', 'employee_doc_10', 'employee_doc_11', 'employee_doc_12',
+                'other_doc_1_desc', 'other_doc_2_desc', 'other_doc_3_desc', 'other_doc_4_desc',
+            ];
+
+            foreach ($columnsToConvert as $column) {
+                if (Schema::hasColumn('employees', $column)) {
+                    $table->text($column)->nullable()->change();
+                }
+            }
+        });
+
         Schema::table('employees', function (Blueprint $table) {
             $table->text('registration_request_number')->nullable()->after('request_number');
             $table->text('renewal_request_number')->nullable()->after('registration_request_number');
@@ -28,6 +44,22 @@ return new class extends Migration
     {
         Schema::table('employees', function (Blueprint $table) {
             $table->dropColumn(['registration_request_number', 'renewal_request_number']);
+        });
+
+        // Revert TEXT columns back to VARCHAR (string)
+        Schema::table('employees', function (Blueprint $table) {
+            $columnsToRevert = [
+                'employee_doc_1', 'employee_doc_2', 'employee_doc_3', 'employee_doc_4',
+                'employee_doc_5', 'employee_doc_6', 'employee_doc_7', 'employee_doc_8',
+                'employee_doc_9', 'employee_doc_10', 'employee_doc_11', 'employee_doc_12',
+                'other_doc_1_desc', 'other_doc_2_desc', 'other_doc_3_desc', 'other_doc_4_desc',
+            ];
+
+            foreach ($columnsToRevert as $column) {
+                if (Schema::hasColumn('employees', $column)) {
+                    $table->string($column, 255)->nullable()->change();
+                }
+            }
         });
     }
 };


### PR DESCRIPTION
Resolves the `Row size too large` database migration error that occurs when applying `2026_03_03_004838_add_menu_request_numbers_to_employees_table`. The `employees` table currently has too many columns set to `VARCHAR(255)` (i.e. `string`), surpassing MySQL's internal 65,535 bytes limit for a single row.

This commit updates the failing migration file to first convert specific large existing columns (`employee_doc_1` to `employee_doc_12` and `other_doc_1_desc` to `other_doc_4_desc`) into `TEXT` types, which are stored off-page. This drastically reduces the calculated inline row size, allowing the subsequent `ALTER TABLE` to successfully add the `registration_request_number` and `renewal_request_number` columns.

---
*PR created automatically by Jules for task [12716799145846551702](https://jules.google.com/task/12716799145846551702) started by @nongjossss-commits*