### PR TITLE
Fix renewal banner totals and calendar functionality

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -566,7 +566,8 @@ class RegistrationController extends Controller
         $financeOrder->load(['financialGroups.transactions.items', 'financialGroups.advanceItems', 'items.employee']);
 
         // Fetch ALL Active Employees for this employer (ignoring search)
-        $query = $employer->employees();
+        $query = $employer->employees()
+            ->whereIn('status', ['registration_pending', 'registration_completed', 'registration_cancelled']);
         if (auth()->user()->can('manage-tickets')) {
             $query->withoutGlobalScope('employerTenancy');
         }

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -55,7 +55,8 @@ class RenewalController extends Controller
         $lastStepId = $steps->sortByDesc('order')->first()?->id;
 
         // --- 1. Global Stats Query (No Fetching All Models) ---
-        $statsQuery = Employee::query();
+        $statsQuery = Employee::query()
+            ->whereIn('status', ['renewal_pending', 'renewal_completed', 'renewal_cancelled']);
 
         if (auth()->user()->can('manage-tickets')) {
             $statsQuery->withoutGlobalScope('employerTenancy');
@@ -84,7 +85,8 @@ class RenewalController extends Controller
         $stepStats = $this->getGlobalStepStats($stepStatsQuery, $steps);
 
         // Total Appointments
-        $appointmentsQuery = Employee::query();
+        $appointmentsQuery = Employee::query()
+            ->whereIn('status', ['renewal_pending', 'renewal_completed']);
         if (auth()->user()->can('manage-tickets')) {
             $appointmentsQuery->withoutGlobalScope('employerTenancy');
         }
@@ -1097,7 +1099,8 @@ class RenewalController extends Controller
         $start = Carbon::createFromDate($year, $month, 1)->startOfMonth();
         $end = Carbon::createFromDate($year, $month, 1)->endOfMonth();
 
-        $query = Employee::query();
+        $query = Employee::query()
+            ->whereIn('status', ['renewal_pending', 'renewal_completed']);
         if (auth()->user()->can('manage-tickets')) {
             $query->withoutGlobalScope('employerTenancy');
         }
@@ -1123,7 +1126,8 @@ class RenewalController extends Controller
         $request->validate(['date' => 'required|date']);
         $date = Carbon::parse($request->date);
 
-        $query = Employee::query();
+        $query = Employee::query()
+            ->whereIn('status', ['renewal_pending', 'renewal_completed']);
         if (auth()->user()->can('manage-tickets')) {
             $query->withoutGlobalScope('employerTenancy');
         }

--- a/resources/views/production/registration/partials/day_appointments_list.blade.php
+++ b/resources/views/production/registration/partials/day_appointments_list.blade.php
@@ -75,11 +75,14 @@
                                             <label class="form-check-label ms-2 d-md-none fw-bold text-muted">{{ __('Select Employee') }}</label>
                                         </div>
 
-                                        <div class="btn-group shadow-sm w-100">
-                                            <button type="button" class="btn btn-outline-primary btn-sm" onclick="previewEmployee({{ $employee->id }})" title="{{ __('Preview Employee') }}">
+                                        <div class="btn-group shadow-sm w-100 mb-2">
+                                            <a href="{{ route('employees.edit', $employee->id) }}" target="_blank" class="btn btn-outline-secondary btn-sm" title="{{ __('Edit Employee') }}">
+                                                <i class="bi bi-pencil"></i>
+                                            </a>
+                                            <button type="button" class="btn btn-outline-primary btn-sm btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="{{ __('Preview Employee') }}">
                                                 <i class="bi bi-person-vcard"></i>
                                             </button>
-                                            <button type="button" class="btn btn-outline-info btn-sm" onclick="previewEmployer({{ $employee->employer_id }})" title="{{ __('Preview Employer') }}">
+                                            <button type="button" class="btn btn-outline-info btn-sm btn-preview" data-model-type="employer" data-model-id="{{ $employee->employer_id }}" title="{{ __('Preview Employer') }}">
                                                 <i class="bi bi-building"></i>
                                             </button>
                                         </div>

--- a/resources/views/production/renewal/partials/day_appointments_list.blade.php
+++ b/resources/views/production/renewal/partials/day_appointments_list.blade.php
@@ -75,11 +75,14 @@
                                             <label class="form-check-label ms-2 d-md-none fw-bold text-muted">{{ __('Select Employee') }}</label>
                                         </div>
 
-                                        <div class="btn-group shadow-sm w-100">
-                                            <button type="button" class="btn btn-outline-primary btn-sm" onclick="previewEmployee({{ $employee->id }})" title="{{ __('Preview Employee') }}">
+                                        <div class="btn-group shadow-sm w-100 mb-2">
+                                            <a href="{{ route('employees.edit', $employee->id) }}" target="_blank" class="btn btn-outline-secondary btn-sm" title="{{ __('Edit Employee') }}">
+                                                <i class="bi bi-pencil"></i>
+                                            </a>
+                                            <button type="button" class="btn btn-outline-primary btn-sm btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="{{ __('Preview Employee') }}">
                                                 <i class="bi bi-person-vcard"></i>
                                             </button>
-                                            <button type="button" class="btn btn-outline-info btn-sm" onclick="previewEmployer({{ $employee->employer_id }})" title="{{ __('Preview Employer') }}">
+                                            <button type="button" class="btn btn-outline-info btn-sm btn-preview" data-model-type="employer" data-model-id="{{ $employee->employer_id }}" title="{{ __('Preview Employer') }}">
                                                 <i class="bi bi-building"></i>
                                             </button>
                                         </div>


### PR DESCRIPTION
Resolves user issues with mismatched total counts on the banner in the Renewal menu and broken calendar appointment data. Enhances calendar cards with edit, preview and bulk action functionality.

---
*PR created automatically by Jules for task [3753069192724346206](https://jules.google.com/task/3753069192724346206) started by @nongjossss-commits*