### PR TITLE
feat: change operator assignment to a popup list

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -225,4 +225,20 @@ class UserController extends Controller
     {
         //
     }
+
+    /**
+     * Get a list of active operators (Super Admin, Admin, Staff).
+     */
+    public function listOperators()
+    {
+        $operators = User::role(['super-admin', 'admin', 'staff'])
+            ->where('status', 'active')
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        return response()->json([
+            'success' => true,
+            'data' => $operators
+        ]);
+    }
 }

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -1823,14 +1823,32 @@ class WorkflowController extends Controller
     public function toggleOperator(Request $request, $itemId)
     {
         $item = ProductionItem::findOrFail($itemId);
-        $userId = auth()->id();
 
-        if ($item->operator_id === $userId) {
-            $item->update(['operator_id' => null]);
-            $message = 'Operator unassigned.';
+        // Handle explicit operator assignment via dropdown
+        if ($request->has('operator_id')) {
+            $userId = $request->input('operator_id');
+            if (empty($userId)) {
+                $item->update(['operator_id' => null]);
+                $message = 'Operator unassigned.';
+            } else {
+                $user = User::find($userId);
+                if ($user) {
+                    $item->update(['operator_id' => $user->id]);
+                    $message = 'Operator assigned to ' . $user->name;
+                } else {
+                     return response()->json(['success' => false, 'message' => 'User not found'], 404);
+                }
+            }
         } else {
-            $item->update(['operator_id' => $userId]);
-            $message = 'Operator assigned to ' . auth()->user()->name;
+            // Legacy Toggle Behavior
+            $userId = auth()->id();
+            if ($item->operator_id === $userId) {
+                $item->update(['operator_id' => null]);
+                $message = 'Operator unassigned.';
+            } else {
+                $item->update(['operator_id' => $userId]);
+                $message = 'Operator assigned to ' . auth()->user()->name;
+            }
         }
 
         return response()->json(['success' => true, 'message' => $message]);

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -1115,39 +1115,85 @@
 
     // --- Operator Toggle ---
     window.toggleOperator = function(itemId, btn, hasOperator) {
-        const performToggle = () => {
-            btn.disabled = true;
-            fetch(`/workflow/item/${itemId}/toggle-operator`, {
-                method: 'POST',
-                headers: { 'X-CSRF-TOKEN': csrfToken }
-            })
+        // Fetch operators first
+        Swal.fire({
+            title: '{{ __("Loading...") }}',
+            allowOutsideClick: false,
+            didOpen: () => { Swal.showLoading(); }
+        });
+
+        fetch('{{ route("api-web.operators.list") }}')
             .then(res => res.json())
             .then(data => {
-                if(data.success) {
-                    refreshItemCard(itemId);
-                } else {
-                    btn.disabled = false;
-                }
-            });
-        };
+                if (!data.success) throw new Error('Failed to load operators');
 
-        if (hasOperator) {
-            Swal.fire({
-                title: '{{ __("Change Operator?") }}',
-                text: '{{ __("Are you sure you want to change or remove the operator?") }}',
-                icon: 'question',
-                showCancelButton: true,
-                confirmButtonText: '{{ __("Yes, Change") }}',
-                confirmButtonColor: '#0d6efd',
-                cancelButtonText: '{{ __("Cancel") }}'
-            }).then((result) => {
-                if (result.isConfirmed) {
-                    performToggle();
-                }
+                let operators = data.data;
+                let optionsHtml = `<option value="">-- {{ __("None / Clear Operator") }} --</option>`;
+
+                // For Pre-production we need the current operator id from the button if possible,
+                // but if not, we rely on the backend. Since the button doesn't currently pass the operator ID,
+                // we'll just not pre-select, or users will just see the list.
+                operators.forEach(op => {
+                    optionsHtml += `<option value="${op.id}">${op.name}</option>`;
+                });
+
+                const htmlContent = `
+                    <div class="form-group text-start">
+                        <label class="form-label mb-2">{{ __("Select Operator") }}</label>
+                        <select id="operator-select-${itemId}" class="form-select form-select-lg">
+                            ${optionsHtml}
+                        </select>
+                    </div>
+                `;
+
+                Swal.fire({
+                    title: '{{ __("Assign Operator") }}',
+                    html: htmlContent,
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonText: '{{ __("Save") }}',
+                    confirmButtonColor: '#0d6efd',
+                    cancelButtonText: '{{ __("Cancel") }}',
+                    showLoaderOnConfirm: true,
+                    didOpen: () => {},
+                    preConfirm: () => {
+                        const selectedId = document.getElementById(`operator-select-${itemId}`).value;
+
+                        return fetch(`/workflow/item/${itemId}/toggle-operator`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': csrfToken
+                            },
+                            body: JSON.stringify({ operator_id: selectedId })
+                        })
+                        .then(response => {
+                            if (!response.ok) throw new Error(response.statusText);
+                            return response.json();
+                        })
+                        .catch(error => {
+                            Swal.showValidationMessage(`Request failed: ${error}`);
+                        });
+                    },
+                    allowOutsideClick: () => !Swal.isLoading()
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        const resData = result.value;
+                        if(resData && resData.success) {
+                            refreshItemCard(itemId);
+                            if(typeof showToast === 'function') {
+                                showToast(resData.message, 'success');
+                            }
+                        } else {
+                            Swal.fire('{{ __("Error") }}', resData ? resData.message : 'Unknown error', 'error');
+                        }
+                    }
+                });
+            })
+            .catch(err => {
+                Swal.fire('Error', '{{ __("Could not load operators list.") }}', 'error');
+                console.error(err);
             });
-        } else {
-            performToggle();
-        }
     }
 
     // --- Reuse Toggle Step from Workflow (Global Function) ---

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -57,8 +57,14 @@
         @endphp
         <button class="btn btn-sm {{ $operatorId ? ($isMe ? 'btn-primary' : 'btn-secondary') : 'btn-outline-secondary' }} rounded-pill shadow-sm py-0 px-2"
                 style="font-size: 0.75rem; border-width: 1px;"
+                @hasanyrole('super-admin|admin|staff')
                 onclick="window.toggleOperator ? window.toggleOperator({{ $employee->id }}, this, '{{ $operatorId ?? '' }}', '{{ $toggleUrl }}') : console.error('toggleOperator not defined')"
-                title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Assign' }}">
+                title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Assign' }}"
+                @else
+                disabled
+                title="{{ $operatorName ? 'Operator: '.$operatorName : 'Not Assigned' }}"
+                @endhasanyrole
+                >
             <i class="bi bi-person-badge-fill"></i>
             @if($operatorName)
                 <span class="ms-1 fw-bold">{{ $operatorName }}</span>

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -1353,57 +1353,86 @@
 
     // --- Operator Toggle ---
     window.toggleOperator = function(employeeId, btn, currentOperatorId, url) {
-        const hasOperator = !!currentOperatorId;
-        const confirmTitle = hasOperator ? '{{ __("Change Operator?") }}' : '{{ __("Assign Operator") }}';
-        const confirmText = hasOperator
-            ? '{{ __("Someone is already assigned. Do you want to take over or unassign?") }}'
-            : '{{ __("Confirm to set Operator?") }}';
-
+        // Fetch operators first
         Swal.fire({
-            title: confirmTitle,
-            text: confirmText,
-            icon: 'question',
-            showCancelButton: true,
-            confirmButtonText: '{{ __("Yes, Confirm") }}',
-            confirmButtonColor: '#0d6efd',
-            cancelButtonText: '{{ __("Cancel") }}',
-            showLoaderOnConfirm: true,
-            preConfirm: () => {
-                const fetchUrl = url || `/production/registration/${employeeId}/toggle-operator`;
-                // Send without body to trigger "Toggle Self" logic in backend
-                return fetch(fetchUrl, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN': csrfToken
-                    }
-                })
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error(response.statusText)
-                    }
-                    return response.json()
-                })
-                .catch(error => {
-                    Swal.showValidationMessage(
-                        `Request failed: ${error}`
-                    )
-                })
-            },
-            allowOutsideClick: () => !Swal.isLoading()
-        }).then((result) => {
-            if (result.isConfirmed) {
-                const data = result.value;
-                if(data && data.success) {
-                    if(data.html) updateCardHTML(employeeId, data.html);
-                    if(typeof showToast === 'function') {
-                        showToast(data.message, 'success');
-                    }
-                } else {
-                     Swal.fire('{{ __("Error") }}', data ? data.message : 'Unknown error', 'error');
-                }
-            }
+            title: '{{ __("Loading...") }}',
+            allowOutsideClick: false,
+            didOpen: () => { Swal.showLoading(); }
         });
+
+        fetch('{{ route("api-web.operators.list") }}')
+            .then(res => res.json())
+            .then(data => {
+                if (!data.success) throw new Error('Failed to load operators');
+
+                let operators = data.data;
+                let optionsHtml = `<option value="">-- {{ __("None / Clear Operator") }} --</option>`;
+
+                operators.forEach(op => {
+                    let selected = (op.id == currentOperatorId) ? 'selected' : '';
+                    optionsHtml += `<option value="${op.id}" ${selected}>${op.name}</option>`;
+                });
+
+                const htmlContent = `
+                    <div class="form-group text-start">
+                        <label class="form-label mb-2">{{ __("Select Operator") }}</label>
+                        <select id="operator-select-${employeeId}" class="form-select form-select-lg">
+                            ${optionsHtml}
+                        </select>
+                    </div>
+                `;
+
+                Swal.fire({
+                    title: '{{ __("Assign Operator") }}',
+                    html: htmlContent,
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonText: '{{ __("Save") }}',
+                    confirmButtonColor: '#0d6efd',
+                    cancelButtonText: '{{ __("Cancel") }}',
+                    showLoaderOnConfirm: true,
+                    didOpen: () => {
+                        // Optional: Initialize Select2 or Choices.js here if needed
+                    },
+                    preConfirm: () => {
+                        const selectedId = document.getElementById(`operator-select-${employeeId}`).value;
+                        const fetchUrl = url || `/production/registration/${employeeId}/toggle-operator`;
+
+                        return fetch(fetchUrl, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': csrfToken
+                            },
+                            body: JSON.stringify({ operator_id: selectedId })
+                        })
+                        .then(response => {
+                            if (!response.ok) throw new Error(response.statusText);
+                            return response.json();
+                        })
+                        .catch(error => {
+                            Swal.showValidationMessage(`Request failed: ${error}`);
+                        });
+                    },
+                    allowOutsideClick: () => !Swal.isLoading()
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        const resData = result.value;
+                        if(resData && resData.success) {
+                            if(resData.html) updateCardHTML(employeeId, resData.html);
+                            if(typeof showToast === 'function') {
+                                showToast(resData.message, 'success');
+                            }
+                        } else {
+                            Swal.fire('{{ __("Error") }}', resData ? resData.message : 'Unknown error', 'error');
+                        }
+                    }
+                });
+            })
+            .catch(err => {
+                Swal.fire('Error', '{{ __("Could not load operators list.") }}', 'error');
+                console.error(err);
+            });
     }
 
     // --- Resolution Status & Note Functions ---

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -982,56 +982,86 @@
 
     // --- Operator Toggle ---
     window.toggleOperator = function(employeeId, btn, currentOperatorId, url) {
-        const hasOperator = !!currentOperatorId;
-        const confirmTitle = hasOperator ? '{{ __("Change Operator?") }}' : '{{ __("Assign Operator") }}';
-        const confirmText = hasOperator
-            ? '{{ __("Someone is already assigned. Do you want to take over or unassign?") }}'
-            : '{{ __("Confirm to set Operator?") }}';
-
+        // Fetch operators first
         Swal.fire({
-            title: confirmTitle,
-            text: confirmText,
-            icon: 'question',
-            showCancelButton: true,
-            confirmButtonText: '{{ __("Yes, Confirm") }}',
-            confirmButtonColor: '#0d6efd',
-            cancelButtonText: '{{ __("Cancel") }}',
-            showLoaderOnConfirm: true,
-            preConfirm: () => {
-                const fetchUrl = url || `/production/renewal/${employeeId}/toggle-operator`;
-                return fetch(fetchUrl, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN': csrfToken
-                    }
-                })
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error(response.statusText)
-                    }
-                    return response.json()
-                })
-                .catch(error => {
-                    Swal.showValidationMessage(
-                        `Request failed: ${error}`
-                    )
-                })
-            },
-            allowOutsideClick: () => !Swal.isLoading()
-        }).then((result) => {
-            if (result.isConfirmed) {
-                const data = result.value;
-                if(data && data.success) {
-                    if(data.html) updateCardHTML(employeeId, data.html);
-                    if(typeof showToast === 'function') {
-                        showToast(data.message, 'success');
-                    }
-                } else {
-                     Swal.fire('{{ __("Error") }}', data ? data.message : 'Unknown error', 'error');
-                }
-            }
+            title: '{{ __("Loading...") }}',
+            allowOutsideClick: false,
+            didOpen: () => { Swal.showLoading(); }
         });
+
+        fetch('{{ route("api-web.operators.list") }}')
+            .then(res => res.json())
+            .then(data => {
+                if (!data.success) throw new Error('Failed to load operators');
+
+                let operators = data.data;
+                let optionsHtml = `<option value="">-- {{ __("None / Clear Operator") }} --</option>`;
+
+                operators.forEach(op => {
+                    let selected = (op.id == currentOperatorId) ? 'selected' : '';
+                    optionsHtml += `<option value="${op.id}" ${selected}>${op.name}</option>`;
+                });
+
+                const htmlContent = `
+                    <div class="form-group text-start">
+                        <label class="form-label mb-2">{{ __("Select Operator") }}</label>
+                        <select id="operator-select-${employeeId}" class="form-select form-select-lg">
+                            ${optionsHtml}
+                        </select>
+                    </div>
+                `;
+
+                Swal.fire({
+                    title: '{{ __("Assign Operator") }}',
+                    html: htmlContent,
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonText: '{{ __("Save") }}',
+                    confirmButtonColor: '#0d6efd',
+                    cancelButtonText: '{{ __("Cancel") }}',
+                    showLoaderOnConfirm: true,
+                    didOpen: () => {
+                        // Optional: Initialize Select2 or Choices.js here if needed
+                    },
+                    preConfirm: () => {
+                        const selectedId = document.getElementById(`operator-select-${employeeId}`).value;
+                        const fetchUrl = url || `/production/renewal/${employeeId}/toggle-operator`;
+
+                        return fetch(fetchUrl, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': csrfToken
+                            },
+                            body: JSON.stringify({ operator_id: selectedId })
+                        })
+                        .then(response => {
+                            if (!response.ok) throw new Error(response.statusText);
+                            return response.json();
+                        })
+                        .catch(error => {
+                            Swal.showValidationMessage(`Request failed: ${error}`);
+                        });
+                    },
+                    allowOutsideClick: () => !Swal.isLoading()
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        const resData = result.value;
+                        if(resData && resData.success) {
+                            if(resData.html) updateCardHTML(employeeId, resData.html);
+                            if(typeof showToast === 'function') {
+                                showToast(resData.message, 'success');
+                            }
+                        } else {
+                            Swal.fire('{{ __("Error") }}', resData ? resData.message : 'Unknown error', 'error');
+                        }
+                    }
+                });
+            })
+            .catch(err => {
+                Swal.fire('Error', '{{ __("Could not load operators list.") }}', 'error');
+                console.error(err);
+            });
     }
 
     // --- Resolution Status & Note Functions ---

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1429,39 +1429,82 @@
 
     // --- Operator Toggle ---
     window.toggleOperator = function(itemId, btn, hasOperator) {
-        const performToggle = () => {
-            btn.disabled = true;
-            fetch(`/workflow/item/${itemId}/toggle-operator`, {
-                method: 'POST',
-                headers: { 'X-CSRF-TOKEN': csrfToken }
-            })
+        // Fetch operators first
+        Swal.fire({
+            title: '{{ __("Loading...") }}',
+            allowOutsideClick: false,
+            didOpen: () => { Swal.showLoading(); }
+        });
+
+        fetch('{{ route("api-web.operators.list") }}')
             .then(res => res.json())
             .then(data => {
-                if(data.success) {
-                    refreshItemCard(itemId);
-                } else {
-                    btn.disabled = false;
-                }
-            });
-        };
+                if (!data.success) throw new Error('Failed to load operators');
 
-        if (hasOperator) {
-            Swal.fire({
-                title: '{{ __("Change Operator?") }}',
-                text: '{{ __("Are you sure you want to change or remove the operator?") }}',
-                icon: 'question',
-                showCancelButton: true,
-                confirmButtonText: '{{ __("Yes, Change") }}',
-                confirmButtonColor: '#0d6efd',
-                cancelButtonText: '{{ __("Cancel") }}'
-            }).then((result) => {
-                if (result.isConfirmed) {
-                    performToggle();
-                }
+                let operators = data.data;
+                let optionsHtml = `<option value="">-- {{ __("None / Clear Operator") }} --</option>`;
+
+                operators.forEach(op => {
+                    optionsHtml += `<option value="${op.id}">${op.name}</option>`;
+                });
+
+                const htmlContent = `
+                    <div class="form-group text-start">
+                        <label class="form-label mb-2">{{ __("Select Operator") }}</label>
+                        <select id="operator-select-${itemId}" class="form-select form-select-lg">
+                            ${optionsHtml}
+                        </select>
+                    </div>
+                `;
+
+                Swal.fire({
+                    title: '{{ __("Assign Operator") }}',
+                    html: htmlContent,
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonText: '{{ __("Save") }}',
+                    confirmButtonColor: '#0d6efd',
+                    cancelButtonText: '{{ __("Cancel") }}',
+                    showLoaderOnConfirm: true,
+                    didOpen: () => {},
+                    preConfirm: () => {
+                        const selectedId = document.getElementById(`operator-select-${itemId}`).value;
+
+                        return fetch(`/workflow/item/${itemId}/toggle-operator`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': csrfToken
+                            },
+                            body: JSON.stringify({ operator_id: selectedId })
+                        })
+                        .then(response => {
+                            if (!response.ok) throw new Error(response.statusText);
+                            return response.json();
+                        })
+                        .catch(error => {
+                            Swal.showValidationMessage(`Request failed: ${error}`);
+                        });
+                    },
+                    allowOutsideClick: () => !Swal.isLoading()
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        const resData = result.value;
+                        if(resData && resData.success) {
+                            refreshItemCard(itemId);
+                            if(typeof showToast === 'function') {
+                                showToast(resData.message, 'success');
+                            }
+                        } else {
+                            Swal.fire('{{ __("Error") }}', resData ? resData.message : 'Unknown error', 'error');
+                        }
+                    }
+                });
+            })
+            .catch(err => {
+                Swal.fire('Error', '{{ __("Could not load operators list.") }}', 'error');
+                console.error(err);
             });
-        } else {
-            performToggle();
-        }
     }
 
     // --- Daily Check ---

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -113,8 +113,14 @@
     <div class="position-absolute bottom-0 end-0 m-2 z-index-10">
         <button class="btn btn-sm {{ $operatorId ? ($isMe ? 'btn-primary' : 'btn-secondary') : 'btn-outline-secondary' }} rounded-pill shadow-sm py-0 px-2"
                 style="font-size: 0.75rem; border-width: 1px;"
+                @hasanyrole('super-admin|admin|staff')
                 onclick="window.toggleOperator ? window.toggleOperator({{ $item->id }}, this, {{ $operatorId ? 'true' : 'false' }}) : console.error('toggleOperator not defined')"
-                title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Claim' }}">
+                title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Assign' }}"
+                @else
+                disabled
+                title="{{ $operatorName ? 'Operator: '.$operatorName : 'Not Assigned' }}"
+                @endhasanyrole
+                >
             <i class="bi bi-person-badge-fill"></i>
             @if($operatorName)
                 <span class="ms-1 fw-bold">{{ $operatorName }}</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -157,6 +157,9 @@ Route::middleware('auth')->group(function () {
         Route::get('employer/employees', [EmployerEmployeeController::class, 'index'])->name('employer.employees.index');
         Route::get('employers/list', [EmployerController::class, 'listApi'])->name('employers.list');
         Route::post('temp-upload', [TemporaryUploadController::class, 'store'])->name('temp_upload.store');
+
+        // Operators API for toggle assignment popup
+        Route::get('operators', [App\Http\Controllers\Admin\UserController::class, 'listOperators'])->name('operators.list');
     });
 
     Route::post('employees/{employee}/transfer', [EmployeeController::class, 'transfer'])->name('employees.transfer');


### PR DESCRIPTION
This pull request changes the way "Operators" are assigned on employee cards across all primary modules (Registration, Renewal, Pre-production, and Workflow). 

**Changes:**
1. **API Endpoint**: Added a new route `api-web/operators` that fetches a list of active users with the `super-admin`, `admin`, or `staff` role.
2. **Dynamic Popup**: The `window.toggleOperator` JavaScript function now fetches this list and displays a SweetAlert (`Swal.fire`) popup. The user can select a specific operator or choose "None / Clear Operator". The selection updates the operator assigned to that specific card/task without reloading the page.
3. **Backend Support**: Updated `WorkflowController@toggleOperator` to gracefully handle the incoming `operator_id` parameter (the `RegistrationController` and `RenewalController` already had logic to handle this).
4. **Security**: Added `@hasanyrole('super-admin|admin|staff')` to the assignment buttons in the Blade templates so the button is visually disabled and cannot be triggered by Employers or Customer Care users.

---
*PR created automatically by Jules for task [13949609481936414882](https://jules.google.com/task/13949609481936414882) started by @nongjossss-commits*