### PR TITLE
Fix: Prevent full page reload on Trash Modal pagination

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2418,7 +2418,7 @@
         if (trashBody) {
             trashBody.addEventListener('click', function(e) {
                 // Check if clicked element is pagination link or inside one
-                const link = e.target.closest('.pagination a, .page-link');
+                const link = e.target.closest('.pagination a, .page-link, a[href]');
                 if (link && link.href) {
                     e.preventDefault();
                     loadTrashContent(link.href);

--- a/resources/views/production/registration/partials/trash_list.blade.php
+++ b/resources/views/production/registration/partials/trash_list.blade.php
@@ -52,6 +52,6 @@
         </tbody>
     </table>
     <div class="d-flex justify-content-center mt-3">
-        {{ $items->links() }}
+        {{ $items->links('pagination::bootstrap-5') }}
     </div>
 </div>

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -2061,7 +2061,7 @@
         if (trashBody) {
             trashBody.addEventListener('click', function(e) {
                 // Check if clicked element is pagination link or inside one
-                const link = e.target.closest('.pagination a, .page-link');
+                const link = e.target.closest('.pagination a, .page-link, a[href]');
                 if (link && link.href) {
                     e.preventDefault();
                     loadTrashContent(link.href);

--- a/resources/views/production/renewal/partials/trash_list.blade.php
+++ b/resources/views/production/renewal/partials/trash_list.blade.php
@@ -52,6 +52,6 @@
         </tbody>
     </table>
     <div class="d-flex justify-content-center mt-3">
-        {{ $items->links() }}
+        {{ $items->links('pagination::bootstrap-5') }}
     </div>
 </div>

--- a/resources/views/workflow/partials/trash_list.blade.php
+++ b/resources/views/workflow/partials/trash_list.blade.php
@@ -65,7 +65,7 @@
         </tbody>
     </table>
     <div class="d-flex justify-content-center mt-3">
-        {{ $items->links() }}
+        {{ $items->links('pagination::bootstrap-5') }}
     </div>
 </div>
 


### PR DESCRIPTION
Fixes a bug where paginating inside the Trash modal in the Registration and Renewal menus would cause a full-page reload, displaying a blank white page with unstyled text instead of loading the new page dynamically via AJAX. This occurred because the pagination implicitly used Tailwind (lacking Bootstrap classes), and the JavaScript was looking for specific Bootstrap classes (`.pagination a, .page-link`) to prevent the default navigation. 

Changes made:
1. Forced `pagination::bootstrap-5` in the `links()` call for the trash lists in Registration, Renewal, and Workflow to ensure the UI looks consistent and beautiful.
2. Updated the Javascript `closest()` selector to intercept all `a[href]` tags within the modal body, preventing any chance of accidental full-page navigation.

---
*PR created automatically by Jules for task [10737393753387217458](https://jules.google.com/task/10737393753387217458) started by @nongjossss-commits*