### PR TITLE
Fix Delegate creation error and Importer address saving error

### DIFF
--- a/resources/views/delegates/create.blade.php
+++ b/resources/views/delegates/create.blade.php
@@ -14,13 +14,10 @@
                 <div class="row mb-4">
                     <div class="col-md-12 text-center">
                         <label class="form-label d-block text-muted mb-2">Photo</label>
-                        <x-image-cropper
-                            name="delegatePhoto"
-                            :imageUrl="null"
-                            width="150"
-                            height="150"
-                            placeholder="Add Photo"
-                        />
+                        <div class="mb-3">
+                            <input type="file" name="delegatePhoto" id="delegatePhoto" class="form-control" accept="image/*" onchange="previewImage(event, 'photoPreview')">
+                        </div>
+                        <img id="photoPreview" src="#" alt="Photo Preview" style="display: none; max-width: 150px; max-height: 150px; margin-top: 10px;" class="img-thumbnail rounded-circle">
                     </div>
                 </div>
 
@@ -333,6 +330,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     addressModalEl.addEventListener('hidden.bs.modal', function () {
         addressForm.reset();
+        document.getElementById('addressable_type').value = 'App\\Models\\Delegate';
         document.getElementById('addrDistrict').disabled = true;
         document.getElementById('addrSubDistrict').disabled = true;
         currentlyEditing = null;
@@ -345,5 +343,18 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
 });
+
+function previewImage(event, previewId) {
+    const input = event.target;
+    if (input.files && input.files[0]) {
+        const reader = new FileReader();
+        reader.onload = function(e) {
+            const preview = document.getElementById(previewId);
+            preview.src = e.target.result;
+            preview.style.display = 'inline-block';
+        }
+        reader.readAsDataURL(input.files[0]);
+    }
+}
 </script>
 @endpush

--- a/resources/views/delegates/edit.blade.php
+++ b/resources/views/delegates/edit.blade.php
@@ -15,13 +15,14 @@
                 <div class="row mb-4">
                     <div class="col-md-12 text-center">
                         <label class="form-label d-block text-muted mb-2">Photo</label>
-                        <x-image-cropper
-                            name="delegatePhoto"
-                            :imageUrl="$delegate->delegatePhoto ? asset('storage/' . $delegate->delegatePhoto) : null"
-                            width="150"
-                            height="150"
-                            placeholder="Add Photo"
-                        />
+                        <div class="mb-3">
+                            <input type="file" name="delegatePhoto" id="delegatePhoto" class="form-control" accept="image/*" onchange="previewImage(event, 'photoPreview')">
+                        </div>
+                        <img id="photoPreview"
+                             src="{{ $delegate->delegatePhoto ? asset('storage/' . $delegate->delegatePhoto) : '#' }}"
+                             alt="Photo Preview"
+                             style="{{ $delegate->delegatePhoto ? '' : 'display: none;' }} max-width: 150px; max-height: 150px; margin-top: 10px;"
+                             class="img-thumbnail rounded-circle">
                     </div>
                 </div>
 
@@ -119,6 +120,8 @@
                             <button type="button" class="btn btn-sm btn-primary add-address-btn"
                                     data-bs-toggle="modal"
                                     data-bs-target="#addressModal"
+                                    data-addressable-id="{{ $delegate->id }}"
+                                    data-addressable-type="App\Models\Delegate"
                                     data-type="registered">
                                 {{ __('Add Address') }}
                             </button>
@@ -148,6 +151,8 @@
                             <button type="button" class="btn btn-sm btn-primary add-address-btn"
                                     data-bs-toggle="modal"
                                     data-bs-target="#addressModal"
+                                    data-addressable-id="{{ $delegate->id }}"
+                                    data-addressable-type="App\Models\Delegate"
                                     data-type="workplace">
                                 {{ __('Add Address') }}
                             </button>
@@ -284,10 +289,25 @@ document.addEventListener('DOMContentLoaded', function () {
     addressModalEl.addEventListener('hidden.bs.modal', function () {
         addressForm.reset();
         document.getElementById('address_id').value = '';
+        document.getElementById('addressable_id').value = delegateId;
+        document.getElementById('addressable_type').value = 'App\\Models\\Delegate';
         document.getElementById('addressFormMethod').value = '';
         document.getElementById('addrDistrict').disabled = true;
         document.getElementById('addrSubDistrict').disabled = true;
     });
 });
+
+function previewImage(event, previewId) {
+    const input = event.target;
+    if (input.files && input.files[0]) {
+        const reader = new FileReader();
+        reader.onload = function(e) {
+            const preview = document.getElementById(previewId);
+            preview.src = e.target.result;
+            preview.style.display = 'inline-block';
+        }
+        reader.readAsDataURL(input.files[0]);
+    }
+}
 </script>
 @endpush

--- a/resources/views/importers/create.blade.php
+++ b/resources/views/importers/create.blade.php
@@ -307,6 +307,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     addressModalEl.addEventListener('hidden.bs.modal', function () {
         addressForm.reset();
+        document.getElementById('addressable_type').value = 'App\\Models\\Importer';
         document.getElementById('addrDistrict').disabled = true;
         document.getElementById('addrSubDistrict').disabled = true;
         currentlyEditing = null;

--- a/resources/views/importers/edit.blade.php
+++ b/resources/views/importers/edit.blade.php
@@ -95,6 +95,8 @@
                     <button type="button" class="btn btn-sm btn-primary add-address-btn"
                             data-bs-toggle="modal"
                             data-bs-target="#addressModal"
+                            data-addressable-id="{{ $importer->id }}"
+                            data-addressable-type="App\Models\Importer"
                             data-type="registered">
                         {{ __('Add Address') }}
                     </button>
@@ -124,6 +126,8 @@
                     <button type="button" class="btn btn-sm btn-primary add-address-btn"
                             data-bs-toggle="modal"
                             data-bs-target="#addressModal"
+                            data-addressable-id="{{ $importer->id }}"
+                            data-addressable-type="App\Models\Importer"
                             data-type="workplace">
                         {{ __('Add Address') }}
                     </button>
@@ -258,6 +262,8 @@ document.addEventListener('DOMContentLoaded', function () {
     addressModalEl.addEventListener('hidden.bs.modal', function () {
         addressForm.reset();
         document.getElementById('address_id').value = '';
+        document.getElementById('addressable_id').value = importerId;
+        document.getElementById('addressable_type').value = 'App\\Models\\Importer';
         document.getElementById('addressFormMethod').value = '';
         document.getElementById('addrDistrict').disabled = true;
         document.getElementById('addrSubDistrict').disabled = true;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1332,7 +1332,11 @@ document.addEventListener('DOMContentLoaded', function () {
             addressForm.reset();
             fields.id.value = '';
             fields.addressable_id.value = targetBtn.dataset.addressableId;
-            fields.addressable_type.value = 'App\\Models\\Employer';
+            if (targetBtn.dataset.addressableType) {
+                fields.addressable_type.value = targetBtn.dataset.addressableType;
+            } else {
+                fields.addressable_type.value = 'App\\Models\\Employer';
+            }
             fields.type.value = targetBtn.dataset.type;
 
             // Re-trigger Alpine's reactivity by firing a change event


### PR DESCRIPTION
Fixes two specific UI errors raised by the user regarding Delegate creation and Importer address creation.

The first issue (`InvalidArgumentException` for `image-cropper` component) is fixed by providing standard HTML file input elements with image previews inside the `delegates.create` and `delegates.edit` blade templates.

The second issue (No query results for model `Employer` when adding Importer addresses) is fixed by ensuring that the frontend modal javascript correctly retrieves the `addressable_type` and `addressable_id` dataset attributes from the triggering buttons, rather than hardcoding it to `Employer`. The address "Add" buttons in the Importer and Delegate edit menus have been updated to provide these dataset properties, ensuring the `AddressController` accurately associates new addresses with their corresponding parent entity.

---
*PR created automatically by Jules for task [1346276106187543789](https://jules.google.com/task/1346276106187543789) started by @nongjossss-commits*