### PR TITLE
Fix pagination reload bug in Trash modals

### DIFF
--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -1345,26 +1345,24 @@
     }
 
     // Intercept Pagination Clicks inside Trash Modal
-    document.addEventListener('DOMContentLoaded', function() {
-        const trashBody = document.getElementById('trashModalBody');
-        if (trashBody) {
-            trashBody.addEventListener('click', function(e) {
-                // Check if clicked element is pagination link or inside one
-                const link = e.target.closest('.pagination a, .page-link');
-                if (link && link.href) {
-                    e.preventDefault();
-                    // Append is_pre_production flag if not present in pagination link
-                    let fetchUrl = link.href;
-                    if (!fetchUrl.includes('is_pre_production')) {
-                        const urlObj = new URL(fetchUrl);
-                        urlObj.searchParams.set('is_pre_production', '1');
-                        fetchUrl = urlObj.toString();
-                    }
-                    loadTrashContent(fetchUrl);
+    const trashBody = document.getElementById('trashModalBody');
+    if (trashBody) {
+        trashBody.addEventListener('click', function(e) {
+            // Check if clicked element is pagination link or inside one
+            const link = e.target.closest('.pagination a, .page-link');
+            if (link && link.href) {
+                e.preventDefault();
+                // Append is_pre_production flag if not present in pagination link
+                let fetchUrl = link.href;
+                if (!fetchUrl.includes('is_pre_production')) {
+                    const urlObj = new URL(fetchUrl);
+                    urlObj.searchParams.set('is_pre_production', '1');
+                    fetchUrl = urlObj.toString();
                 }
-            });
-        }
-    });
+                loadTrashContent(fetchUrl);
+            }
+        });
+    }
 
     // --- GPS / Deep Linking ---
     document.addEventListener('DOMContentLoaded', function() {

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2442,19 +2442,17 @@
     }
 
     // Intercept Pagination Clicks inside Trash Modal
-    document.addEventListener('DOMContentLoaded', function() {
-        const trashBody = document.getElementById('trashModalBody');
-        if (trashBody) {
-            trashBody.addEventListener('click', function(e) {
-                // Check if clicked element is pagination link or inside one
-                const link = e.target.closest('.pagination a, .page-link, a[href]');
-                if (link && link.href) {
-                    e.preventDefault();
-                    loadTrashContent(link.href);
-                }
-            });
-        }
-    });
+    const trashBody = document.getElementById('trashModalBody');
+    if (trashBody) {
+        trashBody.addEventListener('click', function(e) {
+            // Check if clicked element is pagination link or inside one
+            const link = e.target.closest('.pagination a, .page-link, a[href]');
+            if (link && link.href) {
+                e.preventDefault();
+                loadTrashContent(link.href);
+            }
+        });
+    }
 
         // --- Restore UI State on Load (After Reload) ---
         const urlParams = new URLSearchParams(window.location.search);

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -2086,19 +2086,17 @@
     }
 
     // Intercept Pagination Clicks inside Trash Modal
-    document.addEventListener('DOMContentLoaded', function() {
-        const trashBody = document.getElementById('trashModalBody');
-        if (trashBody) {
-            trashBody.addEventListener('click', function(e) {
-                // Check if clicked element is pagination link or inside one
-                const link = e.target.closest('.pagination a, .page-link, a[href]');
-                if (link && link.href) {
-                    e.preventDefault();
-                    loadTrashContent(link.href);
-                }
-            });
-        }
-    });
+    const trashBody = document.getElementById('trashModalBody');
+    if (trashBody) {
+        trashBody.addEventListener('click', function(e) {
+            // Check if clicked element is pagination link or inside one
+            const link = e.target.closest('.pagination a, .page-link, a[href]');
+            if (link && link.href) {
+                e.preventDefault();
+                loadTrashContent(link.href);
+            }
+        });
+    }
 
         // --- Restore UI State on Load (After Reload) ---
         const urlParams = new URLSearchParams(window.location.search);

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1602,19 +1602,17 @@
     }
 
     // Intercept Pagination Clicks inside Trash Modal
-    document.addEventListener('DOMContentLoaded', function() {
-        const trashBody = document.getElementById('trashModalBody');
-        if (trashBody) {
-            trashBody.addEventListener('click', function(e) {
-                // Check if clicked element is pagination link or inside one
-                const link = e.target.closest('.pagination a, .page-link');
-                if (link && link.href) {
-                    e.preventDefault();
-                    loadTrashContent(link.href);
-                }
-            });
-        }
-    });
+    const trashBody = document.getElementById('trashModalBody');
+    if (trashBody) {
+        trashBody.addEventListener('click', function(e) {
+            // Check if clicked element is pagination link or inside one
+            const link = e.target.closest('.pagination a, .page-link');
+            if (link && link.href) {
+                e.preventDefault();
+                loadTrashContent(link.href);
+            }
+        });
+    }
 
     // --- GPS / Deep Linking ---
     document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
Fixes a bug where clicking pagination links inside the Trash modal in the Registration and Renewal menus caused a full page reload (displaying a raw/unstyled webpage) instead of dynamically loading the content.

Root cause: 
The JavaScript event listener designed to intercept pagination clicks (`trashBody.addEventListener('click', ...)`) was wrapped inside a `document.addEventListener('DOMContentLoaded', ...)` block. Since the modal content is dynamically fetched via AJAX after the initial page load, the `DOMContentLoaded` event had already fired, causing the pagination event listener to never be bound.

Solution:
Removed the nested `DOMContentLoaded` wrapper from the scripts in:
- `resources/views/production/registration/index.blade.php`
- `resources/views/production/renewal/index.blade.php`
- `resources/views/production/index.blade.php`
- `resources/views/workflow/index.blade.php` (already worked but updated structure for consistency).

This perfectly aligns the non-working menus with the working Workflow menu structure.

---
*PR created automatically by Jules for task [16352735842964372838](https://jules.google.com/task/16352735842964372838) started by @nongjossss-commits*