### PR TITLE
Fix document scanner missing files on multiple selection

### DIFF
--- a/resources/views/components/document-scanner.blade.php
+++ b/resources/views/components/document-scanner.blade.php
@@ -424,7 +424,8 @@
     // Global Interceptor Function
     window.interceptFileSelect = function(event) {
         const input = event.target;
-        const files = input.files;
+        // Convert FileList to a static Array immediately so clearing the input later doesn't destroy the list during async processing
+        const files = Array.from(input.files);
 
         // 1. Check if this change was triggered by the scanner itself
         if (input.dataset.scannerSource === 'true') {


### PR DESCRIPTION
Fixed a bug where selecting multiple files through a standard file attachment button only imported one file into the Document Scanner.

The bug was caused by passing a live `FileList` object to an asynchronous import function, and then clearing the input field immediately after. This destroyed the list of files before the system could process all of them. Converting the `FileList` to a static Array via `Array.from(input.files)` ensures all files are preserved and imported correctly.

---
*PR created automatically by Jules for task [1541996666972163202](https://jules.google.com/task/1541996666972163202) started by @nongjossss-commits*