### PR TITLE
Fix empty Thai address dropdowns in Employer "Add Address" modal

### DIFF
--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -871,9 +871,11 @@
             modalInstance: null,
 
             init() {
-                this.modalInstance = new bootstrap.Modal(document.getElementById('signatureSettingsModal'));
-
                 window.addEventListener('open-signature-modal', (event) => {
+                    if (!this.modalInstance) {
+                        this.modalInstance = new bootstrap.Modal(document.getElementById('signatureSettingsModal'));
+                    }
+
                     this.targetField = event.detail.field;
                     const currentAction = event.detail.currentAction;
 


### PR DESCRIPTION
Fixes empty Thai address dropdowns in the Employer "Add Address" modal caused by an Alpine.js/Bootstrap initialization crash.

---
*PR created automatically by Jules for task [12217982176559635293](https://jules.google.com/task/12217982176559635293) started by @nongjossss-commits*