### PR TITLE
Fix: Cancel processes on operational menus instead of deleting employee

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -877,8 +877,13 @@ class RegistrationController extends Controller
             abort(403);
         }
 
-        $employerId = $employee->employer_id; // Capture ID before deletion
-        $employee->delete(); // Soft delete
+        $employerId = $employee->employer_id;
+
+        // "Cancel" instead of "Delete" so the employee remains in the system database
+        $employee->update([
+            'status' => 'registration_cancelled',
+            'resolution_completed_at' => now(), // End the tracking
+        ]);
 
         if ($request->ajax()) {
             return response()->json([
@@ -886,7 +891,7 @@ class RegistrationController extends Controller
                 'stats' => $this->getStats($employerId, $request)
             ]);
         }
-        return back()->with('success', 'Employee deleted.');
+        return back()->with('success', 'Employee removed from registration.');
     }
 
     /**

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -1425,11 +1425,17 @@ class RenewalController extends Controller
     public function destroy(Request $request, Employee $employee)
     {
         if (!auth()->user()->can('edit-employees')) abort(403);
-        $employee->delete();
+
+        // "Cancel" instead of "Delete" so the employee remains in the system database
+        $employee->update([
+            'status' => 'renewal_cancelled',
+            'resolution_completed_at' => now(), // End the tracking
+        ]);
+
         if ($request->ajax()) {
             return response()->json(['success' => true]);
         }
-        return back()->with('success', 'Employee deleted.');
+        return back()->with('success', 'Employee removed from renewal.');
     }
 
     public function cancelEmployer(Request $request, Employer $employer)

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -1555,23 +1555,18 @@ class WorkflowController extends Controller
     }
 
     /**
-     * Soft Delete an Item.
+     * Cancel/Remove an Item from Workflow/Production.
      */
     public function destroyItem(Request $request, $itemId)
     {
         $item = ProductionItem::with(['employee', 'order'])->findOrFail($itemId);
-        $order = $item->order; // Capture order before delete
+        $order = $item->order;
 
-        // Capture employee before deleting the item
-        $employee = $item->employee;
-
-        $item->delete();
-
-        // Check if employee should also be deleted
-        // Logic: If employee was created specifically for this workflow (status 'onboarding')
-        if ($employee && $employee->status === 'onboarding') {
-            $employee->delete();
-        }
+        // "Cancel" instead of "Delete" so the employee remains in the system database
+        $item->update([
+            'status' => 'cancelled',
+            'completed_at' => now(), // End the tracking
+        ]);
 
         // Recalculate Stats
         $orderStats = $this->calculateOrderStats($order);

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -17,6 +17,30 @@ class Employee extends Model
 
     protected static function booted(): void
     {
+        static::deleted(function ($employee) {
+            // Cancel active production/workflow items
+            $employee->productionItems()
+                ->whereNotIn('status', ['completed', 'cancelled'])
+                ->update(['status' => 'cancelled']);
+
+            // Cancel active notifications
+            $employee->notifications()
+                ->whereNotIn('status', ['cancelled'])
+                ->update([
+                    'status' => 'cancelled',
+                    'cancellation_reason' => 'Employee moved to trash',
+                    'cancelled_at' => now(),
+                ]);
+
+            // Cancel active Registration/Renewal resolutions
+            if (in_array($employee->status, ['registration_pending', 'renewal_pending'])) {
+                $newStatus = $employee->status === 'registration_pending' ? 'registration_cancelled' : 'renewal_cancelled';
+                // Use DB facade or query builder to update without triggering further model events
+                // if we just want to suppress updated_at changes, but it's fine to use regular update:
+                $employee->updateQuietly(['status' => $newStatus]);
+            }
+        });
+
         static::addGlobalScope('employerTenancy', function (Builder $builder) {
             if (Auth::check()) {
                 $user = Auth::user();

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -1175,11 +1175,11 @@
     window.deleteEmployee = function(employeeId, itemId) {
         if (!itemId) return;
         Swal.fire({
-            title: '{{ __("Delete Item?") }}',
-            text: '{{ __("This will move the employee to the trash.") }}',
-            icon: 'error',
+            title: '{{ __("Cancel Item?") }}',
+            text: '{{ __("This will cancel the process for this employee in this workflow.") }}',
+            icon: 'warning',
             showCancelButton: true,
-            confirmButtonText: '{{ __("Delete") }}',
+            confirmButtonText: '{{ __("Cancel Process") }}',
             confirmButtonColor: '#d33'
         }).then((result) => {
             if (result.isConfirmed) {

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1493,11 +1493,11 @@ window.loadBatchStats = function() {
 
     window.deleteItem = function(itemId) {
         Swal.fire({
-            title: '{{ __("Delete Item?") }}',
-            text: '{{ __("This cannot be undone.") }}',
-            icon: 'error',
+            title: '{{ __("Cancel Item?") }}',
+            text: '{{ __("This will cancel the process for this employee in this workflow.") }}',
+            icon: 'warning',
             showCancelButton: true,
-            confirmButtonText: '{{ __("Delete") }}',
+            confirmButtonText: '{{ __("Cancel Process") }}',
             confirmButtonColor: '#d33'
         }).then((result) => {
             if (result.isConfirmed) {


### PR DESCRIPTION
This PR addresses the user requirement to separate "cancelling an employee from an operational flow" from "deleting an employee from the system".

- **Employee Model**: Added a `deleted` event hook. If an employee is soft deleted (from the Employee Database menu), all of their active processes (Production Items, Registration, Renewal) and pending notifications are marked as `cancelled`. This effectively halts their operations across the system.
- **Workflow/Pre-Production Menu**: Updating the "delete item" button to instead update the `ProductionItem`'s `status` to `cancelled`, rather than soft-deleting the `ProductionItem` and the associated `Employee`. UI text updated to "Cancel Process".
- **Registration & Renewal Resolutions**: Clicking the delete button for an employee on these menus will now set their status to `registration_cancelled` and `renewal_cancelled` respectively, completing their resolution time tracking without soft-deleting the user from the database.

---
*PR created automatically by Jules for task [5164308422414875122](https://jules.google.com/task/5164308422414875122) started by @nongjossss-commits*