### PR TITLE
feat: Allow assignment of custom external operators

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -167,8 +167,11 @@ class RegistrationController extends Controller
             $opFilter = $request->operator_filter;
             $employerQuery->whereHas('employees', function($q) use ($opFilter) {
                 // Should only check relevant status?
-                $q
-                  ->where('operator_id', $opFilter);
+                if ($opFilter === 'external') {
+                    $q->whereNotNull('custom_operator_name')->where('custom_operator_name', '!=', '');
+                } else {
+                    $q->where('operator_id', $opFilter);
+                }
             });
         }
 
@@ -451,7 +454,11 @@ class RegistrationController extends Controller
 
             // Operator Filter
             if ($request->has('operator_filter') && $request->operator_filter) {
-                $query->where('operator_id', $request->operator_filter);
+                if ($request->operator_filter === 'external') {
+                    $query->whereNotNull('custom_operator_name')->where('custom_operator_name', '!=', '');
+                } else {
+                    $query->where('operator_id', $request->operator_filter);
+                }
             }
 
             if (!$employerMatches && $search) {
@@ -632,7 +639,11 @@ class RegistrationController extends Controller
 
         // Operator Filter
         if ($request->has('operator_filter') && $request->operator_filter) {
-            $query->where('operator_id', $request->operator_filter);
+            if ($request->operator_filter === 'external') {
+                $query->whereNotNull('custom_operator_name')->where('custom_operator_name', '!=', '');
+            } else {
+                $query->where('operator_id', $request->operator_filter);
+            }
         }
 
         // Apply Filter
@@ -2236,16 +2247,32 @@ class RegistrationController extends Controller
         $employee = Employee::findOrFail($employeeId);
 
         // Check for specific user assignment
-        if ($request->has('operator_id')) {
+        if ($request->has('operator_id') || $request->has('custom_operator_name')) {
             $userId = $request->input('operator_id');
-            // If explicit null or empty, remove operator
-            if (empty($userId)) {
-                $employee->update(['operator_id' => null]);
+            $customOperatorName = $request->input('custom_operator_name');
+
+            // If custom operator name is provided (external operator)
+            if (!empty($customOperatorName)) {
+                $employee->update([
+                    'operator_id' => null,
+                    'custom_operator_name' => $customOperatorName
+                ]);
+                $message = 'Operator assigned to external: ' . $customOperatorName;
+            }
+            // If explicit null or empty and no custom name, remove operator
+            else if (empty($userId)) {
+                $employee->update([
+                    'operator_id' => null,
+                    'custom_operator_name' => null
+                ]);
                 $message = 'Operator unassigned.';
             } else {
                 $user = User::find($userId);
                 if ($user) {
-                    $employee->update(['operator_id' => $user->id]);
+                    $employee->update([
+                        'operator_id' => $user->id,
+                        'custom_operator_name' => null
+                    ]);
                     $message = 'Operator assigned to ' . $user->name;
                 } else {
                      return response()->json(['success' => false, 'message' => 'User not found'], 404);
@@ -2254,11 +2281,11 @@ class RegistrationController extends Controller
         } else {
             // Legacy Toggle Behavior (Toggle Me)
             $userId = auth()->id();
-            if ($employee->operator_id === $userId) {
-                $employee->update(['operator_id' => null]);
+            if ($employee->operator_id === $userId && empty($employee->custom_operator_name)) {
+                $employee->update(['operator_id' => null, 'custom_operator_name' => null]);
                 $message = 'Operator unassigned.';
             } else {
-                $employee->update(['operator_id' => $userId]);
+                $employee->update(['operator_id' => $userId, 'custom_operator_name' => null]);
                 $message = 'Operator assigned to ' . auth()->user()->name;
             }
         }

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -152,8 +152,11 @@ class RenewalController extends Controller
         if ($request->has('operator_filter') && $request->operator_filter) {
             $opFilter = $request->operator_filter;
             $employerQuery->whereHas('employees', function($q) use ($opFilter) {
-                $q
-                  ->where('operator_id', $opFilter);
+                if ($opFilter === 'external') {
+                    $q->whereNotNull('custom_operator_name')->where('custom_operator_name', '!=', '');
+                } else {
+                    $q->where('operator_id', $opFilter);
+                }
             });
         }
 
@@ -419,7 +422,11 @@ class RenewalController extends Controller
 
             // Operator Filter
             if ($request->has('operator_filter') && $request->operator_filter) {
-                $query->where('operator_id', $request->operator_filter);
+                if ($request->operator_filter === 'external') {
+                    $query->whereNotNull('custom_operator_name')->where('custom_operator_name', '!=', '');
+                } else {
+                    $query->where('operator_id', $request->operator_filter);
+                }
             }
 
             // Insurance Filter
@@ -546,7 +553,11 @@ class RenewalController extends Controller
 
         // Operator Filter
         if ($request->has('operator_filter') && $request->operator_filter) {
-            $query->where('operator_id', $request->operator_filter);
+            if ($request->operator_filter === 'external') {
+                $query->whereNotNull('custom_operator_name')->where('custom_operator_name', '!=', '');
+            } else {
+                $query->where('operator_id', $request->operator_filter);
+            }
         }
 
         // Insurance Filter
@@ -1684,15 +1695,29 @@ class RenewalController extends Controller
     {
         $employee = Employee::findOrFail($employeeId);
 
-        if ($request->has('operator_id')) {
+        if ($request->has('operator_id') || $request->has('custom_operator_name')) {
             $userId = $request->input('operator_id');
-            if (empty($userId)) {
-                $employee->update(['operator_id' => null]);
+            $customOperatorName = $request->input('custom_operator_name');
+
+            if (!empty($customOperatorName)) {
+                $employee->update([
+                    'operator_id' => null,
+                    'custom_operator_name' => $customOperatorName
+                ]);
+                $message = 'Operator assigned to external: ' . $customOperatorName;
+            } else if (empty($userId)) {
+                $employee->update([
+                    'operator_id' => null,
+                    'custom_operator_name' => null
+                ]);
                 $message = 'Operator unassigned.';
             } else {
                 $user = User::find($userId);
                 if ($user) {
-                    $employee->update(['operator_id' => $user->id]);
+                    $employee->update([
+                        'operator_id' => $user->id,
+                        'custom_operator_name' => null
+                    ]);
                     $message = 'Operator assigned to ' . $user->name;
                 } else {
                      return response()->json(['success' => false, 'message' => 'User not found'], 404);
@@ -1700,11 +1725,11 @@ class RenewalController extends Controller
             }
         } else {
             $userId = auth()->id();
-            if ($employee->operator_id === $userId) {
-                $employee->update(['operator_id' => null]);
+            if ($employee->operator_id === $userId && empty($employee->custom_operator_name)) {
+                $employee->update(['operator_id' => null, 'custom_operator_name' => null]);
                 $message = 'Operator unassigned.';
             } else {
-                $employee->update(['operator_id' => $userId]);
+                $employee->update(['operator_id' => $userId, 'custom_operator_name' => null]);
                 $message = 'Operator assigned to ' . auth()->user()->name;
             }
         }

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -152,6 +152,7 @@ class Employee extends Model
         'renewal_remarks',
         'last_daily_checked_at',
         'operator_id',
+        'custom_operator_name',
     ];
 
     protected $casts = [

--- a/app/Models/ProductionItem.php
+++ b/app/Models/ProductionItem.php
@@ -26,7 +26,8 @@ class ProductionItem extends Model
         'completed_at', // NEW: Workflow finished
         'is_transfer_processed', // NEW: Flag to prevent duplicate delayed transfers
         'new_employee_data', // JSON for temp employees
-        'operator_id', // NEW: Assigned Operator
+        'operator_id',
+        'custom_operator_name', // NEW: Assigned Operator
         'remarks', // Added remarks
     ];
 

--- a/database/migrations/2026_03_22_154313_add_custom_operator_name_to_employees_and_production_items_table.php
+++ b/database/migrations/2026_03_22_154313_add_custom_operator_name_to_employees_and_production_items_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->string('custom_operator_name')->nullable()->after('operator_id');
+        });
+
+        Schema::table('production_items', function (Blueprint $table) {
+            $table->string('custom_operator_name')->nullable()->after('operator_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('custom_operator_name');
+        });
+
+        Schema::table('production_items', function (Blueprint $table) {
+            $table->dropColumn('custom_operator_name');
+        });
+    }
+};

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -29,9 +29,16 @@
 
     // Operator Logic
     $operator = $employee->operator;
-    $operatorName = $operator ? $operator->name : null;
     $operatorId = $employee->operator_id;
+    $customOperatorName = $employee->custom_operator_name;
     $isMe = $operatorId === auth()->id();
+
+    if ($customOperatorName) {
+        $operatorName = $customOperatorName . ' (ภายนอก)';
+        $operatorId = 'external'; // Used for JS logic
+    } else {
+        $operatorName = $operator ? $operator->name : null;
+    }
 @endphp
 
 <div class="d-flex align-items-center employee-card-outer mb-3 employee-card-wrapper"
@@ -54,11 +61,18 @@
             $toggleUrl = request()->is('production/renewal*')
                 ? route('production.renewal.toggle_operator', $employee->id)
                 : route('production.registration.toggle_operator', $employee->id);
+
+            $btnClass = 'btn-outline-secondary';
+            if ($customOperatorName) {
+                $btnClass = 'btn-info text-dark';
+            } else if ($operatorId && $operatorId !== 'external') {
+                $btnClass = $isMe ? 'btn-primary' : 'btn-secondary';
+            }
         @endphp
-        <button class="btn btn-sm {{ $operatorId ? ($isMe ? 'btn-primary' : 'btn-secondary') : 'btn-outline-secondary' }} rounded-pill shadow-sm py-0 px-2"
+        <button class="btn btn-sm {{ $btnClass }} rounded-pill shadow-sm py-0 px-2"
                 style="font-size: 0.75rem; border-width: 1px;"
                 @hasanyrole('super-admin|admin|staff')
-                onclick="window.toggleOperator ? window.toggleOperator({{ $employee->id }}, this, '{{ $operatorId ?? '' }}', '{{ $toggleUrl }}') : console.error('toggleOperator not defined')"
+                onclick="window.toggleOperator ? window.toggleOperator({{ $employee->id }}, this, '{{ $employee->operator_id ?? '' }}', '{{ addslashes($customOperatorName ?? '') }}', '{{ $toggleUrl }}') : console.error('toggleOperator not defined')"
                 title="{{ $operatorName ? 'Operator: '.$operatorName : 'Click to Assign' }}"
                 @else
                 disabled

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -276,10 +276,16 @@
                 <div class="dropdown">
                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i class="bi bi-person-fill me-1"></i>
-                        {{ request('operator_filter') ? ($activeOperators->firstWhere('id', request('operator_filter'))->name ?? __('Operator')) : __('Operator') }}
+                        @if(request('operator_filter') == 'external')
+                            ผู้ยื่นภายนอก
+                        @else
+                            {{ request('operator_filter') ? ($activeOperators->firstWhere('id', request('operator_filter'))->name ?? __('Operator')) : __('Operator') }}
+                        @endif
                     </button>
                     <ul class="dropdown-menu" style="max-height: 300px; overflow-y: auto;">
                         <li><a class="dropdown-item" href="{{ route('production.registration.index', array_merge(request()->query(), ['operator_filter' => null])) }}">{{ __('All Operators') }}</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item {{ request('operator_filter') == 'external' ? 'active' : '' }}" href="{{ route('production.registration.index', array_merge(request()->query(), ['operator_filter' => 'external'])) }}">ผู้ยื่นภายนอก (พิมพ์ชื่อเอง)</a></li>
                         <li><hr class="dropdown-divider"></li>
                         @foreach($activeOperators as $user)
                             <li><a class="dropdown-item {{ request('operator_filter') == $user->id ? 'active' : '' }}" href="{{ route('production.registration.index', array_merge(request()->query(), ['operator_filter' => $user->id])) }}">{{ $user->name }}</a></li>
@@ -1694,7 +1700,7 @@
     }
 
     // --- Operator Toggle ---
-    window.toggleOperator = function(employeeId, btn, currentOperatorId, url) {
+    window.toggleOperator = function(employeeId, btn, currentOperatorId, customOperatorName, url) {
         // Fetch operators first
         Swal.fire({
             title: '{{ __("Loading...") }}',
@@ -1709,18 +1715,24 @@
 
                 let operators = data.data;
                 let optionsHtml = `<option value="">-- {{ __("None / Clear Operator") }} --</option>`;
+                optionsHtml += `<option value="external" ${customOperatorName ? 'selected' : ''}>-- ผู้ยื่นภายนอก (พิมพ์ชื่อเอง) --</option>`;
 
                 operators.forEach(op => {
-                    let selected = (op.id == currentOperatorId) ? 'selected' : '';
+                    let selected = (op.id == currentOperatorId && !customOperatorName) ? 'selected' : '';
                     optionsHtml += `<option value="${op.id}" ${selected}>${op.name}</option>`;
                 });
 
                 const htmlContent = `
                     <div class="form-group text-start">
                         <label class="form-label mb-2">{{ __("Select Operator") }}</label>
-                        <select id="operator-select-${employeeId}" class="form-select form-select-lg">
+                        <select id="operator-select-${employeeId}" class="form-select form-select-lg mb-3">
                             ${optionsHtml}
                         </select>
+
+                        <div id="custom-operator-container-${employeeId}" style="display: ${customOperatorName ? 'block' : 'none'};">
+                            <label class="form-label mb-2">ระบุชื่อผู้ดำเนินการภายนอก</label>
+                            <input type="text" id="custom-operator-input-${employeeId}" class="form-control form-control-lg" placeholder="พิมพ์ชื่อผู้ดำเนินการ...">
+                        </div>
                     </div>
                 `;
 
@@ -1734,10 +1746,34 @@
                     cancelButtonText: '{{ __("Cancel") }}',
                     showLoaderOnConfirm: true,
                     didOpen: () => {
-                        // Optional: Initialize Select2 or Choices.js here if needed
+                        const selectEl = document.getElementById(`operator-select-${employeeId}`);
+                        const containerEl = document.getElementById(`custom-operator-container-${employeeId}`);
+                        const input = document.getElementById(`custom-operator-input-${employeeId}`);
+
+                        if (customOperatorName) {
+                            input.value = customOperatorName;
+                        }
+                        selectEl.addEventListener('change', function() {
+                            if (this.value === 'external') {
+                                containerEl.style.display = 'block';
+                                document.getElementById(`custom-operator-input-${employeeId}`).focus();
+                            } else {
+                                containerEl.style.display = 'none';
+                            }
+                        });
                     },
                     preConfirm: () => {
                         const selectedId = document.getElementById(`operator-select-${employeeId}`).value;
+                        let customName = null;
+
+                        if (selectedId === 'external') {
+                            customName = document.getElementById(`custom-operator-input-${employeeId}`).value.trim();
+                            if (!customName) {
+                                Swal.showValidationMessage('กรุณาระบุชื่อผู้ดำเนินการภายนอก');
+                                return false;
+                            }
+                        }
+
                         const fetchUrl = url || `/production/registration/${employeeId}/toggle-operator`;
 
                         return fetch(fetchUrl, {
@@ -1746,7 +1782,10 @@
                                 'Content-Type': 'application/json',
                                 'X-CSRF-TOKEN': csrfToken
                             },
-                            body: JSON.stringify({ operator_id: selectedId })
+                            body: JSON.stringify({
+                                operator_id: selectedId === 'external' ? null : selectedId,
+                                custom_operator_name: customName
+                            })
                         })
                         .then(response => {
                             if (!response.ok) throw new Error(response.statusText);

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -260,10 +260,16 @@
                 <div class="dropdown">
                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i class="bi bi-person-fill me-1"></i>
-                        {{ request('operator_filter') ? ($activeOperators->firstWhere('id', request('operator_filter'))->name ?? __('Operator')) : __('Operator') }}
+                        @if(request('operator_filter') == 'external')
+                            ผู้ยื่นภายนอก
+                        @else
+                            {{ request('operator_filter') ? ($activeOperators->firstWhere('id', request('operator_filter'))->name ?? __('Operator')) : __('Operator') }}
+                        @endif
                     </button>
                     <ul class="dropdown-menu" style="max-height: 300px; overflow-y: auto;">
                         <li><a class="dropdown-item" href="{{ route('production.renewal.index', array_merge(request()->query(), ['operator_filter' => null])) }}">{{ __('All Operators') }}</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item {{ request('operator_filter') == 'external' ? 'active' : '' }}" href="{{ route('production.renewal.index', array_merge(request()->query(), ['operator_filter' => 'external'])) }}">ผู้ยื่นภายนอก (พิมพ์ชื่อเอง)</a></li>
                         <li><hr class="dropdown-divider"></li>
                         @foreach($activeOperators as $user)
                             <li><a class="dropdown-item {{ request('operator_filter') == $user->id ? 'active' : '' }}" href="{{ route('production.renewal.index', array_merge(request()->query(), ['operator_filter' => $user->id])) }}">{{ $user->name }}</a></li>
@@ -1498,7 +1504,7 @@
     });
 
     // --- Operator Toggle ---
-    window.toggleOperator = function(employeeId, btn, currentOperatorId, url) {
+    window.toggleOperator = function(employeeId, btn, currentOperatorId, customOperatorName, url) {
         // Fetch operators first
         Swal.fire({
             title: '{{ __("Loading...") }}',
@@ -1513,18 +1519,24 @@
 
                 let operators = data.data;
                 let optionsHtml = `<option value="">-- {{ __("None / Clear Operator") }} --</option>`;
+                optionsHtml += `<option value="external" ${customOperatorName ? 'selected' : ''}>-- ผู้ยื่นภายนอก (พิมพ์ชื่อเอง) --</option>`;
 
                 operators.forEach(op => {
-                    let selected = (op.id == currentOperatorId) ? 'selected' : '';
+                    let selected = (op.id == currentOperatorId && !customOperatorName) ? 'selected' : '';
                     optionsHtml += `<option value="${op.id}" ${selected}>${op.name}</option>`;
                 });
 
                 const htmlContent = `
                     <div class="form-group text-start">
                         <label class="form-label mb-2">{{ __("Select Operator") }}</label>
-                        <select id="operator-select-${employeeId}" class="form-select form-select-lg">
+                        <select id="operator-select-${employeeId}" class="form-select form-select-lg mb-3">
                             ${optionsHtml}
                         </select>
+
+                        <div id="custom-operator-container-${employeeId}" style="display: ${customOperatorName ? 'block' : 'none'};">
+                            <label class="form-label mb-2">ระบุชื่อผู้ดำเนินการภายนอก</label>
+                            <input type="text" id="custom-operator-input-${employeeId}" class="form-control form-control-lg" placeholder="พิมพ์ชื่อผู้ดำเนินการ...">
+                        </div>
                     </div>
                 `;
 
@@ -1538,10 +1550,34 @@
                     cancelButtonText: '{{ __("Cancel") }}',
                     showLoaderOnConfirm: true,
                     didOpen: () => {
-                        // Optional: Initialize Select2 or Choices.js here if needed
+                        const selectEl = document.getElementById(`operator-select-${employeeId}`);
+                        const containerEl = document.getElementById(`custom-operator-container-${employeeId}`);
+                        const input = document.getElementById(`custom-operator-input-${employeeId}`);
+
+                        if (customOperatorName) {
+                            input.value = customOperatorName;
+                        }
+                        selectEl.addEventListener('change', function() {
+                            if (this.value === 'external') {
+                                containerEl.style.display = 'block';
+                                document.getElementById(`custom-operator-input-${employeeId}`).focus();
+                            } else {
+                                containerEl.style.display = 'none';
+                            }
+                        });
                     },
                     preConfirm: () => {
                         const selectedId = document.getElementById(`operator-select-${employeeId}`).value;
+                        let customName = null;
+
+                        if (selectedId === 'external') {
+                            customName = document.getElementById(`custom-operator-input-${employeeId}`).value.trim();
+                            if (!customName) {
+                                Swal.showValidationMessage('กรุณาระบุชื่อผู้ดำเนินการภายนอก');
+                                return false;
+                            }
+                        }
+
                         const fetchUrl = url || `/production/renewal/${employeeId}/toggle-operator`;
 
                         return fetch(fetchUrl, {
@@ -1550,7 +1586,10 @@
                                 'Content-Type': 'application/json',
                                 'X-CSRF-TOKEN': csrfToken
                             },
-                            body: JSON.stringify({ operator_id: selectedId })
+                            body: JSON.stringify({
+                                operator_id: selectedId === 'external' ? null : selectedId,
+                                custom_operator_name: customName
+                            })
                         })
                         .then(response => {
                             if (!response.ok) throw new Error(response.statusText);


### PR DESCRIPTION
This adds the ability to assign custom "External" operators to employees without requiring a system user account. The assignment allows typing a custom name (e.g. พี่เจี๊ยบ) that will be displayed in the UI. Also adds filter support for this feature.

---
*PR created automatically by Jules for task [332368881343457342](https://jules.google.com/task/332368881343457342) started by @nongjossss-commits*