### PR TITLE
Fix manual bill aggregating employees from other bills

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -597,14 +597,20 @@ class ProductionController extends Controller
 
         // 2. Fetch Shared Financial Groups
         // Look for groups belonging to this Employer + WorkType
-        $sharedGroups = ProductionFinancialGroup::where('employer_id', $production->employer_id)
-            ->where('work_type_id', $production->work_type_id)
-            ->with(['transactions.items', 'advanceItems'])
-            ->get();
-
-        // If no shared groups exist, but the order has old groups (migration fallback), fetch them
-        if ($sharedGroups->isEmpty()) {
+        // IMPORTANT: Manual bills have work_type_id = null. We do NOT want to share groups
+        // across all manual bills for the same employer. If null, fetch ONLY its own groups.
+        if ($production->work_type_id === null) {
              $sharedGroups = $production->financialGroups()->with(['transactions.items', 'advanceItems'])->get();
+        } else {
+             $sharedGroups = ProductionFinancialGroup::where('employer_id', $production->employer_id)
+                ->where('work_type_id', $production->work_type_id)
+                ->with(['transactions.items', 'advanceItems'])
+                ->get();
+
+             // If no shared groups exist, but the order has old groups (migration fallback), fetch them
+             if ($sharedGroups->isEmpty()) {
+                 $sharedGroups = $production->financialGroups()->with(['transactions.items', 'advanceItems'])->get();
+             }
         }
 
         // Attach shared groups to the production object for the view


### PR DESCRIPTION
Fix manual bill aggregating employees from other bills

In `ProductionController@edit`, manual bills (which have `work_type_id = null`) were accidentally querying and sharing all financial groups across the employer where the work type was also null. This caused the financial tab to aggregate pricing tiers and employee counts from multiple manual bills together (e.g., showing 13 instead of 3).

Added a conditional check: if `work_type_id` is null, it now exclusively fetches the financial groups tied directly to the current `ProductionOrder`, isolating its items and totals properly.

---
*PR created automatically by Jules for task [2992855172521950142](https://jules.google.com/task/2992855172521950142) started by @nongjossss-commits*