### PR TITLE
Fix mobile layout bug in registration employee card

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -73,11 +73,11 @@
     </div>
 
     <div class="card-body p-3 pt-4">
-        <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-3">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-3 w-100" style="min-width: 0;">
             {{-- Checkbox & Basic Info --}}
-            <div class="d-flex flex-column flex-xl-row align-items-start gap-3 w-100">
-                <div class="d-flex flex-column flex-xl-row align-items-start align-items-xl-center gap-3 w-100">
-                    <div class="d-flex align-items-center gap-3 w-100">
+            <div class="d-flex flex-column flex-xl-row align-items-start gap-3 w-100" style="min-width: 0;">
+                <div class="d-flex flex-column flex-xl-row align-items-start align-items-xl-center gap-3 w-100" style="min-width: 0;">
+                    <div class="d-flex align-items-center gap-3 w-100" style="min-width: 0;">
                 @can('edit-employees')
                 {{-- Only show checkbox if Active (Pending) --}}
                 <div class="form-check flex-shrink-0 {{ ($isCompleted || $isCancelled) ? 'd-none' : '' }}" id="checkbox-container-{{ $employee->id }}">
@@ -102,7 +102,7 @@
                 @endcan
 
                 {{-- Container for Checkbox + Info on all screen sizes --}}
-                <div class="d-flex align-items-start align-items-sm-center flex-row gap-3 w-100 {{ $overlayClass }}" id="info-container-{{ $employee->id }}">
+                <div class="d-flex align-items-start align-items-sm-center flex-row gap-3 w-100 {{ $overlayClass }}" id="info-container-{{ $employee->id }}" style="min-width: 0;">
                     {{-- Avatar --}}
                     <div class="avatar-container position-relative flex-shrink-0">
                         @if($employee->employeePhoto)
@@ -144,7 +144,7 @@
                     </div>
 
                     {{-- Info --}}
-                    <div class="w-100 ">
+                    <div class="w-100" style="min-width: 0;">
                         <div class="fw-bold text-dark text-break">
                              {{-- English Name + Title --}}
                             {{ $employee->employeeTitleEn ?? '' }} {{ $employee->employeeNameEn ?? '-' }}
@@ -193,7 +193,7 @@
 
             {{-- Outsource Login Information --}}
             @can('edit-employees')
-            <div class="ms-0 ms-xl-4 w-100" style="max-width: 100%;" x-data="{
+            <div class="ms-0 ms-xl-4 w-100" style="max-width: 100%; min-width: 0;" x-data="{
                 isEditing: false,
                 email: '{{ $employee->email ?? '' }}',
                 originalEmail: '{{ $employee->email ?? '' }}',
@@ -243,31 +243,31 @@
                     });
                 }
             }">
-                <div class="w-100" >
+                <div class="w-100" style="min-width: 0;">
                     <small class="text-muted d-block" style="font-size: 0.7rem;"><i class="bi bi-lock-fill"></i> {{ __('ข้อมูลการเข้าสู่ระบบ Outsource') }}</small>
 
-                    <div x-show="!isEditing" class="d-flex align-items-center gap-2 position-relative w-100">
-                         <div class="small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center w-100" style="min-height: 38px;">
+                    <div x-show="!isEditing" class="d-flex align-items-center gap-2 position-relative w-100" style="min-width: 0;">
+                         <div class="small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center w-100" style="min-width: 0; min-height: 38px;">
                             <div class="d-flex align-items-center justify-content-between mb-1">
                                 <span class="fw-bold text-primary">Login Info</span>
                                 <i class="bi bi-pencil-fill text-muted cursor-pointer" style="font-size: 0.7rem;" @click="isEditing = true"></i>
                             </div>
 
-                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem;">
+                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="min-width: 0; font-size: 0.75rem;">
                                 <span class="text-muted text-truncate flex-grow-1" style="padding-right: 5px;">
                                     <i class="bi bi-envelope me-1"></i><span x-text="email || '-'"></span>
                                 </span>
                                 <button x-show="email" @click="copyToClipboard(email, 'อีเมล')" class="btn btn-sm btn-link p-0 text-secondary flex-shrink-0" title="คัดลอกอีเมล"><i class="bi bi-clipboard"></i></button>
                             </div>
 
-                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem;">
+                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="min-width: 0; font-size: 0.75rem;">
                                 <span class="text-muted text-truncate flex-grow-1" style="padding-right: 5px;">
                                     <i class="bi bi-key me-1"></i><span x-text="password || '-'"></span>
                                 </span>
                                 <button x-show="password" @click="copyToClipboard(password, 'รหัสสำหรับอีเมล')" class="btn btn-sm btn-link p-0 text-secondary flex-shrink-0" title="คัดลอกรหัสผ่าน"><i class="bi bi-clipboard"></i></button>
                             </div>
 
-                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="font-size: 0.75rem;">
+                            <div class="d-flex align-items-center justify-content-between mt-1 w-100" style="min-width: 0; font-size: 0.75rem;">
                                 <span class="text-muted text-truncate flex-grow-1" style="padding-right: 5px;">
                                     <i class="bi bi-shield-lock me-1"></i><span x-text="outsource_code || '-'"></span>
                                 </span>
@@ -312,7 +312,7 @@
                     $isRenewalContext = request()->is('production/renewal*');
                     $modulePath = $isRenewalContext ? 'production/renewal' : 'production/registration';
                 @endphp
-                <div class="mt-2 w-100"  x-data="{
+                <div class="mt-2 w-100" style="min-width: 0;" x-data="{
                     isEditing: false,
                     isAppCompleted: {{ $isAppCompleted ? 'true' : 'false' }},
                     dateValue: '{{ $appValue }}',
@@ -381,17 +381,17 @@
                         </div>
                     </div>
 
-                    <div x-show="!isEditing" class="d-flex align-items-center gap-2 cursor-pointer position-relative w-100"
+                    <div x-show="!isEditing" class="d-flex align-items-center gap-2 cursor-pointer position-relative w-100" style="min-width: 0;"
                          @click="isEditing = true; $nextTick(() => initFlatpickr())"
                          :class="{ 'opacity-50': isAppCompleted }">
 
-                         <div class="text-primary fw-bold small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center px-2 w-100" style="min-height: 38px;">
-                            <div class="d-flex align-items-center w-100" >
+                         <div class="text-primary fw-bold small border rounded px-2 py-1 bg-white shadow-sm d-flex flex-column justify-content-center px-2 w-100" style="min-width: 0; min-height: 38px;">
+                            <div class="d-flex align-items-center w-100" style="min-width: 0;" >
                                 <i class="bi bi-calendar-event text-warning me-1 flex-shrink-0"></i>
                                 <span x-text="displayValue" class="text-truncate flex-grow-1" ></span>
                                 <i x-show="isAppCompleted" class="bi bi-check-circle-fill text-success ms-auto flex-shrink-0"></i>
                             </div>
-                            <div x-show="locationValue" class="text-muted text-truncate w-100" style="font-size: 0.7rem;">
+                            <div x-show="locationValue" class="text-muted text-truncate w-100" style="min-width: 0; font-size: 0.7rem;">
                                 <i class="bi bi-geo-alt me-1"></i><span x-text="locationValue"></span>
                             </div>
                          </div>
@@ -413,7 +413,7 @@
 
             </div>
             @endcan
-            <div class="d-flex flex-column gap-2 ms-0 ms-xl-4 w-100" style="max-width: 100%;">
+            <div class="d-flex flex-column gap-2 ms-0 ms-xl-4 w-100" style="max-width: 100%; min-width: 0;">
             {{-- REMARKS SECTION --}}
             @php
                 $isRenewal = request()->is('production/renewal*');
@@ -424,7 +424,7 @@
                     ? route('production.renewal.remarks', $employee->id)
                     : route('production.registration.remarks', $employee->id);
             @endphp
-            <div class="w-100"  x-data="{
+            <div class="w-100" style="min-width: 0;" x-data="{
                 isEditing: false,
                 remarkText: {{ json_encode($remarkText ?? '') }},
                 tempRemarkText: '',
@@ -473,12 +473,12 @@
                     });
                 }
             }">
-                <div class="w-100" >
+                <div class="w-100" style="min-width: 0;">
                     <small class="text-muted d-block fw-bold" style="font-size: 0.7rem;">หมายเหตุ</small>
 
-                    <div class="d-flex align-items-start gap-1 mb-2 w-100" >
-                        <div x-cloak :style="{ display: !isEditing ? 'flex' : 'none' }" class="align-items-start gap-1 w-100" >
-                            <div class="text-dark small border rounded px-2 py-1 bg-light flex-grow-1 text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word;">
+                    <div class="d-flex align-items-start gap-1 mb-2 w-100" style="min-width: 0;" >
+                        <div x-cloak :style="{ display: !isEditing ? 'flex' : 'none' }" class="align-items-start gap-1 w-100" style="min-width: 0;" >
+                            <div class="text-dark small border rounded px-2 py-1 bg-light flex-grow-1 text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word; min-width: 0;">
                                 <span x-text="remarkText || '-'"></span>
                             </div>
                             <button @click="startEditing()" class="btn btn-sm btn-outline-secondary rounded-circle flex-shrink-0" style="padding: 2px 6px;" title="แก้ไขหมายเหตุ">
@@ -486,7 +486,7 @@
                             </button>
                         </div>
 
-                        <div x-cloak :style="{ display: isEditing ? 'block' : 'none' }" class="w-100">
+                        <div x-cloak :style="{ display: isEditing ? 'block' : 'none' }" class="w-100" style="min-width: 0;">
                             <textarea x-ref="remarkInput" x-model="tempRemarkText" class="form-control form-control-sm mb-1" rows="3" placeholder="กรอกข้อความหมายเหตุ..."></textarea>
                             <div class="d-flex gap-1">
                                 <button @click="saveRemark()" :disabled="isSaving" class="btn btn-sm btn-success flex-grow-1">
@@ -531,7 +531,7 @@
             @endphp
 
             {{-- 3 Extra Fields (Editable) --}}
-            <div class="d-flex flex-column gap-2 w-100"  x-data="{
+            <div class="d-flex flex-column gap-2 w-100" style="min-width: 0;" x-data="{
                 isEditing: false,
                 nameList: '{{ $employee->name_list_number }}',
                 reqNo: '{{ $currentRequestNumber }}',
@@ -623,17 +623,17 @@
                     });
                 }
             }">
-                <div class="d-flex align-items-end gap-2 w-100" >
+                <div class="d-flex align-items-end gap-2 w-100" style="min-width: 0;">
                     {{-- Field 1: Name List (Renamed to RA) --}}
-                    <div class="w-100" style="flex-grow: 1;">
+                    <div class="w-100" style="flex-grow: 1; min-width: 0;">
                         <small class="text-muted d-block" style="font-size: 0.7rem;">เลข RA จากระบบ outsource</small>
-                        <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px;">
-                            <div x-ref="raDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1"  x-text="nameList || '-'"></div>
+                        <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px; min-width: 0;">
+                            <div x-ref="raDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1" style="min-width: 0;" x-text="nameList || '-'"></div>
                             <button x-show="nameList" @click="copy($event.currentTarget, nameList)" class="btn btn-link p-0 text-secondary ms-1 flex-shrink-0" title="{{ __('Copy') }}">
                                 <i class="bi bi-clipboard" style="font-size: 0.8rem;"></i>
                             </button>
                         </div>
-                        <input x-show="isEditing" type="text" class="form-control form-control-sm w-100" x-model="nameList" placeholder="RA No.">
+                        <input x-show="isEditing" type="text" class="form-control form-control-sm w-100" style="min-width: 0;" x-model="nameList" placeholder="RA No.">
                     </div>
 
                     {{-- Action Buttons --}}
@@ -651,27 +651,27 @@
                 </div>
 
                 {{-- Field 2: Request No --}}
-                <div class="w-100" >
+                <div class="w-100" style="min-width: 0;">
                     <small class="text-muted d-block" style="font-size: 0.7rem;">เลขที่คำขอ</small>
-                    <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px;">
-                        <div x-ref="reqDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1"  x-text="reqNo || '-'"></div>
+                    <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px; min-width: 0;">
+                        <div x-ref="reqDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1" style="min-width: 0;" x-text="reqNo || '-'"></div>
                         <button x-show="reqNo" @click="copy($event.currentTarget, reqNo)" class="btn btn-link p-0 text-secondary ms-1 flex-shrink-0" title="{{ __('Copy') }}">
                             <i class="bi bi-clipboard" style="font-size: 0.8rem;"></i>
                         </button>
                     </div>
-                    <input x-show="isEditing" type="text" class="form-control form-control-sm w-100" x-model="reqNo" placeholder="Request No.">
+                    <input x-show="isEditing" type="text" class="form-control form-control-sm w-100" style="min-width: 0;" x-model="reqNo" placeholder="Request No.">
                 </div>
 
                 {{-- Field 3: Ref ID --}}
-                <div class="w-100" >
+                <div class="w-100" style="min-width: 0;">
                     <small class="text-muted d-block" style="font-size: 0.7rem;">เลขอ้างอิงคนงาน</small>
-                    <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px;">
-                        <div x-ref="refDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1"  x-text="refId || '-'"></div>
+                    <div x-show="!isEditing" class="d-flex align-items-center justify-content-between small text-dark border rounded px-2 py-1 bg-light overflow-hidden w-100" style="min-height: 31px; min-width: 0;">
+                        <div x-ref="refDisplay" x-init="fitText($el)" class="text-nowrap overflow-hidden flex-grow-1" style="min-width: 0;" x-text="refId || '-'"></div>
                         <button x-show="refId" @click="copy($event.currentTarget, refId)" class="btn btn-link p-0 text-secondary ms-1 flex-shrink-0" title="{{ __('Copy') }}">
                             <i class="bi bi-clipboard" style="font-size: 0.8rem;"></i>
                         </button>
                     </div>
-                    <input x-show="isEditing" type="text" class="form-control form-control-sm w-100" x-model="refId" placeholder="Ref ID">
+                    <input x-show="isEditing" type="text" class="form-control form-control-sm w-100" style="min-width: 0;" x-model="refId" placeholder="Ref ID">
                 </div>
             </div>
 


### PR DESCRIPTION
Added `style="min-width: 0;"` to `.w-100` flex containers within `resources/views/production/registration/_employee_card.blade.php`. This resolves an issue where long strings of text or nested UI elements caused flex items to stretch beyond the viewport on mobile devices, resulting in text wrapping into a single character column width. This fix ensures the layout aligns correctly with other menus.

---
*PR created automatically by Jules for task [4209969653116862807](https://jules.google.com/task/4209969653116862807) started by @nongjossss-commits*