### PR TITLE
Fix mobile layout overflow in workflow and production item cards

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -76,10 +76,11 @@
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-3">
             {{-- Checkbox & Basic Info --}}
             <div class="d-flex flex-column flex-xl-row align-items-start gap-3 w-100">
-                <div class="d-flex align-items-center gap-3 w-100">
+                <div class="d-flex flex-column flex-xl-row align-items-start align-items-xl-center gap-3 w-100">
+                    <div class="d-flex align-items-center gap-3 w-100">
                 @can('edit-employees')
                 {{-- Only show checkbox if Active (Pending) --}}
-                <div class="form-check {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}" id="checkbox-container-{{ $employee->id }}">
+                <div class="form-check flex-shrink-0 {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}" id="checkbox-container-{{ $employee->id }}">
                     <input class="form-check-input employee-checkbox"
                            type="checkbox"
                            value="{{ $employee->id }}"
@@ -100,7 +101,8 @@
                 </div>
                 @endcan
 
-                <div class="d-flex align-items-start align-items-sm-center flex-column flex-sm-row gap-3 w-100 {{ $overlayClass }}" id="info-container-{{ $employee->id }}">
+                {{-- Container for Checkbox + Info on all screen sizes --}}
+                <div class="d-flex align-items-start align-items-sm-center flex-row gap-3 w-100 {{ $overlayClass }}" id="info-container-{{ $employee->id }}">
                     {{-- Avatar --}}
                     <div class="avatar-container position-relative flex-shrink-0">
                         @if($employee->employeePhoto)
@@ -191,7 +193,7 @@
 
             {{-- Outsource Login Information --}}
             @can('edit-employees')
-            <div class="ms-md-2 w-100" style="max-width: 100%;" x-data="{
+            <div class="ms-0 ms-xl-4 w-100" style="max-width: 100%;" x-data="{
                 isEditing: false,
                 email: '{{ $employee->email ?? '' }}',
                 originalEmail: '{{ $employee->email ?? '' }}',
@@ -411,7 +413,7 @@
 
             </div>
             @endcan
-            <div class="d-flex flex-column gap-2 ms-md-2 w-100" style="max-width: 100%;">
+            <div class="d-flex flex-column gap-2 ms-0 ms-xl-4 w-100" style="max-width: 100%;">
             {{-- REMARKS SECTION --}}
             @php
                 $isRenewal = request()->is('production/renewal*');

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -132,9 +132,10 @@
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-3">
             {{-- Checkbox & Basic Info --}}
             <div class="d-flex flex-column flex-xl-row align-items-start gap-3 w-100">
-                <div class="d-flex align-items-center gap-3 w-100">
+                <div class="d-flex flex-column flex-xl-row align-items-start align-items-xl-center gap-3 w-100">
+                    <div class="d-flex align-items-center gap-3 w-100">
                 {{-- Checkbox (Optional, for bulk actions if implemented later) --}}
-                <div class="form-check" id="checkbox-container-{{ $item->id }}">
+                <div class="form-check flex-shrink-0" id="checkbox-container-{{ $item->id }}">
                 <input class="form-check-input employee-checkbox"
                            type="checkbox"
                        value="{{ $item->employee_id ?? '' }}"
@@ -153,7 +154,8 @@
                        {{ (!$item->employee_id || $isReadOnly) ? 'disabled' : '' }}>
                 </div>
 
-                <div class="d-flex align-items-start align-items-sm-center flex-column flex-sm-row gap-3 w-100 {{ $overlayClass }}" id="info-container-{{ $item->id }}">
+                {{-- Container for Checkbox + Info on all screen sizes, so they sit together even when outer wrapper stacks --}}
+                <div class="d-flex align-items-start align-items-sm-center flex-row gap-3 w-100 {{ $overlayClass }}" id="info-container-{{ $item->id }}">
                     {{-- Avatar --}}
                     <div class="avatar-container position-relative flex-shrink-0">
                         <img src="{{ $empPhoto }}" class="rounded-circle shadow-sm" style="width: 50px; height: 50px; object-fit: cover;">
@@ -207,9 +209,10 @@
                         </div>
                     </div>
                 </div>
+                </div>
 
                 {{-- Appointment Date & Location --}}
-                <div class="ms-md-4 w-100" style="max-width: 100%;" x-data="{
+                <div class="ms-0 ms-xl-4 w-100" style="max-width: 100%;" x-data="{
                     isEditing: false,
                     isAppCompleted: {{ $isAppCompleted ? 'true' : 'false' }},
                     dateValue: '{{ $appValue }}',
@@ -349,7 +352,7 @@
                 </div>
 
                 {{-- NEW CREDENTIALS SECTION --}}
-                <div class="ms-md-4 w-100" style="max-width: 100%;" x-data="{
+                <div class="ms-0 ms-xl-4 w-100" style="max-width: 100%;" x-data="{
                     isEditing: false,
                     email: {{ json_encode($item->employee->email ?? '') }},
                     outsource_code: {{ json_encode($item->employee->outsource_code ?? '') }},
@@ -439,7 +442,7 @@
                 </div>
 
                 {{-- REMARKS & 3 Extra Fields SECTION --}}
-                <div class="ms-md-4 d-flex flex-column gap-2 w-100" style="min-width: 0; max-width: 100%;">
+                <div class="ms-0 ms-xl-4 d-flex flex-column gap-2 w-100" style="min-width: 0; max-width: 100%;">
                     <div class="w-100" style="min-width: 0;" x-data="{
                         isEditing: false,
                         remarkText: {{ json_encode($item->remarks ?? '') }},


### PR DESCRIPTION
This commit fixes the mobile layout issues reported where item cards in the Workflow and Production (Registration/Renewal) modules break out of bounds horizontally on small devices. By utilizing responsive flexbox utilities (`flex-column` dropping into `flex-xl-row`) and fixing margin adjustments, the layout is now safe for varying screen sizes.

---
*PR created automatically by Jules for task [6751455976319584453](https://jules.google.com/task/6751455976319584453) started by @nongjossss-commits*