### PR TITLE
Fix performance lag on Pre Production / Workflow menus

### DIFF
--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -850,6 +850,18 @@ if (typeof window.financialManager === 'undefined') {
                 return this.filteredTransactions.filter(t => t.type === 'advance_payment');
             },
 
+            get totalPaidAmount() {
+                return this.filteredTransactions.reduce((sum, t) => sum + parseFloat(t.paid_amount || 0), 0);
+            },
+            get remainingBalance() {
+                return Math.max(0, this.grandTotalReceivable - this.totalPaidAmount);
+            },
+            get advancePaid() {
+                return this.advanceTransactions.reduce((sum, t) => sum + parseFloat(t.paid_amount || 0), 0);
+            },
+            get advanceRemaining() {
+                return Math.max(0, this.advanceTotal - this.advancePaid);
+            },
             get scheduledAmount() {
                 return this.filteredTransactions.reduce((sum, t) => sum + parseFloat(t.amount || 0), 0);
             },


### PR DESCRIPTION
This fixes the severe performance lag issue when clicking into "เปลี่ยนนายจ้าง", "แจ้งออก", "MOU นำเข้า", and "ต่ออายุ MOU" sub-menus in the Pre Production and Workflow areas. 

The issue was caused by an out-of-sync `public/js/financial-manager.js` file lacking several required getters (`advancePaid`, `advanceRemaining`, `totalPaidAmount`, `remainingBalance`), which triggered constant `ReferenceError`s and an Alpine.js reactivity loop, effectively locking up the browser. The missing getters have been synced into the public file without losing other features recently added to it.

The React nested DOM warnings and API `404` errors were also investigated, but these are artifacts of browser extensions injected into the DOM, as this application does not use React or perform those API checks.

---
*PR created automatically by Jules for task [2044860016640404074](https://jules.google.com/task/2044860016640404074) started by @nongjossss-commits*