### PR TITLE
Add Employer Info fields to Advanced Export

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -1663,7 +1663,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
             return back()->with('error', 'No employees selected.');
         }
 
-        $employees = Employee::whereIn('id', $employeeIds)->with('employer.addresses')->get();
+        $employees = Employee::whereIn('id', $employeeIds)->with('employer.addresses', 'employer.jobOwner')->get();
 
         // Define labels for the header
         $columnLabels = [
@@ -1715,6 +1715,9 @@ public function create(Request $request) // เพิ่ม Request $request เ
             'outsource_code' => 'รหัสสำหรับระบบ Outsource',
             'bank_name' => 'ชื่อธนาคาร',
             'bank_account_number' => 'เลขบัญชีธนาคาร',
+            'employerTaxId' => 'เลขประจำตัวนายจ้าง',
+            'businessType' => 'ประเภทกิจการ',
+            'job_owner_id' => 'ชื่อเจ้าของงาน',
             'employerNameTh' => 'Employer Name (TH)',
             'employerNameEn' => 'Employer Name (EN)',
             'employerAddressTh' => 'Employer Address (TH)',
@@ -1823,6 +1826,12 @@ public function create(Request $request) // เพิ่ม Request $request เ
                     $cell->setValue($employee->age);
                 } elseif ($col === 'employeeGender') {
                     $cell->setValue($employee->gender ?? $employee->employeeGender);
+                } elseif ($col === 'employerTaxId') {
+                    $cell->setValueExplicit($employee->employer->employerTaxId ?? '-', \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+                } elseif ($col === 'businessType') {
+                    $cell->setValue($employee->employer->businessType ?? '-');
+                } elseif ($col === 'job_owner_id') {
+                    $cell->setValue($employee->employer->jobOwner->name ?? '-');
                 } elseif ($col === 'employerNameTh') {
                     $cell->setValue($employee->employer->employerNameTh ?? '-');
                 } elseif ($col === 'employerNameEn') {

--- a/resources/views/employees/modals/advanced_export.blade.php
+++ b/resources/views/employees/modals/advanced_export.blade.php
@@ -352,6 +352,24 @@
                             <div class="row g-2">
                                 <div class="col-md-3 col-sm-6">
                                     <div class="form-check">
+                                        <input class="form-check-input export-checkbox" type="checkbox" name="columns[]" value="employerTaxId" id="col_emp_tax_id">
+                                        <label class="form-check-label" for="col_emp_tax_id">เลขประจำตัวนายจ้าง</label>
+                                    </div>
+                                </div>
+                                <div class="col-md-3 col-sm-6">
+                                    <div class="form-check">
+                                        <input class="form-check-input export-checkbox" type="checkbox" name="columns[]" value="businessType" id="col_emp_business_type">
+                                        <label class="form-check-label" for="col_emp_business_type">ประเภทกิจการ</label>
+                                    </div>
+                                </div>
+                                <div class="col-md-3 col-sm-6">
+                                    <div class="form-check">
+                                        <input class="form-check-input export-checkbox" type="checkbox" name="columns[]" value="job_owner_id" id="col_emp_job_owner">
+                                        <label class="form-check-label" for="col_emp_job_owner">ชื่อเจ้าของงาน</label>
+                                    </div>
+                                </div>
+                                <div class="col-md-3 col-sm-6">
+                                    <div class="form-check">
                                         <input class="form-check-input export-checkbox" type="checkbox" name="columns[]" value="employerNameTh" id="col_emp_name_th">
                                         <label class="form-check-label" for="col_emp_name_th">{{ __('Employer Name (TH)') }}</label>
                                     </div>


### PR DESCRIPTION
Adds "Employer Tax ID", "Business Type", and "Job Owner Name" as selectable columns in the Employee Advanced Export modal. Eager loads relationships and properly formats the tax ID column as text for Excel output.

---
*PR created automatically by Jules for task [2690106595278781481](https://jules.google.com/task/2690106595278781481) started by @nongjossss-commits*