### PR TITLE
Add Delegate Signature Upload and PDF Template Integration

### DIFF
--- a/app/Http/Controllers/DelegateController.php
+++ b/app/Http/Controllers/DelegateController.php
@@ -46,9 +46,14 @@ class DelegateController extends Controller
             'delegate_doc_other_2_desc' => 'nullable|string|max:255',
             'delegate_doc_other_3' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:5120',
             'delegate_doc_other_3_desc' => 'nullable|string|max:255',
+            'delegate_signature' => 'nullable|image|max:5120',
         ]);
 
         $data = $request->all();
+
+        if ($request->hasFile('delegate_signature')) {
+            $data['signature_path'] = $request->file('delegate_signature')->store('signatures/delegates', 'public');
+        }
 
         if ($request->hasFile('delegatePhoto')) {
             $path = $request->file('delegatePhoto')->store('delegate_photos', 'public');
@@ -125,9 +130,17 @@ class DelegateController extends Controller
             'delegate_doc_other_2_desc' => 'nullable|string|max:255',
             'delegate_doc_other_3' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:5120',
             'delegate_doc_other_3_desc' => 'nullable|string|max:255',
+            'delegate_signature' => 'nullable|image|max:5120',
         ]);
 
         $data = $request->all();
+
+        if ($request->hasFile('delegate_signature')) {
+            if ($delegate->signature_path) {
+                Storage::disk('public')->delete($delegate->signature_path);
+            }
+            $data['signature_path'] = $request->file('delegate_signature')->store('signatures/delegates', 'public');
+        }
 
         if ($request->hasFile('delegatePhoto')) {
             // Delete old photo

--- a/app/Models/Delegate.php
+++ b/app/Models/Delegate.php
@@ -20,6 +20,7 @@ class Delegate extends Model
         'delegatePhone',
         'delegateEmail',
         'delegatePhoto',
+        'signature_path',
         'delegate_doc_other_1',
         'delegate_doc_other_1_desc',
         'delegate_doc_other_2',

--- a/app/Services/PdfGeneratorService.php
+++ b/app/Services/PdfGeneratorService.php
@@ -376,6 +376,11 @@ class PdfGeneratorService
         $emprSig1Path = null;
         $emprSig2Path = null;
         $emprStampPath = null;
+        $delegateSigPath = null;
+
+        if ($targetDelegate && $targetDelegate->signature_path && Storage::disk('public')->exists($targetDelegate->signature_path)) {
+            $delegateSigPath = Storage::disk('public')->path($targetDelegate->signature_path);
+        }
 
         if ($effectiveEmployer) {
             // Signer 1
@@ -462,6 +467,7 @@ class PdfGeneratorService
                             if ($group === 'employee') $targetPath = $empSigPath;
                             elseif ($group === 'employer') $targetPath = $emprSig1Path;
                             elseif ($group === 'employer_2') $targetPath = $emprSig2Path;
+                            elseif ($group === 'delegate') $targetPath = $delegateSigPath;
                             elseif (str_starts_with($group, 'witness_')) $targetPath = $witnessSigPaths[$group] ?? null;
                         } elseif ($item['type'] === 'stamp') {
                             $targetPath = $emprStampPath;
@@ -629,6 +635,11 @@ class PdfGeneratorService
         $emprSig1Path = null;
         $emprSig2Path = null;
         $emprStampPath = null;
+        $delegateSigPath = null;
+
+        if ($targetDelegate && $targetDelegate->signature_path && Storage::disk('public')->exists($targetDelegate->signature_path)) {
+            $delegateSigPath = Storage::disk('public')->path($targetDelegate->signature_path);
+        }
 
         if ($effectiveEmployer) {
             if ($effectiveEmployer->signature_1_path && Storage::disk('public')->exists($effectiveEmployer->signature_1_path)) {
@@ -710,6 +721,7 @@ class PdfGeneratorService
                             if ($group === 'employee' && $employee) $targetPath = $employeeSigPaths[$employee->id] ?? null;
                             elseif ($group === 'employer') $targetPath = $emprSig1Path;
                             elseif ($group === 'employer_2') $targetPath = $emprSig2Path;
+                            elseif ($group === 'delegate') $targetPath = $delegateSigPath;
                             elseif (str_starts_with($group, 'witness_')) $targetPath = $witnessSigPaths[$group] ?? null;
                         } elseif ($item['type'] === 'stamp') {
                             $targetPath = $emprStampPath;

--- a/database/migrations/2026_03_17_000909_add_signature_path_to_delegates_table.php
+++ b/database/migrations/2026_03_17_000909_add_signature_path_to_delegates_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('delegates', function (Blueprint $table) {
+            $table->string('signature_path')->nullable()->after('delegatePhoto');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('delegates', function (Blueprint $table) {
+            $table->dropColumn('signature_path');
+        });
+    }
+};

--- a/resources/views/delegates/create.blade.php
+++ b/resources/views/delegates/create.blade.php
@@ -12,13 +12,26 @@
                 @csrf
 
                 <div class="row mb-4">
-                    <div class="col-md-12 text-center">
+                    <div class="col-md-6 text-center">
                         <label class="form-label d-block text-muted mb-2">Photo</label>
                         <div class="mb-3">
                             <input type="file" name="delegatePhoto" id="delegatePhoto" class="form-control" accept="image/*" onchange="previewImage(event, 'photoPreview')">
                         </div>
                         <img id="photoPreview" src="#" alt="Photo Preview" style="display: none; max-width: 150px; max-height: 150px; margin-top: 10px;" class="img-thumbnail rounded-circle">
                     </div>
+
+                    @if(auth()->user()->hasAnyRole(['super-admin', 'admin', 'staff']))
+                    <div class="col-md-6 text-center border-start">
+                        <label class="form-label d-block text-muted mb-2">ลายเซ็นพนักงานบริษัท (Delegate Signature)</label>
+                        <div class="mb-3 d-flex gap-2">
+                            <input type="file" name="delegate_signature" id="delegate_signature" class="form-control" accept="image/*" onchange="previewImage(event, 'signaturePreview'); if(window.interceptFileSelect) window.interceptFileSelect(event)">
+                            <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'delegate_signature' } }))" title="สแกนเอกสาร">
+                                <i class="bi bi-camera"></i>
+                            </button>
+                        </div>
+                        <img id="signaturePreview" src="#" alt="Signature Preview" style="display: none; max-width: 200px; max-height: 100px; margin-top: 10px;" class="img-thumbnail">
+                    </div>
+                    @endif
                 </div>
 
                 <div class="row mb-3">

--- a/resources/views/delegates/edit.blade.php
+++ b/resources/views/delegates/edit.blade.php
@@ -13,7 +13,7 @@
                 @method('PUT')
 
                 <div class="row mb-4">
-                    <div class="col-md-12 text-center">
+                    <div class="col-md-6 text-center">
                         <label class="form-label d-block text-muted mb-2">Photo</label>
                         <div class="mb-3">
                             <input type="file" name="delegatePhoto" id="delegatePhoto" class="form-control" accept="image/*" onchange="previewImage(event, 'photoPreview')">
@@ -24,6 +24,23 @@
                              style="{{ $delegate->delegatePhoto ? '' : 'display: none;' }} max-width: 150px; max-height: 150px; margin-top: 10px;"
                              class="img-thumbnail rounded-circle">
                     </div>
+
+                    @if(auth()->user()->hasAnyRole(['super-admin', 'admin', 'staff']))
+                    <div class="col-md-6 text-center border-start">
+                        <label class="form-label d-block text-muted mb-2">ลายเซ็นพนักงานบริษัท (Delegate Signature)</label>
+                        <div class="mb-3 d-flex gap-2">
+                            <input type="file" name="delegate_signature" id="delegate_signature" class="form-control" accept="image/*" onchange="previewImage(event, 'signaturePreview'); if(window.interceptFileSelect) window.interceptFileSelect(event)">
+                            <button type="button" class="btn btn-outline-secondary" onclick="document.dispatchEvent(new CustomEvent('open-document-scanner', { detail: { inputId: 'delegate_signature' } }))" title="สแกนเอกสาร">
+                                <i class="bi bi-camera"></i>
+                            </button>
+                        </div>
+                        <img id="signaturePreview"
+                             src="{{ $delegate->signature_path ? asset('storage/' . $delegate->signature_path) : '#' }}"
+                             alt="Signature Preview"
+                             style="{{ $delegate->signature_path ? '' : 'display: none;' }} max-width: 200px; max-height: 100px; margin-top: 10px;"
+                             class="img-thumbnail">
+                    </div>
+                    @endif
                 </div>
 
                 <div class="row mb-3">

--- a/resources/views/partials/sidebar-menu.blade.php
+++ b/resources/views/partials/sidebar-menu.blade.php
@@ -137,6 +137,7 @@
     @endif
 @endif
 
+@if(auth()->user()->hasAnyRole(['super-admin', 'admin', 'staff']))
 @if(\App\Facades\SuperAdmin::isVisible('importers'))
 @can('view-importers')
 <a href="{{ route('importers.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('importers.*') ? 'active' : '' }}"><i class="bi bi-box-arrow-in-down-left me-2"></i>{{ __('Importers') }}</a>
@@ -151,6 +152,7 @@
 @can('view-delegates')
 <a href="{{ route('delegates.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('delegates.*') ? 'active' : '' }}"><i class="bi bi-people-fill me-2"></i>{{ __('Delegates') }}</a>
 @endcan
+@endif
 @endif
 
 @if(\App\Facades\SuperAdmin::isVisible('user_management'))

--- a/resources/views/pdf_templates/builder.blade.php
+++ b/resources/views/pdf_templates/builder.blade.php
@@ -273,6 +273,7 @@
                                     <option value="employee">Employee</option>
                                     <option value="employer">Employer 1 (Signer 1)</option>
                                     <option value="employer_2">Employer 2 (Signer 2)</option>
+                                    <option value="delegate">ลายเซ็นพนักงานบริษัท (Delegate)</option>
                                     <option value="witness_1">Witness 1</option>
                                     <option value="witness_2">Witness 2</option>
                                     <option value="witness_3">Witness 3</option>
@@ -963,6 +964,7 @@
                     'employee': '(Employee)',
                     'employer': '(Signer 1)',
                     'employer_2': '(Signer 2)',
+                    'delegate': '(Delegate)',
                     'witness_1': '(Witness 1)',
                     'witness_2': '(Witness 2)',
                     'witness_3': '(Witness 3)',


### PR DESCRIPTION
This submission implements the feature to allow uploading signatures for delegates (Company Employees). The feature includes:
1. Adding a `signature_path` column to the `delegates` database table.
2. Updating the form views for creating and editing delegates to include an image upload input for the signature. This includes support for the document scanner.
3. Restricting access to the signature fields, as well as the entire Delegates, Importers, and Agents menu items, to users with the `super-admin`, `admin`, or `staff` roles.
4. Adding a new "Delegate" signature type to the PDF Template Builder so it can be dragged and dropped into templates.
5. Updating the `PdfGeneratorService` to dynamically load and place the delegate's signature onto generated PDFs when the template requires it.

---
*PR created automatically by Jules for task [10441436246112611959](https://jules.google.com/task/10441436246112611959) started by @nongjossss-commits*