### PR TITLE
Fix auto-update after 24 hours and hide resolution workflow badges

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
         \App\Console\Commands\CheckExpiries::class,
         \App\Console\Commands\PruneSoftDeletes::class,
         \App\Console\Commands\ProcessEmployeeTransfers::class,
+        \App\Console\Commands\UpdateResolutionData::class,
     ];
 
     /**
@@ -29,6 +30,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('app:check-expiries')->daily()->timezone('Asia/Bangkok');
         $schedule->command('app:prune-soft-deletes')->daily();
         $schedule->command('app:process-employee-transfers')->hourly();
+        $schedule->command('app:update-resolution-data')->hourly();
     }
 
     /**

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -305,34 +305,41 @@ class Employee extends Model
                 ];
             });
 
+        // Check if resolution was completed more than 24 hours ago
+        $resolutionCompletedOlderThan24h = $this->resolution_completed_at && $this->resolution_completed_at->diffInHours(now()) >= 24;
+
         // Add Registration Resolution (Purple)
         if (in_array($this->status, ['registration_pending', 'registration_completed'])) {
-            $workflows->push((object)[
-                'name' => 'Registration Resolution',
-                'status_label' => 'Resolution',
-                'is_pre_production' => false,
-                'is_registration' => true,
-                'is_renewal' => false,
-                'url' => route('production.registration.index', [
-                    'highlight_employer_id' => $this->employer_id,
-                    'highlight_employee_id' => $this->id
-                ]),
-            ]);
+            if (!($this->status === 'registration_completed' && $resolutionCompletedOlderThan24h)) {
+                $workflows->push((object)[
+                    'name' => 'Registration Resolution',
+                    'status_label' => 'Resolution',
+                    'is_pre_production' => false,
+                    'is_registration' => true,
+                    'is_renewal' => false,
+                    'url' => route('production.registration.index', [
+                        'highlight_employer_id' => $this->employer_id,
+                        'highlight_employee_id' => $this->id
+                    ]),
+                ]);
+            }
         }
 
         // Add Renewal Resolution (Pink)
         if (in_array($this->status, ['renewal_pending', 'renewal_completed'])) {
-            $workflows->push((object)[
-                'name' => 'Renewal Resolution',
-                'status_label' => 'Resolution',
-                'is_pre_production' => false,
-                'is_registration' => false,
-                'is_renewal' => true,
-                'url' => route('production.renewal.index', [
-                    'highlight_employer_id' => $this->employer_id,
-                    'highlight_employee_id' => $this->id
-                ]),
-            ]);
+            if (!($this->status === 'renewal_completed' && $resolutionCompletedOlderThan24h)) {
+                $workflows->push((object)[
+                    'name' => 'Renewal Resolution',
+                    'status_label' => 'Resolution',
+                    'is_pre_production' => false,
+                    'is_registration' => false,
+                    'is_renewal' => true,
+                    'url' => route('production.renewal.index', [
+                        'highlight_employer_id' => $this->employer_id,
+                        'highlight_employee_id' => $this->id
+                    ]),
+                ]);
+            }
         }
 
         return $workflows;


### PR DESCRIPTION
Fixed the issue where the automatic update of work permit, visa, and MOU group after a 24-hour completion period was not running. Additionally, modified the logic to hide workflow badges (Registration Resolution and Renewal Resolution) and remove the color overlay on the employee cards when the process was completed over 24 hours ago.

---
*PR created automatically by Jules for task [6435037262918834348](https://jules.google.com/task/6435037262918834348) started by @nongjossss-commits*