### PR TITLE
Fix z-index for draggable assets in financial profile builder

### DIFF
--- a/resources/views/finance/profiles/builder.blade.php
+++ b/resources/views/finance/profiles/builder.blade.php
@@ -183,11 +183,11 @@
 
                         <!-- Signature Draggable -->
                         <img x-show="formData.signature_url" :src="formData.signature_url" id="drag-signature" class="draggable-asset" data-type="signature"
-                             :style="getAssetStyle('signature') + ' z-index: 10;'">
+                             :style="getAssetStyle('signature')">
 
                         <!-- Stamp Draggable -->
                         <img x-show="formData.stamp_url" :src="formData.stamp_url" id="drag-stamp" class="draggable-asset" data-type="stamp"
-                             :style="getAssetStyle('stamp') + ' z-index: 10;'">
+                             :style="getAssetStyle('stamp')">
                     </div>
 
                 </div>
@@ -211,6 +211,7 @@
         border: 1px dashed transparent;
         cursor: move;
         transform-origin: center center;
+        z-index: 10 !important;
     }
     .draggable-asset:hover {
         border-color: #0d6efd;


### PR DESCRIPTION
This PR fixes an issue in the Financial Profile Builder where uploaded signature and company stamp images were hidden behind the background document mockup. The fix involves moving the z-index configuration from dynamic inline styles directly into the `.draggable-asset` CSS class with an `!important` modifier to ensure it cannot be overwritten by `interact.js` when the user resizes or drags the image.

---
*PR created automatically by Jules for task [4164390113337055391](https://jules.google.com/task/4164390113337055391) started by @nongjossss-commits*