### PR TITLE
Add inline editable insurance_type to employee card

### DIFF
--- a/current_card_section.txt
+++ b/current_card_section.txt
@@ -1,0 +1,132 @@
+            <div class="d-flex flex-column gap-2 ms-md-2">
+            {{-- REMARKS SECTION --}}
+            @php
+                $isRenewal = request()->is('production/renewal*');
+                $remarkText = $isRenewal ? $employee->renewal_remarks : $employee->registration_remarks;
+                // Need absolute or generated URL because we are in shared partial, but we will use route named params if possible
+                // It's safer to generate based on request
+                $remarkUrl = $isRenewal
+                    ? route('production.renewal.remarks', $employee->id)
+                    : route('production.registration.remarks', $employee->id);
+            @endphp
+            <div x-data="{
+                isEditing: false,
+                remarkText: {{ json_encode($remarkText ?? '') }},
+                tempRemarkText: '',
+                isSaving: false,
+                startEditing() {
+                    this.tempRemarkText = this.remarkText;
+                    this.isEditing = true;
+                    this.$nextTick(() => { this.$refs.remarkInput.focus(); });
+                },
+                saveRemark() {
+                    this.isSaving = true;
+                    fetch('{{ $remarkUrl }}', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content,
+                            'Accept': 'application/json'
+                        },
+                        body: JSON.stringify({ remarks: this.tempRemarkText })
+                    })
+                    .then(response => {
+                        if (!response.ok) throw new Error(response.statusText);
+                        return response.json();
+                    })
+                    .then(data => {
+                        if (data.success) {
+                            this.remarkText = data.remarks ?? this.tempRemarkText;
+                            this.isEditing = false;
+                            Swal.fire({
+                                toast: true,
+                                position: 'top-end',
+                                icon: 'success',
+                                title: 'บันทึกหมายเหตุสำเร็จ',
+                                showConfirmButton: false,
+                                timer: 1500
+                            });
+                        } else {
+                            Swal.fire('Error', 'เกิดข้อผิดพลาดในการบันทึก', 'error');
+                        }
+                    })
+                    .catch(error => {
+                        Swal.fire('Error', `เกิดข้อผิดพลาด: ${error}`, 'error');
+                    })
+                    .finally(() => {
+                        this.isSaving = false;
+                    });
+                }
+            }">
+                <div style="min-width: 140px; max-width: 250px;">
+                    <small class="text-muted d-block fw-bold" style="font-size: 0.7rem;">หมายเหตุ</small>
+
+                    <div class="d-flex align-items-start gap-1 mb-2">
+                        <div x-cloak :style="{ display: !isEditing ? 'flex' : 'none' }" class="align-items-start gap-1 w-100">
+                            <div class="text-dark small border rounded px-2 py-1 bg-light flex-grow-1 text-wrap overflow-hidden" style="min-height: 31px; word-break: break-word;">
+                                <span x-text="remarkText || '-'"></span>
+                            </div>
+                            <button @click="startEditing()" class="btn btn-sm btn-outline-secondary rounded-circle flex-shrink-0" style="padding: 2px 6px;" title="แก้ไขหมายเหตุ">
+                                <i class="bi bi-pencil-fill" style="font-size: 0.75rem;"></i>
+                            </button>
+                        </div>
+
+                        <div x-cloak :style="{ display: isEditing ? 'block' : 'none' }" class="w-100">
+                            <textarea x-ref="remarkInput" x-model="tempRemarkText" class="form-control form-control-sm mb-1" rows="3" placeholder="กรอกข้อความหมายเหตุ..."></textarea>
+                            <div class="d-flex gap-1">
+                                <button @click="saveRemark()" :disabled="isSaving" class="btn btn-sm btn-success flex-grow-1">
+                                    <i class="bi bi-check-lg" x-show="!isSaving"></i>
+                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" x-show="isSaving" style="display: none;"></span>
+                                </button>
+                                <button @click="isEditing = false" :disabled="isSaving" class="btn btn-sm btn-outline-secondary flex-shrink-0">
+                                    <i class="bi bi-x-lg"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            @php
+                $isRegistration = request()->is('*registration*');
+                $isRenewal = request()->is('*renewal*');
+                $isPreProduction = request()->is('*production*') && !$isRegistration && !$isRenewal;
+                $isWorkflow = request()->is('*workflow*');
+
+                // Determine request number
+                $currentRequestNumber = '';
+                $updateUrl = route('employees.update', $employee->id);
+                $updateMethod = 'employee_update';
+
+                if (isset($item) && $item instanceof \App\Models\ProductionItem) {
+                    $currentRequestNumber = $item->request_number;
+                    $updateUrl = route('production.items.update_fields', $item->id);
+                    $updateMethod = 'item_update';
+                } elseif ($isRegistration) {
+                    $currentRequestNumber = $employee->registration_request_number;
+                    $updateUrl = route('employees.update_menu_fields', $employee->id);
+                    $updateMethod = 'menu_update';
+                } elseif ($isRenewal) {
+                    $currentRequestNumber = $employee->renewal_request_number;
+                    $updateUrl = route('employees.update_menu_fields', $employee->id);
+                    $updateMethod = 'menu_update';
+                } else {
+                    $currentRequestNumber = $employee->request_number; // Fallback
+                }
+            @endphp
+
+            {{-- 3 Extra Fields (Editable) --}}
+            <div class="d-flex flex-column gap-2" x-data="{
+                isEditing: false,
+                nameList: '{{ $employee->name_list_number }}',
+                reqNo: '{{ $currentRequestNumber }}',
+                refId: '{{ $employee->employee_reference_id }}',
+                updateMethod: '{{ $updateMethod }}',
+                updateUrl: '{{ $updateUrl }}',
+                copy(el, text) {
+                    if (!text) return;
+                    navigator.clipboard.writeText(text).then(() => {
+                        const originalHtml = el.innerHTML;
+                        el.innerHTML = '<i class=\'bi bi-check text-success\'></i>';
+                        setTimeout(() => el.innerHTML = originalHtml, 1000);
+                    });

--- a/patch_remarks.diff
+++ b/patch_remarks.diff
@@ -1,0 +1,29 @@
+<<<<<<< SEARCH
+            <div class="d-flex flex-column gap-2 ms-md-2">
+            {{-- REMARKS SECTION --}}
+            @php
+                $isRenewal = request()->is('production/renewal*');
+                $remarkText = $isRenewal ? $employee->renewal_remarks : $employee->registration_remarks;
+                // Need absolute or generated URL because we are in shared partial, but we will use route named params if possible
+                // It's safer to generate based on request
+                $remarkUrl = $isRenewal
+                    ? route('production.renewal.remarks', $employee->id)
+                    : route('production.registration.remarks', $employee->id);
+            @endphp
+            <div x-data="{
+=======
+            <div class="d-flex flex-column gap-2 ms-md-2">
+
+            <div class="d-flex gap-2 align-items-start">
+            {{-- REMARKS SECTION --}}
+            @php
+                $isRenewal = request()->is('production/renewal*');
+                $remarkText = $isRenewal ? $employee->renewal_remarks : $employee->registration_remarks;
+                // Need absolute or generated URL because we are in shared partial, but we will use route named params if possible
+                // It's safer to generate based on request
+                $remarkUrl = $isRenewal
+                    ? route('production.renewal.remarks', $employee->id)
+                    : route('production.registration.remarks', $employee->id);
+            @endphp
+            <div x-data="{
+>>>>>>> REPLACE

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -412,6 +412,7 @@
             </div>
             @endcan
             <div class="d-flex flex-column gap-2 ms-md-2">
+            <div class="d-flex gap-2 align-items-start">
             {{-- REMARKS SECTION --}}
             @php
                 $isRenewal = request()->is('production/renewal*');
@@ -499,6 +500,103 @@
                     </div>
                 </div>
             </div>
+
+            {{-- INSURANCE TYPE SECTION --}}
+            <div x-data="{
+                isEditing: false,
+                insuranceType: '{{ $employee->insurance_type ?? '' }}',
+                tempInsuranceType: '{{ $employee->insurance_type ?? '' }}',
+                isSaving: false,
+                startEditing() {
+                    this.tempInsuranceType = this.insuranceType;
+                    this.isEditing = true;
+                    this.$nextTick(() => { this.$refs.insuranceInput.focus(); });
+                },
+                saveInsurance() {
+                    this.isSaving = true;
+
+                    let formData = new FormData();
+                    formData.append('_method', 'PUT');
+                    formData.append('_token', '{{ csrf_token() }}');
+                    formData.append('insurance_type', this.tempInsuranceType);
+                    // required fields for employees.update usually include these for safety if not using patch
+                    formData.append('employer_id', '{{ $employee->employer_id }}');
+                    formData.append('employeeNameEn', '{{ $employee->employeeNameEn }}');
+
+                    fetch('{{ route('employees.update', $employee->id) }}', {
+                        method: 'POST',
+                        headers: {
+                            'Accept': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest'
+                        },
+                        body: formData
+                    })
+                    .then(response => {
+                        if (!response.ok) throw new Error(response.statusText);
+                        return response.json();
+                    })
+                    .then(data => {
+                        this.insuranceType = this.tempInsuranceType;
+                        this.isEditing = false;
+
+                        // Also update the hidden data attribute if it exists, so bulk actions or finance tab might pick it up
+                        let checkbox = document.querySelector('#check_{{ $employee->id }}');
+                        if (checkbox) {
+                            checkbox.setAttribute('data-insurance-type', this.insuranceType);
+                        }
+
+                        Swal.fire({
+                            toast: true,
+                            position: 'top-end',
+                            icon: 'success',
+                            title: 'บันทึกประเภทประกันสำเร็จ',
+                            showConfirmButton: false,
+                            timer: 1500
+                        });
+                    })
+                    .catch(error => {
+                        Swal.fire('Error', `เกิดข้อผิดพลาด: ${error}`, 'error');
+                    })
+                    .finally(() => {
+                        this.isSaving = false;
+                    });
+                }
+            }">
+                <div style="min-width: 140px; max-width: 250px;">
+                    <small class="text-muted d-block fw-bold" style="font-size: 0.7rem;">ประเภทประกัน</small>
+
+                    <div class="d-flex align-items-start gap-1 mb-2">
+                        <div x-cloak :style="{ display: !isEditing ? 'flex' : 'none' }" class="align-items-center gap-1 w-100">
+                            <div class="text-dark small border rounded px-2 py-1 bg-light flex-grow-1 text-truncate" style="min-height: 31px;">
+                                <span x-text="insuranceType || '-'"></span>
+                            </div>
+                            <button @click="startEditing()" class="btn btn-sm btn-outline-secondary rounded-circle flex-shrink-0" style="padding: 2px 6px;" title="แก้ไขประเภทประกัน">
+                                <i class="bi bi-pencil-fill" style="font-size: 0.75rem;"></i>
+                            </button>
+                        </div>
+
+                        <div x-cloak :style="{ display: isEditing ? 'block' : 'none' }" class="w-100">
+                            <select x-ref="insuranceInput" x-model="tempInsuranceType" class="form-select form-select-sm mb-1">
+                                <option value="">{{ __('- ไม่ระบุ -') }}</option>
+                                <option value="ประกันเอกชน">{{ __('ประกันเอกชน') }}</option>
+                                <option value="ประกันโรงพยาบาล">{{ __('ประกันโรงพยาบาล') }}</option>
+                                <option value="ประกันสังคม">{{ __('ประกันสังคม') }}</option>
+                            </select>
+                            <div class="d-flex gap-1">
+                                <button @click="saveInsurance()" :disabled="isSaving" class="btn btn-sm btn-success flex-grow-1">
+                                    <i class="bi bi-check-lg" x-show="!isSaving"></i>
+                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" x-show="isSaving" style="display: none;"></span>
+                                </button>
+                                <button @click="isEditing = false" :disabled="isSaving" class="btn btn-sm btn-outline-secondary flex-shrink-0">
+                                    <i class="bi bi-x-lg"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            </div> {{-- End d-flex gap-2 align-items-start --}}
 
             @php
                 $isRegistration = request()->is('*registration*');


### PR DESCRIPTION
This PR introduces an editable "Insurance Type" (ประเภทประกัน) dropdown field directly onto the employee cards within the Registration and Renewal views. 

**Key Changes:**
* Modified `resources/views/production/registration/_employee_card.blade.php` to include a new UI section to the right of the "Remarks" block.
* Utilized Alpine.js to toggle between viewing and editing states.
* Configured the select dropdown with `ประกันเอกชน`, `ประกันโรงพยาบาล`, and `ประกันสังคม`, which are strictly required for the Finance feature to correctly determine pricing.
* Setup AJAX requests that utilize the existing `employees.update` endpoint to save the `insurance_type` value straight into the database, avoiding the need for full page reloads.

---
*PR created automatically by Jules for task [6012076157454383581](https://jules.google.com/task/6012076157454383581) started by @nongjossss-commits*