### PR TITLE
Persist Employer Signatures and Add PDF Template Preview

### DIFF
--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -248,6 +248,27 @@ class PdfTemplateController extends Controller
             ->with('success', 'Template deleted successfully.');
     }
 
+    public function preview(Request $request, PdfTemplate $pdf_template, PdfGeneratorService $pdfService)
+    {
+        $this->authorize('view-pdf-templates');
+
+        try {
+            $content = $pdfService->generatePreviewPdf($pdf_template);
+
+            $filename = 'preview_' . ($pdf_template->meta_data['original_filename'] ?? ($pdf_template->name . '.pdf'));
+            if (!str_ends_with($filename, '.pdf')) {
+                $filename .= '.pdf';
+            }
+
+            return response()->streamDownload(function () use ($content) {
+                echo $content;
+            }, $filename, ['Content-Type' => 'application/pdf']);
+        } catch (\Exception $e) {
+            \Log::error("PDF Preview Error: " . $e->getMessage());
+            return back()->with('danger', 'Failed to generate preview: ' . $e->getMessage());
+        }
+    }
+
     public function file(Request $request, PdfTemplate $pdf_template)
     {
         $this->authorize('view-pdf-templates');

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -91,6 +91,148 @@ class PdfGeneratorService
         return $results;
     }
 
+    public function generatePreviewPdf(PdfTemplate $template)
+    {
+        $pdf = new Fpdi();
+
+        $reflection = new \ReflectionClass($pdf);
+        if ($reflection->hasProperty('fontpath')) {
+            $property = $reflection->getProperty('fontpath');
+            $property->setAccessible(true);
+            $property->setValue($pdf, public_path('fonts') . DIRECTORY_SEPARATOR);
+        }
+
+        $templatePath = Storage::disk('public')->path($template->file_path);
+
+        $fontLoaded = false;
+        if (file_exists($this->fontPath)) {
+             $pdf->AddFont('THSarabunNew', '', 'THSarabunNew.php');
+             $pdf->SetFont('THSarabunNew', '', 14);
+             $fontLoaded = true;
+        } else {
+             $pdf->SetFont('Arial', '', 12);
+        }
+
+        try {
+            $pageCount = $pdf->setSourceFile($templatePath);
+        } catch (\Exception $e) {
+             try {
+                $normalizedPath = $this->tryNormalizePdf($templatePath);
+                if ($normalizedPath) {
+                    $pageCount = $pdf->setSourceFile($normalizedPath);
+                    $this->tempFiles[] = $normalizedPath;
+                } else {
+                    throw $e;
+                }
+             } catch (\Exception $ex) {
+                 throw new \Exception('Failed to process PDF template: ' . $e->getMessage());
+             }
+        }
+
+        try {
+            for ($pageNo = 1; $pageNo <= $pageCount; $pageNo++) {
+                $templateId = $pdf->importPage($pageNo);
+                $size = $pdf->getTemplateSize($templateId);
+
+                $pdf->AddPage($size['orientation'], [$size['width'], $size['height']]);
+                $pdf->useTemplate($templateId);
+
+                $items = collect($template->field_mapping)->where('page', $pageNo);
+
+                foreach ($items as $item) {
+                    $x = ($item['x'] / 100) * $size['width'];
+                    $y = ($item['y'] / 100) * $size['height'];
+
+                    if (isset($item['type']) && $item['type'] === 'signature') {
+                        $w = ($item['w'] / 100) * $size['width'];
+                        $h = ($item['h'] / 100) * $size['height'];
+
+                        // Draw a placeholder box for signatures
+                        $pdf->SetDrawColor(200, 200, 200);
+                        $pdf->SetFillColor(240, 240, 240);
+                        $pdf->Rect($x, $y, $w, $h, 'DF');
+
+                        $pdf->SetTextColor(150, 150, 150);
+                        $groupName = $item['signatureGroup'] ?? 'signature';
+
+                        $pdf->SetFontSize(10);
+                        // Center text in signature box
+                        $textX = $x + 2;
+                        $textY = $y + ($h / 2) + 2;
+                        $pdf->Text($textX, $textY, "[$groupName]");
+                        $pdf->SetTextColor(0, 0, 0); // Reset
+                        continue;
+                    }
+
+                    $text = '';
+                    if ($item['type'] === 'static') {
+                        $text = $item['text'] ?? '';
+                    } elseif ($item['type'] === 'db') {
+                        $key = $item['key'] ?? 'data';
+                        $text = "[$key]";
+                    }
+
+                    if ($text) {
+                        $boxW = ($item['w'] / 100) * $size['width'];
+                        $boxH = ($item['h'] / 100) * $size['height'];
+
+                        if ($fontLoaded) {
+                            $encodedText = @iconv('UTF-8', 'cp874', $text);
+                            if ($encodedText === false) $encodedText = $text;
+                        } else {
+                            $encodedText = @iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $text);
+                        }
+
+                        $fontSize = $item['fontSize'] ?? 12;
+
+                        if (!empty($item['autoFit'])) {
+                            $maxFontSizeH = ($boxH * 0.7) * 2.83;
+                            $pdf->SetFontSize($maxFontSizeH);
+                            $textWidth = $pdf->GetStringWidth($encodedText);
+
+                            if ($textWidth > ($boxW * 0.95)) {
+                                $ratio = ($boxW * 0.95) / $textWidth;
+                                $fontSize = $maxFontSizeH * $ratio;
+                            } else {
+                                $fontSize = $maxFontSizeH;
+                            }
+                        }
+
+                        $pdf->SetFontSize($fontSize);
+
+                        $align = $item['align'] ?? 'center';
+                        $textWidth = $pdf->GetStringWidth($encodedText);
+                        $textX = $x;
+
+                        if ($align === 'center') {
+                            $textX = $x + ($boxW - $textWidth) / 2;
+                        } elseif ($align === 'right') {
+                             $textX = $x + $boxW - $textWidth - 1;
+                        } else {
+                             $textX = $x + 1;
+                        }
+
+                        $textY = $y + $boxH;
+
+                        // Optionally draw a light border around text field for visibility in preview
+                        $pdf->SetDrawColor(200, 200, 200);
+                        $pdf->Rect($x, $y, $boxW, $boxH);
+
+                        $pdf->Text($textX, $textY, $encodedText);
+                    }
+                }
+            }
+            $content = $pdf->Output('S');
+        } finally {
+            foreach ($this->tempFiles as $tempFile) {
+                if (file_exists($tempFile)) @unlink($tempFile);
+            }
+            $this->tempFiles = [];
+        }
+
+        return $content;
+    }
+
     public function generateSinglePdf(PdfTemplate $template, Employee $employee, ?Employer $targetEmployer = null, bool $useEmptyEmployer = false)
     {
         $pdf = new Fpdi();
@@ -182,23 +324,30 @@ class PdfGeneratorService
             if ($effectiveEmployer->signature_1_path && Storage::disk('public')->exists($effectiveEmployer->signature_1_path)) {
                 $emprSig1Path = Storage::disk('public')->path($effectiveEmployer->signature_1_path);
             } else {
-                // Generate temporary unique
-                $content = $this->signatureService->generate('EMPR-' . $effectiveEmployer->id . '-1-' . uniqid());
-                $temp = tempnam(sys_get_temp_dir(), 'sig_empr1_');
-                file_put_contents($temp, $content);
-                $emprSig1Path = $temp;
-                $tempSigPaths[] = $temp;
+                // Generate persistent unique signature
+                $seed = 'EMPR-' . $effectiveEmployer->id . '-1-' . uniqid(more_entropy: true);
+                $content = $this->signatureService->generate($seed);
+                $filename = 'signatures/employers/empr_' . $effectiveEmployer->id . '_1_' . time() . '.png';
+                Storage::disk('public')->put($filename, $content);
+
+                // Update employer model
+                $effectiveEmployer->update(['signature_1_path' => $filename]);
+                $emprSig1Path = Storage::disk('public')->path($filename);
             }
 
             // Signer 2
             if ($effectiveEmployer->signature_2_path && Storage::disk('public')->exists($effectiveEmployer->signature_2_path)) {
                 $emprSig2Path = Storage::disk('public')->path($effectiveEmployer->signature_2_path);
             } else {
-                $content = $this->signatureService->generate('EMPR-' . $effectiveEmployer->id . '-2-' . uniqid());
-                $temp = tempnam(sys_get_temp_dir(), 'sig_empr2_');
-                file_put_contents($temp, $content);
-                $emprSig2Path = $temp;
-                $tempSigPaths[] = $temp;
+                // Generate persistent unique signature
+                $seed = 'EMPR-' . $effectiveEmployer->id . '-2-' . uniqid(more_entropy: true);
+                $content = $this->signatureService->generate($seed);
+                $filename = 'signatures/employers/empr_' . $effectiveEmployer->id . '_2_' . time() . '.png';
+                Storage::disk('public')->put($filename, $content);
+
+                // Update employer model
+                $effectiveEmployer->update(['signature_2_path' => $filename]);
+                $emprSig2Path = Storage::disk('public')->path($filename);
             }
         }
 

--- a/resources/views/pdf_templates/index.blade.php
+++ b/resources/views/pdf_templates/index.blade.php
@@ -176,8 +176,12 @@
                                     <i class="bi bi-pencil-square"></i> Builder
                                 </a>
 
+                                <a href="{{ route('admin.pdf-templates.preview', $template->id) }}" class="btn btn-sm btn-outline-info me-2" title="Download Preview">
+                                    <i class="bi bi-eye"></i> Preview
+                                </a>
+
                                 <a href="{{ route('admin.pdf-templates.file', ['pdf_template' => $template->id, 'download' => 1]) }}" class="btn btn-sm btn-outline-secondary me-2" title="Download Original">
-                                    <i class="bi bi-download"></i>
+                                    <i class="bi bi-download"></i> Original
                                 </a>
 
                                 @can('delete-pdf-templates', $template)

--- a/routes/web.php
+++ b/routes/web.php
@@ -200,6 +200,7 @@ Route::middleware(['auth', 'permission:manage-tickets', 'menu:ticket_inbox'])->p
     // PDF Templates
     Route::get('pdf-templates/list-templates', [\App\Http\Controllers\Admin\PdfTemplateController::class, 'listTemplates'])->name('pdf-templates.list'); // AJAX API
     Route::get('pdf-templates/{pdf_template}/file', [\App\Http\Controllers\Admin\PdfTemplateController::class, 'file'])->name('pdf-templates.file');
+    Route::get('pdf-templates/{pdf_template}/preview', [\App\Http\Controllers\Admin\PdfTemplateController::class, 'preview'])->name('pdf-templates.preview');
     Route::resource('pdf-templates', \App\Http\Controllers\Admin\PdfTemplateController::class)->middleware('menu:pdf_templates')->except(['show']);
     Route::get('pdf-templates/{pdf_template}/builder', [\App\Http\Controllers\Admin\PdfTemplateController::class, 'builder'])->name('pdf-templates.builder');
 


### PR DESCRIPTION
Fixes the issue where randomly generated employer signatures were different for every document by saving the first generated signature to the Employer profile. Also adds a "Preview" feature to the PDF Templates page, allowing users to download a sample PDF with their configured text fields and signature placeholders rendered, resolving the confusion where downloading the template only provided the blank original file.

---
*PR created automatically by Jules for task [6743710592929257462](https://jules.google.com/task/6743710592929257462) started by @nongjossss-commits*