### PR TITLE
Add inline notes to Employer Cards

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -33,6 +33,24 @@ class RegistrationController extends Controller
     }
 
     /**
+     * Update employer registration resolution note (inline).
+     */
+    public function updateResolutionNote(Request $request, Employer $employer)
+    {
+        if (!auth()->user()->can('edit-employees')) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'note' => 'nullable|string',
+        ]);
+
+        $employer->update(['registration_resolution_note' => $validated['note']]);
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
      * Display the main dashboard for Registration Resolution.
      */
     public function index(Request $request)

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -30,6 +30,24 @@ class RenewalController extends Controller
     /**
      * Display the main dashboard for Renewal Resolution.
      */
+    /**
+     * Update employer renewal resolution note (inline).
+     */
+    public function updateResolutionNote(Request $request, Employer $employer)
+    {
+        if (!auth()->user()->can('edit-employees')) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'note' => 'nullable|string',
+        ]);
+
+        $employer->update(['renewal_resolution_note' => $validated['note']]);
+
+        return response()->json(['success' => true]);
+    }
+
     public function index(Request $request)
     {
         $steps = RegistrationStep::renewal()->orderBy('order')->get();

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -844,6 +844,21 @@ class ProductionController extends Controller
     /**
      * Calculate Stats per Order via AJAX
      */
+    public function updateRemarks(Request $request, ProductionOrder $order)
+    {
+        if (!auth()->user()->can('edit-employees')) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'remarks' => 'nullable|string',
+        ]);
+
+        $order->update(['remarks' => $validated['remarks']]);
+
+        return response()->json(['success' => true]);
+    }
+
     public function batchStats(Request $request)
     {
         $request->validate([

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -274,6 +274,21 @@ class WorkflowController extends Controller
     /**
      * Update Remarks for a ProductionItem via AJAX.
      */
+    public function updateOrderRemarks(Request $request, ProductionOrder $order)
+    {
+        if (!auth()->user()->can('manage-own-workflow')) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'remarks' => 'nullable|string',
+        ]);
+
+        $order->update(['remarks' => $validated['remarks']]);
+
+        return response()->json(['success' => true]);
+    }
+
     public function updateRemarks(Request $request, $itemId)
     {
         $request->validate(['remarks' => 'nullable|string']);

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -73,6 +73,7 @@ class Employer extends Model
         'assigned_staff_id',
         'registration_resolution_status',
         'registration_resolution_note',
+        'renewal_resolution_note',
     ];
 
     /**

--- a/app/Models/ProductionOrder.php
+++ b/app/Models/ProductionOrder.php
@@ -17,6 +17,7 @@ class ProductionOrder extends Model
         'project_name',
         'description',
         'status',
+        'remarks',
         'financial_data',
         'created_by',
         'updated_by', // NEW

--- a/database/migrations/2026_03_08_211546_add_renewal_resolution_note_to_employers_table.php
+++ b/database/migrations/2026_03_08_211546_add_renewal_resolution_note_to_employers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->text('renewal_resolution_note')->nullable()->after('registration_resolution_note');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employers', function (Blueprint $table) {
+            $table->dropColumn('renewal_resolution_note');
+        });
+    }
+};

--- a/database/migrations/2026_03_08_211611_add_remarks_to_production_orders_table.php
+++ b/database/migrations/2026_03_08_211611_add_remarks_to_production_orders_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('production_orders', function (Blueprint $table) {
+            $table->text('remarks')->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('production_orders', function (Blueprint $table) {
+            $table->dropColumn('remarks');
+        });
+    }
+};

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -259,6 +259,54 @@
                 <div class="card border-0 shadow-sm flex-grow-1 production-order-card {{ !$isActive ? 'grayscale-mode' : '' }}">
                     <div class="card-header bg-white border-bottom py-3 px-4" id="heading-{{ $order->id }}">
 
+                    {{-- Inline Note Editor (Top Center) --}}
+                    <div class="d-flex justify-content-center mb-2">
+                        <div class="position-relative w-50 text-center" x-data="{
+                            editing: false,
+                            note: {{ json_encode($order->remarks ?? '') }},
+                            saving: false,
+                            saveNote() {
+                                this.saving = true;
+                                fetch(`{{ url('production') }}/{{ $order->id }}/remarks`, {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/json',
+                                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                                        'X-Requested-With': 'XMLHttpRequest'
+                                    },
+                                    body: JSON.stringify({ remarks: this.note })
+                                })
+                                .then(res => res.json())
+                                .then(data => {
+                                    this.saving = false;
+                                    if(data.success) {
+                                        this.editing = false;
+                                    } else {
+                                        Swal.fire('Error', 'Failed to save note', 'error');
+                                    }
+                                })
+                                .catch(err => {
+                                    this.saving = false;
+                                    Swal.fire('Error', 'Network error', 'error');
+                                });
+                            }
+                        }">
+                            <div x-show="!editing" class="p-2 border rounded bg-light shadow-sm d-flex align-items-center justify-content-center cursor-pointer" @click="editing = true" style="min-height: 40px;">
+                                <span class="text-muted fw-bold me-2" x-show="!note"><i class="bi bi-pencil-square me-1"></i>{{ __('Add Note') }}</span>
+                                <span class="text-dark fw-bold text-truncate" style="max-width: 80%;" x-text="note" x-show="note"></span>
+                                <i class="bi bi-pencil-square text-secondary ms-2" x-show="note"></i>
+                            </div>
+                            <div x-show="editing" class="d-flex align-items-center gap-1" style="display: none;">
+                                <input type="text" class="form-control form-control-sm" x-model="note" @keydown.enter="saveNote()" placeholder="{{ __('Note...') }}">
+                                <button class="btn btn-sm btn-success" @click="saveNote()" :disabled="saving">
+                                    <i class="bi bi-check-lg" x-show="!saving"></i>
+                                    <span class="spinner-border spinner-border-sm" x-show="saving"></span>
+                                </button>
+                                <button class="btn btn-sm btn-secondary" @click="editing = false" :disabled="saving"><i class="bi bi-x-lg"></i></button>
+                            </div>
+                        </div>
+                    </div>
+
                         {{-- Top Row: Identity + Stats + Actions --}}
                     <div class="row align-items-xl-center g-3 mb-3">
                         {{-- Identity --}}

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -397,16 +397,57 @@
                             <span class="badge bg-{{ $statusColor }}">{{ $statusLabel }}</span>
                         @endcan
 
-                        {{-- Job Order / Note Button --}}
-                        <button class="btn btn-sm btn-outline-secondary border-0"
-                                data-note="{{ $employer->registration_resolution_note ?? '' }}"
-                                onclick="openResolutionNoteModal({{ $employer->id }}, this.getAttribute('data-note'))"
-                                title="{{ __('Job Order / Notes') }}">
-                            <i class="bi bi-file-text-fill"></i>
-                        </button>
                     </div>
 
                     <div class="card-header py-3 px-4 border-bottom {{ $employerHeaderClass }}" id="heading{{ $employer->id }}">
+
+                    {{-- Inline Note Editor (Top Center) --}}
+                    <div class="d-flex justify-content-center mb-2">
+                        <div class="position-relative w-50 text-center" x-data="{
+                            editing: false,
+                            note: {{ json_encode($employer->registration_resolution_note ?? '') }},
+                            saving: false,
+                            saveNote() {
+                                this.saving = true;
+                                fetch(`{{ url('production/registration/employer') }}/{{ $employer->id }}/resolution-note`, {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/json',
+                                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                                        'X-Requested-With': 'XMLHttpRequest'
+                                    },
+                                    body: JSON.stringify({ note: this.note })
+                                })
+                                .then(res => res.json())
+                                .then(data => {
+                                    this.saving = false;
+                                    if(data.success) {
+                                        this.editing = false;
+                                    } else {
+                                        Swal.fire('Error', 'Failed to save note', 'error');
+                                    }
+                                })
+                                .catch(err => {
+                                    this.saving = false;
+                                    Swal.fire('Error', 'Network error', 'error');
+                                });
+                            }
+                        }">
+                            <div x-show="!editing" class="p-2 border rounded bg-white shadow-sm d-flex align-items-center justify-content-center cursor-pointer" @click="editing = true" style="min-height: 40px;">
+                                <span class="text-muted fw-bold me-2" x-show="!note"><i class="bi bi-pencil-square me-1"></i>{{ __('Add Note') }}</span>
+                                <span class="text-dark fw-bold text-truncate" style="max-width: 80%;" x-text="note" x-show="note"></span>
+                                <i class="bi bi-pencil-square text-secondary ms-2" x-show="note"></i>
+                            </div>
+                            <div x-show="editing" class="d-flex align-items-center gap-1" style="display: none;">
+                                <input type="text" class="form-control form-control-sm" x-model="note" @keydown.enter="saveNote()" placeholder="{{ __('Note...') }}">
+                                <button class="btn btn-sm btn-success" @click="saveNote()" :disabled="saving">
+                                    <i class="bi bi-check-lg" x-show="!saving"></i>
+                                    <span class="spinner-border spinner-border-sm" x-show="saving"></span>
+                                </button>
+                                <button class="btn btn-sm btn-secondary" @click="editing = false" :disabled="saving"><i class="bi bi-x-lg"></i></button>
+                            </div>
+                        </div>
+                    </div>
 
                     {{-- Top Row: Identity + Stats + Actions (Using Grid for Alignment) --}}
                     <div class="row align-items-xl-center g-3 mb-3">

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -376,16 +376,57 @@
                             <span class="badge bg-{{ $statusColor }}">{{ $statusLabel }}</span>
                         @endcan
 
-                        {{-- Job Order / Note Button --}}
-                        <button class="btn btn-sm btn-outline-secondary border-0"
-                                data-note="{{ $employer->registration_resolution_note ?? '' }}"
-                                onclick="openResolutionNoteModal({{ $employer->id }}, this.getAttribute('data-note'))"
-                                title="{{ __('Job Order / Notes') }}">
-                            <i class="bi bi-file-text-fill"></i>
-                        </button>
                     </div>
 
                     <div class="card-header py-3 px-4 border-bottom {{ $employerHeaderClass }}" id="heading{{ $employer->id }}">
+
+                    {{-- Inline Note Editor (Top Center) --}}
+                    <div class="d-flex justify-content-center mb-2">
+                        <div class="position-relative w-50 text-center" x-data="{
+                            editing: false,
+                            note: {{ json_encode($employer->renewal_resolution_note ?? '') }},
+                            saving: false,
+                            saveNote() {
+                                this.saving = true;
+                                fetch(`{{ url('production/renewal/employer') }}/{{ $employer->id }}/resolution-note`, {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/json',
+                                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                                        'X-Requested-With': 'XMLHttpRequest'
+                                    },
+                                    body: JSON.stringify({ note: this.note })
+                                })
+                                .then(res => res.json())
+                                .then(data => {
+                                    this.saving = false;
+                                    if(data.success) {
+                                        this.editing = false;
+                                    } else {
+                                        Swal.fire('Error', 'Failed to save note', 'error');
+                                    }
+                                })
+                                .catch(err => {
+                                    this.saving = false;
+                                    Swal.fire('Error', 'Network error', 'error');
+                                });
+                            }
+                        }">
+                            <div x-show="!editing" class="p-2 border rounded bg-white shadow-sm d-flex align-items-center justify-content-center cursor-pointer" @click="editing = true" style="min-height: 40px;">
+                                <span class="text-muted fw-bold me-2" x-show="!note"><i class="bi bi-pencil-square me-1"></i>{{ __('Add Note') }}</span>
+                                <span class="text-dark fw-bold text-truncate" style="max-width: 80%;" x-text="note" x-show="note"></span>
+                                <i class="bi bi-pencil-square text-secondary ms-2" x-show="note"></i>
+                            </div>
+                            <div x-show="editing" class="d-flex align-items-center gap-1" style="display: none;">
+                                <input type="text" class="form-control form-control-sm" x-model="note" @keydown.enter="saveNote()" placeholder="{{ __('Note...') }}">
+                                <button class="btn btn-sm btn-success" @click="saveNote()" :disabled="saving">
+                                    <i class="bi bi-check-lg" x-show="!saving"></i>
+                                    <span class="spinner-border spinner-border-sm" x-show="saving"></span>
+                                </button>
+                                <button class="btn btn-sm btn-secondary" @click="editing = false" :disabled="saving"><i class="bi bi-x-lg"></i></button>
+                            </div>
+                        </div>
+                    </div>
 
                     {{-- Top Row: Identity + Stats + Actions (Using Grid for Alignment) --}}
                     <div class="row align-items-xl-center g-3 mb-3">

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -268,6 +268,54 @@
                 <div class="card border-0 shadow-sm flex-grow-1 production-order-card {{ !$isActive ? 'grayscale-mode' : '' }}">
                     <div class="card-header bg-white border-bottom py-3 px-4" id="heading-{{ $order->id }}">
 
+                    {{-- Inline Note Editor (Top Center) --}}
+                    <div class="d-flex justify-content-center mb-2">
+                        <div class="position-relative w-50 text-center" x-data="{
+                            editing: false,
+                            note: {{ json_encode($order->remarks ?? '') }},
+                            saving: false,
+                            saveNote() {
+                                this.saving = true;
+                                fetch(`{{ url('workflow/order') }}/{{ $order->id }}/remarks`, {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/json',
+                                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                                        'X-Requested-With': 'XMLHttpRequest'
+                                    },
+                                    body: JSON.stringify({ remarks: this.note })
+                                })
+                                .then(res => res.json())
+                                .then(data => {
+                                    this.saving = false;
+                                    if(data.success) {
+                                        this.editing = false;
+                                    } else {
+                                        Swal.fire('Error', 'Failed to save note', 'error');
+                                    }
+                                })
+                                .catch(err => {
+                                    this.saving = false;
+                                    Swal.fire('Error', 'Network error', 'error');
+                                });
+                            }
+                        }">
+                            <div x-show="!editing" class="p-2 border rounded bg-light shadow-sm d-flex align-items-center justify-content-center cursor-pointer" @click="editing = true" style="min-height: 40px;">
+                                <span class="text-muted fw-bold me-2" x-show="!note"><i class="bi bi-pencil-square me-1"></i>{{ __('Add Note') }}</span>
+                                <span class="text-dark fw-bold text-truncate" style="max-width: 80%;" x-text="note" x-show="note"></span>
+                                <i class="bi bi-pencil-square text-secondary ms-2" x-show="note"></i>
+                            </div>
+                            <div x-show="editing" class="d-flex align-items-center gap-1" style="display: none;">
+                                <input type="text" class="form-control form-control-sm" x-model="note" @keydown.enter="saveNote()" placeholder="{{ __('Note...') }}">
+                                <button class="btn btn-sm btn-success" @click="saveNote()" :disabled="saving">
+                                    <i class="bi bi-check-lg" x-show="!saving"></i>
+                                    <span class="spinner-border spinner-border-sm" x-show="saving"></span>
+                                </button>
+                                <button class="btn btn-sm btn-secondary" @click="editing = false" :disabled="saving"><i class="bi bi-x-lg"></i></button>
+                            </div>
+                        </div>
+                    </div>
+
                         {{-- Top Row: Identity + Stats + Actions --}}
                     <div class="row align-items-xl-center g-3 mb-3">
                         {{-- Identity --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -277,6 +277,7 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/employer/{employer}/cancel', [App\Http\Controllers\Production\RegistrationController::class, 'cancelEmployer'])->name('cancel_employer');
         Route::post('/employer/{employer}/restore', [App\Http\Controllers\Production\RegistrationController::class, 'restoreEmployer'])->name('restore_employer');
         Route::post('/employer/{employer}/resolution-status', [App\Http\Controllers\Production\RegistrationController::class, 'updateResolutionStatus'])->name('employer_resolution.update');
+        Route::post('/employer/{employer}/resolution-note', [App\Http\Controllers\Production\RegistrationController::class, 'updateResolutionNote'])->name('employer_resolution.update_note');
 
         // Biometrics
         Route::post('/{employee}/biometrics', [App\Http\Controllers\Production\RegistrationController::class, 'updateBiometrics'])->name('biometrics.update');
@@ -352,6 +353,7 @@ Route::middleware(['auth'])->group(function () {
         // Employer Actions
         Route::post('/employer/{employer}/cancel', [App\Http\Controllers\Production\RenewalController::class, 'cancelEmployer'])->name('cancel_employer');
         Route::post('/employer/{employer}/restore', [App\Http\Controllers\Production\RenewalController::class, 'restoreEmployer'])->name('restore_employer');
+        Route::post('/employer/{employer}/resolution-note', [App\Http\Controllers\Production\RenewalController::class, 'updateResolutionNote'])->name('employer_resolution.update_note');
 
         // Trash Routes
         Route::get('/trash', [App\Http\Controllers\Production\RenewalController::class, 'fetchTrash'])->name('trash');
@@ -373,6 +375,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('production/{id}/toggle-status', [\App\Http\Controllers\ProductionController::class, 'toggleStatus'])->name('production.toggle_status');
     Route::put('production/items/{item}/update-fields', [\App\Http\Controllers\ProductionController::class, 'updateItemFields'])->name('production.items.update_fields');
     Route::post('production/{id}/upload-logo', [\App\Http\Controllers\ProductionController::class, 'uploadLogo'])->name('production.upload_logo');
+    Route::post('production/{order}/remarks', [\App\Http\Controllers\ProductionController::class, 'updateRemarks'])->name('production.order.remarks');
 
     Route::middleware('menu:finance')->group(function() {
         Route::post('production/{id}/financial-groups', [\App\Http\Controllers\ProductionController::class, 'storeFinancialGroup'])->name('production.financial_groups.store');
@@ -430,6 +433,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('workflow/appointments/export', [\App\Http\Controllers\WorkflowController::class, 'exportAppointments'])->name('workflow.appointments.export');
     Route::post('workflow/item/{item}/check-daily', [\App\Http\Controllers\WorkflowController::class, 'checkDaily'])->name('workflow.item.check_daily');
     Route::post('workflow/item/{item}/remarks', [\App\Http\Controllers\WorkflowController::class, 'updateRemarks'])->name('workflow.item.remarks');
+    Route::post('workflow/order/{order}/remarks', [\App\Http\Controllers\WorkflowController::class, 'updateOrderRemarks'])->name('workflow.order.remarks');
     Route::post('workflow/item/{item}/group', [\App\Http\Controllers\WorkflowController::class, 'updateGroup'])->name('workflow.item.group');
     Route::post('workflow/item/{item}/finalize', [\App\Http\Controllers\WorkflowController::class, 'finalizeItem'])->name('workflow.item.finalize');
     Route::post('workflow/item/{item}/cancel', [\App\Http\Controllers\WorkflowController::class, 'cancelItem'])->name('workflow.item.cancel');


### PR DESCRIPTION
This PR adds an inline note-taking feature directly to the top center of the Employer/Production Order cards across the following 4 menus:
1. Pre Production
2. Workflow
3. Registration Resolution
4. Renewal Resolution

Users can now click the pencil icon to type their remarks/notes and save them without refreshing the page or navigating to a separate modal. Data is persisted to the database and remembered across sessions.

---
*PR created automatically by Jules for task [10766780179840082655](https://jules.google.com/task/10766780179840082655) started by @nongjossss-commits*