### PR TITLE
Fix pagination state bleed across employer lists in Registration and Renewal

### DIFF
--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -1358,6 +1358,7 @@
 
     // --- Lazy Loading Logic ---
     window.loadedEmployers = {};
+    window.employerCurrentPages = {};
 
     window.loadEmployees = function(employerId, pageUrl = null) {
         // Only skip if already loaded AND not a pagination request
@@ -1366,17 +1367,23 @@
         const container = document.getElementById(`employee-list-${employerId}`);
         if(pageUrl) {
             container.innerHTML = '<div class="d-flex justify-content-center align-items-center py-5"><div class="spinner-border text-primary" role="status"></div><span class="ms-2 small text-muted">Loading employees...</span></div>';
+            // Save the pageUrl for this employer so it remembers its state
+            window.employerCurrentPages[employerId] = pageUrl;
         }
 
         // Base URL for the new AJAX route
-        let baseUrl = pageUrl || `{{ route('production.registration.index') }}/employer/${employerId}/employees`;
+        // Use the saved page state if available, otherwise default to first page
+        let baseUrl = pageUrl || window.employerCurrentPages[employerId] || `{{ route('production.registration.index') }}/employer/${employerId}/employees`;
 
         // Append current search/filter params
         const url = new URL(baseUrl, window.location.origin);
         const currentParams = new URLSearchParams(window.location.search);
+
+        // Strip out the main window 'page' param so it doesn't bleed into the AJAX URL
+        // If the main window is on page 2, we do NOT want this employer's initial load to be on page 2
+        // unless it was specifically saved via employerCurrentPages
         currentParams.forEach((value, key) => {
-             // Don't overwrite 'page' if we have it in the pageUrl
-             if(key !== 'page' || !url.searchParams.has('page')) {
+             if(key !== 'page') {
                  url.searchParams.append(key, value);
              }
         });

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -1306,6 +1306,7 @@
 
     // --- Lazy Loading Logic ---
     window.loadedEmployers = {};
+    window.employerCurrentPages = {};
 
     window.loadEmployees = function(employerId, pageUrl = null) {
         // Only skip if already loaded AND not a pagination request
@@ -1314,17 +1315,23 @@
         const container = document.getElementById(`employee-list-${employerId}`);
         if(pageUrl) {
             container.innerHTML = '<div class="d-flex justify-content-center align-items-center py-5"><div class="spinner-border text-primary" role="status"></div><span class="ms-2 small text-muted">Loading employees...</span></div>';
+            // Save the pageUrl for this employer so it remembers its state
+            window.employerCurrentPages[employerId] = pageUrl;
         }
 
         // Base URL for the new AJAX route
-        let baseUrl = pageUrl || `{{ route('production.renewal.index') }}/employer/${employerId}/employees`;
+        // Use the saved page state if available, otherwise default to first page
+        let baseUrl = pageUrl || window.employerCurrentPages[employerId] || `{{ route('production.renewal.index') }}/employer/${employerId}/employees`;
 
         // Append current search/filter params
         const url = new URL(baseUrl, window.location.origin);
         const currentParams = new URLSearchParams(window.location.search);
+
+        // Strip out the main window 'page' param so it doesn't bleed into the AJAX URL
+        // If the main window is on page 2, we do NOT want this employer's initial load to be on page 2
+        // unless it was specifically saved via employerCurrentPages
         currentParams.forEach((value, key) => {
-             // Don't overwrite 'page' if we have it in the pageUrl
-             if(key !== 'page' || !url.searchParams.has('page')) {
+             if(key !== 'page') {
                  url.searchParams.append(key, value);
              }
         });


### PR DESCRIPTION
Fixed an issue in the Registration and Renewal menus where the pagination state of the employee list was bleeding across different employers. Previously, if a user navigated to page 3 of Employer A's employee list, then closed Employer A and opened Employer B (who only had 1 page of employees), Employer B's list would incorrectly attempt to load page 3, resulting in no employees being shown.

The fix introduces a per-employer pagination state tracker (`window.employerCurrentPages`) and explicitly strips the global `?page=` parameter from the AJAX request when fetching the employee list. This ensures each employer remembers its own pagination state independently until the main page is reloaded.

---
*PR created automatically by Jules for task [11604924890018658106](https://jules.google.com/task/11604924890018658106) started by @nongjossss-commits*