### PR TITLE
Add Employer Stamp Field and PDF Builder Integration

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -113,9 +113,10 @@ class EmployerController extends Controller
             'job_owner_id' => 'required|exists:job_owners,id',
             'assigned_staff_ids' => 'nullable|array',
             'assigned_staff_ids.*' => 'exists:users,id',
-            // Signatures
+            // Signatures & Stamp
             'signature_1_file' => 'nullable|image|max:2048',
             'signature_2_file' => 'nullable|image|max:2048',
+            'employer_stamp_file' => 'nullable|image|max:2048',
         ]);
 
         // Generate ID
@@ -140,10 +141,14 @@ class EmployerController extends Controller
         if ($request->hasFile('signature_2_file')) {
             $validated['signature_2_path'] = $request->file('signature_2_file')->store('signatures/employers', 'public');
         }
+        if ($request->hasFile('employer_stamp_file')) {
+            $validated['employer_stamp_path'] = $request->file('employer_stamp_file')->store('signatures/employers', 'public');
+        }
 
         // Remove file inputs from array before create
         unset($validated['signature_1_file']);
         unset($validated['signature_2_file']);
+        unset($validated['employer_stamp_file']);
 
         $staffIds = $validated['assigned_staff_ids'] ?? [];
         unset($validated['assigned_staff_ids']);
@@ -293,14 +298,24 @@ class EmployerController extends Controller
             'job_owner_id' => 'required|exists:job_owners,id',
             'assigned_staff_ids' => 'nullable|array',
             'assigned_staff_ids.*' => 'exists:users,id',
-            // Signatures
+            // Signatures & Stamp
             'signature_1_action' => 'nullable|in:keep,generate,upload,draw',
             'signature_1_file' => 'nullable|required_if:signature_1_action,upload|image|max:2048',
             'signature_1_base64' => 'nullable|string',
             'signature_2_action' => 'nullable|in:keep,generate,upload,draw',
             'signature_2_file' => 'nullable|required_if:signature_2_action,upload|image|max:2048',
             'signature_2_base64' => 'nullable|string',
+            'employer_stamp_action' => 'nullable|in:keep,upload,draw',
+            'employer_stamp_file' => 'nullable|required_if:employer_stamp_action,upload|image|max:2048',
+            'employer_stamp_base64' => 'nullable|string',
         ]);
+
+        // Employers shouldn't be updating signatures or stamps. Clear them if present just in case.
+        if (auth()->user()->hasRole('employer')) {
+            unset($validated['signature_1_action'], $validated['signature_1_file'], $validated['signature_1_base64']);
+            unset($validated['signature_2_action'], $validated['signature_2_file'], $validated['signature_2_base64']);
+            unset($validated['employer_stamp_action'], $validated['employer_stamp_file'], $validated['employer_stamp_base64']);
+        }
 
         // Handle docs
         $docFields = ['employer_doc_company', 'employer_doc_lease', 'employer_doc_construction', 'employer_doc_other_1', 'employer_doc_other_2', 'employer_doc_other_3'];
@@ -364,6 +379,25 @@ class EmployerController extends Controller
              }
         }
 
+        // Employer Stamp
+        if (!auth()->user()->hasRole('employer')) {
+            $stampAction = $request->input('employer_stamp_action', 'keep');
+            if ($stampAction === 'upload' && $request->hasFile('employer_stamp_file')) {
+                if ($employer->employer_stamp_path) Storage::disk('public')->delete($employer->employer_stamp_path);
+                $validated['employer_stamp_path'] = $request->file('employer_stamp_file')->store('signatures/employers', 'public');
+            } elseif ($stampAction === 'draw' && $request->filled('employer_stamp_base64')) {
+                $base64Image = $request->input('employer_stamp_base64');
+                if (preg_match('/^data:image\/(\w+);base64,/', $base64Image, $type)) {
+                    if ($employer->employer_stamp_path) Storage::disk('public')->delete($employer->employer_stamp_path);
+                    $data = substr($base64Image, strpos($base64Image, ',') + 1);
+                    $data = base64_decode($data);
+                    $path = 'signatures/employers/emp_' . $employer->id . '_stamp_' . time() . '.' . strtolower($type[1]);
+                    Storage::disk('public')->put($path, $data);
+                    $validated['employer_stamp_path'] = $path;
+                }
+            }
+        }
+
         // Cleanup fields not in DB
         unset($validated['signature_1_action']);
         unset($validated['signature_1_file']);
@@ -371,6 +405,9 @@ class EmployerController extends Controller
         unset($validated['signature_2_action']);
         unset($validated['signature_2_file']);
         unset($validated['signature_2_base64']);
+        unset($validated['employer_stamp_action']);
+        unset($validated['employer_stamp_file']);
+        unset($validated['employer_stamp_base64']);
 
         $staffIds = $validated['assigned_staff_ids'] ?? [];
         unset($validated['assigned_staff_ids']);

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -53,6 +53,7 @@ class Employer extends Model
         'signer_2_name_en',
         'signature_1_path',
         'signature_2_path',
+        'employer_stamp_path',
         'businessTypeEn',
         'regCapital',
         'regDate',

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -432,23 +432,30 @@ class PdfGeneratorService
                     $x = ($item['x'] / 100) * $size['width'];
                     $y = ($item['y'] / 100) * $size['height'];
 
-                    // --- Handle Signatures ---
-                    if (isset($item['type']) && $item['type'] === 'signature') {
+                    // --- Handle Signatures & Stamps ---
+                    if (isset($item['type']) && ($item['type'] === 'signature' || $item['type'] === 'stamp')) {
                         $w = ($item['w'] / 100) * $size['width'];
                         $h = ($item['h'] / 100) * $size['height'];
 
-                        $group = $item['signatureGroup'] ?? 'employee';
                         $targetPath = null;
 
-                        if ($group === 'employee') $targetPath = $empSigPath;
-                        elseif ($group === 'employer') $targetPath = $emprSig1Path;
-                        elseif ($group === 'employer_2') $targetPath = $emprSig2Path;
-                        elseif (str_starts_with($group, 'witness_')) $targetPath = $witnessSigPaths[$group] ?? null;
+                        if ($item['type'] === 'signature') {
+                            $group = $item['signatureGroup'] ?? 'employee';
+
+                            if ($group === 'employee') $targetPath = $empSigPath;
+                            elseif ($group === 'employer') $targetPath = $emprSig1Path;
+                            elseif ($group === 'employer_2') $targetPath = $emprSig2Path;
+                            elseif (str_starts_with($group, 'witness_')) $targetPath = $witnessSigPaths[$group] ?? null;
+                        } elseif ($item['type'] === 'stamp') {
+                            $targetPath = $emprStampPath;
+                        }
 
                         if ($targetPath && file_exists($targetPath)) {
-                            // FPDF Image supports PNG/JPG. If path is real, it works.
-                            // If temp, it works.
-                            $pdf->Image($targetPath, $x, $y, $w, $h, 'PNG');
+                            $ext = strtolower(pathinfo($targetPath, PATHINFO_EXTENSION));
+                            $imgType = in_array($ext, ['png', 'jpg', 'jpeg']) ? strtoupper($ext) : 'PNG';
+                            if ($imgType === 'JPG') $imgType = 'JPEG';
+
+                            $pdf->Image($targetPath, $x, $y, $w, $h, $imgType);
                         }
                         continue;
                     }
@@ -604,6 +611,7 @@ class PdfGeneratorService
 
         $emprSig1Path = null;
         $emprSig2Path = null;
+        $emprStampPath = null;
 
         if ($effectiveEmployer) {
             if ($effectiveEmployer->signature_1_path && Storage::disk('public')->exists($effectiveEmployer->signature_1_path)) {
@@ -626,6 +634,10 @@ class PdfGeneratorService
                 Storage::disk('public')->put($filename, $content);
                 $effectiveEmployer->update(['signature_2_path' => $filename]);
                 $emprSig2Path = Storage::disk('public')->path($filename);
+            }
+
+            if ($effectiveEmployer->employer_stamp_path && Storage::disk('public')->exists($effectiveEmployer->employer_stamp_path)) {
+                $emprStampPath = Storage::disk('public')->path($effectiveEmployer->employer_stamp_path);
             }
         }
 
@@ -668,21 +680,30 @@ class PdfGeneratorService
                         continue;
                     }
 
-                    // --- Handle Signatures ---
-                    if (isset($item['type']) && $item['type'] === 'signature') {
+                    // --- Handle Signatures & Stamps ---
+                    if (isset($item['type']) && ($item['type'] === 'signature' || $item['type'] === 'stamp')) {
                         $w = ($item['w'] / 100) * $size['width'];
                         $h = ($item['h'] / 100) * $size['height'];
 
-                        $group = $item['signatureGroup'] ?? 'employee';
                         $targetPath = null;
 
-                        if ($group === 'employee' && $employee) $targetPath = $employeeSigPaths[$employee->id] ?? null;
-                        elseif ($group === 'employer') $targetPath = $emprSig1Path;
-                        elseif ($group === 'employer_2') $targetPath = $emprSig2Path;
-                        elseif (str_starts_with($group, 'witness_')) $targetPath = $witnessSigPaths[$group] ?? null;
+                        if ($item['type'] === 'signature') {
+                            $group = $item['signatureGroup'] ?? 'employee';
+
+                            if ($group === 'employee' && $employee) $targetPath = $employeeSigPaths[$employee->id] ?? null;
+                            elseif ($group === 'employer') $targetPath = $emprSig1Path;
+                            elseif ($group === 'employer_2') $targetPath = $emprSig2Path;
+                            elseif (str_starts_with($group, 'witness_')) $targetPath = $witnessSigPaths[$group] ?? null;
+                        } elseif ($item['type'] === 'stamp') {
+                            $targetPath = $emprStampPath;
+                        }
 
                         if ($targetPath && file_exists($targetPath)) {
-                            $pdf->Image($targetPath, $x, $y, $w, $h, 'PNG');
+                            $ext = strtolower(pathinfo($targetPath, PATHINFO_EXTENSION));
+                            $imgType = in_array($ext, ['png', 'jpg', 'jpeg']) ? strtoupper($ext) : 'PNG';
+                            if ($imgType === 'JPG') $imgType = 'JPEG';
+
+                            $pdf->Image($targetPath, $x, $y, $w, $h, $imgType);
                         }
                         continue;
                     }

--- a/database/migrations/2026_03_06_225722_add_employer_stamp_path_to_employers_table.php
+++ b/database/migrations/2026_03_06_225722_add_employer_stamp_path_to_employers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->string('employer_stamp_path')->nullable()->after('signature_2_path');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->dropColumn('employer_stamp_path');
+        });
+    }
+};

--- a/resources/views/employers/create.blade.php
+++ b/resources/views/employers/create.blade.php
@@ -214,6 +214,19 @@
                 @enderror
             </div>
         </div>
+        @unless(auth()->user()->hasRole('employer'))
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="employer_stamp_file" class="form-label">{{ __('Employer Stamp') }}</label>
+                <input type="file" class="form-control @error('employer_stamp_file') is-invalid @enderror" id="employer_stamp_file" name="employer_stamp_file" accept="image/png, image/jpeg, image/jpg">
+                @error('employer_stamp_file')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+                <div class="form-text">{{ __('Max size: 2MB. Allowed formats: PNG, JPG.') }}</div>
+            </div>
+        </div>
+        @endunless
+
         <div class="row mb-3">
             <div class="col-md-6">
                 <label for="regCapital" class="form-label">{{ __('Registered Capital') }}</label>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -194,7 +194,7 @@
  </div>
  </div>
 
-        <h5 class="mb-3 text-primary mt-4">{{ __('Authorized Signatories') }}</h5>
+        <h5 class="mb-3 text-primary mt-4">{{ __('Authorized Signatories & Stamp') }}</h5>
         <!-- Signer 1 -->
         <div class="card bg-light mb-3" x-data="signatureField('signature_1', '{{ $employer->signature_1_path ? Storage::url($employer->signature_1_path) : '' }}')">
             <div class="card-body">
@@ -211,6 +211,7 @@
                 </div>
 
                 <!-- Hidden Inputs for State Persistence -->
+                @unless(auth()->user()->hasRole('employer'))
                 <input type="hidden" name="signature_1_action" x-model="action">
                 <input type="hidden" name="signature_1_base64" x-model="base64">
                 <div x-ref="fileInputContainer" class="d-none"></div>
@@ -238,6 +239,7 @@
                         <div class="form-text mt-1">{{ __('Click to edit, upload, or draw signature.') }}</div>
                      </div>
                 </div>
+                @endunless
             </div>
         </div>
 
@@ -257,6 +259,7 @@
                 </div>
 
                  <!-- Hidden Inputs for State Persistence -->
+                 @unless(auth()->user()->hasRole('employer'))
                  <input type="hidden" name="signature_2_action" x-model="action">
                  <input type="hidden" name="signature_2_base64" x-model="base64">
                  <div x-ref="fileInputContainer" class="d-none"></div>
@@ -284,8 +287,47 @@
                          <div class="form-text mt-1">{{ __('Click to edit, upload, or draw signature.') }}</div>
                       </div>
                  </div>
+                 @endunless
             </div>
         </div>
+
+        <!-- Employer Stamp -->
+        @unless(auth()->user()->hasRole('employer'))
+        <div class="card bg-light mb-3" x-data="signatureField('employer_stamp', '{{ $employer->employer_stamp_path ? Storage::url($employer->employer_stamp_path) : '' }}')">
+            <div class="card-body">
+                <h6 class="card-title text-muted fw-bold">{{ __('Employer Stamp') }} (Optional)</h6>
+
+                 <!-- Hidden Inputs for State Persistence -->
+                 <input type="hidden" name="employer_stamp_action" x-model="action">
+                 <input type="hidden" name="employer_stamp_base64" x-model="base64">
+                 <div x-ref="fileInputContainer" class="d-none"></div>
+
+                 <!-- Preview and Trigger -->
+                 <div class="d-flex flex-column flex-md-row align-items-start gap-3 mt-2">
+                      <div class="d-flex flex-column">
+                         <label class="form-label small text-muted mb-1">{{ __('Stamp Preview') }}</label>
+                         <div class="border rounded bg-white d-flex justify-content-center align-items-center overflow-hidden position-relative" style="width: 180px; height: 100px;">
+                              <template x-if="previewUrl">
+                                  <img :src="previewUrl" class="img-fluid" style="max-height: 100%;">
+                              </template>
+                              <template x-if="!previewUrl">
+                                  <span class="text-muted small italic">{{ __('No Stamp') }}</span>
+                              </template>
+                              <template x-if="action !== 'keep' && action !== ''">
+                                <span class="position-absolute top-0 end-0 badge bg-warning text-dark m-1" style="font-size: 0.6rem;">{{ __('Pending Save') }}</span>
+                            </template>
+                         </div>
+                      </div>
+                      <div class="mt-md-4">
+                         <button type="button" class="btn btn-outline-primary" @click="$dispatch('open-signature-modal', { field: 'employer_stamp', currentAction: action, currentUrl: previewUrl, currentBase64: base64 })">
+                             <i class="bi bi-pen me-2"></i> {{ __('Stamp Settings') }}
+                         </button>
+                         <div class="form-text mt-1">{{ __('Click to upload or draw stamp.') }}</div>
+                      </div>
+                 </div>
+            </div>
+        </div>
+        @endunless
 
         <div class="row mb-3">
             <div class="col-md-6">

--- a/resources/views/pdf_templates/builder.blade.php
+++ b/resources/views/pdf_templates/builder.blade.php
@@ -90,6 +90,14 @@
                             <i class="bi bi-pen text-xl text-gray-600"></i>
                             <span class="text-xs font-medium">Signature</span>
                         </div>
+
+                        <!-- Stamp -->
+                        <div class="border rounded p-2 bg-white cursor-move hover:border-red-500 hover:bg-red-50 flex flex-col items-center justify-center gap-1 text-center"
+                             draggable="true"
+                             @dragstart="dragStart($event, {type: 'stamp', label: 'Employer Stamp'})">
+                            <i class="bi bi-vinyl text-xl text-gray-600"></i>
+                            <span class="text-xs font-medium">Stamp</span>
+                        </div>
                     </div>
                 </div>
 
@@ -141,10 +149,26 @@
                                      :class="{
                                         'border-blue-500 bg-blue-50/30 hover:bg-blue-100/50': item.type === 'db',
                                         'border-gray-500 bg-gray-50/30 hover:bg-gray-100/50': item.type === 'static',
-                                        'border-purple-500 bg-purple-50/30 hover:bg-purple-100/50': item.type === 'signature'
+                                        'border-purple-500 bg-purple-50/30 hover:bg-purple-100/50': item.type === 'signature',
+                                        'border-red-500 bg-red-50/30 hover:bg-red-100/50': item.type === 'stamp'
                                      }"
                                      :style="`left: ${item.x}%; top: ${item.y}%; width: ${item.w}%; height: ${item.h}%;`"
                                      @mousedown.self="startMove($event, index, pageNum)">
+
+                                    <!-- Stamp Content -->
+                                    <template x-if="item.type === 'stamp'">
+                                        <div class="w-full h-full flex flex-col items-center justify-center pointer-events-none select-none relative">
+                                            <!-- SVG Stamp Placeholder -->
+                                            <div class="w-16 h-16 rounded-full border-4 border-red-500/50 flex items-center justify-center text-red-500/50 font-bold rotate-12 bg-white/30">
+                                                STAMP
+                                            </div>
+
+                                            <!-- Label Overlay -->
+                                            <div class="absolute bottom-0 right-0 bg-white/80 text-[10px] px-1 rounded border border-red-200 text-red-800 font-bold flex gap-1">
+                                                <span>(Employer Stamp)</span>
+                                            </div>
+                                        </div>
+                                    </template>
 
                                     <!-- Signature Content -->
                                     <template x-if="item.type === 'signature'">
@@ -162,7 +186,7 @@
                                     </template>
 
                                     <!-- Text Content (DB & Static) -->
-                                    <template x-if="item.type !== 'signature'">
+                                    <template x-if="item.type !== 'signature' && item.type !== 'stamp'">
                                         <div class="w-full h-full flex flex-col justify-end overflow-hidden pointer-events-none select-none relative"
                                              :style="`font-family: 'THSarabunNew', sans-serif; font-size: ${getFontSize(item, pageNum)}; text-align: ${item.align || 'left'}; color: #000;`">
 
@@ -681,6 +705,9 @@
                     if (data.type === 'signature') {
                         wPct = 10;
                         hPct = 6; // Signatures are taller
+                    } else if (data.type === 'stamp') {
+                        wPct = 8;
+                        hPct = 8; // Stamps are usually square
                     }
 
                     this.items.push({
@@ -697,7 +724,7 @@
                         autoFit: true, // Default to true
                         align: 'left', // Default align
                         signatureGroup: data.type === 'signature' ? 'employee' : null,
-                        employeeIndex: data.type !== 'static' ? this.currentEmployeeSlot : null
+                        employeeIndex: (data.type !== 'static' && data.type !== 'stamp') ? this.currentEmployeeSlot : null
                     });
 
                     // Auto-open settings for new static text
@@ -853,7 +880,7 @@
             },
 
             getFontSize(item, pageNum) {
-                if (item.type === 'signature') return '12px';
+                if (item.type === 'signature' || item.type === 'stamp') return '12px';
 
                 if (item.autoFit) {
                     const dims = this.pageDimensions[pageNum];


### PR DESCRIPTION
This submission adds the ability for system administrators to upload a "Company Stamp" image for employers. The feature strictly restricts employer accounts from viewing or modifying the stamp (or signatures) to maintain company confidentiality. Furthermore, this newly uploaded stamp can now be dragged, resized, and placed anywhere onto dynamically generated PDF documents using the PDF Builder interface, rendering natively into the generated PDF through the PDF generator service.

---
*PR created automatically by Jules for task [7711098752813207680](https://jules.google.com/task/7711098752813207680) started by @nongjossss-commits*