### PR TITLE
Update File Download Ordering for Insurance Document

### DIFF
--- a/resources/views/components/download-modals.blade.php
+++ b/resources/views/components/download-modals.blade.php
@@ -45,10 +45,6 @@
                                     <label class="form-check-label" for="chkPhoto">รูปถ่าย (Photo)</label>
                                 </div>
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" name="files[]" value="insurance" id="chkInsurance" checked>
-                                    <label class="form-check-label" for="chkInsurance">ไฟล์แนบประกัน (Insurance)</label>
-                                </div>
-                                <div class="form-check">
                                     <input class="form-check-input" type="checkbox" name="files[]" value="passport" id="chkPassport" checked>
                                     <label class="form-check-label" for="chkPassport">1. พาสปอร์ต (Passport)</label>
                                 </div>
@@ -67,6 +63,10 @@
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" name="files[]" value="tor_ror_38" id="chkTorRor38">
                                     <label class="form-check-label" for="chkTorRor38">5. ทร. 38</label>
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="files[]" value="insurance" id="chkInsurance" checked>
+                                    <label class="form-check-label" for="chkInsurance">ไฟล์แนบประกัน (Insurance)</label>
                                 </div>
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" name="files[]" value="medical_certificate" id="chkMedicalCertificate" checked>


### PR DESCRIPTION
I have successfully updated the Advanced Download modal as per your instructions.

**Changes made:**
- In `resources/views/components/download-modals.blade.php`, I moved the `insurance` (ไฟล์แนบประกัน) file checkbox to position it directly below the `tor_ror_38` (5. ทร. 38) checkbox. 
- Because the backend processes the files sequentially based on the order they are submitted from the form (`files[]`), this single structural update in the HTML seamlessly resolves the file ordering within both the generated ZIP files and Merged PDFs.

I have verified this visually, and it looks exactly as you requested. The insurance document will no longer be placed as the first file.

---
*PR created automatically by Jules for task [8814176873813941210](https://jules.google.com/task/8814176873813941210) started by @nongjossss-commits*