### PR TITLE
feat: Implement contextual financial status badges on employee cards across all menus

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -666,28 +666,7 @@ class RegistrationController extends Controller
             ->whereIn('status', ['registration_resolution', 'registration_resolution_cancelled'])
             ->first();
 
-        $employeeFinancialStatus = [];
-        if ($financeOrder) {
-            foreach ($financeOrder->financialGroups as $group) {
-                foreach ($group->transactions as $transaction) {
-                    foreach ($transaction->items as $item) {
-                        if (!$item->employee_id) continue;
-
-                        $empId = $item->employee_id;
-                        $currentStatus = $employeeFinancialStatus[$empId] ?? 'none';
-                        $txStatus = $transaction->status;
-
-                        if ($txStatus === 'paid') {
-                            if ($currentStatus === 'none') {
-                                $employeeFinancialStatus[$empId] = 'paid';
-                            }
-                        } else {
-                            $employeeFinancialStatus[$empId] = 'partial';
-                        }
-                    }
-                }
-            }
-        }
+        $employeeFinancialStatus = \App\Services\FinancialStatusService::calculateStatusForEmployees($financeOrder, $employees->pluck('id'));
 
         foreach ($employees as $emp) {
             $emp->financialStatus = $employeeFinancialStatus[$emp->id] ?? null;

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -404,6 +404,17 @@ class RenewalController extends Controller
             $employees = $query->paginate($perPage)->withQueryString();
         }
 
+        $financeOrder = ProductionOrder::with('financialGroups.transactions.items')
+            ->where('employer_id', $employerId)
+            ->whereIn('status', ['renewal_resolution', 'renewal_resolution_cancelled'])
+            ->first();
+
+        $employeeFinancialStatus = \App\Services\FinancialStatusService::calculateStatusForEmployees($financeOrder, $employees->pluck('id'));
+
+        foreach ($employees as $emp) {
+            $emp->financialStatus = $employeeFinancialStatus[$emp->id] ?? null;
+        }
+
         return view('production.renewal._employee_list_content', [
             'employees' => $employees,
             'employer' => $employer,

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -188,6 +188,30 @@ class ProductionController extends Controller
                 'financialGroups.advanceItems'
             ]);
 
+            foreach ($orders as $order) {
+                // Determine shared groups for proper financial status calculation if work_type_id is set
+                $sharedGroups = $order->financialGroups;
+                if ($order->work_type_id !== null) {
+                    $sharedGroups = \App\Models\ProductionFinancialGroup::where('employer_id', $order->employer_id)
+                        ->where('work_type_id', $order->work_type_id)
+                        ->with(['transactions.items', 'advanceItems'])
+                        ->get();
+                    if ($sharedGroups->isEmpty()) {
+                        $sharedGroups = $order->financialGroups;
+                    }
+                }
+                $order->setRelation('financialGroups', $sharedGroups);
+
+                $empIds = $order->items->pluck('employee_id')->filter()->unique();
+                $employeeFinancialStatus = \App\Services\FinancialStatusService::calculateStatusForEmployees($order, $empIds);
+
+                foreach ($order->items as $item) {
+                    if ($item->employee) {
+                        $item->employee->financialStatus = $employeeFinancialStatus[$item->employee->id] ?? null;
+                    }
+                }
+            }
+
             // Get Steps
             $steps = WorkTypeStep::where('work_type_id', $activeTab->id)
                         ->where('stage', 'preparation')
@@ -622,6 +646,12 @@ class ProductionController extends Controller
         $employees = $production->items->map(function($item) {
             return $item->employee;
         })->filter()->values();
+
+        $employeeFinancialStatus = \App\Services\FinancialStatusService::calculateStatusForEmployees($production, $employees->pluck('id'));
+
+        foreach ($employees as $emp) {
+            $emp->financialStatus = $employeeFinancialStatus[$emp->id] ?? null;
+        }
 
         // 4. Return View
         return view('production.edit', compact('production', 'employeeCount', 'employees'));

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -162,6 +162,30 @@ class WorkflowController extends Controller
         // Calculate Stats PER ORDER for the view (Accordion Header)
         $orders->load(['items.completedWorkTypeSteps', 'items.employee', 'employer.addresses', 'financialGroups.transactions.items', 'financialGroups.advanceItems']);
 
+        foreach ($orders as $order) {
+            // Determine shared groups for proper financial status calculation if work_type_id is set
+            $sharedGroups = $order->financialGroups;
+            if ($order->work_type_id !== null) {
+                $sharedGroups = \App\Models\ProductionFinancialGroup::where('employer_id', $order->employer_id)
+                    ->where('work_type_id', $order->work_type_id)
+                    ->with(['transactions.items', 'advanceItems'])
+                    ->get();
+                if ($sharedGroups->isEmpty()) {
+                    $sharedGroups = $order->financialGroups;
+                }
+            }
+            $order->setRelation('financialGroups', $sharedGroups);
+
+            $empIds = $order->items->pluck('employee_id')->filter()->unique();
+            $employeeFinancialStatus = \App\Services\FinancialStatusService::calculateStatusForEmployees($order, $empIds);
+
+            foreach ($order->items as $item) {
+                if ($item->employee) {
+                    $item->employee->financialStatus = $employeeFinancialStatus[$item->employee->id] ?? null;
+                }
+            }
+        }
+
         // Employers for Dropdown
         $employers = Employer::orderBy('employerNameTh')->get();
 

--- a/app/Services/FinancialStatusService.php
+++ b/app/Services/FinancialStatusService.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ProductionOrder;
+use App\Models\Employee;
+use Illuminate\Support\Collection;
+
+class FinancialStatusService
+{
+    /**
+     * Calculate financial status for a list of employees in the context of a specific ProductionOrder.
+     *
+     * @param ProductionOrder|null $order The active production order for the current context (menu/workflow).
+     * @param Collection|array $employeeIds A collection or array of employee IDs to calculate status for.
+     * @return array Associative array mapping employee_id to their financial status.
+     *               Possible statuses: 'none', 'priced', 'installment_created', 'partial', 'paid'
+     */
+    public static function calculateStatusForEmployees(?ProductionOrder $order, $employeeIds): array
+    {
+        $statuses = [];
+        // Extract array of integer IDs
+        if ($employeeIds instanceof Collection) {
+            $ids = $employeeIds->map(fn($item) => is_object($item) ? $item->id : $item)->toArray();
+        } else {
+            $ids = is_array($employeeIds) ? array_map(fn($item) => is_object($item) ? $item->id : $item, $employeeIds) : (array)$employeeIds;
+        }
+
+        foreach ($ids as $id) {
+            $statuses[$id] = 'none'; // Default status
+        }
+
+        if (!$order) {
+            return $statuses;
+        }
+
+        // Preload relationships to avoid N+1 queries
+        $order->loadMissing('financialGroups.transactions.items', 'items.employee');
+
+        $itemToEmployeeMap = $order->items->pluck('employee_id', 'id')->toArray();
+        $employeeToItemMap = $order->items->pluck('id', 'employee_id')->toArray();
+
+        foreach ($order->financialGroups as $group) {
+            $groupData = is_array($group->financial_data) ? $group->financial_data : json_decode($group->financial_data, true);
+
+            $pricingMode = $groupData['pricing_mode'] ?? 'lump_sum';
+            $pricingTiers = collect($groupData['pricing_tiers'] ?? []);
+
+            // 1. Determine which employees are priced in this group
+            if ($pricingMode === 'per_head') {
+                foreach ($ids as $empId) {
+                    $itemId = $employeeToItemMap[$empId] ?? null;
+                    if (!$itemId) continue;
+
+                    // Find if the item/employee is assigned to any tier
+                    $tier = $pricingTiers->first(function ($t) use ($itemId, $empId) {
+                        $itemIds = array_map('strval', $t['item_ids'] ?? []);
+                        return in_array(strval($itemId), $itemIds, true) ||
+                               in_array('emp_' . $itemId, $itemIds, true) ||
+                               in_array('emp_' . $empId, $itemIds, true) ||
+                               in_array(strval($empId), $itemIds, true);
+                    });
+
+                    // If assigned to a tier (or there's a default tier), they are 'priced'
+                    if ($tier || $pricingTiers->contains(fn($t) => empty($t['item_ids']) || ($t['name'] ?? '') === 'Default Tier')) {
+                        if ($statuses[$empId] === 'none') {
+                            $statuses[$empId] = 'priced';
+                        }
+                    }
+                }
+            } else {
+                // lump_sum applies to everyone in the order (or those selected for the group)
+                $selectedItems = $groupData['selected_item_ids'] ?? [];
+                if (!empty($selectedItems)) {
+                    foreach ($selectedItems as $itemId) {
+                        $empId = $itemToEmployeeMap[$itemId] ?? null;
+                        if ($empId && in_array($empId, $ids) && $statuses[$empId] === 'none') {
+                            $statuses[$empId] = 'priced';
+                        }
+                    }
+                } else {
+                    // Applies to all items in the order
+                    foreach ($ids as $empId) {
+                        if ($statuses[$empId] === 'none') {
+                            $statuses[$empId] = 'priced';
+                        }
+                    }
+                }
+            }
+
+            // For manual bills (work_type_id is null), the pricing logic is usually directly on the items
+            if ($order->work_type_id === null) {
+                $manualItems = $groupData['items'] ?? [];
+                $pricedEmpIds = [];
+                foreach ($manualItems as $mItem) {
+                    if (!empty($mItem['employee_ids'])) {
+                        foreach ($mItem['employee_ids'] as $eId) {
+                            $pricedEmpIds[] = $eId;
+                        }
+                    }
+                }
+                foreach (array_unique($pricedEmpIds) as $empId) {
+                    if (in_array($empId, $ids) && $statuses[$empId] === 'none') {
+                        $statuses[$empId] = 'priced';
+                    }
+                }
+            }
+        }
+
+        // 2. Map Transactions to Employees
+        $employeeTransactions = [];
+
+        foreach ($order->financialGroups as $group) {
+            foreach ($group->transactions as $transaction) {
+                foreach ($transaction->items as $item) {
+                    $empId = $item->employee_id;
+                    if ($empId && in_array($empId, $ids)) {
+                        if (!isset($employeeTransactions[$empId])) {
+                            $employeeTransactions[$empId] = [];
+                        }
+                        $employeeTransactions[$empId][] = $transaction;
+                    }
+                }
+            }
+        }
+
+        // 3. Evaluate 'installment_created', 'partial', 'paid'
+        foreach ($employeeTransactions as $empId => $transactions) {
+            if (empty($transactions)) {
+                // Should not happen as we only added transactions, but safety check
+                continue;
+            }
+
+            $allPaid = true;
+            $anyPaidOrPartial = false;
+
+            foreach ($transactions as $txn) {
+                if ($txn->status === 'paid') {
+                    $anyPaidOrPartial = true;
+                } elseif ($txn->status === 'partial' || $txn->paid_amount > 0) {
+                    $anyPaidOrPartial = true;
+                    $allPaid = false;
+                } else {
+                    // pending or overdue, and 0 paid
+                    $allPaid = false;
+                }
+            }
+
+            if ($allPaid) {
+                $statuses[$empId] = 'paid';
+            } elseif ($anyPaidOrPartial) {
+                $statuses[$empId] = 'partial';
+            } else {
+                // Transactions exist, but none are paid or partial
+                $statuses[$empId] = 'installment_created';
+            }
+        }
+
+        return $statuses;
+    }
+}

--- a/database/seeders/FinanceStatusSeeder.php
+++ b/database/seeders/FinanceStatusSeeder.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ProductionOrder;
+use App\Models\ProductionItem;
+use App\Models\ProductionFinancialGroup;
+use App\Models\FinancialTransaction;
+use App\Models\Employer;
+use App\Models\Employee;
+
+class FinanceStatusSeeder extends Seeder
+{
+    public function run()
+    {
+        $employer = Employer::first();
+        $employees = $employer->employees()->take(4)->get();
+
+        $order = ProductionOrder::create([
+            'employer_id' => $employer->id,
+            'status' => 'registration_resolution',
+            'type' => 'employer',
+            'project_name' => 'Test Registration Resolution',
+            'financial_data' => []
+        ]);
+
+        $group = ProductionFinancialGroup::create([
+            'production_order_id' => $order->id,
+            'employer_id' => $employer->id,
+            'name' => 'General',
+            'financial_data' => [
+                'pricing_mode' => 'per_head',
+                'pricing_tiers' => [
+                    [
+                        'name' => 'Default Tier',
+                        'price' => 5000,
+                        'item_ids' => [strval($employees[0]->id), strval($employees[1]->id), strval($employees[2]->id), strval($employees[3]->id)]
+                    ]
+                ]
+            ]
+        ]);
+
+        $items = [];
+        foreach ($employees as $emp) {
+            $items[] = ProductionItem::create([
+                'production_order_id' => $order->id,
+                'employee_id' => $emp->id,
+                'status' => 'pending'
+            ]);
+            $emp->status = 'registration_pending';
+            $emp->save();
+        }
+
+        // Emp 1: Installment Created
+        $tx1 = FinancialTransaction::create([
+            'production_order_id' => $order->id,
+            'production_financial_group_id' => $group->id,
+            'type' => 'installment',
+            'amount' => 5000,
+            'paid_amount' => 0,
+            'status' => 'pending'
+        ]);
+        \DB::table('financial_transaction_items')->insert(['financial_transaction_id' => $tx1->id, 'production_item_id' => $items[1]->id]);
+
+        // Emp 2: Partial
+        $tx2 = FinancialTransaction::create([
+            'production_order_id' => $order->id,
+            'production_financial_group_id' => $group->id,
+            'type' => 'installment',
+            'amount' => 5000,
+            'paid_amount' => 2000,
+            'status' => 'partial'
+        ]);
+        \DB::table('financial_transaction_items')->insert(['financial_transaction_id' => $tx2->id, 'production_item_id' => $items[2]->id]);
+
+        // Emp 3: Paid
+        $tx3 = FinancialTransaction::create([
+            'production_order_id' => $order->id,
+            'production_financial_group_id' => $group->id,
+            'type' => 'installment',
+            'amount' => 5000,
+            'paid_amount' => 5000,
+            'status' => 'paid'
+        ]);
+        \DB::table('financial_transaction_items')->insert(['financial_transaction_id' => $tx3->id, 'production_item_id' => $items[3]->id]);
+    }
+}

--- a/resources/views/employees/_employee_card.blade.php
+++ b/resources/views/employees/_employee_card.blade.php
@@ -94,8 +94,29 @@
         </div>
 
         {{-- Employee Photo --}}
-        <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
-             alt="Photo" class="employee-photo-thumb">
+        <div class="position-relative" style="margin-right: 1rem;">
+            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
+                 alt="Photo" class="employee-photo-thumb" style="width: 48px; height: 48px; object-fit: cover; border-radius: 50%;">
+            @if(isset($employee->financialStatus))
+                @if($employee->financialStatus === 'paid')
+                    <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-success border border-white" title="{{ __('Fully Paid') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                        <i class="bi bi-currency-dollar"></i>
+                    </span>
+                @elseif($employee->financialStatus === 'partial')
+                    <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-primary border border-white" title="{{ __('Partial/Pending Payment') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                        <i class="bi bi-currency-dollar"></i>
+                    </span>
+                @elseif($employee->financialStatus === 'installment_created')
+                    <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-warning text-dark border border-white" title="{{ __('Installment Created') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                        <i class="bi bi-currency-dollar"></i>
+                    </span>
+                @elseif($employee->financialStatus === 'priced')
+                    <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-secondary border border-white" title="{{ __('Priced') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                        <i class="bi bi-currency-dollar"></i>
+                    </span>
+                @endif
+            @endif
+        </div>
 
         {{-- Employee Details --}}
         <div class="flex-grow-1">

--- a/resources/views/employers/_employee_card.blade.php
+++ b/resources/views/employers/_employee_card.blade.php
@@ -57,10 +57,31 @@
     <div class="card-body">
         <div class="d-flex justify-content-between align-items-start gap-3">
             <div class="d-flex align-items-center flex-grow-1">
-                <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
-                     class="employee-photo-thumb"
-                     style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover; margin-right: 1rem;"
-                     alt="Photo">
+                <div class="position-relative" style="margin-right: 1rem;">
+                    <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/48x48/e2e8f0/6c757d?text=PIC' }}"
+                         class="employee-photo-thumb"
+                         style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover;"
+                         alt="Photo">
+                    @if(isset($employee->financialStatus))
+                        @if($employee->financialStatus === 'paid')
+                            <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-success border border-white" title="{{ __('Fully Paid') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                                <i class="bi bi-currency-dollar"></i>
+                            </span>
+                        @elseif($employee->financialStatus === 'partial')
+                            <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-primary border border-white" title="{{ __('Partial/Pending Payment') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                                <i class="bi bi-currency-dollar"></i>
+                            </span>
+                        @elseif($employee->financialStatus === 'installment_created')
+                            <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-warning text-dark border border-white" title="{{ __('Installment Created') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                                <i class="bi bi-currency-dollar"></i>
+                            </span>
+                        @elseif($employee->financialStatus === 'priced')
+                            <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-secondary border border-white" title="{{ __('Priced') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                                <i class="bi bi-currency-dollar"></i>
+                            </span>
+                        @endif
+                    @endif
+                </div>
                 <div class="flex-grow-1">
                     <p class="mb-0">
                         <strong>{{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? 'No English Name' }}</strong>

--- a/resources/views/partials/_employee_card.blade.php
+++ b/resources/views/partials/_employee_card.blade.php
@@ -91,8 +91,29 @@
             <input class="form-check-input employee-checkbox" type="checkbox" value="{{ $employee->id }}" data-employee-id="{{ $employee->id }}" data-employer-id="{{ $employee->employer_id }}" data-name-th="{{ $employee->employeeNameTh }}" data-name-en="{{ $employee->employeeNameEn }}" data-photo="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : asset('images/default-profile.png') }}" data-employer-name="{{ $employee->employer->employerNameTh ?? 'N/A' }}">
         </div>
 
-        <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : asset('images/default-profile.png') }}"
-            alt="Photo" class="employee-photo-thumb" style="width: 48px; height: 48px; object-fit: cover; border-radius: 50%; margin-right: 1rem;">
+        <div class="position-relative" style="margin-right: 1rem;">
+            <img src="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : asset('images/default-profile.png') }}"
+                alt="Photo" class="employee-photo-thumb" style="width: 48px; height: 48px; object-fit: cover; border-radius: 50%;">
+            @if(isset($employee->financialStatus))
+                @if($employee->financialStatus === 'paid')
+                    <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-success border border-white" title="{{ __('Fully Paid') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                        <i class="bi bi-currency-dollar"></i>
+                    </span>
+                @elseif($employee->financialStatus === 'partial')
+                    <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-primary border border-white" title="{{ __('Partial/Pending Payment') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                        <i class="bi bi-currency-dollar"></i>
+                    </span>
+                @elseif($employee->financialStatus === 'installment_created')
+                    <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-warning text-dark border border-white" title="{{ __('Installment Created') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                        <i class="bi bi-currency-dollar"></i>
+                    </span>
+                @elseif($employee->financialStatus === 'priced')
+                    <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-secondary border border-white" title="{{ __('Priced') }}" style="font-size: 0.6rem; padding: 0.25em 0.4em;">
+                        <i class="bi bi-currency-dollar"></i>
+                    </span>
+                @endif
+            @endif
+        </div>
 
         <div class="employee-info flex-grow-1 position-relative">
             {{-- Group & Team Tags --}}

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -119,14 +119,24 @@
                         </span>
 
                         {{-- Financial Status Badge --}}
-                        @if(isset($employee->financialStatus) && $employee->financialStatus === 'paid')
-                            <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-success border border-white" title="{{ __('Fully Paid') }}">
-                                <i class="bi bi-currency-dollar"></i>
-                            </span>
-                        @elseif(isset($employee->financialStatus) && $employee->financialStatus === 'partial')
-                            <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-warning text-dark border border-white" title="{{ __('Partial/Pending Payment') }}">
-                                <i class="bi bi-currency-dollar"></i>
-                            </span>
+                        @if(isset($employee->financialStatus))
+                            @if($employee->financialStatus === 'paid')
+                                <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-success border border-white" title="{{ __('Fully Paid') }}">
+                                    <i class="bi bi-currency-dollar"></i>
+                                </span>
+                            @elseif($employee->financialStatus === 'partial')
+                                <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-primary border border-white" title="{{ __('Partial/Pending Payment') }}">
+                                    <i class="bi bi-currency-dollar"></i>
+                                </span>
+                            @elseif($employee->financialStatus === 'installment_created')
+                                <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-warning text-dark border border-white" title="{{ __('Installment Created') }}">
+                                    <i class="bi bi-currency-dollar"></i>
+                                </span>
+                            @elseif($employee->financialStatus === 'priced')
+                                <span class="position-absolute bottom-0 start-100 translate-middle badge rounded-pill bg-secondary border border-white" title="{{ __('Priced') }}">
+                                    <i class="bi bi-currency-dollar"></i>
+                                </span>
+                            @endif
                         @endif
                     </div>
 


### PR DESCRIPTION
Implements a unified financial status indicator on employee cards across all four main production and workflow menus (`Pre Production`, `Workflow`, `Registration`, `Renewal`).

**Changes:**
1. **Created `FinancialStatusService`**: Dynamically calculates an employee's financial status (`none`, `priced`, `installment_created`, `partial`, `paid`) based on their involvement in a specific `ProductionOrder`'s financial groups and the payments made on related `FinancialTransaction` items. This ensures the status is contextual to the current menu being viewed, rather than a global historical state.
2. **Updated Controllers**: Integrated the new service into `ProductionController`, `WorkflowController`, `RegistrationController`, and `RenewalController` to pass the `financialStatus` property to the views.
3. **Updated UI**: Modified all variations of `_employee_card.blade.php` to display the correct color-coded badge (`bi-currency-dollar`) over the employee's photo:
   - **Grey (`bg-secondary`)**: Priced (added to a tier but no installment created).
   - **Yellow (`bg-warning text-dark`)**: Installment created but unpaid.
   - **Blue (`bg-primary`)**: Partially paid.
   - **Green (`bg-success`)**: Fully paid.
4. Added a `FinanceStatusSeeder` for local testing.

---
*PR created automatically by Jules for task [7007402729884929018](https://jules.google.com/task/7007402729884929018) started by @nongjossss-commits*