### PR TITLE
Fix financial profile builder preview and PDF asset positioning

### DIFF
--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -33,7 +33,7 @@ if (typeof window.financialManager === 'undefined') {
             // Custom Header Data
             showCustomHeaderModal: false,
             useCustomHeader: false,
-            customHeader: { name:'', address:'', tax_id:'', phone:'', logo:'' },
+            customHeader: { name:'', address:'', tax_id:'', phone:'', logo:'', biller_profile_id: '', customer_profile_id: '' },
             selectedProfileId: '',
 
             // Custom Customer (Bill To) Data
@@ -106,8 +106,8 @@ if (typeof window.financialManager === 'undefined') {
                 this.whtEnabled = !!data.wht_enabled;
                 this.whtRate = data.wht_rate !== undefined && data.wht_rate !== null && data.wht_rate !== '' ? parseFloat(data.wht_rate) : 3;
 
-                this.useCustomHeader = !!data.custom_header;
-                this.customHeader = data.custom_header || { name:'', address:'', tax_id:'', phone:'', logo:'' };
+                this.useCustomHeader = !!(data.custom_header && (data.custom_header.name || data.custom_header.address || data.custom_header.tax_id || data.custom_header.phone || data.custom_header.logo));
+                this.customHeader = data.custom_header || { name:'', address:'', tax_id:'', phone:'', logo:'', biller_profile_id: '', customer_profile_id: '' };
                 this.selectedProfileId = data.profile_id || '';
 
                 this.useCustomCustomer = !!data.customer_override;
@@ -847,6 +847,7 @@ if (typeof window.financialManager === 'undefined') {
             },
             get headerNameDisplay() {
                 if (this.useCustomHeader) return this.customHeader.name || 'Custom Header';
+                if (this.customHeader.biller_profile_id) return 'Selected Profile';
                 return this.selectedProfileId ? 'Selected System Profile' : 'Default Profile';
             },
             get customerNameDisplay() {
@@ -872,7 +873,7 @@ if (typeof window.financialManager === 'undefined') {
                     wht_enabled: this.whtEnabled,
                     wht_rate: this.whtRate,
                     advance_items: this.advanceItems,
-                    custom_header: this.useCustomHeader ? this.customHeader : null,
+                    custom_header: this.useCustomHeader ? this.customHeader : (this.customHeader.biller_profile_id || this.customHeader.customer_profile_id ? { biller_profile_id: this.customHeader.biller_profile_id, customer_profile_id: this.customHeader.customer_profile_id } : null),
                     profile_id: this.selectedProfileId,
                     customer_override: this.useCustomCustomer ? this.customCustomerData : null
                 };

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -167,7 +167,7 @@
                             width: {{ $billerProfile->signature_position['width'] ?? 150 }}px;
                             height: {{ $billerProfile->signature_position['height'] ?? 75 }}px;
                             transform: rotate({{ $billerProfile->signature_position['rotate'] ?? 0 }}deg);
-                            z-index: -1;" alt="Signature">
+                            z-index: 10;" alt="Signature">
             @endif
             @if($billerProfile->stamp_path && $billerProfile->stamp_position)
                 <img src="{{ asset('storage/' . $billerProfile->stamp_path) }}"
@@ -177,7 +177,7 @@
                             width: {{ $billerProfile->stamp_position['width'] ?? 100 }}px;
                             height: {{ $billerProfile->stamp_position['height'] ?? 100 }}px;
                             transform: rotate({{ $billerProfile->stamp_position['rotate'] ?? 0 }}deg);
-                            z-index: -1;" alt="Stamp">
+                            z-index: 5; opacity: 0.8;" alt="Stamp">
             @endif
         @endif
 
@@ -601,7 +601,7 @@
         </div>
 
         <!-- Absolute Positioned Elements (Direct children of .page) -->
-        @if($profile->use_signature && $profile->signature_path)
+        @if(!isset($billerProfile) && $profile->use_signature && $profile->signature_path)
             @php
                 $sigPos = is_array($profile->signature_pos) ? $profile->signature_pos : (is_string($profile->signature_pos) ? json_decode($profile->signature_pos, true) : null);
                 $sigLeft = $sigPos['x'] ?? 50;
@@ -612,7 +612,7 @@
                     style="position: absolute; left: {{ $sigLeft }}%; top: {{ $sigTop }}%; width: {{ $sigWidth }}%; z-index: 10;">
         @endif
 
-        @if($profile->use_stamp && $profile->stamp_path)
+        @if(!isset($billerProfile) && $profile->use_stamp && $profile->stamp_path)
             @php
                 $stampPos = is_array($profile->stamp_pos) ? $profile->stamp_pos : (is_string($profile->stamp_pos) ? json_decode($profile->stamp_pos, true) : null);
                 $stampLeft = $stampPos['x'] ?? 55;

--- a/resources/views/finance/profiles/builder.blade.php
+++ b/resources/views/finance/profiles/builder.blade.php
@@ -194,7 +194,8 @@
             </div>
 
             <div class="alert alert-info mt-3" x-show="currentMode === 'form'">
-                <i class="bi bi-info-circle"></i> <strong>Tip:</strong> You can Drag, Resize, and Rotate the Signature and Stamp images directly on the document preview above. They will be printed in exactly these positions.
+                <i class="bi bi-info-circle"></i> <strong>Tip:</strong> You can Drag, Resize, and Rotate the Signature and Stamp images directly on the document preview above. They will be printed in exactly these positions. <br>
+                <small><strong>Note:</strong> To rotate, scroll your mouse wheel while hovering over the image.</small>
             </div>
         </div>
     </div>
@@ -326,14 +327,32 @@ document.addEventListener('alpine:init', () => {
                 this.formData[`${type}_url`] = URL.createObjectURL(file);
                 this.removals[type] = false; // Cancel removal if new one selected
 
-                // Initialize default positions for newly added items
+                // Initialize default positions for newly added items if null
+                if (type !== 'logo' && !this.formData[`${type}_position`]) {
+                    this.formData[`${type}_position`] = { x: 300, y: 300, width: 150, height: 75, rotate: 0 };
+                }
+
                 this.$nextTick(() => {
                     const el = document.getElementById(`drag-${type}`);
                     if(el && this.formData[`${type}_position`]) {
                          el.setAttribute('data-x', this.formData[`${type}_position`].x);
                          el.setAttribute('data-y', this.formData[`${type}_position`].y);
                          el.setAttribute('data-angle', this.formData[`${type}_position`].rotate || 0);
+
+                         el.style.transform = `translate(${this.formData[`${type}_position`].x}px, ${this.formData[`${type}_position`].y}px) rotate(${this.formData[`${type}_position`].rotate || 0}deg)`;
+                         el.style.width = this.formData[`${type}_position`].width + 'px';
+                         el.style.height = this.formData[`${type}_position`].height + 'px';
                     }
+
+                    Swal.fire({
+                        title: 'Success',
+                        text: `${type} image loaded. You can now drag, resize, and rotate it on the document.`,
+                        icon: 'success',
+                        toast: true,
+                        position: 'top-end',
+                        showConfirmButton: false,
+                        timer: 3000
+                    });
                 });
             }
         },
@@ -518,6 +537,34 @@ document.addEventListener('alpine:init', () => {
                     _this.formData[`${type}_position`].rotate = angle;
                 });
             });
+
+            // Add MutationObserver to attach wheel events dynamically to new elements
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach(mutation => {
+                    mutation.addedNodes.forEach(node => {
+                        if (node.nodeType === 1 && node.classList.contains('draggable-asset')) {
+                            node.addEventListener('wheel', (e) => {
+                                e.preventDefault();
+                                const type = node.getAttribute('data-type');
+                                let angle = parseFloat(node.getAttribute('data-angle')) || _this.formData[`${type}_position`].rotate || 0;
+                                angle += e.deltaY > 0 ? 5 : -5;
+                                if(angle >= 360) angle = 0;
+                                if(angle < 0) angle = 355;
+                                node.setAttribute('data-angle', angle);
+                                const x = parseFloat(node.getAttribute('data-x')) || _this.formData[`${type}_position`].x;
+                                const y = parseFloat(node.getAttribute('data-y')) || _this.formData[`${type}_position`].y;
+                                node.style.transform = `translate(${x}px, ${y}px) rotate(${angle}deg)`;
+                                _this.formData[`${type}_position`].rotate = angle;
+                            });
+                        }
+                    });
+                });
+            });
+
+            const canvas = document.getElementById('pdf-canvas');
+            if(canvas) {
+                observer.observe(canvas, { childList: true, subtree: true });
+            }
         }
     }));
 });


### PR DESCRIPTION
- Fixed PDF generation (`layout.blade.php`) to correctly map and apply the `z-index`, `width`, `height`, `x`, `y`, and `rotate` coordinates from the `FinancialProfile`'s `signature_position` and `stamp_position` JSON properties.
- Enhanced the `builder.blade.php` to immediately show the image preview when uploaded and initialize default coordinates for dragging.
- Added a `Swal.fire` success notification and a mouse-wheel rotation listener for a better UX when configuring signatures/stamps in the builder.
- Updated `financial-manager.js` to correctly persist `biller_profile_id` and `customer_profile_id` within the `custom_header` payload without breaking the UI toggle state.

---
*PR created automatically by Jules for task [17622838926952122739](https://jules.google.com/task/17622838926952122739) started by @nongjossss-commits*