### PR TITLE
Implement Financial Payment History and Breakdown

### DIFF
--- a/app/Http/Controllers/FinancialController.php
+++ b/app/Http/Controllers/FinancialController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\ProductionOrder;
 use App\Models\FinancialTransaction;
+use App\Models\FinancialPayment;
 use App\Models\CompanyProfile;
 use App\Models\ProductionItem;
 use Illuminate\Http\Request;
@@ -96,10 +97,9 @@ class FinancialController extends Controller
              return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
         }
 
-        $transaction = FinancialTransaction::findOrFail($id);
+        $transaction = FinancialTransaction::with('payments')->findOrFail($id);
 
         $rules = [
-            'paid_amount' => 'nullable|numeric',
             'status' => 'nullable|in:pending,partial,paid,overdue',
             'notes' => 'nullable|string',
             'bank_account_id' => 'nullable|exists:bank_accounts,id',
@@ -108,13 +108,11 @@ class FinancialController extends Controller
             'slip_file' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:5120', // 5MB
             'wht_document' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:5120', // 5MB
             'item_ids' => 'nullable', // Can be array or string "1,2,3" if FormData
-            'employee_ids' => 'nullable' // Can be array or string
+            'employee_ids' => 'nullable', // Can be array or string
+            'amount' => 'nullable|numeric|min:0'
         ];
 
         $request->validate($rules);
-
-        $oldPaidAmount = $transaction->paid_amount;
-        $oldBankAccountId = $transaction->bank_account_id;
 
         if ($request->has('notes')) {
             $transaction->notes = $request->notes;
@@ -152,36 +150,20 @@ class FinancialController extends Controller
             $transaction->amount = $request->amount;
         }
 
-        if ($request->has('paid_amount')) {
-            $transaction->paid_amount = $request->paid_amount;
-            if (!$transaction->paid_at && $transaction->paid_amount > 0) {
-                $transaction->paid_at = now();
-            }
-        }
-
         if ($request->has('status')) {
             $transaction->status = $request->status;
         }
 
-        // Auto-update status if fully paid
-        if ($transaction->paid_amount >= $transaction->amount && $transaction->status !== 'paid') {
+        // Auto-update status if fully paid (based on current paid_amount)
+        if ($transaction->paid_amount > 0 && $transaction->paid_amount >= $transaction->amount && $transaction->status !== 'paid') {
             $transaction->status = 'paid';
-            $transaction->paid_at = now(); // Ensure date is set
+        } elseif ($transaction->paid_amount > 0 && $transaction->paid_amount < $transaction->amount && $transaction->status !== 'partial') {
+            $transaction->status = 'partial';
+        } elseif ($transaction->paid_amount == 0 && $transaction->status !== 'pending') {
+            $transaction->status = 'pending';
         }
 
         $transaction->save();
-
-        // Handle Bank Account Balance Logic
-        if ($transaction->paid_amount != $oldPaidAmount || $transaction->bank_account_id != $oldBankAccountId) {
-            // Revert old balance
-            if ($oldBankAccountId && $oldPaidAmount > 0) {
-                \App\Models\BankAccount::where('id', $oldBankAccountId)->decrement('current_balance', $oldPaidAmount);
-            }
-            // Add new balance
-            if ($transaction->bank_account_id && $transaction->paid_amount > 0) {
-                \App\Models\BankAccount::where('id', $transaction->bank_account_id)->increment('current_balance', $transaction->paid_amount);
-            }
-        }
 
         // Sync Items
         // We need to merge item_ids and employee_ids logic
@@ -231,8 +213,162 @@ class FinancialController extends Controller
             }
         }
 
-        $transaction->load('items.employee');
+        $transaction->load(['items.employee', 'payments', 'bankAccount']);
 
+        return response()->json(['success' => true, 'transaction' => $transaction]);
+    }
+
+    /**
+     * Store a payment for a transaction.
+     */
+    public function storePayment(Request $request, $transactionId)
+    {
+         if (!auth()->user()->can('manage-finance') && !auth()->user()->hasAnyRole(['admin', 'super-admin'])) {
+             return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
+        }
+
+        $transaction = FinancialTransaction::findOrFail($transactionId);
+
+        $request->validate([
+            'amount' => 'required|numeric|min:0.01',
+            'paid_at' => 'required|date',
+            'bank_account_id' => 'nullable|exists:bank_accounts,id',
+            'slip_file' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:5120',
+            'notes' => 'nullable|string'
+        ]);
+
+        $slipPath = null;
+        if ($request->hasFile('slip_file')) {
+            $slipPath = $request->file('slip_file')->store('financial_slips', 'public');
+        }
+
+        $payment = $transaction->payments()->create([
+            'amount' => $request->amount,
+            'paid_at' => \Carbon\Carbon::parse($request->paid_at),
+            'bank_account_id' => $request->bank_account_id,
+            'slip_path' => $slipPath,
+            'notes' => $request->notes,
+            'created_by' => auth()->id()
+        ]);
+
+        // Update transaction paid amount
+        $transaction->paid_amount += $payment->amount;
+        $transaction->paid_at = now();
+
+        if ($transaction->paid_amount >= $transaction->amount) {
+            $transaction->status = 'paid';
+        } else {
+            $transaction->status = 'partial';
+        }
+        $transaction->save();
+
+        // Update Bank Balance
+        if ($payment->bank_account_id) {
+            \App\Models\BankAccount::where('id', $payment->bank_account_id)
+                ->increment('current_balance', $payment->amount);
+        }
+
+        $transaction->load(['items.employee', 'payments', 'bankAccount']);
+        return response()->json(['success' => true, 'transaction' => $transaction]);
+    }
+
+    /**
+     * Update an existing payment.
+     */
+    public function updatePayment(Request $request, $paymentId)
+    {
+         if (!auth()->user()->can('manage-finance') && !auth()->user()->hasAnyRole(['admin', 'super-admin'])) {
+             return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
+        }
+
+        $payment = FinancialPayment::with('transaction')->findOrFail($paymentId);
+        $transaction = $payment->transaction;
+
+        $request->validate([
+            'amount' => 'required|numeric|min:0.01',
+            'paid_at' => 'required|date',
+            'bank_account_id' => 'nullable|exists:bank_accounts,id',
+            'slip_file' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:5120',
+            'notes' => 'nullable|string'
+        ]);
+
+        $oldAmount = $payment->amount;
+        $oldBankAccountId = $payment->bank_account_id;
+
+        // Revert old bank balance
+        if ($oldBankAccountId) {
+            \App\Models\BankAccount::where('id', $oldBankAccountId)->decrement('current_balance', $oldAmount);
+        }
+
+        if ($request->hasFile('slip_file')) {
+            if ($payment->slip_path) {
+                Storage::disk('public')->delete($payment->slip_path);
+            }
+            $payment->slip_path = $request->file('slip_file')->store('financial_slips', 'public');
+        }
+
+        $payment->amount = $request->amount;
+        $payment->paid_at = \Carbon\Carbon::parse($request->paid_at);
+        $payment->bank_account_id = $request->bank_account_id;
+        $payment->notes = $request->notes;
+        $payment->save();
+
+        // Apply new bank balance
+        if ($payment->bank_account_id) {
+            \App\Models\BankAccount::where('id', $payment->bank_account_id)
+                ->increment('current_balance', $payment->amount);
+        }
+
+        // Recalculate transaction totals
+        $newTotalPaid = $transaction->payments()->sum('amount');
+        $transaction->paid_amount = $newTotalPaid;
+
+        if ($newTotalPaid >= $transaction->amount) {
+            $transaction->status = 'paid';
+        } else if ($newTotalPaid > 0) {
+            $transaction->status = 'partial';
+        } else {
+            $transaction->status = 'pending';
+        }
+        $transaction->save();
+
+        $transaction->load(['items.employee', 'payments', 'bankAccount']);
+        return response()->json(['success' => true, 'transaction' => $transaction]);
+    }
+
+    /**
+     * Delete an existing payment.
+     */
+    public function destroyPayment($paymentId)
+    {
+         if (!auth()->user()->can('manage-finance') && !auth()->user()->hasAnyRole(['admin', 'super-admin'])) {
+             return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
+        }
+
+        $payment = FinancialPayment::with('transaction')->findOrFail($paymentId);
+        $transaction = $payment->transaction;
+
+        // Revert bank balance
+        if ($payment->bank_account_id) {
+            \App\Models\BankAccount::where('id', $payment->bank_account_id)->decrement('current_balance', $payment->amount);
+        }
+
+        $payment->delete();
+
+        // Recalculate transaction totals
+        $newTotalPaid = $transaction->payments()->sum('amount');
+        $transaction->paid_amount = $newTotalPaid;
+
+        if ($newTotalPaid >= $transaction->amount) {
+            $transaction->status = 'paid';
+        } else if ($newTotalPaid > 0) {
+            $transaction->status = 'partial';
+        } else {
+            $transaction->status = 'pending';
+        }
+        $transaction->save();
+
+        $transaction->load(['items.employee', 'payments', 'bankAccount']);
         return response()->json(['success' => true, 'transaction' => $transaction]);
     }
 
@@ -290,14 +426,16 @@ class FinancialController extends Controller
              return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
         }
 
-        $transaction = FinancialTransaction::findOrFail($id);
+        $transaction = FinancialTransaction::with('payments')->findOrFail($id);
 
-        // Revert bank balance
-        if ($transaction->bank_account_id && $transaction->paid_amount > 0) {
-            \App\Models\BankAccount::where('id', $transaction->bank_account_id)->decrement('current_balance', $transaction->paid_amount);
+        // Revert bank balances for all associated payments
+        foreach ($transaction->payments as $payment) {
+            if ($payment->bank_account_id) {
+                \App\Models\BankAccount::where('id', $payment->bank_account_id)->decrement('current_balance', $payment->amount);
+            }
         }
 
-        $transaction->delete();
+        $transaction->delete(); // payments will cascade via DB if configured, but let's be safe.
 
         return response()->json(['success' => true]);
     }

--- a/app/Models/FinancialPayment.php
+++ b/app/Models/FinancialPayment.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class FinancialPayment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'financial_transaction_id',
+        'amount',
+        'paid_at',
+        'bank_account_id',
+        'slip_path',
+        'notes',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'paid_at' => 'datetime',
+    ];
+
+    public function transaction()
+    {
+        return $this->belongsTo(FinancialTransaction::class, 'financial_transaction_id');
+    }
+
+    public function bankAccount()
+    {
+        return $this->belongsTo(BankAccount::class);
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/FinancialTransaction.php
+++ b/app/Models/FinancialTransaction.php
@@ -58,4 +58,9 @@ class FinancialTransaction extends Model
     {
         return $this->belongsTo(FinancialProfile::class);
     }
+
+    public function payments()
+    {
+        return $this->hasMany(FinancialPayment::class);
+    }
 }

--- a/database/migrations/2026_03_20_224216_create_financial_payments_table.php
+++ b/database/migrations/2026_03_20_224216_create_financial_payments_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('financial_payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('financial_transaction_id')->constrained()->cascadeOnDelete();
+            $table->decimal('amount', 15, 2);
+            $table->datetime('paid_at');
+            $table->foreignId('bank_account_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('slip_path')->nullable();
+            $table->text('notes')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('financial_payments');
+    }
+};

--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -56,8 +56,11 @@ if (typeof window.financialManager === 'undefined') {
             // Transaction State
             transactions: initialData.transactions || [],
             newTransaction: { type: 'installment', amount: '', due_date: '', notes: '' },
-            editingTransaction: {},
+            editingTransaction: { payments: [] },
             selectedFile: null,
+            newPayment: { amount: '', paid_at: '', bank_account_id: '', notes: '' },
+            paymentSlipFile: null,
+            isSavingPayment: false,
 
             // Separate Saving States
             isSavingSettings: false,
@@ -573,6 +576,15 @@ if (typeof window.financialManager === 'undefined') {
                 this.editingTransaction.withholding_tax_amount = t.withholding_tax_amount || '';
                 this.editingTransaction.bank_account_id = t.bank_account_id || '';
                 this.editingTransaction.wht_file = null;
+
+                // Initialize default payment
+                let defaultAmount = (t.amount - (t.paid_amount || 0)).toFixed(2);
+                if (defaultAmount < 0) defaultAmount = 0;
+
+                let today = new Date().toISOString().split('T')[0];
+                this.newPayment = { amount: defaultAmount, paid_at: today, bank_account_id: '', notes: '' };
+                this.paymentSlipFile = null;
+
                 if (t.items) {
                     this.selectedTransactionItems = t.items.map(i => i.id);
                 } else {
@@ -586,10 +598,86 @@ if (typeof window.financialManager === 'undefined') {
                 this.editingTransaction.wht_file = e.target.files[0];
             },
 
+            handlePaymentSlipSelect(e) {
+                this.paymentSlipFile = e.target.files[0];
+            },
+
+            addPayment() {
+                if(!this.newPayment.amount || !this.newPayment.paid_at) {
+                    Swal.fire('Warning', 'Amount and Date are required.', 'warning');
+                    return;
+                }
+
+                this.isSavingPayment = true;
+                const formData = new FormData();
+                formData.append('amount', this.newPayment.amount);
+                formData.append('paid_at', this.newPayment.paid_at);
+                formData.append('bank_account_id', this.newPayment.bank_account_id || '');
+                formData.append('notes', this.newPayment.notes || '');
+                if (this.paymentSlipFile) {
+                    formData.append('slip_file', this.paymentSlipFile);
+                }
+
+                fetch(`/production/transactions/${this.editingTransaction.id}/payments`, {
+                    method: 'POST',
+                    headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+                    body: formData
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if(data.success) {
+                        const idx = this.transactions.findIndex(t => t.id === data.transaction.id);
+                        if(idx !== -1) this.transactions[idx] = data.transaction;
+
+                        this.editingTransaction = { ...data.transaction };
+
+                        // Reset form
+                        let defaultAmount = (data.transaction.amount - (data.transaction.paid_amount || 0)).toFixed(2);
+                        if (defaultAmount < 0) defaultAmount = 0;
+                        this.newPayment = { amount: defaultAmount, paid_at: new Date().toISOString().split('T')[0], bank_account_id: '', notes: '' };
+                        this.paymentSlipFile = null;
+
+                        Swal.fire({ toast: true, position: 'top-end', icon: 'success', title: 'Payment Added', showConfirmButton: false, timer: 3000 });
+                    } else {
+                        throw new Error(data.message || 'Error adding payment');
+                    }
+                })
+                .catch(err => Swal.fire('Error', err.message, 'error'))
+                .finally(() => this.isSavingPayment = false);
+            },
+
+            deletePayment(paymentId) {
+                Swal.fire({
+                    title: 'Delete this payment?',
+                    text: 'This will revert the paid amount and bank balances.',
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonText: 'Yes, delete it!'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        fetch(`/production/payments/${paymentId}`, {
+                            method: 'DELETE',
+                            headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' }
+                        })
+                        .then(res => res.json())
+                        .then(data => {
+                            if(data.success) {
+                                const idx = this.transactions.findIndex(t => t.id === data.transaction.id);
+                                if(idx !== -1) this.transactions[idx] = data.transaction;
+                                this.editingTransaction = { ...data.transaction };
+                                Swal.fire({ toast: true, position: 'top-end', icon: 'success', title: 'Payment Deleted', showConfirmButton: false, timer: 3000 });
+                            } else {
+                                throw new Error(data.message || 'Error deleting payment');
+                            }
+                        })
+                        .catch(err => Swal.fire('Error', err.message, 'error'));
+                    }
+                });
+            },
+
             updateTransaction() {
                 const formData = new FormData();
                 formData.append('_method', 'PUT');
-                formData.append('paid_amount', this.editingTransaction.paid_amount);
                 formData.append('status', this.editingTransaction.status);
                 formData.append('notes', this.editingTransaction.notes || '');
                 formData.append('bank_account_id', this.editingTransaction.bank_account_id || '');

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -472,7 +472,10 @@ class="row">
                                     </td>
                                     <td x-text="formatDate(t.due_date)"></td>
                                     <td class="text-end" x-text="formatCurrency(t.amount)"></td>
-                                    <td class="text-end" x-text="formatCurrency(t.paid_amount)"></td>
+                                    <td class="text-end">
+                                        <span x-text="formatCurrency(t.paid_amount || 0)"></span><br>
+                                        <small class="text-muted" x-show="t.amount - (t.paid_amount || 0) > 0">Remaining: <span x-text="formatCurrency(Math.max(0, t.amount - (t.paid_amount || 0)))"></span></small>
+                                    </td>
                                     <td class="text-center">
                                         <span class="badge" :class="statusClass(t.status)" x-text="formatStatus(t.status)"></span>
                                     </td>
@@ -521,7 +524,10 @@ class="row">
                                     </td>
                                     <td x-text="formatDate(t.due_date)"></td>
                                     <td class="text-end text-primary" x-text="formatCurrency(t.amount)"></td>
-                                    <td class="text-end" x-text="formatCurrency(t.paid_amount)"></td>
+                                    <td class="text-end">
+                                        <span x-text="formatCurrency(t.paid_amount)"></span><br>
+                                        <small class="text-muted" x-show="t.amount - t.paid_amount > 0">Remaining: <span x-text="formatCurrency(Math.max(0, t.amount - t.paid_amount))"></span></small>
+                                    </td>
                                     <td class="text-center">
                                         <span class="badge" :class="statusClass(t.status)" x-text="formatStatus(t.status)"></span>
                                     </td>
@@ -923,43 +929,116 @@ class="row">
 
     <!-- Update Payment Modal -->
     <div class="modal fade" :id="'updatePaymentModal-' + productionId" tabindex="-1" x-ref="payModal">
-        <div class="modal-dialog modal-lg">
+        <div class="modal-dialog modal-xl">
             <div class="modal-content">
                 <div class="modal-header py-2">
-                    <h6 class="modal-title">Update Payment & Items</h6>
+                    <h6 class="modal-title">Payment History & Details</h6>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
-                    <form @submit.prevent="updateTransaction">
-                        <div class="row">
-                             <div class="col-md-6">
-                                <div class="mb-2">
-                                    <label class="form-label small">Paid Amount</label>
-                                    <input type="number" step="0.01" class="form-control form-control-sm" x-model="editingTransaction.paid_amount">
-                                    <div class="d-flex justify-content-between small text-muted mt-1" style="font-size: 0.75rem;">
-                                         <span>Total: <span x-text="formatCurrency(editingTransaction.amount)"></span></span>
-                                         <span :class="(editingTransaction.amount - (parseFloat(editingTransaction.paid_amount) || 0)) > 0.01 ? 'text-danger fw-bold' : 'text-success'">
-                                             Remaining: <span x-text="formatCurrency(Math.max(0, editingTransaction.amount - (parseFloat(editingTransaction.paid_amount) || 0)))"></span>
-                                         </span>
+                    <div class="row">
+                        <!-- Left Column: Payments History -->
+                        <div class="col-md-5">
+                            <h6 class="fw-bold mb-3 border-bottom pb-2">Payments</h6>
+
+                            <!-- Payment List -->
+                            <div class="list-group list-group-flush mb-3 border rounded shadow-sm" style="max-height: 250px; overflow-y: auto;">
+                                <template x-for="pay in editingTransaction.payments" :key="pay.id">
+                                    <div class="list-group-item py-2 px-3">
+                                        <div class="d-flex justify-content-between align-items-center mb-1">
+                                            <div class="fw-bold text-success" x-text="formatCurrency(pay.amount)"></div>
+                                            <div class="text-muted small" x-text="formatDate(pay.paid_at)"></div>
+                                        </div>
+                                        <div class="small text-muted mb-1 d-flex justify-content-between">
+                                            <span x-text="pay.bank_account ? pay.bank_account.bank_name : 'No Account'"></span>
+                                            <span>
+                                                <a x-show="pay.slip_path" href="#" @click.prevent="viewPDF('/storage/' + pay.slip_path, 'View Slip')" class="badge bg-info text-decoration-none">View Slip</a>
+                                            </span>
+                                        </div>
+                                        <div class="d-flex justify-content-between align-items-center mt-2">
+                                            <div class="small fst-italic text-muted" x-text="pay.notes"></div>
+                                            <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1" @click="deletePayment(pay.id)">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </template>
+                                <div x-show="!editingTransaction.payments || editingTransaction.payments.length === 0" class="text-center text-muted p-3 small">
+                                    No payments recorded yet.
+                                </div>
+                            </div>
+
+                            <!-- Add New Payment Form -->
+                            <div class="card shadow-sm border-success">
+                                <div class="card-header bg-success text-white py-1 small fw-bold">Add Payment</div>
+                                <div class="card-body p-2">
+                                    <div class="row g-2 mb-2">
+                                        <div class="col-6">
+                                            <label class="form-label small mb-0">Amount</label>
+                                            <input type="number" step="0.01" class="form-control form-control-sm" x-model="newPayment.amount">
+                                        </div>
+                                        <div class="col-6">
+                                            <label class="form-label small mb-0">Date</label>
+                                            <input type="date" class="form-control form-control-sm" x-model="newPayment.paid_at">
+                                        </div>
+                                    </div>
+                                    <div class="mb-2">
+                                        <label class="form-label small mb-0">Account</label>
+                                        <select class="form-select form-select-sm" x-model="newPayment.bank_account_id">
+                                            <option value="">-- Select Account --</option>
+                                            @foreach(\App\Models\BankAccount::where('is_active', true)->get() as $bank)
+                                                <option value="{{ $bank->id }}">{{ $bank->bank_name }} {{ $bank->account_number ? '('.$bank->account_number.')' : '' }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                    <div class="mb-2">
+                                        <label class="form-label small mb-0">Slip</label>
+                                        <input type="file" class="form-control form-control-sm" @change="handlePaymentSlipSelect" accept=".jpg,.jpeg,.png,.pdf">
+                                    </div>
+                                    <div class="mb-2">
+                                        <label class="form-label small mb-0">Notes</label>
+                                        <input type="text" class="form-control form-control-sm" x-model="newPayment.notes">
+                                    </div>
+                                    <button type="button" class="btn btn-success btn-sm w-100" @click="addPayment" :disabled="isSavingPayment">
+                                        <span x-show="isSavingPayment" class="spinner-border spinner-border-sm me-1"></span>
+                                        Save Payment
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Right Column: Transaction Options & Items -->
+                        <div class="col-md-7 border-start ps-3">
+                            <form @submit.prevent="updateTransaction">
+                                <h6 class="fw-bold mb-3 border-bottom pb-2">Transaction Options</h6>
+
+                                <!-- Summary Display -->
+                                <div class="d-flex justify-content-between small mb-3 bg-light p-2 rounded border">
+                                    <div><span class="text-muted">Total:</span> <span class="fw-bold" x-text="formatCurrency(editingTransaction.amount)"></span></div>
+                                    <div><span class="text-muted">Paid:</span> <span class="fw-bold text-success" x-text="formatCurrency(editingTransaction.paid_amount || 0)"></span></div>
+                                    <div><span class="text-muted">Remaining:</span> <span class="fw-bold text-danger" x-text="formatCurrency(Math.max(0, editingTransaction.amount - (editingTransaction.paid_amount || 0)))"></span></div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-6 mb-2">
+                                        <label class="form-label small">Status Override</label>
+                                        <select class="form-select form-select-sm" x-model="editingTransaction.status">
+                                            <option value="pending">Pending</option>
+                                            <option value="partial">Partial</option>
+                                            <option value="paid">Paid</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-6 mb-2">
+                                        <label class="form-label small">Receive to Account (Legacy)</label>
+                                        <select class="form-select form-select-sm" x-model="editingTransaction.bank_account_id" disabled title="Please update account via the Payments tab below.">
+                                            <option value="">-- Legacy Field --</option>
+                                            @foreach(\App\Models\BankAccount::where('is_active', true)->get() as $bank)
+                                                <option value="{{ $bank->id }}">{{ $bank->bank_name }}</option>
+                                            @endforeach
+                                        </select>
                                     </div>
                                 </div>
-                                <div class="mb-2">
-                                    <label class="form-label small">Status</label>
-                                    <select class="form-select form-select-sm" x-model="editingTransaction.status">
-                                        <option value="pending">Pending</option>
-                                        <option value="partial">Partial</option>
-                                        <option value="paid">Paid</option>
-                                    </select>
-                                </div>
-                                <div class="mb-2">
-                                    <label class="form-label small">Receive to Account</label>
-                                    <select class="form-select form-select-sm" x-model="editingTransaction.bank_account_id">
-                                        <option value="">-- Select Account --</option>
-                                        @foreach(\App\Models\BankAccount::where('is_active', true)->get() as $bank)
-                                            <option value="{{ $bank->id }}">{{ $bank->bank_name }} {{ $bank->account_number ? '('.$bank->account_number.')' : '' }}</option>
-                                        @endforeach
-                                    </select>
-                                </div>
+
                                 <div class="mb-2" x-show="editingTransaction.type !== 'advance_payment' && editingTransaction.type !== 'advance_receipt'">
                                     <label class="form-label small">WHT (หัก ณ ที่จ่าย 3%)</label>
                                     <select class="form-select form-select-sm mb-1" x-model="editingTransaction.wht_status">

--- a/routes/web.php
+++ b/routes/web.php
@@ -426,6 +426,9 @@ Route::middleware(['auth'])->group(function () {
         Route::put('production/transactions/{id}', [FinancialController::class, 'updateTransaction']); // For status updates
         Route::post('production/transactions/{id}', [FinancialController::class, 'updateTransaction']); // For file uploads (method spoofing)
         Route::delete('production/transactions/{id}', [FinancialController::class, 'destroyTransaction']);
+        Route::post('production/transactions/{id}/payments', [FinancialController::class, 'storePayment']);
+        Route::post('production/payments/{id}', [FinancialController::class, 'updatePayment']);
+        Route::delete('production/payments/{id}', [FinancialController::class, 'destroyPayment']);
     });
     // Replaced by dedicated ProductionDocumentController
     // Route::get('production/{id}/documents/{type}', [FinancialController::class, 'generateDocument']);


### PR DESCRIPTION
This PR upgrades the financial system to handle multiple payments against a single installment (FinancialTransaction). Previously, users could only overwrite a `paid_amount` value, causing a loss of history regarding when and how much was paid in distinct increments.

We've introduced a `FinancialPayment` model, which records discrete payment amounts, their dates, bank accounts, and uploaded slips. The UI has been completely revamped to show a detailed breakdown of payments inside the update modal, along with clear summary cards for Totals, Paid, and Remaining balances both on the modal and the main transaction list.

---
*PR created automatically by Jules for task [4254032561792598625](https://jules.google.com/task/4254032561792598625) started by @nongjossss-commits*