### PR TITLE
Fix Renewal Calendar API crashes

### DIFF
--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Models\SystemSetting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -1138,7 +1139,7 @@ class RenewalController extends Controller
             ->with(['employer'])
             ->get();
 
-        $steps = RenewalStep::renewal()->orderBy('order')->get();
+        $steps = RegistrationStep::renewal()->orderBy('order')->get();
 
         $html = view('production.renewal.partials.day_appointments_list', compact('employees', 'steps'))->render();
 


### PR DESCRIPTION
Fixes the issue in the Renewal Resolution module where the calendar was not properly populating appointment counts due to a missing Carbon import, and not properly fetching daily appointments due to a non-existent class `RenewalStep`.

---
*PR created automatically by Jules for task [12701415731651565039](https://jules.google.com/task/12701415731651565039) started by @nongjossss-commits*