### PR TITLE
Enhance Employee Search & Implement 24h Auto-Transfer for Change Employer

### DIFF
--- a/app/Console/Commands/ProcessEmployeeTransfers.php
+++ b/app/Console/Commands/ProcessEmployeeTransfers.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\ProductionItem;
+use App\Models\WorkType;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class ProcessEmployeeTransfers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:process-employee-transfers';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Processes employee transfers (Notify In / Change Employer) that have passed the 24-hour completion mark.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Starting employee transfer process...');
+
+        // Find the specific work type for "แจ้งเข้า / เปลี่ยนนายจ้าง"
+        // Adjust the matching string or use slug if available
+        $workType = WorkType::where('name', 'like', '%แจ้งเข้า / เปลี่ยนนายจ้าง%')
+            ->orWhere('slug', 'notify_in')
+            ->first();
+
+        if (!$workType) {
+            $this->error('Work Type "แจ้งเข้า / เปลี่ยนนายจ้าง" not found.');
+            return;
+        }
+
+        $thresholdDate = Carbon::now()->subHours(24);
+
+        // Find completed items older than 24 hours that haven't been processed yet
+        $items = ProductionItem::whereHas('order', function ($query) use ($workType) {
+                $query->where('work_type_id', $workType->id);
+            })
+            ->where('status', 'completed')
+            ->whereNotNull('completed_at')
+            ->where('completed_at', '<=', $thresholdDate)
+            ->where('is_transfer_processed', false)
+            ->with(['order', 'employee'])
+            ->get();
+
+        if ($items->isEmpty()) {
+            $this->info('No pending transfers found.');
+            return;
+        }
+
+        $transferredCount = 0;
+
+        foreach ($items as $item) {
+            $employee = $item->employee;
+            $order = $item->order;
+
+            if (!$employee || !$order) {
+                // If there's an issue with the relationship, still mark as processed so it isn't stuck forever.
+                $item->update(['is_transfer_processed' => true]);
+                continue;
+            }
+
+            // Proceed with transfer (different employer or still marked as terminated)
+            if ($employee->employer_id !== $order->employer_id || $employee->terminated_at !== null) {
+                DB::transaction(function () use ($employee, $order, $item) {
+                    $employee->update([
+                        'employer_id' => $order->employer_id,
+                        'status' => 'active',
+                        'terminated_at' => null,
+                        'termination_reason' => null,
+                        'termination_date' => null
+                    ]);
+
+                    $item->update(['is_transfer_processed' => true]);
+                });
+
+                $this->info("Transferred Employee ID {$employee->id} to Employer ID {$order->employer_id}.");
+                Log::info("Schedule Job ProcessEmployeeTransfers: Transferred Employee ID {$employee->id} to Employer ID {$order->employer_id} from Production Item {$item->id}");
+                $transferredCount++;
+            } else {
+                // Even if no change was needed, we still mark it as processed so it doesn't get picked up again.
+                $item->update(['is_transfer_processed' => true]);
+            }
+        }
+
+        $this->info("Successfully transferred {$transferredCount} employees.");
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         \App\Console\Commands\CheckExpiries::class,
         \App\Console\Commands\PruneSoftDeletes::class,
+        \App\Console\Commands\ProcessEmployeeTransfers::class,
     ];
 
     /**
@@ -27,6 +28,7 @@ class Kernel extends ConsoleKernel
     {
         $schedule->command('app:check-expiries')->daily()->timezone('Asia/Bangkok');
         $schedule->command('app:prune-soft-deletes')->daily();
+        $schedule->command('app:process-employee-transfers')->hourly();
     }
 
     /**

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -999,8 +999,21 @@ class WorkflowController extends Controller
     public function searchResignedEmployees(Request $request)
     {
         $search = $request->query('q');
+        $employerId = $request->query('employer_id');
+
         $query = Employee::query()
-             ->whereNotNull('terminated_at')
+             ->where(function ($q) use ($employerId) {
+                 // Condition 1: Employees who have been terminated (resigned) from any employer
+                 $q->whereNotNull('terminated_at');
+
+                 // Condition 2: Active employees belonging to the target employer
+                 if ($employerId) {
+                     $q->orWhere(function ($subQ) use ($employerId) {
+                         $subQ->whereNull('terminated_at')
+                              ->where('employer_id', $employerId);
+                     });
+                 }
+             })
              ->with('employer');
 
         if ($search) {
@@ -1398,7 +1411,9 @@ class WorkflowController extends Controller
         $slug = $item->order->workType->slug ?? '';
 
         DB::transaction(function () use ($item, $slug) {
-            if (in_array($slug, ['notify_in', 'mou_import', 'mou_renewal'])) {
+            // For 'notify_in' (Change Employer), we DELAY the update by 24 hours.
+            // So we DO NOT update the employee record here. The Scheduled Job will handle it.
+            if (in_array($slug, ['mou_import', 'mou_renewal'])) {
                 if ($item->employee) {
                     $item->employee->update([
                         'employer_id' => $item->order->employer_id,

--- a/app/Models/ProductionItem.php
+++ b/app/Models/ProductionItem.php
@@ -24,6 +24,7 @@ class ProductionItem extends Model
         'appointment_updated_at',
         'status',
         'completed_at', // NEW: Workflow finished
+        'is_transfer_processed', // NEW: Flag to prevent duplicate delayed transfers
         'new_employee_data', // JSON for temp employees
         'operator_id', // NEW: Assigned Operator
         'remarks', // Added remarks

--- a/database/migrations/2026_03_03_174042_add_is_transfer_processed_to_production_items_table.php
+++ b/database/migrations/2026_03_03_174042_add_is_transfer_processed_to_production_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('production_items', function (Blueprint $table) {
+            $table->boolean('is_transfer_processed')->default(false)->after('completed_at')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('production_items', function (Blueprint $table) {
+            $table->dropColumn('is_transfer_processed');
+        });
+    }
+};

--- a/resources/views/workflow/partials/add_employee_modal.blade.php
+++ b/resources/views/workflow/partials/add_employee_modal.blade.php
@@ -407,7 +407,14 @@
             if(query.length < 2) return;
 
             searchTimeout = setTimeout(() => {
-                fetch(`{{ route('workflow.api.resigned') }}?q=${query}`)
+                    const employerId = document.getElementById('modal_employer_id').value;
+                    const url = new URL(`{{ route('workflow.api.resigned') }}`);
+                    url.searchParams.append('q', query);
+                    if (employerId) {
+                        url.searchParams.append('employer_id', employerId);
+                    }
+
+                    fetch(url)
                     .then(res => res.json())
                     .then(data => {
                         const container = document.getElementById('resigned-results');
@@ -419,11 +426,16 @@
                         data.forEach(emp => {
                             const item = document.createElement('label');
                             item.className = 'list-group-item list-group-item-action d-flex align-items-center gap-3 cursor-pointer';
+
+                                const statusBadge = emp.terminated_at ?
+                                    '<span class="badge bg-danger ms-2">Terminated</span>' :
+                                    '<span class="badge bg-success ms-2">Active</span>';
+
                             item.innerHTML = `
                                 <input class="form-check-input flex-shrink-0" type="checkbox" name="employee_ids[]" value="${emp.id}">
                                 <div>
-                                    <div class="fw-bold">${emp.employeeNameEn || emp.employeeNameTh || '-'}</div>
-                                    <div class="small text-muted">Old Employer: ${emp.employer ? (emp.employer.employerNameTh || emp.employer.employerNameEn) : 'N/A'}</div>
+                                        <div class="fw-bold">${emp.employeeNameEn || emp.employeeNameTh || '-'} ${statusBadge}</div>
+                                        <div class="small text-muted">Employer: ${emp.employer ? (emp.employer.employerNameTh || emp.employer.employerNameEn) : 'N/A'}</div>
                                     <div class="small text-muted" style="font-size: 0.75rem;">Passport: ${emp.employeePassport || '-'}</div>
                                 </div>
                             `;


### PR DESCRIPTION
The "Change Employer" workflow previously only allowed searching for employees already terminated. This commit updates the search to also allow finding *active* employees currently working for the target employer. Additionally, it implements an automated, scheduled transfer system. When an employee successfully finishes the change-employer workflow, the system will wait 24 hours before making the final update. After 24 hours, an hourly scheduled job will automatically assign the employee to the new employer and erase their termination history, seamlessly returning them to active status while protecting against duplicate processing via an `is_transfer_processed` flag.

---
*PR created automatically by Jules for task [7116720549310746831](https://jules.google.com/task/7116720549310746831) started by @nongjossss-commits*