### PR TITLE
Fix undefined variable $emprStampPath during PDF generation

### DIFF
--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -363,6 +363,7 @@ class PdfGeneratorService
         // 2. Employer Signatures (Check file -> Generate Fallback)
         $emprSig1Path = null;
         $emprSig2Path = null;
+        $emprStampPath = null;
 
         if ($effectiveEmployer) {
             // Signer 1
@@ -393,6 +394,10 @@ class PdfGeneratorService
                 // Update employer model
                 $effectiveEmployer->update(['signature_2_path' => $filename]);
                 $emprSig2Path = Storage::disk('public')->path($filename);
+            }
+
+            if ($effectiveEmployer->employer_stamp_path && Storage::disk('public')->exists($effectiveEmployer->employer_stamp_path)) {
+                $emprStampPath = Storage::disk('public')->path($effectiveEmployer->employer_stamp_path);
             }
         }
 


### PR DESCRIPTION
Resolves an issue where single employee PDF generation fails if the template includes a stamp placeholder. The `$emprStampPath` was not being initialized in `generateSinglePdf`, leading to an exception when it was later checked.

Changes:
* Initialized `$emprStampPath = null;` at the beginning of the `generateSinglePdf` signature retrieval block.
* Extracted and assigned the correct path from `$effectiveEmployer->employer_stamp_path` if it exists.

---
*PR created automatically by Jules for task [11500793198500332240](https://jules.google.com/task/11500793198500332240) started by @nongjossss-commits*