### PR TITLE
Fix UI layout issues in Employee and Employer cards

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -144,7 +144,7 @@
                     </div>
 
                     {{-- Info --}}
-                    <div class="w-100 min-w-0">
+                    <div class="w-100 ">
                         <div class="fw-bold text-dark text-break">
                              {{-- English Name + Title --}}
                             {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? '-' }}
@@ -243,32 +243,32 @@
                     });
                 }
             }">
-                <div class="w-100" style="min-width: 0;">
+                <div class="w-100" >
                     <small class="text-muted d-block" style="font-size: 0.7rem;"><i class="bi bi-lock-fill"></i> {{ __('ข้อมูลการเข้าสู่ระบบ Outsource') }}</small>
 
                     <div x-show="!isEditing" class="d-flex align-items-center gap-2 position-relative w-100">
-                         <div class="small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center w-100" style="min-height: 38px; min-width: 0;">
+                         <div class="small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center w-100" style="min-height: 38px;">
                             <div class="d-flex align-items-center justify-content-between mb-1">
                                 <span class="fw-bold text-primary">Login Info</span>
                                 <i class="bi bi-pencil-fill text-muted cursor-pointer" style="font-size: 0.7rem;" @click="isEditing = true"></i>
                             </div>
 
-                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem; min-width: 0;">
-                                <span class="text-muted text-truncate flex-grow-1" style="min-width: 0; padding-right: 5px;">
+                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem;">
+                                <span class="text-muted text-truncate flex-grow-1" style="padding-right: 5px;">
                                     <i class="bi bi-envelope me-1"></i><span x-text="email || '-'"></span>
                                 </span>
                                 <button x-show="email" @click="copyToClipboard(email, 'อีเมล')" class="btn btn-sm btn-link p-0 text-secondary flex-shrink-0" title="คัดลอกอีเมล"><i class="bi bi-clipboard"></i></button>
                             </div>
 
-                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem; min-width: 0;">
-                                <span class="text-muted text-truncate flex-grow-1" style="min-width: 0; padding-right: 5px;">
+                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem;">
+                                <span class="text-muted text-truncate flex-grow-1" style="padding-right: 5px;">
                                     <i class="bi bi-key me-1"></i><span x-text="password || '-'"></span>
                                 </span>
                                 <button x-show="password" @click="copyToClipboard(password, 'รหัสสำหรับอีเมล')" class="btn btn-sm btn-link p-0 text-secondary flex-shrink-0" title="คัดลอกรหัสผ่าน"><i class="bi bi-clipboard"></i></button>
                             </div>
 
-                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem; min-width: 0;">
-                                <span class="text-muted text-truncate flex-grow-1" style="min-width: 0; padding-right: 5px;">
+                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem;">
+                                <span class="text-muted text-truncate flex-grow-1" style="padding-right: 5px;">
                                     <i class="bi bi-shield-lock me-1"></i><span x-text="outsource_code || '-'"></span>
                                 </span>
                                 <button x-show="outsource_code" @click="copyToClipboard(outsource_code, 'รหัส Outsource')" class="btn btn-sm btn-link p-0 text-secondary flex-shrink-0" title="คัดลอกรหัส Outsource"><i class="bi bi-clipboard"></i></button>
@@ -312,7 +312,7 @@
                     $isRenewalContext = request()->is('production/renewal*');
                     $modulePath = $isRenewalContext ? 'production/renewal' : 'production/registration';
                 @endphp
-                <div class="mt-2 w-100" style="min-width: 0;" x-data="{
+                <div class="mt-2 w-100"  x-data="{
                     isEditing: false,
                     isAppCompleted: {{ $isAppCompleted ? 'true' : 'false' }},
                     dateValue: '{{ $appValue }}',
@@ -385,13 +385,13 @@
                          @click="isEditing = true; $nextTick(() => initFlatpickr())"
                          :class="{ 'opacity-50': isAppCompleted }">
 
-                         <div class="text-primary fw-bold small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center px-2 w-100" style="min-height: 38px; min-width: 0;">
-                            <div class="d-flex align-items-center w-100" style="min-width: 0;">
+                         <div class="text-primary fw-bold small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center px-2 w-100" style="min-height: 38px;">
+                            <div class="d-flex align-items-center w-100" >
                                 <i class="bi bi-calendar-event text-warning me-1 flex-shrink-0"></i>
-                                <span x-text="displayValue" class="text-truncate flex-grow-1" style="min-width: 0;"></span>
+                                <span x-text="displayValue" class="text-truncate flex-grow-1" ></span>
                                 <i x-show="isAppCompleted" class="bi bi-check-circle-fill text-success ms-auto flex-shrink-0"></i>
                             </div>
-                            <div x-show="locationValue" class="text-muted text-truncate w-100" style="font-size: 0.7rem; min-width: 0;">
+                            <div x-show="locationValue" class="text-muted text-truncate w-100" style="font-size: 0.7rem;">
                                 <i class="bi bi-geo-alt me-1"></i><span x-text="locationValue"></span>
                             </div>
                          </div>
@@ -424,7 +424,7 @@
                     ? route('production.renewal.remarks', $employee->id)
                     : route('production.registration.remarks', $employee->id);
             @endphp
-            <div class="w-100" style="min-width: 0;" x-data="{
+            <div class="w-100"  x-data="{
                 isEditing: false,
                 remarkText: {{ json_encode($remarkText ?? '') }},
                 tempRemarkText: '',
@@ -473,12 +473,12 @@
                     });
                 }
             }">
-                <div class="w-100" style="min-width: 0; max-width: 100%;">
+                <div class="w-100" >
                     <small class="text-muted d-block fw-bold" style="font-size: 0.7rem;">หมายเหตุ</small>
 
-                    <div class="d-flex align-items-start gap-1 mb-2 w-100" style="min-width: 0;">
-                        <div x-cloak :style="{ display: !isEditing ? 'flex' : 'none' }" class="align-items-start gap-1 w-100" style="min-width: 0;">
-                            <div class="text-dark small border rounded px-2 py-1 bg-light flex-grow-1 text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word; min-width: 0;">
+                    <div class="d-flex align-items-start gap-1 mb-2 w-100" >
+                        <div x-cloak :style="{ display: !isEditing ? 'flex' : 'none' }" class="align-items-start gap-1 w-100" >
+                            <div class="text-dark small border rounded px-2 py-1 bg-light flex-grow-1 text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word;">
                                 <span x-text="remarkText || '-'"></span>
                             </div>
                             <button @click="startEditing()" class="btn btn-sm btn-outline-secondary rounded-circle flex-shrink-0" style="padding: 2px 6px;" title="แก้ไขหมายเหตุ">
@@ -531,7 +531,7 @@
             @endphp
 
             {{-- 3 Extra Fields (Editable) --}}
-            <div class="d-flex flex-column gap-2 w-100" style="min-width: 0;" x-data="{
+            <div class="d-flex flex-column gap-2 w-100"  x-data="{
                 isEditing: false,
                 nameList: '{{ $employee->name_list_number }}',
                 reqNo: '{{ $currentRequestNumber }}',
@@ -623,12 +623,12 @@
                     });
                 }
             }">
-                <div class="d-flex align-items-end gap-2 w-100" style="min-width: 0;">
+                <div class="d-flex align-items-end gap-2 w-100" >
                     {{-- Field 1: Name List (Renamed to RA) --}}
-                    <div class="w-100" style="flex-grow: 1; min-width: 0;">
+                    <div class="w-100" style="flex-grow: 1;">
                         <small class="text-muted d-block" style="font-size: 0.7rem;">เลข RA จากระบบ outsource</small>
-                        <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px; min-width: 0;">
-                            <div x-ref="raDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1" style="min-width: 0;" x-text="nameList || '-'"></div>
+                        <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px;">
+                            <div x-ref="raDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1"  x-text="nameList || '-'"></div>
                             <button x-show="nameList" @click="copy($event.currentTarget, nameList)" class="btn btn-link p-0 text-secondary ms-1 flex-shrink-0" title="{{ __('Copy') }}">
                                 <i class="bi bi-clipboard" style="font-size: 0.8rem;"></i>
                             </button>
@@ -651,10 +651,10 @@
                 </div>
 
                 {{-- Field 2: Request No --}}
-                <div class="w-100" style="min-width: 0; max-width: 100%;">
+                <div class="w-100" >
                     <small class="text-muted d-block" style="font-size: 0.7rem;">เลขที่คำขอ</small>
-                    <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px; min-width: 0;">
-                        <div x-ref="reqDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1" style="min-width: 0;" x-text="reqNo || '-'"></div>
+                    <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px;">
+                        <div x-ref="reqDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1"  x-text="reqNo || '-'"></div>
                         <button x-show="reqNo" @click="copy($event.currentTarget, reqNo)" class="btn btn-link p-0 text-secondary ms-1 flex-shrink-0" title="{{ __('Copy') }}">
                             <i class="bi bi-clipboard" style="font-size: 0.8rem;"></i>
                         </button>
@@ -663,10 +663,10 @@
                 </div>
 
                 {{-- Field 3: Ref ID --}}
-                <div class="w-100" style="min-width: 0; max-width: 100%;">
+                <div class="w-100" >
                     <small class="text-muted d-block" style="font-size: 0.7rem;">เลขอ้างอิงคนงาน</small>
-                    <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px; min-width: 0;">
-                        <div x-ref="refDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1" style="min-width: 0;" x-text="refId || '-'"></div>
+                    <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px;">
+                        <div x-ref="refDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1"  x-text="refId || '-'"></div>
                         <button x-show="refId" @click="copy($event.currentTarget, refId)" class="btn btn-link p-0 text-secondary ms-1 flex-shrink-0" title="{{ __('Copy') }}">
                             <i class="bi bi-clipboard" style="font-size: 0.8rem;"></i>
                         </button>

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -539,30 +539,30 @@
                         <div class="col-12 col-xl text-xl-end">
                             <div class="d-flex align-items-center justify-content-xl-end gap-2 flex-wrap">
                                  {{-- Stats Badges (Fixed Widths for Alignment) --}}
-                                 <div class="d-flex align-items-center gap-2 me-xl-3">
+                                 <div class="d-flex flex-wrap align-items-center gap-2 me-xl-3">
                                     {{-- Total --}}
-                                    <span class="badge bg-light text-dark border d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 90px;" title="{{ __('Total Employees') }}">
+                                    <span class="badge bg-light text-dark border d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Total Employees') }}">
                                         <i class="bi bi-people-fill text-muted"></i>
                                         <span class="fw-bold" id="employer-total-{{ $employer->id }}">{{ $employer->activeEmployeesCount ?? 0 }}</span>
                                         <span class="text-muted small ms-1" style="font-size: 0.70rem;">{{ __('TOTAL') }}</span>
                                     </span>
                                     {{-- Not Started --}}
-                                    <span class="badge bg-danger bg-opacity-10 text-danger border border-danger d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 100px;" title="{{ __('Pending') }}">
+                                    <span class="badge bg-danger bg-opacity-10 text-danger border border-danger d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Pending') }}">
                                          <span class="fw-bold" id="employer-not-started-{{ $employer->id }}">{{ $employer->notStartedCount ?? 0 }}</span>
                                          <span class="small ms-1 opacity-75" style="font-size: 0.70rem;">{{ __('PENDING') }}</span>
                                     </span>
                                     {{-- Saved --}}
-                                    <span class="badge bg-success bg-opacity-10 text-success border border-success d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 90px;" title="{{ __('Saved') }}">
+                                    <span class="badge bg-success bg-opacity-10 text-success border border-success d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Saved') }}">
                                          <span class="fw-bold" id="employer-saved-{{ $employer->id }}">{{ $employer->savedCount ?? 0 }}</span>
                                          <span class="small ms-1 opacity-75" style="font-size: 0.70rem;">{{ __('SAVED') }}</span>
                                     </span>
                                     {{-- Cancelled --}}
-                                    <span class="badge bg-secondary bg-opacity-10 text-secondary border border-secondary d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 95px;" title="{{ __('Cancelled') }}">
+                                    <span class="badge bg-secondary bg-opacity-10 text-secondary border border-secondary d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Cancelled') }}">
                                         <span class="fw-bold" id="employer-cancelled-{{ $employer->id }}">{{ $employer->cancelledCount ?? 0 }}</span>
                                         <span class="small ms-1 opacity-75" style="font-size: 0.70rem;">{{ __('CANCEL') }}</span>
                                     </span>
                                     {{-- Biometrics --}}
-                                    <span class="badge bg-info bg-opacity-10 text-info border border-info d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 95px;" title="{{ __('Biometrics Collected') }}">
+                                    <span class="badge bg-info bg-opacity-10 text-info border border-info d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Biometrics Collected') }}">
                                         <i class="bi bi-fingerprint"></i>
                                         <span class="fw-bold" id="employer-biometrics-collected-{{ $employer->id }}">{{ $employer->biometricsCollectedCount ?? 0 }}</span>
                                     </span>

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -531,25 +531,25 @@
                         <div class="col-12 col-xl text-xl-end">
                             <div class="d-flex align-items-center justify-content-xl-end gap-2 flex-wrap">
                                  {{-- Stats Badges (Fixed Widths for Alignment) --}}
-                                 <div class="d-flex align-items-center gap-2 me-xl-3">
+                                 <div class="d-flex flex-wrap align-items-center gap-2 me-xl-3">
                                     {{-- Total --}}
-                                    <span class="badge bg-light text-dark border d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 90px;" title="{{ __('Total Employees') }}">
+                                    <span class="badge bg-light text-dark border d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Total Employees') }}">
                                         <i class="bi bi-people-fill text-muted"></i>
                                         <span class="fw-bold" id="employer-total-{{ $employer->id }}">{{ $employer->activeEmployeesCount ?? 0 }}</span>
                                         <span class="text-muted small ms-1" style="font-size: 0.70rem;">{{ __('TOTAL') }}</span>
                                     </span>
                                     {{-- Not Started --}}
-                                    <span class="badge bg-danger bg-opacity-10 text-danger border border-danger d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 100px;" title="{{ __('Pending') }}">
+                                    <span class="badge bg-danger bg-opacity-10 text-danger border border-danger d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Pending') }}">
                                          <span class="fw-bold" id="employer-not-started-{{ $employer->id }}">{{ $employer->notStartedCount ?? 0 }}</span>
                                          <span class="small ms-1 opacity-75" style="font-size: 0.70rem;">{{ __('PENDING') }}</span>
                                     </span>
                                     {{-- Saved --}}
-                                    <span class="badge bg-success bg-opacity-10 text-success border border-success d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 90px;" title="{{ __('Saved') }}">
+                                    <span class="badge bg-success bg-opacity-10 text-success border border-success d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Saved') }}">
                                          <span class="fw-bold" id="employer-saved-{{ $employer->id }}">{{ $employer->savedCount ?? 0 }}</span>
                                          <span class="small ms-1 opacity-75" style="font-size: 0.70rem;">{{ __('SAVED') }}</span>
                                     </span>
                                     {{-- Cancelled --}}
-                                    <span class="badge bg-secondary bg-opacity-10 text-secondary border border-secondary d-flex align-items-center justify-content-center gap-2 px-2 py-1" style="min-width: 95px;" title="{{ __('Cancelled') }}">
+                                    <span class="badge bg-secondary bg-opacity-10 text-secondary border border-secondary d-flex align-items-center justify-content-center gap-2 px-2 py-1"  title="{{ __('Cancelled') }}">
                                         <span class="fw-bold" id="employer-cancelled-{{ $employer->id }}">{{ $employer->cancelledCount ?? 0 }}</span>
                                         <span class="small ms-1 opacity-75" style="font-size: 0.70rem;">{{ __('CANCEL') }}</span>
                                     </span>


### PR DESCRIPTION
This submission fixes the UI layout issues reported by the user in the Registration and Renewal views:
1. Removed `min-width: 0;` inline styles from the employee card (`_employee_card.blade.php`), which caused text (like names, remarks, and custom fields) to be squeezed into a single vertical column when flex space was tight.
2. Modified the statistics badges container in both `registration/index.blade.php` and `renewal/index.blade.php` to use `flex-wrap` and removed fixed `min-width` inline styles, preventing the status badges from overflowing the employer card horizontally on smaller screens.

---
*PR created automatically by Jules for task [9924216662873966046](https://jules.google.com/task/9924216662873966046) started by @nongjossss-commits*