### PR TITLE
Fix dragging origin for signature and stamp in Profile Builder

### DIFF
--- a/resources/views/finance/profiles/builder.blade.php
+++ b/resources/views/finance/profiles/builder.blade.php
@@ -217,6 +217,8 @@
         border: 1px dashed transparent;
         cursor: move;
         transform-origin: center center;
+        top: 0;
+        left: 0;
         z-index: 10 !important;
     }
     .draggable-asset:hover {


### PR DESCRIPTION
Fix dragging origin for signature and stamp in Profile Builder. By explicitly setting `top: 0` and `left: 0` on `.draggable-asset`, we ensure the `translate(x, y)` coordinates exactly match the top-left positioning origin of the generated PDF documents. This fixes the issue where signatures appeared floating halfway up the page due to inheriting natural document flow as their zero-point.

---
*PR created automatically by Jules for task [5538076647052172471](https://jules.google.com/task/5538076647052172471) started by @nongjossss-commits*