### PR TITLE
Fix dynamic UI updates for Send to Workflow button in Pre-Production

### DIFF
--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -878,16 +878,27 @@
                 .then(data => {
                     if(data.success) {
                         // Remove card from UI
-                        const card = document.getElementById(`item-card-${itemId}`);
-                        const wrapper = card.closest('.order-content-wrapper');
-                        card.remove();
-                        recalculateSequenceNumbers();
+                        let card = document.getElementById(`item-card-${itemId}`);
+                        let wrapper = null;
 
-                        // Check if wrapper is empty
-                        if(wrapper && wrapper.querySelectorAll('.item-card-wrapper').length === 0) {
-                            const orderCard = wrapper.closest('.production-order-card');
-                            if(orderCard) {
-                                orderCard.classList.add('grayscale-mode');
+                        if (!card) {
+                            const checkbox = document.querySelector(`.employee-checkbox[data-production-item-id="${itemId}"]`);
+                            if (checkbox) {
+                                card = checkbox.closest('.employee-card-wrapper');
+                            }
+                        }
+
+                        if (card) {
+                            wrapper = card.closest('.order-content-wrapper');
+                            card.remove();
+                            recalculateSequenceNumbers();
+
+                            // Check if wrapper is empty
+                            if(wrapper && wrapper.querySelectorAll('.item-card-wrapper').length === 0 && wrapper.querySelectorAll('.employee-card-wrapper').length === 0) {
+                                const orderCard = wrapper.closest('.production-order-card');
+                                if(orderCard) {
+                                    orderCard.classList.add('grayscale-mode');
+                                }
                             }
                         }
 


### PR DESCRIPTION
The "Send to Workflow" button inside the employee cards in the Pre-Production menu correctly sent the request to the server but failed to dynamically remove the card from the UI, requiring the user to manually refresh the page.

This PR addresses the issue by updating the `sendToWorkflow` JavaScript function. It ensures that the function can accurately locate the employee card DOM element by falling back to `data-production-item-id` if `item-card-{id}` is unavailable (due to varying HTML partials). Once the success response is received, the card is immediately removed from the DOM, sequence numbers are recalculated, and if it was the last employee, the parent employer card correctly toggles to its empty `grayscale-mode` styling.

---
*PR created automatically by Jules for task [43349744108791960](https://jules.google.com/task/43349744108791960) started by @nongjossss-commits*