### PR TITLE
Fix "Select All" functionality in Group & Team menu

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1545,7 +1545,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
             // Check if it's visible to determine "Select All" state
             const cardWrapper = cb.closest('.item-card-wrapper') || cb.closest('.employee-card-wrapper') || cb.closest('tr');
-            const isHidden = cardWrapper && (cardWrapper.classList.contains('d-none') || cardWrapper.classList.contains('hide-cancelled') || cardWrapper.style.display === 'none');
+            const accordionCollapse = cb.closest('.accordion-collapse');
+            const isHiddenByAccordion = accordionCollapse && !accordionCollapse.classList.contains('show');
+            const isHidden = (cardWrapper && (cardWrapper.classList.contains('d-none') || cardWrapper.classList.contains('hide-cancelled') || cardWrapper.style.display === 'none')) || isHiddenByAccordion;
 
             if (!isHidden) {
                 visibleCount++;
@@ -1640,7 +1642,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
             const visibleCheckboxes = Array.from(currentCheckboxes).filter(cb => {
                 const cardWrapper = cb.closest('.item-card-wrapper') || cb.closest('.employee-card-wrapper') || cb.closest('tr');
-                const isHidden = cardWrapper && (cardWrapper.classList.contains('d-none') || cardWrapper.classList.contains('hide-cancelled') || cardWrapper.style.display === 'none');
+                const accordionCollapse = cb.closest('.accordion-collapse');
+                const isHiddenByAccordion = accordionCollapse && !accordionCollapse.classList.contains('show');
+                const isHidden = (cardWrapper && (cardWrapper.classList.contains('d-none') || cardWrapper.classList.contains('hide-cancelled') || cardWrapper.style.display === 'none')) || isHiddenByAccordion;
                 return !isHidden;
             });
 


### PR DESCRIPTION
Fixes an issue in the Group & Team menu where "Select All" would incorrectly check and select employees located in other (collapsed/hidden) team accordions. This resulted in unintended actions being applied to employees the user was not currently viewing.

The fix adds a condition in the `layouts/app.blade.php` global JavaScript select logic to check if the wrapper is inside an `.accordion-collapse` that is not currently `.show`.

---
*PR created automatically by Jules for task [3089871716097461315](https://jules.google.com/task/3089871716097461315) started by @nongjossss-commits*