### PR TITLE
Fix Financial Profile Signature Positioning and Add Signatory Name

### DIFF
--- a/app/Http/Controllers/FinancialProfileController.php
+++ b/app/Http/Controllers/FinancialProfileController.php
@@ -44,6 +44,7 @@ class FinancialProfileController extends Controller
             'address' => 'nullable|string',
             'phone' => 'nullable|string|max:50',
             'email' => 'nullable|email|max:100',
+            'authorized_signatory_name' => 'nullable|string|max:255',
             'logo' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
             'signature' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
             'stamp' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
@@ -51,7 +52,7 @@ class FinancialProfileController extends Controller
             'stamp_position' => 'nullable|array',
         ]);
 
-        $data = $request->only(['type', 'name', 'tax_id', 'branch', 'address', 'phone', 'email', 'signature_position', 'stamp_position']);
+        $data = $request->only(['type', 'name', 'tax_id', 'branch', 'address', 'phone', 'email', 'authorized_signatory_name', 'signature_position', 'stamp_position']);
 
         if ($request->hasFile('logo')) {
             $data['logo_path'] = $request->file('logo')->store('financial_profiles/logos', 'public');
@@ -96,6 +97,7 @@ class FinancialProfileController extends Controller
             'address' => 'nullable|string',
             'phone' => 'nullable|string|max:50',
             'email' => 'nullable|email|max:100',
+            'authorized_signatory_name' => 'nullable|string|max:255',
             'logo' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
             'signature' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
             'stamp' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
@@ -106,7 +108,7 @@ class FinancialProfileController extends Controller
             'remove_stamp' => 'nullable|boolean',
         ]);
 
-        $data = $request->only(['name', 'tax_id', 'branch', 'address', 'phone', 'email', 'signature_position', 'stamp_position']);
+        $data = $request->only(['name', 'tax_id', 'branch', 'address', 'phone', 'email', 'authorized_signatory_name', 'signature_position', 'stamp_position']);
 
         // Handle File Removals
         if ($request->input('remove_logo') && $profile->logo_path) {

--- a/app/Models/FinancialProfile.php
+++ b/app/Models/FinancialProfile.php
@@ -17,6 +17,7 @@ class FinancialProfile extends Model
         'address',
         'phone',
         'email',
+        'authorized_signatory_name',
         'logo_path',
         'signature_path',
         'signature_position',

--- a/database/migrations/2026_03_05_013702_add_authorized_signatory_name_to_financial_profiles_table.php
+++ b/database/migrations/2026_03_05_013702_add_authorized_signatory_name_to_financial_profiles_table.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('financial_profiles', function (Blueprint $table) {
+            $table->string('authorized_signatory_name')->nullable()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('financial_profiles', function (Blueprint $table) {
+            $table->dropColumn('authorized_signatory_name');
+        });
+    }
+};

--- a/resources/views/documents/layout.blade.php
+++ b/resources/views/documents/layout.blade.php
@@ -100,16 +100,16 @@
         }
 
         /* Signatures */
-        .signatures { margin-top: 60px; display: flex; justify-content: space-between; page-break-inside: avoid; }
+        .signatures { position: absolute; bottom: 80px; left: 40px; right: 40px; display: flex; justify-content: space-between; page-break-inside: avoid; }
         .sig-block { width: 40%; text-align: center; position: relative; } /* Added relative for positioning context if needed locally */
-        .sig-line { border-bottom: 1px solid #ccc; height: 40px; margin-bottom: 10px; }
+        .sig-line { border-bottom: 1px solid #ccc; height: 40px; margin-bottom: 10px; width: 80%; margin-left: 10%; }
         .sig-text { font-size: 14px; color: #555; }
         .sig-title { font-weight: bold; margin-bottom: 40px; }
 
         /* Footer */
         .footer {
             position: absolute;
-            bottom: 40px;
+            bottom: 20px;
             left: 40px;
             right: 40px;
             border-top: 1px solid #eee;
@@ -599,7 +599,8 @@
             <div class="sig-block">
                 <div class="sig-title">Authorized Signature <span class="en-label">/ ผู้มีอำนาจลงนาม</span></div>
                 <div class="sig-line"></div>
-                <div class="sig-text">{{ isset($billerProfile) ? $billerProfile->name : $profile->name }}</div>
+                @php $biller = $billerProfile ?? $profile; @endphp
+                <div class="sig-text">{{ $biller->authorized_signatory_name ?: $biller->name }}</div>
             </div>
         </div>
 

--- a/resources/views/finance/profiles/builder.blade.php
+++ b/resources/views/finance/profiles/builder.blade.php
@@ -77,6 +77,10 @@
                                 <input type="email" class="form-control" x-model="formData.email">
                             </div>
                         </div>
+                        <div class="mb-3">
+                            <label class="form-label">Authorized Signatory Name</label>
+                            <input type="text" class="form-control" x-model="formData.authorized_signatory_name" placeholder="Name of person signing (replaces company name)">
+                        </div>
 
                         <hr>
                         <h6>Assets (1:1 Drag & Drop placement)</h6>
@@ -165,14 +169,16 @@
                                 </tbody>
                             </table>
 
-                            <div class="row" style="position: absolute; bottom: 80px; left: 0; right: 0;">
-                                <div class="col-6 text-center">
-                                    _______________________<br>
-                                    Customer Signature
+                            <div class="row" style="position: absolute; bottom: 80px; left: 40px; right: 40px;">
+                                <div class="col-6 text-center" style="position: relative;">
+                                    <div style="font-weight: bold; margin-bottom: 40px;">Received By <span style="color: #888; font-weight: normal; font-size: 0.9em; margin-left: 3px;">/ ผู้รับเงิน</span></div>
+                                    <div style="border-bottom: 1px solid #ccc; height: 40px; margin-bottom: 10px; width: 80%; margin-left: 10%;"></div>
+                                    <div style="font-size: 14px; color: #555;">Date <span style="color: #888; font-weight: normal; font-size: 0.9em; margin-left: 3px;">/ วันที่</span>: ____/____/______</div>
                                 </div>
-                                <div class="col-6 text-center">
-                                    _______________________<br>
-                                    Authorized Signature
+                                <div class="col-6 text-center" style="position: relative;">
+                                    <div style="font-weight: bold; margin-bottom: 40px;">Authorized Signature <span style="color: #888; font-weight: normal; font-size: 0.9em; margin-left: 3px;">/ ผู้มีอำนาจลงนาม</span></div>
+                                    <div style="border-bottom: 1px solid #ccc; height: 40px; margin-bottom: 10px; width: 80%; margin-left: 10%;"></div>
+                                    <div style="font-size: 14px; color: #555;" x-text="formData.authorized_signatory_name || formData.name || 'Company Name'"></div>
                                 </div>
                             </div>
                         </div>
@@ -238,6 +244,7 @@ document.addEventListener('alpine:init', () => {
             address: '',
             phone: '',
             email: '',
+            authorized_signatory_name: '',
             logo_url: null,
             signature_url: null,
             stamp_url: null,
@@ -272,7 +279,7 @@ document.addEventListener('alpine:init', () => {
             this.editingProfileId = null;
             this.formData = {
                 type: this.currentType,
-                name: '', tax_id: '', branch: '', address: '', phone: '', email: '',
+                name: '', tax_id: '', branch: '', address: '', phone: '', email: '', authorized_signatory_name: '',
                 logo_url: null, signature_url: null, stamp_url: null,
                 signature_position: { x: 400, y: 400, width: 150, height: 75, rotate: 0 },
                 stamp_position: { x: 500, y: 400, width: 100, height: 100, rotate: 0 },
@@ -292,6 +299,7 @@ document.addEventListener('alpine:init', () => {
                 address: profile.address,
                 phone: profile.phone,
                 email: profile.email,
+                authorized_signatory_name: profile.authorized_signatory_name,
                 logo_url: profile.logo_path ? `/storage/${profile.logo_path}` : null,
                 signature_url: profile.signature_path ? `/storage/${profile.signature_path}` : null,
                 stamp_url: profile.stamp_path ? `/storage/${profile.stamp_path}` : null,
@@ -386,7 +394,7 @@ document.addEventListener('alpine:init', () => {
             const data = new FormData();
 
             // Text fields
-            ['type', 'name', 'tax_id', 'branch', 'address', 'phone', 'email'].forEach(f => {
+            ['type', 'name', 'tax_id', 'branch', 'address', 'phone', 'email', 'authorized_signatory_name'].forEach(f => {
                 if(this.formData[f] !== null && this.formData[f] !== undefined) {
                     data.append(f, this.formData[f]);
                 }


### PR DESCRIPTION
Fixes the issue where the signature placement in the Financial Profile Builder preview did not accurately match the generated document due to dynamic content pushing the signature block down. This is fixed by using absolute positioning anchored to the bottom.

Also adds an `authorized_signatory_name` field to the profile, which replaces the company name printed under the signature line if provided.

---
*PR created automatically by Jules for task [3520392019853207815](https://jules.google.com/task/3520392019853207815) started by @nongjossss-commits*