### PR TITLE
Fix P Production Step Buttons and Send to Workflow Functionality

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -341,6 +341,101 @@ class ProductionController extends Controller
         return response()->json(['success' => true]);
     }
 
+    public function bulkSendToWorkflow(Request $request)
+    {
+        $request->validate([
+            'item_ids' => 'required|array',
+            'item_ids.*' => 'exists:production_items,id'
+        ]);
+
+        $successCount = 0;
+        $failedCount = 0;
+        $errors = [];
+
+        foreach ($request->item_ids as $itemId) {
+            $item = ProductionItem::with(['order', 'employee'])->find($itemId);
+            if (!$item) continue;
+
+            $currentOrder = $item->order;
+
+            if ($currentOrder->status !== 'pre_production') {
+                $failedCount++;
+                $errors[] = "Item ID {$itemId} is not in Pre-Production.";
+                continue;
+            }
+
+            // Strict Validation: Check if employee already exists in any Active Workflow for this WorkType
+            $hasDuplicate = ProductionItem::where('employee_id', $item->employee_id)
+                ->whereHas('order', function($q) use ($currentOrder) {
+                    $q->where('work_type_id', $currentOrder->work_type_id)
+                      ->where('status', '!=', 'pre_production') // Active Workflow Order
+                      ->where('status', '!=', 'cancelled');
+                })
+                ->whereNotIn('status', ['cancelled', 'completed'])
+                ->exists();
+
+            if ($hasDuplicate) {
+                 $failedCount++;
+                 $errors[] = "Employee {$item->employee->employeeNameTh} is already active in the Workflow.";
+                 continue;
+            }
+
+            DB::beginTransaction();
+            try {
+                // Find an Active Order for this Employer + WorkType
+                $activeOrder = ProductionOrder::where('employer_id', $currentOrder->employer_id)
+                                    ->where('work_type_id', $currentOrder->work_type_id)
+                                    ->where('status', '!=', 'pre_production') // Active
+                                    ->where('status', '!=', 'cancelled')
+                                    ->latest()
+                                    ->first();
+
+                if (!$activeOrder) {
+                    // Create new Active Order
+                    $workTypeName = $currentOrder->workType->name ?? 'Job';
+                    $employerName = $currentOrder->employer->employerNameTh ?? 'Unknown';
+
+                    $activeOrder = ProductionOrder::create([
+                        'employer_id' => $currentOrder->employer_id,
+                        'work_type_id' => $currentOrder->work_type_id,
+                        'type' => $currentOrder->type,
+                        'project_name' => "$workTypeName - $employerName",
+                        'description' => $currentOrder->description,
+                        'status' => 'active',
+                        'created_by' => auth()->id(),
+                    ]);
+                }
+
+                // Move Item: Update the production_order_id to the new active order
+                $item->update([
+                    'production_order_id' => $activeOrder->id,
+                    'status' => 'pending', // Reset status to pending in workflow
+                    'last_checked_at' => null, // Reset checks
+                    'appointment_date' => null, // Reset appointment date as it is stage-specific
+                    'appointment_location' => null,
+                    'appointment_completed_at' => null,
+                    'operator_id' => null, // Reset operator as requested
+                ]);
+
+                // Clear Completed Steps (Preparation steps do not map to Workflow steps 1:1)
+                $item->completedWorkTypeSteps()->detach();
+
+                DB::commit();
+                $successCount++;
+            } catch (\Exception $e) {
+                DB::rollBack();
+                $failedCount++;
+                $errors[] = "Error processing employee {$item->employee->employeeNameTh}: " . $e->getMessage();
+            }
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => "Successfully sent $successCount items to Workflow. Failed: $failedCount.",
+            'errors' => $errors
+        ]);
+    }
+
     public function sendToWorkflow(Request $request, $itemId)
     {
         $item = ProductionItem::with(['order', 'employee'])->findOrFail($itemId);

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1571,7 +1571,8 @@ document.addEventListener('DOMContentLoaded', function () {
             country_code: cb.dataset.countryCode || '',
             gender: cb.dataset.gender || '',
             insurance_type: cb.dataset.insuranceType || '',
-            passport: cb.dataset.passport || ''
+            passport: cb.dataset.passport || '',
+            production_item_id: cb.dataset.productionItemId || ''
         };
     }
 

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -231,6 +231,7 @@
                 <li><a class="dropdown-item" href="#" id="bulk-advanced-export-btn"><i class="bi bi-file-earmark-spreadsheet me-2"></i>{{ __('Advanced Export') }}</a></li>
                 <li><hr class="dropdown-divider"></li>
                 <li><a class="dropdown-item" href="#" id="bulk-download-btn"><i class="bi bi-download me-2"></i>{{ __('Download Files') }}</a></li>
+                <li><a class="dropdown-item" href="#" id="bulk-send-to-workflow-btn"><i class="bi bi-send-check me-2"></i>{{ __('Send to Workflow') }}</a></li>
                 @can('manage-tickets')
                 <li><a class="dropdown-item" href="#" id="bulk-generate-pdf-btn"><i class="bi bi-file-earmark-pdf me-2"></i>{{ __('Automated PDF') }}</a></li>
                 @endcan
@@ -893,11 +894,6 @@
                         Swal.fire('{{ __("Sent!") }}', '{{ __("Employee moved to Workflow.") }}', 'success');
 
                         if(data.order_stats) {
-                             const card = document.getElementById(`item-card-${itemId}`);
-                             // The card is removed above, but we can get orderId from wrapper if we saved reference,
-                             // OR we assume we can find the order header by ID if we pass orderId.
-                             // But wait, the card is removed!
-                             // "const wrapper = card.closest('.order-content-wrapper');" was called BEFORE removal.
                              if(wrapper) {
                                  const orderId = wrapper.id.replace('order-content-', '');
                                  updateOrderHeaderStats(orderId, data.order_stats);
@@ -910,6 +906,55 @@
             }
         });
     }
+
+    // --- Bulk Send to Workflow ---
+    document.getElementById('bulk-send-to-workflow-btn')?.addEventListener('click', function(e) {
+        e.preventDefault();
+        const selectedData = window.getGlobalSelectedData();
+        const selectedIds = selectedData.map(item => item.production_item_id || item.id); // For Pre-Prod, the item has the prod_item_id
+
+        if (selectedIds.length === 0) {
+            Swal.fire('{{ __("Warning") }}', '{{ __("Please select employees first.") }}', 'warning');
+            return;
+        }
+
+        Swal.fire({
+            title: '{{ __("Send to Workflow?") }}',
+            text: `{{ __("Move") }} ${selectedIds.length} {{ __("employees to the Active Job list?") }}`,
+            icon: 'question',
+            showCancelButton: true,
+            confirmButtonText: '{{ __("Yes, Send All") }}',
+            confirmButtonColor: '#0d6efd'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Swal.fire({
+                    title: '{{ __("Processing...") }}',
+                    allowOutsideClick: false,
+                    didOpen: () => { Swal.showLoading(); }
+                });
+
+                fetch('{{ route("production.bulk_send_to_workflow") }}', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': csrfToken },
+                    body: JSON.stringify({ item_ids: selectedIds })
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success) {
+                        Swal.fire('{{ __("Success") }}', data.message, 'success').then(() => {
+                            window.location.reload();
+                        });
+                    } else {
+                        Swal.fire('{{ __("Error") }}', data.message || 'Unknown error', 'error');
+                    }
+                })
+                .catch(err => {
+                    console.error(err);
+                    Swal.fire('{{ __("Error") }}', 'An error occurred during bulk operation.', 'error');
+                });
+            }
+        });
+    });
 
     // --- Helper to Refresh Order Content (List) ---
     window.refreshOrderContent = function(orderId) {
@@ -1309,13 +1354,33 @@
         if(btn) {
             if(completed) {
                 btn.classList.remove('btn-light', 'text-secondary');
-                btn.classList.add('btn-success', 'text-white');
-                 if(!btn.innerHTML.includes('bi-check')) btn.innerHTML += ' <i class="bi bi-check-circle-fill ms-1"></i>';
+                // Use original color logic if it has hex-color data attribute
+                const hexColor = btn.getAttribute('data-hex-color');
+                const bsColor = btn.getAttribute('data-color');
+
+                if (hexColor) {
+                    btn.classList.add('text-white', 'border-0');
+                    btn.style.setProperty('background-color', hexColor, 'important');
+                    btn.style.setProperty('border-color', hexColor, 'important');
+                } else if (bsColor && ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'].includes(bsColor)) {
+                    btn.classList.add(`btn-${bsColor}`);
+                    if(bsColor === 'warning' || bsColor === 'light') {
+                        btn.classList.add('text-dark');
+                    } else {
+                        btn.classList.add('text-white');
+                    }
+                } else {
+                    btn.classList.add('btn-success', 'text-white');
+                }
+
+                if(!btn.innerHTML.includes('bi-check')) btn.innerHTML += ' <i class="bi bi-check-circle-fill ms-1"></i>';
                 btn.setAttribute('onclick', `toggleWorkStep(${itemId}, ${stepId}, false)`);
             } else {
-                btn.classList.add('btn-light', 'text-secondary');
-                btn.classList.remove('btn-success', 'text-white');
-                 const icon = btn.querySelector('i');
+                // Remove custom colors and classes
+                btn.className = `btn btn-sm btn-light border text-secondary rounded-pill px-3 step-btn-${itemId}-${stepId}`;
+                btn.style.backgroundColor = '';
+                btn.style.borderColor = '';
+                const icon = btn.querySelector('i');
                 if(icon) icon.remove();
                 btn.setAttribute('onclick', `toggleWorkStep(${itemId}, ${stepId}, true)`);
             }

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -95,7 +95,8 @@
                            data-photo="{{ $employee->employeePhoto ? asset('storage/' . $employee->employeePhoto) : 'https://placehold.co/40x40/e2e8f0/6c757d?text=PIC' }}"
                            data-employer-name="{{ $employee->employer->employerNameTh ?? 'N/A' }}"
                            data-insurance-type="{{ $employee->insurance_type }}"
-                           data-passport="{{ $employee->employeePassport }}">
+                           data-passport="{{ $employee->employeePassport }}"
+                           data-production-item-id="{{ isset($employee->production_item) ? $employee->production_item->id : '' }}">
                 </div>
                 @endcan
 
@@ -791,13 +792,27 @@
                     <i class="bi bi-pencil-fill"></i>
                 </button>
 
-                {{-- SAVE TO DB --}}
-                <button class="btn btn-sm btn-success rounded-pill px-3 {{ ($isCompleted || $isCancelled || $isHistory) ? 'd-none' : '' }}"
-                    id="btn-save-{{ $employee->id }}"
-                    title="Save to Database"
-                    onclick="finalizeEmployee({{ $employee->id }})">
-                    <i class="bi bi-check-lg"></i> <span class="d-none d-lg-inline">{{ __('Save to DB') }}</span>
-                </button>
+                @php
+                    $isPreProductionContext = isset($activeTab) && $activeTab instanceof \App\Models\WorkType;
+                @endphp
+
+                @if($isPreProductionContext && isset($employee->production_item))
+                    {{-- SEND TO WORKFLOW (P Production Context) --}}
+                    <button class="btn btn-sm btn-primary rounded-pill px-3"
+                        id="btn-send-to-workflow-{{ $employee->id }}"
+                        title="{{ __('Send to Workflow') }}"
+                        onclick="sendToWorkflow({{ $employee->production_item->id }})">
+                        <i class="bi bi-send-check"></i> <span class="d-none d-lg-inline">{{ __('Send to Workflow') }}</span>
+                    </button>
+                @else
+                    {{-- SAVE TO DB (Registration Context) --}}
+                    <button class="btn btn-sm btn-success rounded-pill px-3 {{ ($isCompleted || $isCancelled || $isHistory) ? 'd-none' : '' }}"
+                        id="btn-save-{{ $employee->id }}"
+                        title="Save to Database"
+                        onclick="finalizeEmployee({{ $employee->id }})">
+                        <i class="bi bi-check-lg"></i> <span class="d-none d-lg-inline">{{ __('Save to DB') }}</span>
+                    </button>
+                @endif
 
                 {{-- CANCEL --}}
                 <button class="btn btn-sm btn-outline-secondary rounded-pill px-3 {{ ($isCompleted || $isCancelled || $isHistory) ? 'd-none' : '' }}"
@@ -875,9 +890,16 @@
             <div class="d-flex gap-2 flex-wrap">
                 @foreach($steps as $step)
                     @php
-                        $isStepCompleted = $employee->registrationSteps->contains($step->id);
+                        $isPreProductionContext = isset($activeTab) && $activeTab instanceof \App\Models\WorkType;
+
+                        if ($isPreProductionContext) {
+                            $isStepCompleted = isset($employee->production_item) && $employee->production_item->completedWorkTypeSteps->contains('id', $step->id);
+                        } else {
+                            $isStepCompleted = $employee->registrationSteps->contains($step->id);
+                        }
+
                         // Determine styles based on hex or class
-                        $hexColor = str_starts_with($step->color, '#') ? $step->color : null;
+                        $hexColor = isset($step->color) && str_starts_with($step->color, '#') ? $step->color : null;
 
                         // Default State: Incomplete -> Solid Gray (visible "To Do" state)
                         $btnClass = 'btn-light border text-secondary';
@@ -891,7 +913,7 @@
                             } else {
                                 // For standard bootstrap classes like 'primary', 'success', etc.
                                 // We check if it is one of the standard contextual classes
-                                if (in_array($step->color, ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'])) {
+                                if (isset($step->color) && in_array($step->color, ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'])) {
                                      $btnClass = "btn-{$step->color} text-white";
                                      if($step->color == 'warning' || $step->color == 'light') {
                                          $btnClass = "btn-{$step->color} text-dark"; // Better contrast
@@ -907,14 +929,26 @@
                             $canManage = auth()->user()->can('edit-employees');
                             $disabled = ($isCompleted || $isCancelled || !$canManage) ? 'disabled' : '';
                             $pointerEvents = !$canManage ? 'pointer-events: none;' : '';
-                            $onclick = $canManage ? "onclick=\"toggleStep({$employee->id}, {$step->id}, " . ($isStepCompleted ? 'false' : 'true') . ")\"" : '';
+
+                            // Check context to determine which toggle function to use
+                            // Pre-Production reuses this card but its steps are WorkTypeStep, not RegistrationStep
+                            $isPreProductionContext = isset($activeTab) && $activeTab instanceof \App\Models\WorkType;
+
+                            if ($isPreProductionContext) {
+                                // In Pre-Production, the 'employee' variable is mapped from the ProductionItem,
+                                // but we need the production item ID for the toggleWorkStep function
+                                $itemId = isset($employee->production_item) ? $employee->production_item->id : $employee->id;
+                                $onclick = $canManage ? "onclick=\"toggleWorkStep({$itemId}, {$step->id}, " . ($isStepCompleted ? 'false' : 'true') . ")\"" : '';
+                            } else {
+                                $onclick = $canManage ? "onclick=\"toggleStep({$employee->id}, {$step->id}, " . ($isStepCompleted ? 'false' : 'true') . ")\"" : '';
+                            }
                         @endphp
                     <button
-                        class="btn btn-sm {{ $btnClass }} rounded-pill px-3"
+                        class="btn btn-sm {{ $btnClass }} rounded-pill px-3 step-btn-{{ isset($employee->production_item) ? $employee->production_item->id : $employee->id }}-{{ $step->id }}"
                             style="font-size: 0.8rem; {{ $btnStyle }} {{ $pointerEvents }}"
                             {!! $onclick !!}
                         data-step-id="{{ $step->id }}"
-                        data-color="{{ $step->color }}"
+                        data-color="{{ $step->color ?? '' }}"
                         data-hex-color="{{ $hexColor }}"
                             {{ $disabled }}
                     >

--- a/routes/web.php
+++ b/routes/web.php
@@ -370,6 +370,7 @@ Route::middleware(['auth'])->group(function () {
 
     // NEW: Pre-Production Routes
     Route::post('production/{item}/send-to-workflow', [\App\Http\Controllers\ProductionController::class, 'sendToWorkflow'])->name('production.item.send_to_workflow');
+    Route::post('production/bulk-send-to-workflow', [\App\Http\Controllers\ProductionController::class, 'bulkSendToWorkflow'])->name('production.bulk_send_to_workflow');
     Route::post('production/steps', [\App\Http\Controllers\ProductionController::class, 'storeStep'])->name('production.steps.store');
 
     Route::post('production/{id}/toggle-status', [\App\Http\Controllers\ProductionController::class, 'toggleStatus'])->name('production.toggle_status');


### PR DESCRIPTION
The step buttons in the `P Production` menu were broken because the view reused the `Registration` view's `_employee_card.blade.php` partial. This partial hardcoded the `toggleStep` function and the standard `employee->id`, whereas the `P Production` view required `toggleWorkStep` and `production_item->id`. The code has been refactored to conditionally check its `$activeTab` context and correctly assign the target variables and function calls. The JS function `toggleWorkStep` was also missing support for Bootstrap color classes, causing visual issues.

Additionally, the "Send to Workflow" functionality was improved and re-added:
1. Re-added the single action "Send to Workflow" button per employee card.
2. Re-added the bulk action "Send to Workflow" button to the actions dropdown.
3. A backend endpoint (`bulk-send-to-workflow`) was developed to loop over `ProductionItem` models and securely shift them into active orders while properly wrapping transactions and detaching old workflow steps.

---
*PR created automatically by Jules for task [15794445722425990558](https://jules.google.com/task/15794445722425990558) started by @nongjossss-commits*