### PR TITLE
feat: context-aware request number mapping for advanced export

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -1654,16 +1654,26 @@ public function create(Request $request) // เพิ่ม Request $request เ
         $validated = $request->validate([
             'employee_ids' => 'required|string',
             'columns' => 'required|array|max:15',
+            'export_source_menu' => 'nullable|string',
         ]);
 
         $employeeIds = json_decode($validated['employee_ids'], true);
         $selectedColumns = $validated['columns'];
+        $sourceMenu = $validated['export_source_menu'] ?? null;
 
         if (empty($employeeIds)) {
             return back()->with('error', 'No employees selected.');
         }
 
-        $employees = Employee::whereIn('id', $employeeIds)->with('employer.addresses', 'employer.jobOwner')->get();
+        $employeesQuery = Employee::whereIn('id', $employeeIds)->with('employer.addresses', 'employer.jobOwner');
+
+        if (in_array($sourceMenu, ['pre_production', 'workflow'])) {
+             $employeesQuery->with(['productionItems' => function ($query) {
+                 $query->latest();
+             }]);
+        }
+
+        $employees = $employeesQuery->get();
 
         // Define labels for the header
         $columnLabels = [
@@ -1870,13 +1880,31 @@ public function create(Request $request) // เพิ่ม Request $request เ
                         $fullAddress = implode(', ', $parts);
                     }
                     $cell->setValue($fullAddress);
+                } elseif ($col === 'request_number') {
+                    $val = '-';
+                    if ($sourceMenu === 'registration') {
+                        $val = $employee->registration_request_number ?? '-';
+                    } elseif ($sourceMenu === 'renewal') {
+                        $val = $employee->renewal_request_number ?? '-';
+                    } elseif (in_array($sourceMenu, ['pre_production', 'workflow'])) {
+                        $latestItem = $employee->productionItems->first();
+                        $val = $latestItem ? ($latestItem->request_number ?? '-') : '-';
+                    } else {
+                        $val = $employee->request_number ?? '-';
+                    }
+
+                    if ($val !== '-') {
+                        $cell->setValueExplicit($val, \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+                    } else {
+                        $cell->setValue($val);
+                    }
                 } else {
                     $val = $employee->$col ?? '-';
                     // List of columns that might contain long numbers (e.g. 13 digits) and should be explicitly set as text
                     $textColumns = [
                         'employeePassport', 'employeeWorkPermit', 'pinkCardNo', 'tax_id_number',
                         'social_security_number', 'employer_employee_id', 'employee_id_number',
-                        'request_number', 'name_list_number', 'bank_account_number', 'employeePhone',
+                        'name_list_number', 'bank_account_number', 'employeePhone',
                         'outsource_code', 'employee_reference_id'
                     ];
 

--- a/resources/views/employees/modals/advanced_export.blade.php
+++ b/resources/views/employees/modals/advanced_export.blade.php
@@ -4,6 +4,7 @@
             <form id="advancedExportForm" action="{{ route('employees.advanced_export') }}" method="POST">
                 @csrf
                 <input type="hidden" name="employee_ids" id="export_employee_ids">
+                <input type="hidden" name="export_source_menu" id="export_source_menu" value="">
 
                 <div class="modal-header">
                     <h5 class="modal-title" id="advancedExportModalLabel">{{ __('Advanced Export') }} (Max 15 items)</h5>

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -858,6 +858,9 @@
             return;
         }
         document.getElementById('export_employee_ids').value = JSON.stringify(selected);
+        if (document.getElementById('export_source_menu')) {
+            document.getElementById('export_source_menu').value = 'pre_production';
+        }
         new bootstrap.Modal(document.getElementById('advancedExportModal')).show();
     });
 

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2615,6 +2615,9 @@
                 }
 
                 document.getElementById('export_employee_ids').value = JSON.stringify(selected);
+                if (document.getElementById('export_source_menu')) {
+                    document.getElementById('export_source_menu').value = 'registration';
+                }
                 const modalEl = document.getElementById('advancedExportModal');
                 const modal = new bootstrap.Modal(modalEl);
                 modal.show();

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -2474,6 +2474,9 @@
                 }
 
                 document.getElementById('export_employee_ids').value = JSON.stringify(selected);
+                if (document.getElementById('export_source_menu')) {
+                    document.getElementById('export_source_menu').value = 'renewal';
+                }
                 const modalEl = document.getElementById('advancedExportModal');
                 const modal = new bootstrap.Modal(modalEl);
                 modal.show();

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1016,6 +1016,9 @@ window.loadBatchStats = function() {
             return;
         }
         document.getElementById('export_employee_ids').value = JSON.stringify(selected);
+        if (document.getElementById('export_source_menu')) {
+            document.getElementById('export_source_menu').value = 'workflow';
+        }
         new bootstrap.Modal(document.getElementById('advancedExportModal')).show();
     });
 


### PR DESCRIPTION
This pull request implements context-aware logic for the Advanced Export feature. When exporting the "Request Number" column, the system will now intelligently pull the correct database column based on the menu the user triggered the export from (e.g., pulling `registration_request_number` if exported from the Registration menu, or the related `ProductionItem`'s request number if exported from Workflow). 

This solves the issue where users were unable to export specific module-related request numbers via the bulk action advanced export feature.

---
*PR created automatically by Jules for task [6633552779253875423](https://jules.google.com/task/6633552779253875423) started by @nongjossss-commits*