### PR TITLE
feat: allow editing PDF template name in builder settings

### DIFF
--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -221,11 +221,13 @@ class PdfTemplateController extends Controller
         $this->authorize('edit-pdf-templates', $pdf_template);
 
         $request->validate([
+            'name' => 'required|string|max:255',
             'field_mapping' => 'nullable|array',
             'meta_data' => 'nullable|array',
         ]);
 
         $pdf_template->update([
+            'name' => $request->name,
             'field_mapping' => $request->field_mapping ?? [],
             'meta_data' => $request->meta_data ?? [],
         ]);

--- a/resources/views/pdf_templates/builder.blade.php
+++ b/resources/views/pdf_templates/builder.blade.php
@@ -8,7 +8,7 @@
             <a href="{{ route('admin.pdf-templates.index') }}" class="text-gray-500 hover:text-gray-700">
                 <i class="bi bi-arrow-left"></i> Back
             </a>
-            <h1 class="text-lg font-bold text-gray-800">{{ $template->name }} <span class="text-sm font-normal text-gray-500">(Builder Mode)</span></h1>
+            <h1 class="text-lg font-bold text-gray-800"><span x-text="templateName"></span> <span class="text-sm font-normal text-gray-500">(Builder Mode)</span></h1>
         </div>
         <div class="flex items-center gap-3">
             <!-- Page Navigation -->
@@ -346,6 +346,11 @@
                         </div>
                     </div>
 
+                    <div class="mb-4">
+                        <label class="form-label fw-bold">Template Name</label>
+                        <input type="text" x-model="templateName" class="form-control" placeholder="Enter template name">
+                    </div>
+
                     <div class="form-check form-switch p-3 border rounded bg-light mb-3">
                         <input class="form-check-input" type="checkbox" id="autoPrefixToggle" x-model="metaData.auto_prefix_titles">
                         <label class="form-check-label fw-bold" for="autoPrefixToggle">
@@ -375,6 +380,7 @@
             let _pdfDoc = null; // Store PDF doc outside Alpine reactive scope to avoid Proxy issues
 
             return {
+                templateName: @json($template->name ?? ''),
                 currentPage: 1,
                 totalPages: 1,
                 scale: 1.5,
@@ -907,6 +913,7 @@
                             'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
                         },
                         body: JSON.stringify({
+                            name: this.templateName,
                             field_mapping: itemsToSave,
                             meta_data: metaDataToSave
                         })

--- a/tests/Feature/PdfTemplateUpdateNameTest.php
+++ b/tests/Feature/PdfTemplateUpdateNameTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\PdfTemplate;
+use Spatie\Permission\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PdfTemplateUpdateNameTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Create role if not exists
+        Role::firstOrCreate(['name' => 'super-admin']);
+    }
+
+    public function test_can_update_template_name()
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super-admin');
+
+        $template = PdfTemplate::create([
+            'name' => 'Old Name',
+            'file_path' => 'fake_path.pdf',
+            'type' => 'global',
+            'created_by' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->putJson(route('admin.pdf-templates.update', $template), [
+            'name' => 'New Awesome Name',
+            'field_mapping' => [],
+            'meta_data' => []
+        ]);
+
+        $response->assertOk();
+
+        $template->refresh();
+        $this->assertEquals('New Awesome Name', $template->name);
+    }
+}


### PR DESCRIPTION
Allows users to edit the name of an existing PDF template via the template builder's settings modal.

**Changes:**
- Added a `name` field to the update payload in `PdfTemplateController@update` and updated the `PdfTemplate` model.
- Added a text input field within the `templateSettingsModal` in `resources/views/pdf_templates/builder.blade.php`.
- Bound the template's name to a reactive Alpine.js variable (`templateName`) so that edits in the modal immediately reflect in the header title without requiring a page reload.
- Included the new `templateName` variable in the `saveMapping` JavaScript method's PUT request.
- Implemented a test to verify updating the template name on the backend.

---
*PR created automatically by Jules for task [15029227925516003531](https://jules.google.com/task/15029227925516003531) started by @nongjossss-commits*