### PR TITLE
Fix: Prevent employee email and outsource credentials from being cleared during partial updates

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -680,8 +680,15 @@ public function create(Request $request) // เพิ่ม Request $request เ
 
         // --- V6: Step 2: Handle email and password mapping & hashing ---
         $data = $validated;
-        $data['email'] = $validated['employeeEmail'] ?? null;
-        unset($data['employeeEmail']);
+
+        // Fix: Only update email if 'employeeEmail' is present in the request
+        // Otherwise, forms that do not contain the email field (like quick inline updates) will clear it out.
+        if (array_key_exists('employeeEmail', $validated)) {
+            $data['email'] = $validated['employeeEmail'];
+            unset($data['employeeEmail']);
+        } else {
+            unset($data['employeeEmail']);
+        }
 
         // Helper to map and upload file
         // REVERTED: Sensitive files are now stored in 'public' disk to prevent 403 Forbidden errors in views.
@@ -720,6 +727,11 @@ public function create(Request $request) // เพิ่ม Request $request เ
         // If it's empty, we should not update the password.
         if (empty($data['password'])) {
             unset($data['password']); // Prevent updating with an empty value
+        }
+
+        // Prevent outsource_code from being cleared out by inline updates
+        if (!array_key_exists('outsource_code', $request->all())) {
+            unset($data['outsource_code']);
         }
 
         $validated = $data;

--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -1078,13 +1078,27 @@ class RegistrationController extends Controller
             $validated['insuranceExpiryDate'] = null;
         }
 
-        $validated['email'] = $validated['employeeEmail'] ?? null;
-        unset($validated['employeeEmail']);
+        // Prevent email from being overwritten with null during partial updates
+        if (array_key_exists('employeeEmail', $validated)) {
+            $validated['email'] = $validated['employeeEmail'];
+            unset($validated['employeeEmail']);
+        } else {
+            unset($validated['employeeEmail']);
+        }
 
         if (!empty($validated['employeePassword'])) {
             $validated['password'] = $validated['employeePassword'];
+        } else if (array_key_exists('employeePassword', $validated) && empty($validated['employeePassword'])) {
+            // Do not clear the password if it's explicitly submitted as empty,
+            // or if it's missing from the form completely.
+            unset($validated['password']);
         }
         unset($validated['employeePassword']);
+
+        // Prevent outsource_code from being cleared out by inline updates
+        if (!array_key_exists('outsource_code', $request->all())) {
+            unset($validated['outsource_code']);
+        }
 
         // File Uploads
         $fileFields = [

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -919,13 +919,27 @@ class RenewalController extends Controller
             $validated['insuranceExpiryDate'] = null;
         }
 
-        $validated['email'] = $validated['employeeEmail'] ?? null;
-        unset($validated['employeeEmail']);
+        // Prevent email from being overwritten with null during partial updates
+        if (array_key_exists('employeeEmail', $validated)) {
+            $validated['email'] = $validated['employeeEmail'];
+            unset($validated['employeeEmail']);
+        } else {
+            unset($validated['employeeEmail']);
+        }
 
         if (!empty($validated['employeePassword'])) {
             $validated['password'] = $validated['employeePassword'];
+        } else if (array_key_exists('employeePassword', $validated) && empty($validated['employeePassword'])) {
+            // Do not clear the password if it's explicitly submitted as empty,
+            // or if it's missing from the form completely.
+            unset($validated['password']);
         }
         unset($validated['employeePassword']);
+
+        // Prevent outsource_code from being cleared out by inline updates
+        if (!array_key_exists('outsource_code', $request->all())) {
+            unset($validated['outsource_code']);
+        }
 
         // File Uploads
         $fileFields = [


### PR DESCRIPTION
Fixed a critical bug where an employee's saved email, password, and outsource code were being silently deleted. The issue occurred when partial or inline updates from the UI (like in the Production and Workflow menus) sent payloads that didn't include the email or outsource code fields. The backend controllers incorrectly mapped these missing fields to `null`, wiping out existing data.

Modified `EmployeeController`, `RegistrationController`, and `RenewalController` to ensure that `email`, `password`, and `outsource_code` are only updated if they are explicitly present in the request array.

---
*PR created automatically by Jules for task [8801908448469047176](https://jules.google.com/task/8801908448469047176) started by @nongjossss-commits*