### PR TITLE
feat: add MOU 2 Years Later work permit type

### DIFF
--- a/app/Console/Commands/CheckExpiries.php
+++ b/app/Console/Commands/CheckExpiries.php
@@ -105,7 +105,7 @@ class CheckExpiries extends Command
                 $currentNotificationType = $notificationType;
 
                 if ($notificationType === 'work_permit_expiry') {
-                     if ($employee->workPermitMOUGroup === 'MOU') {
+                     if ($employee->workPermitMOUGroup === 'MOU' || $employee->workPermitMOUGroup === 'MOU 2 ปีหลัง') {
                         $currentNotificationType = 'work_permit_mou';
                     } elseif ($employee->workPermitMOUGroup === 'มติต่ออายุในประเทศ') {
                         $currentNotificationType = 'resolution_renewal';

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -1447,7 +1447,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
             'passport_type_cambodia' => ['เล่ม TD' => 'เล่ม TD', 'เล่มอินเตอร์' => 'เล่มอินเตอร์'],
             'insurance_type' => ['ประกันสังคม' => 'ประกันสังคม', 'ประกันโรงพยาบาล' => 'ประกันโรงพยาบาล', 'ประกันเอกชน' => 'ประกันเอกชน'],
             // Note: 'workPermitType' in bulk selection often maps to the MOU Group dropdown in Create/Edit forms
-            'workPermitMOUGroup' => ['MOU' => 'MOU', 'มติต่ออายุในประเทศ' => 'มติต่ออายุในประเทศ', 'มติขึ้นทะเบียน' => 'มติขึ้นทะเบียน', 'อื่นๆ' => 'อื่นๆ'],
+            'workPermitMOUGroup' => ['MOU' => 'MOU', 'MOU 2 ปีหลัง' => 'MOU 2 ปีหลัง', 'มติต่ออายุในประเทศ' => 'มติต่ออายุในประเทศ', 'มติขึ้นทะเบียน' => 'มติขึ้นทะเบียน', 'อื่นๆ' => 'อื่นๆ'],
         ];
 
         // Map keys to labels (simplified version of what was in selectFields)

--- a/resources/views/admin/incomplete_employees/index.blade.php
+++ b/resources/views/admin/incomplete_employees/index.blade.php
@@ -33,6 +33,7 @@
                 <select name="mou_group" class="form-select form-select-sm" style="width: auto;">
                     <option value="">-- {{ __('All MOU Types') }} --</option>
                     <option value="MOU" @if(request('mou_group') == 'MOU') selected @endif>{{ __('MOU') }}</option>
+                    <option value="MOU 2 ปีหลัง" @if(request('mou_group') == 'MOU 2 ปีหลัง') selected @endif>{{ __('MOU 2 Years Later') }}</option>
                     <option value="มติต่ออายุในประเทศ" @if(request('mou_group') == 'มติต่ออายุในประเทศ') selected @endif>{{ __('MOU Extension in Country') }}</option>
                     <option value="มติขึ้นทะเบียน" @if(request('mou_group') == 'มติขึ้นทะเบียน') selected @endif>{{ __('MOU Registration') }}</option>
                     <option value="อื่นๆ" @if(request('mou_group') == 'อื่นๆ') selected @endif>{{ __('Others') }}</option>

--- a/resources/views/employees/history.blade.php
+++ b/resources/views/employees/history.blade.php
@@ -23,6 +23,7 @@
             <select name="mou_group" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- ทุกประเภท มติ. --</option>
                 <option value="MOU" @if(request('mou_group') == 'MOU') selected @endif>MOU</option>
+                <option value="MOU 2 ปีหลัง" @if(request('mou_group') == 'MOU 2 ปีหลัง') selected @endif>MOU 2 ปีหลัง</option>
                 <option value="มติต่ออายุในประเทศ" @if(request('mou_group') == 'มติต่ออายุในประเทศ') selected @endif>มติต่ออายุในประเทศ</option>
                 <option value="มติขึ้นทะเบียน" @if(request('mou_group') == 'มติขึ้นทะเบียน') selected @endif>มติขึ้นทะเบียน</option>
                 <option value="อื่นๆ" @if(request('mou_group') == 'อื่นๆ') selected @endif>อื่นๆ</option>

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -43,6 +43,7 @@
             <select name="mou_group" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- {{ __('All MOU Types') }} --</option>
                 <option value="MOU" @if(request('mou_group') == 'MOU') selected @endif>{{ __('MOU') }}</option>
+                <option value="MOU 2 ปีหลัง" @if(request('mou_group') == 'MOU 2 ปีหลัง') selected @endif>{{ __('MOU 2 Years Later') }}</option>
                 <option value="มติต่ออายุในประเทศ" @if(request('mou_group') == 'มติต่ออายุในประเทศ') selected @endif>{{ __('MOU Extension in Country') }}</option>
                 <option value="มติขึ้นทะเบียน" @if(request('mou_group') == 'มติขึ้นทะเบียน') selected @endif>{{ __('MOU Registration') }}</option>
                 <option value="อื่นๆ" @if(request('mou_group') == 'อื่นๆ') selected @endif>{{ __('Others') }}</option>

--- a/resources/views/employees/partials/_edit_form.blade.php
+++ b/resources/views/employees/partials/_edit_form.blade.php
@@ -275,6 +275,7 @@
             <select class="form-select" id="edit_workPermitMOUGroup" name="workPermitMOUGroup">
                 <option value="">-- กรุณาเลือก --</option>
                 <option value="MOU" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'MOU')>MOU</option>
+                <option value="MOU 2 ปีหลัง" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'MOU 2 ปีหลัง')>MOU 2 ปีหลัง</option>
                 <option value="มติต่ออายุในประเทศ" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'มติต่ออายุในประเทศ')>มติต่ออายุในประเทศ</option>
                 <option value="มติขึ้นทะเบียน" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'มติขึ้นทะเบียน')>มติขึ้นทะเบียน</option>
                 <option value="อื่นๆ" @selected(old('workPermitMOUGroup', $employee->workPermitMOUGroup) == 'อื่นๆ')>อื่นๆ ระบุ..</option>

--- a/resources/views/employees/partials/create_form_partial_content.blade.php
+++ b/resources/views/employees/partials/create_form_partial_content.blade.php
@@ -326,6 +326,7 @@
         <select class="form-select" id="workPermitMOUGroup" name="workPermitMOUGroup">
             <option value="">-- กรุณาเลือก --</option>
             <option value="MOU" {{ old('workPermitMOUGroup') == 'MOU' ? 'selected' : '' }}>MOU</option>
+            <option value="MOU 2 ปีหลัง" {{ old('workPermitMOUGroup') == 'MOU 2 ปีหลัง' ? 'selected' : '' }}>MOU 2 ปีหลัง</option>
             <option value="มติต่ออายุในประเทศ" {{ old('workPermitMOUGroup') == 'มติต่ออายุในประเทศ' ? 'selected' : '' }}>มติต่ออายุในประเทศ</option>
             <option value="มติขึ้นทะเบียน" {{ old('workPermitMOUGroup') == 'มติขึ้นทะเบียน' ? 'selected' : '' }}>มติขึ้นทะเบียน</option>
             <option value="อื่นๆ" {{ old('workPermitMOUGroup') == 'อื่นๆ' ? 'selected' : '' }}>อื่นๆ ระบุ..</option>

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -571,6 +571,7 @@
                 <select name="mou_group" class="form-select form-select-sm" style="width: auto;">
                     <option value="">-- {{ __('All MOU Types') }} --</option>
                     <option value="MOU" @if(request('mou_group') == 'MOU') selected @endif>MOU</option>
+                    <option value="MOU 2 ปีหลัง" @if(request('mou_group') == 'MOU 2 ปีหลัง') selected @endif>MOU 2 ปีหลัง</option>
                     <option value="มติต่ออายุในประเทศ" @if(request('mou_group') == 'มติต่ออายุในประเทศ') selected @endif>มติต่ออายุในประเทศ</option>
                     <option value="มติขึ้นทะเบียน" @if(request('mou_group') == 'มติขึ้นทะเบียน') selected @endif>มติขึ้นทะเบียน</option>
                     <option value="อื่นๆ" @if(request('mou_group') == 'อื่นๆ') selected @endif>อื่นๆ</option>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -54,6 +54,7 @@
                         <select name="mou_type" class="form-select form-select-sm">
                             <option value="">-- {{ __('All MOU Types') }} --</option>
                             <option value="MOU" @selected(request('mou_type') == 'MOU')>{{ __('MOU') }}</option>
+                            <option value="MOU 2 ปีหลัง" @selected(request('mou_type') == 'MOU 2 ปีหลัง')>{{ __('MOU 2 Years Later') }}</option>
                             <option value="มติต่ออายุในประเทศ" @selected(request('mou_type') == 'มติต่ออายุในประเทศ')>{{ __('MOU Extension in Country') }}</option>
                             <option value="มติขึ้นทะเบียน" @selected(request('mou_type') == 'มติขึ้นทะเบียน')>{{ __('MOU Registration') }}</option>
                             <option value="อื่นๆ" @selected(request('mou_type') == 'อื่นๆ')>{{ __('Others') }}</option>

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -863,6 +863,7 @@
                     <select class="form-select" id="autoMouInput">
                         <option value="">-- {{ __('No Auto Update') }} --</option>
                         <option value="MOU" {{ ($resolutionSettings['registration_auto_mou_group'] ?? '') == 'MOU' ? 'selected' : '' }}>MOU</option>
+                        <option value="MOU 2 ปีหลัง" {{ ($resolutionSettings['registration_auto_mou_group'] ?? '') == 'MOU 2 ปีหลัง' ? 'selected' : '' }}>MOU 2 ปีหลัง</option>
                         <option value="มติต่ออายุในประเทศ" {{ ($resolutionSettings['registration_auto_mou_group'] ?? '') == 'มติต่ออายุในประเทศ' ? 'selected' : '' }}>มติต่ออายุในประเทศ</option>
                         <option value="มติขึ้นทะเบียน" {{ ($resolutionSettings['registration_auto_mou_group'] ?? '') == 'มติขึ้นทะเบียน' ? 'selected' : '' }}>มติขึ้นทะเบียน</option>
                         <option value="อื่นๆ" {{ ($resolutionSettings['registration_auto_mou_group'] ?? '') == 'อื่นๆ' ? 'selected' : '' }}>อื่นๆ</option>

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -779,6 +779,7 @@
                     <select class="form-select" id="autoMouInput">
                         <option value="">-- {{ __('No Auto Update') }} --</option>
                         <option value="MOU" {{ ($resolutionSettings['renewal_auto_mou_group'] ?? '') == 'MOU' ? 'selected' : '' }}>MOU</option>
+                        <option value="MOU 2 ปีหลัง" {{ ($resolutionSettings['renewal_auto_mou_group'] ?? '') == 'MOU 2 ปีหลัง' ? 'selected' : '' }}>MOU 2 ปีหลัง</option>
                         <option value="มติต่ออายุในประเทศ" {{ ($resolutionSettings['renewal_auto_mou_group'] ?? '') == 'มติต่ออายุในประเทศ' ? 'selected' : '' }}>มติต่ออายุในประเทศ</option>
                         <option value="มติขึ้นทะเบียน" {{ ($resolutionSettings['renewal_auto_mou_group'] ?? '') == 'มติขึ้นทะเบียน' ? 'selected' : '' }}>มติขึ้นทะเบียน</option>
                         <option value="อื่นๆ" {{ ($resolutionSettings['renewal_auto_mou_group'] ?? '') == 'อื่นๆ' ? 'selected' : '' }}>อื่นๆ</option>

--- a/resources/views/tickets/partials/_new_employee_modal.blade.php
+++ b/resources/views/tickets/partials/_new_employee_modal.blade.php
@@ -180,6 +180,7 @@
                         <select class="form-select" id="modal_workPermitMOUGroup" x-model="newEmployeeForm.workPermitMOUGroup">
                             <option value="">-- กรุณาเลือก --</option>
                             <option value="MOU">MOU</option>
+                            <option value="MOU 2 ปีหลัง">MOU 2 ปีหลัง</option>
                             <option value="มติต่ออายุในประเทศ">มติต่ออายุในประเทศ</option>
                             <option value="มติขึ้นทะเบียน">มติขึ้นทะเบียน</option>
                             <option value="อื่นๆ">อื่นๆ ระบุ..</option>


### PR DESCRIPTION
This PR introduces a new "MOU 2 ปีหลัง" (MOU 2 Years Later) type to the Work Permit MOU Group options across the application. 

**Changes Include:**
- Updated Create and Edit forms in `employees/` and `tickets/` modules to display the new option.
- Added the option to search and filter dropdowns in Employees, Employers, Notifications, and Incomplete Employees pages.
- Added the option to the 'Auto MOU Group' settings in Production Registration/Renewal resolutions.
- Updated `EmployeeController` to accept the new value during bulk Advanced Edits.
- Updated `CheckExpiries` command to ensure the new type receives the correct `work_permit_mou` notification category without creating a separate group.
- Relies on existing fallback logic for UI elements (like blue badges in Workflow cards) which naturally match the `str_contains('MOU')` conditions.

---
*PR created automatically by Jules for task [14208918712653897264](https://jules.google.com/task/14208918712653897264) started by @nongjossss-commits*