### PR TITLE
Fix employee search by registration request number

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -288,6 +288,7 @@ class RegistrationController extends Controller
                                ->orWhere('name_list_number', 'like', "%{$search}%")
                                ->orWhere('pinkCardNo', 'like', "%{$search}%")
                                ->orWhere('request_number', 'like', "%{$search}%")
+                               ->orWhere('registration_request_number', 'like', "%{$search}%")
                                ->orWhere('employer_employee_id', 'like', "%{$search}%")
                                ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                                ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
@@ -435,6 +436,7 @@ class RegistrationController extends Controller
                                ->orWhere('name_list_number', 'like', "%{$trimmedSearch}%")
                                ->orWhere('pinkCardNo', 'like', "%{$trimmedSearch}%")
                                ->orWhere('request_number', 'like', "%{$trimmedSearch}%")
+                               ->orWhere('registration_request_number', 'like', "%{$trimmedSearch}%")
                                ->orWhere('employer_employee_id', 'like', "%{$trimmedSearch}%")
                                ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                                ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
@@ -1769,6 +1771,7 @@ class RegistrationController extends Controller
               ->orWhere('name_list_number', 'like', "%{$search}%")
               ->orWhere('pinkCardNo', 'like', "%{$search}%")
               ->orWhere('request_number', 'like', "%{$search}%")
+              ->orWhere('registration_request_number', 'like', "%{$search}%")
               ->orWhere('employer_employee_id', 'like', "%{$search}%")
               // Robust Name Search (Ignore Spaces)
               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
@@ -1842,6 +1845,7 @@ class RegistrationController extends Controller
                   ->orWhere('name_list_number', 'like', "%{$search}%")
                   ->orWhere('pinkCardNo', 'like', "%{$search}%")
                   ->orWhere('request_number', 'like', "%{$search}%")
+                  ->orWhere('registration_request_number', 'like', "%{$search}%")
                   ->orWhere('employer_employee_id', 'like', "%{$search}%")
                   // Robust Name Search
                   ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
@@ -2045,6 +2049,7 @@ class RegistrationController extends Controller
                    ->orWhere('name_list_number', 'like', "%{$search}%")
                    ->orWhere('pinkCardNo', 'like', "%{$search}%")
                    ->orWhere('request_number', 'like', "%{$search}%")
+                   ->orWhere('registration_request_number', 'like', "%{$search}%")
                    ->orWhere('employer_employee_id', 'like', "%{$search}%")
                    ->orWhereHas('employer', function($q2) use ($search) {
                        $q2->withTrashed()


### PR DESCRIPTION
Fixes an issue in the Registration Resolution menu where searching by the Request Number (เลขที่คำขอ) failed.

The issue occurred because the `RegistrationController` only queried the generic `request_number` column instead of the module-specific `registration_request_number` column, which is where the data is actually stored for this menu.

I have updated the search builders across `RegistrationController.php` to include `registration_request_number` in all `orWhere` clauses alongside the existing fields. All tests continue to pass.

---
*PR created automatically by Jules for task [10460554648924666130](https://jules.google.com/task/10460554648924666130) started by @nongjossss-commits*