### PR TITLE
feat: Multi-Employee PDF Templates (Form/Table Generation)

### DIFF
--- a/app/Http/Controllers/Admin/PdfGenerationController.php
+++ b/app/Http/Controllers/Admin/PdfGenerationController.php
@@ -173,21 +173,41 @@ class PdfGenerationController extends Controller
                     $errorLog = "";
                     $generatedCount = 0;
 
-                    foreach ($employees as $employee) {
-                        try {
-                            // Generate Single PDF
-                            $content = $this->pdfService->generateSinglePdf($template, $employee, $targetEmployerModel, $useEmptyEmployer);
-                            $filename = $this->pdfService->generateFilename($template, $employee);
+                    $chunkSize = $template->meta_data['employees_per_page'] ?? 1;
+                    $chunkSize = max(1, (int)$chunkSize);
 
-                            // Add to Zip
-                            $zip->addFromString($filename, $content);
-                            $generatedCount++;
+                    if ($chunkSize > 1) {
+                        $chunks = $employees->chunk($chunkSize);
+                        foreach ($chunks as $chunkIndex => $chunkEmployees) {
+                            try {
+                                $content = $this->pdfService->generateChunkedPdf($template, $chunkEmployees, $targetEmployerModel, $useEmptyEmployer);
+                                $firstEmp = $chunkEmployees->first();
+                                $filename = "chunk_" . ($chunkIndex + 1) . "_" . $this->pdfService->generateFilename($template, $firstEmp);
 
-                            // Explicitly free memory if possible (though PHP 8 is usually smart)
-                            unset($content);
+                                $zip->addFromString($filename, $content);
+                                $generatedCount += $chunkEmployees->count();
+                                unset($content);
+                            } catch (\Throwable $e) {
+                                $errorLog .= "Error for Chunk " . ($chunkIndex + 1) . ": " . $e->getMessage() . "\n";
+                            }
+                        }
+                    } else {
+                        foreach ($employees as $employee) {
+                            try {
+                                // Generate Single PDF
+                                $content = $this->pdfService->generateSinglePdf($template, $employee, $targetEmployerModel, $useEmptyEmployer);
+                                $filename = $this->pdfService->generateFilename($template, $employee);
 
-                        } catch (\Throwable $e) {
-                            $errorLog .= "Error for Employee ID {$employee->id} ({$employee->employeeNameEn}): " . $e->getMessage() . "\n";
+                                // Add to Zip
+                                $zip->addFromString($filename, $content);
+                                $generatedCount++;
+
+                                // Explicitly free memory if possible (though PHP 8 is usually smart)
+                                unset($content);
+
+                            } catch (\Throwable $e) {
+                                $errorLog .= "Error for Employee ID {$employee->id} ({$employee->employeeNameEn}): " . $e->getMessage() . "\n";
+                            }
                         }
                     }
 

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -46,44 +46,89 @@ class PdfGeneratorService
 
         $useEmptyEmployer = $options['use_empty_employer'] ?? false;
 
-        foreach ($employees as $employee) {
-            try {
-                $pdfContent = $this->generateSinglePdf($template, $employee, $targetEmployer, $useEmptyEmployer);
-                $filename = $this->generateFilename($template, $employee);
+        // Determine Chunk Size (Employees per page) from Template metadata
+        $chunkSize = $template->meta_data['employees_per_page'] ?? 1;
+        $chunkSize = max(1, (int)$chunkSize);
 
-                if ($outputType === 'save_to_slot') {
-                    $this->saveToSlot($employee, $pdfContent, $options['slot_name'], $template);
-                    $results[] = ['employee' => $employee->id, 'status' => 'saved'];
-                } elseif ($outputType === 'raw_content') {
-                    $results[] = [
-                        'employee_id' => $employee->id,
-                        'filename' => $filename,
-                        'content' => $pdfContent
-                    ];
-                } else {
-                    $results[] = ['filename' => $filename, 'content' => $pdfContent];
-                }
-            } catch (\Exception $e) {
-                // If this is a batch process (save_to_slot or raw_content might be batch),
-                // we want to catch individual errors so the whole batch doesn't fail.
-                // However, if it's a synchronous single download, we might want to rethrow?
-                // For now, consistent behavior: log and maybe return error status.
-                // But the Controller expects simple array.
-                Log::error("PDF Generation Error (Emp ID: {$employee->id}): " . $e->getMessage());
+        if ($chunkSize > 1) {
+            // Processing in chunks (Multiple employees per page)
+            $chunks = $employees->chunk($chunkSize);
 
-                if ($outputType === 'save_to_slot') {
-                    $results[] = ['employee' => $employee->id, 'status' => 'error', 'message' => $e->getMessage()];
-                } elseif ($outputType === 'raw_content') {
-                    $results[] = [
-                        'employee_id' => $employee->id,
-                        'status' => 'error',
-                        'message' => $e->getMessage()
-                    ];
+            foreach ($chunks as $chunkIndex => $chunkEmployees) {
+                try {
+                    $pdfContent = $this->generateChunkedPdf($template, $chunkEmployees, $targetEmployer, $useEmptyEmployer);
+
+                    if ($outputType === 'save_to_slot') {
+                        // For slots, we still want to save a copy to each employee's profile
+                        foreach ($chunkEmployees as $employee) {
+                            $this->saveToSlot($employee, $pdfContent, $options['slot_name'], $template);
+                            $results[] = ['employee' => $employee->id, 'status' => 'saved'];
+                        }
+                    } elseif ($outputType === 'raw_content') {
+                        // Raw content might be weird for chunks, so associate with the first employee
+                        $firstEmp = $chunkEmployees->first();
+                        $filename = "chunk_" . ($chunkIndex + 1) . "_" . $this->generateFilename($template, $firstEmp);
+                        foreach ($chunkEmployees as $employee) {
+                            $results[] = [
+                                'employee_id' => $employee->id,
+                                'filename' => $filename,
+                                'content' => $pdfContent
+                            ];
+                        }
+                    } else {
+                        $firstEmp = $chunkEmployees->first();
+                        $filename = "chunk_" . ($chunkIndex + 1) . "_" . $this->generateFilename($template, $firstEmp);
+                        $results[] = ['filename' => $filename, 'content' => $pdfContent];
+                    }
+                } catch (\Exception $e) {
+                    Log::error("PDF Generation Chunk Error: " . $e->getMessage());
+                    if ($outputType === 'save_to_slot' || $outputType === 'raw_content') {
+                        foreach ($chunkEmployees as $employee) {
+                            $results[] = [
+                                'employee' => $employee->id,
+                                'employee_id' => $employee->id,
+                                'status' => 'error',
+                                'message' => $e->getMessage()
+                            ];
+                        }
+                    }
+                    if ($outputType === 'download') throw $e;
                 }
-                // If simple download, maybe throwing is better to alert user?
-                // For now, rethrow to ensure synchronous errors are seen.
-                if ($outputType === 'download') {
-                    throw $e;
+            }
+        } else {
+            // Standard single employee processing
+            foreach ($employees as $employee) {
+                try {
+                    $pdfContent = $this->generateSinglePdf($template, $employee, $targetEmployer, $useEmptyEmployer);
+                    $filename = $this->generateFilename($template, $employee);
+
+                    if ($outputType === 'save_to_slot') {
+                        $this->saveToSlot($employee, $pdfContent, $options['slot_name'], $template);
+                        $results[] = ['employee' => $employee->id, 'status' => 'saved'];
+                    } elseif ($outputType === 'raw_content') {
+                        $results[] = [
+                            'employee_id' => $employee->id,
+                            'filename' => $filename,
+                            'content' => $pdfContent
+                        ];
+                    } else {
+                        $results[] = ['filename' => $filename, 'content' => $pdfContent];
+                    }
+                } catch (\Exception $e) {
+                    Log::error("PDF Generation Error (Emp ID: {$employee->id}): " . $e->getMessage());
+
+                    if ($outputType === 'save_to_slot') {
+                        $results[] = ['employee' => $employee->id, 'status' => 'error', 'message' => $e->getMessage()];
+                    } elseif ($outputType === 'raw_content') {
+                        $results[] = [
+                            'employee_id' => $employee->id,
+                            'status' => 'error',
+                            'message' => $e->getMessage()
+                        ];
+                    }
+                    if ($outputType === 'download') {
+                        throw $e;
+                    }
                 }
             }
         }
@@ -483,6 +528,223 @@ class PdfGeneratorService
 
         } finally {
             // Cleanup temp files
+            foreach ($tempSigPaths as $path) {
+                if (file_exists($path)) @unlink($path);
+            }
+            foreach ($this->tempFiles as $tempFile) {
+                if (file_exists($tempFile)) @unlink($tempFile);
+            }
+            $this->tempFiles = [];
+        }
+
+        return $content;
+    }
+
+    public function generateChunkedPdf(PdfTemplate $template, Collection $employees, ?Employer $targetEmployer = null, bool $useEmptyEmployer = false)
+    {
+        $pdf = new Fpdi();
+
+        $reflection = new \ReflectionClass($pdf);
+        if ($reflection->hasProperty('fontpath')) {
+            $property = $reflection->getProperty('fontpath');
+            $property->setAccessible(true);
+            $property->setValue($pdf, public_path('fonts') . DIRECTORY_SEPARATOR);
+        }
+
+        $templatePath = Storage::disk('public')->path($template->file_path);
+
+        $fontLoaded = false;
+        if (file_exists($this->fontPath)) {
+             $pdf->AddFont('THSarabunNew', '', 'THSarabunNew.php');
+             $pdf->SetFont('THSarabunNew', '', 14);
+             $fontLoaded = true;
+        } else {
+             $pdf->SetFont('Arial', '', 12);
+        }
+
+        try {
+            $pageCount = $pdf->setSourceFile($templatePath);
+        } catch (\Exception $e) {
+             try {
+                $normalizedPath = $this->tryNormalizePdf($templatePath);
+                if ($normalizedPath) {
+                    $pageCount = $pdf->setSourceFile($normalizedPath);
+                    $this->tempFiles[] = $normalizedPath;
+                } else {
+                    throw $e;
+                }
+             } catch (\Exception $ex) {
+                 throw new \Exception('Failed to process PDF template: ' . $e->getMessage());
+             }
+        }
+
+        // Shared Context (Employer and Witnesses from first employee in chunk)
+        $firstEmployee = $employees->first();
+        $effectiveEmployer = null;
+        if (!$useEmptyEmployer) {
+            $effectiveEmployer = $targetEmployer ?: $firstEmployee->employer;
+        }
+
+        // --- Prepare Signatures for entire Chunk ---
+        $tempSigPaths = [];
+        $employeeSigPaths = [];
+
+        foreach ($employees as $emp) {
+            if ($emp->signature_path && Storage::disk('public')->exists($emp->signature_path)) {
+                $employeeSigPaths[$emp->id] = Storage::disk('public')->path($emp->signature_path);
+            } else {
+                $seed = 'EMP-' . $emp->id . '-' . uniqid(more_entropy: true);
+                $content = $this->signatureService->generate($seed);
+                $filename = 'signatures/employees/emp_' . $emp->id . '_' . time() . '.png';
+                Storage::disk('public')->put($filename, $content);
+                $emp->update(['signature_path' => $filename]);
+                $employeeSigPaths[$emp->id] = Storage::disk('public')->path($filename);
+            }
+        }
+
+        $emprSig1Path = null;
+        $emprSig2Path = null;
+
+        if ($effectiveEmployer) {
+            if ($effectiveEmployer->signature_1_path && Storage::disk('public')->exists($effectiveEmployer->signature_1_path)) {
+                $emprSig1Path = Storage::disk('public')->path($effectiveEmployer->signature_1_path);
+            } else {
+                $seed = 'EMPR-' . $effectiveEmployer->id . '-1-' . uniqid(more_entropy: true);
+                $content = $this->signatureService->generate($seed);
+                $filename = 'signatures/employers/empr_' . $effectiveEmployer->id . '_1_' . time() . '.png';
+                Storage::disk('public')->put($filename, $content);
+                $effectiveEmployer->update(['signature_1_path' => $filename]);
+                $emprSig1Path = Storage::disk('public')->path($filename);
+            }
+
+            if ($effectiveEmployer->signature_2_path && Storage::disk('public')->exists($effectiveEmployer->signature_2_path)) {
+                $emprSig2Path = Storage::disk('public')->path($effectiveEmployer->signature_2_path);
+            } else {
+                $seed = 'EMPR-' . $effectiveEmployer->id . '-2-' . uniqid(more_entropy: true);
+                $content = $this->signatureService->generate($seed);
+                $filename = 'signatures/employers/empr_' . $effectiveEmployer->id . '_2_' . time() . '.png';
+                Storage::disk('public')->put($filename, $content);
+                $effectiveEmployer->update(['signature_2_path' => $filename]);
+                $emprSig2Path = Storage::disk('public')->path($filename);
+            }
+        }
+
+        $witnessSigPaths = [];
+        $witnessFields = collect($template->field_mapping)->filter(function($item) {
+            return ($item['type'] ?? '') === 'signature' && str_starts_with($item['signatureGroup'] ?? '', 'witness_');
+        });
+
+        if ($witnessFields->isNotEmpty()) {
+            foreach (['witness_1', 'witness_2', 'witness_3', 'witness_4'] as $alias) {
+                $seed = 'WITNESS-' . $alias . '-' . ($effectiveEmployer ? $effectiveEmployer->id : 'global') . '-' . uniqid();
+                $temp = tempnam(sys_get_temp_dir(), 'sig_') . '.png';
+                file_put_contents($temp, $this->signatureService->generate($seed));
+                $witnessSigPaths[$alias] = $temp;
+                $tempSigPaths[] = $temp;
+            }
+        }
+
+        try {
+            for ($pageNo = 1; $pageNo <= $pageCount; $pageNo++) {
+                $templateId = $pdf->importPage($pageNo);
+                $size = $pdf->getTemplateSize($templateId);
+
+                $pdf->AddPage($size['orientation'], [$size['width'], $size['height']]);
+                $pdf->useTemplate($templateId);
+
+                $items = collect($template->field_mapping)->where('page', $pageNo);
+
+                foreach ($items as $item) {
+                    $x = ($item['x'] / 100) * $size['width'];
+                    $y = ($item['y'] / 100) * $size['height'];
+
+                    // Determine which employee to use based on index
+                    $employeeIndex = isset($item['employeeIndex']) ? (int)$item['employeeIndex'] : 1;
+                    $employee = $employees->values()->get($employeeIndex - 1); // 0-based index
+
+                    if (!$employee && $item['type'] !== 'static' && (!isset($item['signatureGroup']) || $item['signatureGroup'] === 'employee')) {
+                        // Skip if employee doesn't exist (e.g., slot 3 but only 2 employees in chunk)
+                        // And skip only if it's an employee-specific field
+                        continue;
+                    }
+
+                    // --- Handle Signatures ---
+                    if (isset($item['type']) && $item['type'] === 'signature') {
+                        $w = ($item['w'] / 100) * $size['width'];
+                        $h = ($item['h'] / 100) * $size['height'];
+
+                        $group = $item['signatureGroup'] ?? 'employee';
+                        $targetPath = null;
+
+                        if ($group === 'employee' && $employee) $targetPath = $employeeSigPaths[$employee->id] ?? null;
+                        elseif ($group === 'employer') $targetPath = $emprSig1Path;
+                        elseif ($group === 'employer_2') $targetPath = $emprSig2Path;
+                        elseif (str_starts_with($group, 'witness_')) $targetPath = $witnessSigPaths[$group] ?? null;
+
+                        if ($targetPath && file_exists($targetPath)) {
+                            $pdf->Image($targetPath, $x, $y, $w, $h, 'PNG');
+                        }
+                        continue;
+                    }
+
+                    // --- Handle Text ---
+                    $text = '';
+                    if ($item['type'] === 'static') {
+                        $text = $item['text'] ?? '';
+                    } elseif ($item['type'] === 'db') {
+                        // Fallback to first employee for non-employee specific fields to prevent errors
+                        $contextEmployee = $employee ?: $firstEmployee;
+                        $text = $this->resolveValue($contextEmployee, $item['key'], $template, $effectiveEmployer);
+                    }
+
+                    if ($text) {
+                        $boxW = ($item['w'] / 100) * $size['width'];
+                        $boxH = ($item['h'] / 100) * $size['height'];
+
+                        if ($fontLoaded) {
+                            $encodedText = @iconv('UTF-8', 'cp874', $text);
+                            if ($encodedText === false) $encodedText = $text;
+                        } else {
+                            $encodedText = @iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $text);
+                        }
+
+                        $fontSize = $item['fontSize'] ?? 12;
+
+                        if (!empty($item['autoFit'])) {
+                            $maxFontSizeH = ($boxH * 0.7) * 2.83;
+                            $pdf->SetFontSize($maxFontSizeH);
+                            $textWidth = $pdf->GetStringWidth($encodedText);
+
+                            if ($textWidth > ($boxW * 0.95)) {
+                                $ratio = ($boxW * 0.95) / $textWidth;
+                                $fontSize = $maxFontSizeH * $ratio;
+                            } else {
+                                $fontSize = $maxFontSizeH;
+                            }
+                        }
+
+                        $pdf->SetFontSize($fontSize);
+
+                        $align = $item['align'] ?? 'center';
+                        $textWidth = $pdf->GetStringWidth($encodedText);
+                        $textX = $x;
+
+                        if ($align === 'center') {
+                            $textX = $x + ($boxW - $textWidth) / 2;
+                        } elseif ($align === 'right') {
+                             $textX = $x + $boxW - $textWidth - 1;
+                        } else {
+                             $textX = $x + 1;
+                        }
+
+                        $textY = $y + $boxH;
+                        $pdf->Text($textX, $textY, $encodedText);
+                    }
+                }
+            }
+            $content = $pdf->Output('S');
+
+        } finally {
             foreach ($tempSigPaths as $path) {
                 if (file_exists($path)) @unlink($path);
             }

--- a/dummy.pdf
+++ b/dummy.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+188
+%%EOF

--- a/resources/views/pdf_templates/builder.blade.php
+++ b/resources/views/pdf_templates/builder.blade.php
@@ -38,12 +38,40 @@
     <div class="flex flex-1 overflow-hidden h-[calc(100vh-64px)]">
         <!-- Sidebar -->
         <div class="w-80 bg-gray-50 border-r flex flex-col overflow-y-auto z-20 shadow-lg">
-            <div class="p-4 border-b bg-white">
-                <h3 class="font-bold text-gray-700 mb-2">Data Fields</h3>
-                <input type="text" x-model="searchQuery" placeholder="Search fields..." class="form-control form-control-sm">
+            <div class="p-4 border-b bg-white flex flex-col gap-3 shadow-sm z-10 relative">
+                <div>
+                    <div class="flex items-center justify-between mb-2">
+                        <h3 class="font-bold text-gray-700 m-0">Data Fields</h3>
+                        <div class="flex items-center gap-2">
+                            <span class="text-xs text-gray-500" title="Employees per page">Slots:</span>
+                            <div class="btn-group btn-group-sm">
+                                <button type="button" @click="if(metaData.employees_per_page > 1) metaData.employees_per_page--" class="btn btn-outline-secondary px-2 py-0">-</button>
+                                <span class="btn btn-outline-secondary px-3 py-0 disabled bg-light text-dark font-bold" x-text="metaData.employees_per_page || 1"></span>
+                                <button type="button" @click="metaData.employees_per_page = (metaData.employees_per_page || 1) + 1" class="btn btn-outline-secondary px-2 py-0">+</button>
+                            </div>
+                        </div>
+                    </div>
+                    <input type="text" x-model="searchQuery" placeholder="Search fields..." class="form-control form-control-sm">
+                </div>
+
+                <!-- Employee Slots Tabs -->
+                <div x-show="(metaData.employees_per_page || 1) > 1" class="flex flex-wrap gap-1 bg-gray-100 p-1 rounded-md border">
+                    <template x-for="i in (metaData.employees_per_page || 1)" :key="i">
+                        <button type="button"
+                                @click="currentEmployeeSlot = i"
+                                :class="{'bg-white shadow-sm font-bold text-blue-600 border-gray-300': currentEmployeeSlot === i, 'text-gray-500 hover:bg-gray-200 border-transparent': currentEmployeeSlot !== i}"
+                                class="flex-1 min-w-[3rem] text-xs py-1 px-2 rounded border transition-colors flex items-center justify-center gap-1">
+                            <i class="bi bi-person-fill" x-show="currentEmployeeSlot === i"></i>
+                            <span x-text="'Emp ' + i"></span>
+                        </button>
+                    </template>
+                </div>
+                <div x-show="(metaData.employees_per_page || 1) > 1" class="text-[10px] text-orange-600 bg-orange-50 p-1.5 rounded border border-orange-100 mt-1 leading-tight text-center">
+                    <i class="bi bi-info-circle me-1"></i> Dragging fields will assign them to <strong>Emp <span x-text="currentEmployeeSlot"></span></strong>.
+                </div>
             </div>
 
-            <div class="p-3 space-y-4 flex-1">
+            <div class="p-3 space-y-4 flex-1 bg-gray-50">
                 <!-- Tools Section -->
                 <div>
                     <h4 class="text-xs font-bold text-gray-500 uppercase mb-2 border-b pb-1">Tools</h4>
@@ -126,15 +154,22 @@
                                                  class="max-w-full max-h-full opacity-60" style="object-fit: contain;">
 
                                             <!-- Label Overlay -->
-                                            <div class="absolute bottom-0 right-0 bg-white/80 text-[10px] px-1 rounded border border-purple-200 text-purple-800 font-bold"
-                                                 x-text="getSignatureLabel(item.signatureGroup)"></div>
+                                            <div class="absolute bottom-0 right-0 bg-white/80 text-[10px] px-1 rounded border border-purple-200 text-purple-800 font-bold flex gap-1">
+                                                <span x-show="item.employeeIndex && (metaData.employees_per_page || 1) > 1" class="bg-orange-100 text-orange-800 px-1 rounded">E<span x-text="item.employeeIndex"></span></span>
+                                                <span x-text="getSignatureLabel(item.signatureGroup)"></span>
+                                            </div>
                                         </div>
                                     </template>
 
                                     <!-- Text Content (DB & Static) -->
                                     <template x-if="item.type !== 'signature'">
-                                        <div class="w-full h-full flex flex-col justify-end overflow-hidden pointer-events-none select-none"
+                                        <div class="w-full h-full flex flex-col justify-end overflow-hidden pointer-events-none select-none relative"
                                              :style="`font-family: 'THSarabunNew', sans-serif; font-size: ${getFontSize(item, pageNum)}; text-align: ${item.align || 'left'}; color: #000;`">
+
+                                            <div class="absolute top-0 right-0 bg-white/80 text-[10px] px-1 rounded-bl border-b border-l border-blue-200 text-blue-800 font-bold" x-show="item.employeeIndex && (metaData.employees_per_page || 1) > 1">
+                                                E<span x-text="item.employeeIndex"></span>
+                                            </div>
+
                                             <span class="block w-full whitespace-nowrap" x-text="getPreviewText(item)" style="line-height: 1;"></span>
                                         </div>
                                     </template>
@@ -201,6 +236,14 @@
                     <!-- Signature Settings -->
                     <template x-if="items[editingIndex]?.type === 'signature'">
                         <div>
+                            <div class="mb-3" x-show="(metaData.employees_per_page || 1) > 1 && items[editingIndex].signatureGroup === 'employee'">
+                                <label class="form-label text-orange-600 font-bold">Employee Slot Assignment</label>
+                                <select x-model="items[editingIndex].employeeIndex" class="form-select border-orange-300 bg-orange-50">
+                                    <template x-for="i in (metaData.employees_per_page || 1)" :key="i">
+                                        <option :value="i" x-text="'Employee ' + i"></option>
+                                    </template>
+                                </select>
+                            </div>
                             <div class="mb-3">
                                 <label class="form-label">Signature Group</label>
                                 <select x-model="items[editingIndex].signatureGroup" class="form-select">
@@ -219,6 +262,15 @@
                     <!-- Text Field Settings (DB & Static) -->
                     <template x-if="items[editingIndex]?.type === 'db' || items[editingIndex]?.type === 'static'">
                         <div>
+                             <div class="mb-3" x-show="(metaData.employees_per_page || 1) > 1 && items[editingIndex]?.type === 'db'">
+                                <label class="form-label text-orange-600 font-bold">Employee Slot Assignment</label>
+                                <select x-model="items[editingIndex].employeeIndex" class="form-select border-orange-300 bg-orange-50">
+                                    <template x-for="i in (metaData.employees_per_page || 1)" :key="i">
+                                        <option :value="i" x-text="'Employee ' + i"></option>
+                                    </template>
+                                </select>
+                            </div>
+
                              <div class="mb-3">
                                 <label class="form-label">Alignment</label>
                                 <select x-model="items[editingIndex].align" class="form-select">
@@ -304,8 +356,9 @@
                 scale: 1.5,
                 pageDimensions: {},
                 items: @json($template->field_mapping ?? []),
-                metaData: @json($template->meta_data ?? ['auto_prefix_titles' => false]),
+                metaData: @json($template->meta_data ?? ['auto_prefix_titles' => false, 'employees_per_page' => 1]),
 
+                currentEmployeeSlot: 1,
                 searchQuery: '',
                 isSaving: false,
                 editingIndex: null,
@@ -542,7 +595,10 @@
 
                 // Initial Meta Data check
                 if (!this.metaData) {
-                    this.metaData = { auto_prefix_titles: false };
+                    this.metaData = { auto_prefix_titles: false, employees_per_page: 1 };
+                }
+                if (!this.metaData.employees_per_page) {
+                    this.metaData.employees_per_page = 1;
                 }
 
                 // Ensure page numbers are integers for correct comparison
@@ -640,7 +696,8 @@
                         fontSize: 12,
                         autoFit: true, // Default to true
                         align: 'left', // Default align
-                        signatureGroup: data.type === 'signature' ? 'employee' : null
+                        signatureGroup: data.type === 'signature' ? 'employee' : null,
+                        employeeIndex: data.type !== 'static' ? this.currentEmployeeSlot : null
                     });
 
                     // Auto-open settings for new static text


### PR DESCRIPTION
This PR introduces the ability to generate PDF templates that contain data for multiple employees on a single page (e.g., forms or tables).

**Key Features:**
*   **Template Builder Slots:** Users can now configure the number of "Slots" (Employees per page) directly in the template builder.
*   **Employee Field Assignment:** When multiple slots are enabled, the builder displays tabs (Emp 1, Emp 2, etc.). Dragging a field from the sidebar automatically assigns it to the currently selected employee slot.
*   **Visual Indicators:** Mapped fields on the document canvas clearly display an "E1", "E2" badge to indicate which employee slot they belong to.
*   **Smart Generation:** The `PdfGeneratorService` now chunks the selected employees based on the template's slot count. For example, if a 3-slot template is used for 8 employees, it will automatically generate 3 pages, grouping the employees correctly and leaving the last slot on the final page blank. Shared data like Employer or Witness details will fall back to the primary context of the first employee in that chunk.

---
*PR created automatically by Jules for task [7892621305975607167](https://jules.google.com/task/7892621305975607167) started by @nongjossss-commits*