### PR TITLE
Fix employee list pulling incorrect statuses in Renewal finance tab

### DIFF
--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -751,7 +751,8 @@ class RenewalController extends Controller
         $financeOrder->load(['financialGroups.transactions.items', 'financialGroups.advanceItems', 'items.employee']);
 
         // Fetch ALL Active Employees for this employer (ignoring search)
-        $query = $employer->employees();
+        $query = $employer->employees()
+            ->whereIn('status', ['renewal_pending', 'renewal_completed', 'renewal_cancelled']);
         if (auth()->user()->can('manage-tickets')) {
             $query->withoutGlobalScope('employerTenancy');
         }


### PR DESCRIPTION
Fixes the employee query in the `loadFinancialTab` method within `RenewalController.php`. Previously, it omitted the `whereIn('status', ...)` filter that is standard across the other production controllers, causing the Finance tab in the Renewal resolution menu to erroneously list all active employees of an employer rather than only those specifically undergoing renewal.

---
*PR created automatically by Jules for task [3930278078639794221](https://jules.google.com/task/3930278078639794221) started by @nongjossss-commits*