### PR TITLE
Fix "View not found" errors in Production and Workflow menus

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -791,7 +791,38 @@ class ProductionController extends Controller
 
         $users = User::orderBy('name')->get(['id', 'name']);
 
-        return view('production._employees_list', compact('items', 'order', 'steps', 'activeTab', 'users'));
+        // Since items are `ProductionItem` models but the expected blade uses `$employees`, we map them.
+        // We also pass the order's employer since the `_employee_list_content` expects `$employer`.
+        $employees = $items->map(function ($item) {
+            $employee = $item->employee;
+            if ($employee) {
+                $employee->production_item = $item;
+            }
+            return $employee;
+        })->filter();
+
+        // If the view for general production/prepare employees list exists, use it.
+        // Otherwise, fallback to the generic registration employee list content view.
+        if (view()->exists('production._employee_list_content')) {
+            return view('production._employee_list_content', [
+                'employees' => $employees,
+                'employer' => $order->employer,
+                'steps' => $steps,
+                'order' => $order,
+                'users' => $users,
+                'activeTab' => $activeTab
+            ]);
+        }
+
+        // This relies on the _employee_list_content that expects an employer and steps
+        return view('production.registration._employee_list_content', [
+            'employees' => $employees,
+            'employer' => $order->employer,
+            'steps' => $steps,
+            'order' => $order,
+            'users' => $users,
+            'activeTab' => $activeTab
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -1905,7 +1905,35 @@ class WorkflowController extends Controller
         $steps = $activeTab ? $activeTab->workflowSteps : collect();
         $users = User::orderBy('name')->get(['id', 'name']);
 
-        return view('workflow._employees_list', compact('items', 'order', 'steps', 'activeTab', 'users'));
+        // Since items are `ProductionItem` models but the expected blade uses `$employees`, we map them.
+        $employees = $items->map(function ($item) {
+            $employee = $item->employee;
+            if ($employee) {
+                $employee->production_item = $item;
+            }
+            return $employee;
+        })->filter();
+
+        if (view()->exists('workflow._employee_list_content')) {
+            return view('workflow._employee_list_content', [
+                'employees' => $employees,
+                'employer' => $order->employer,
+                'steps' => $steps,
+                'order' => $order,
+                'users' => $users,
+                'activeTab' => $activeTab
+            ]);
+        }
+
+        // Fallback to the production registration view since they share the same base employee card partial
+        return view('production.registration._employee_list_content', [
+            'employees' => $employees,
+            'employer' => $order->employer,
+            'steps' => $steps,
+            'order' => $order,
+            'users' => $users,
+            'activeTab' => $activeTab
+        ]);
     }
 
     /**


### PR DESCRIPTION
Resolves a reported issue where opening employer job cards in the "Pre-Production" and "Workflow" menus resulted in a blank/error screen and caused severe system stuttering and lag.

**Root Cause:**
When loading an employer's employees via the accordion cards, `ProductionController` and `WorkflowController` were trying to return views (`production._employees_list` and `workflow._employees_list`) that did not exist in the codebase.
This triggered a 500 Internal Server Error. The Laravel error page attempted to load, and its internal code highlighter `window.highlight()` malfunctioned and was called repeatedly in an infinite loop, causing massive browser lag.

**Fix:**
- Updated both `ProductionController@fetchEmployees` and `WorkflowController@fetchEmployees` to route to the correct underlying `_employee_list_content.blade.php` templates.
- Since the correct blade template iterates over `$employees`, but the query correctly fetches `$items` (`ProductionItem`), the controller now properly maps the collection before passing it to the view.
- Injected `$order->employer` into the view payload to satisfy `_employee_list_content`'s requirements.

---
*PR created automatically by Jules for task [14157015122079857619](https://jules.google.com/task/14157015122079857619) started by @nongjossss-commits*