### PR TITLE
Feature: Super Admin Download Profiles & Export Stamping

### DIFF
--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -27,6 +27,9 @@ class DownloadController extends Controller
             'employee_ids' => 'required|array',
             'selected_files' => 'required|array',
             'type' => 'required|in:zip,pdf,zip_single',
+            'stamp_employee_info' => 'nullable|boolean',
+            'stamp_company_info' => 'nullable|boolean',
+            'download_profile_id' => 'nullable|exists:download_profiles,id',
         ]);
 
         // Authorization Logic:
@@ -50,9 +53,15 @@ class DownloadController extends Controller
             'status' => 'pending',
         ]);
 
+        $options = [
+            'stamp_employee_info' => $request->boolean('stamp_employee_info'),
+            'stamp_company_info' => $request->boolean('stamp_company_info'),
+            'download_profile_id' => $request->input('download_profile_id'),
+        ];
+
         // Use dispatchSync to ensure immediate execution, avoiding stuck "pending" tasks
         // if the queue worker is not running.
-        ProcessDownload::dispatchSync($task->id, $authorizedEmployeeIds, $validated['selected_files']);
+        ProcessDownload::dispatchSync($task->id, $authorizedEmployeeIds, $validated['selected_files'], $options);
 
         $task->refresh();
 

--- a/app/Http/Controllers/SuperAdmin/DownloadProfileController.php
+++ b/app/Http/Controllers/SuperAdmin/DownloadProfileController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use App\Models\DownloadProfile;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class DownloadProfileController extends Controller
+{
+    public function index()
+    {
+        $profiles = DownloadProfile::latest()->get();
+        return view('super-admin.download-profiles.index', compact('profiles'));
+    }
+
+    public function create()
+    {
+        return view('super-admin.download-profiles.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'phone_number' => 'nullable|string|max:255',
+            'logo' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
+        ]);
+
+        $data = $request->only(['name', 'phone_number']);
+
+        if ($request->hasFile('logo')) {
+            $data['logo_path'] = $request->file('logo')->store('download_profiles', 'public');
+        }
+
+        DownloadProfile::create($data);
+
+        return redirect()->route('super-admin.download-profiles.index')->with('success', 'Download Profile created successfully.');
+    }
+
+    public function edit(DownloadProfile $downloadProfile)
+    {
+        return view('super-admin.download-profiles.edit', compact('downloadProfile'));
+    }
+
+    public function update(Request $request, DownloadProfile $downloadProfile)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'phone_number' => 'nullable|string|max:255',
+            'logo' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
+        ]);
+
+        $data = $request->only(['name', 'phone_number']);
+
+        if ($request->hasFile('logo')) {
+            // Delete old logo if exists
+            if ($downloadProfile->logo_path) {
+                Storage::disk('public')->delete($downloadProfile->logo_path);
+            }
+            $data['logo_path'] = $request->file('logo')->store('download_profiles', 'public');
+        }
+
+        $downloadProfile->update($data);
+
+        return redirect()->route('super-admin.download-profiles.index')->with('success', 'Download Profile updated successfully.');
+    }
+
+    public function destroy(DownloadProfile $downloadProfile)
+    {
+        if ($downloadProfile->logo_path) {
+            Storage::disk('public')->delete($downloadProfile->logo_path);
+        }
+        $downloadProfile->delete();
+
+        return redirect()->route('super-admin.download-profiles.index')->with('success', 'Download Profile deleted successfully.');
+    }
+}

--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -23,6 +23,8 @@ class ProcessDownload implements ShouldQueue
     protected $taskId;
     protected $employeeIds;
     protected $selectedFiles;
+    protected $options;
+    protected $downloadProfile;
     protected $tempImageFiles = [];
 
     // Map frontend checkbox values to model attributes
@@ -50,11 +52,12 @@ class ProcessDownload implements ShouldQueue
         'other_doc_10' => 'employee_doc_18',
     ];
 
-    public function __construct($taskId, $employeeIds, $selectedFiles)
+    public function __construct($taskId, $employeeIds, $selectedFiles, $options = [])
     {
         $this->taskId = $taskId;
         $this->employeeIds = $employeeIds;
         $this->selectedFiles = $selectedFiles;
+        $this->options = $options;
     }
 
     public function handle()
@@ -67,6 +70,10 @@ class ProcessDownload implements ShouldQueue
         if (!$task) return;
 
         $task->update(['status' => 'processing']);
+
+        if (!empty($this->options['stamp_company_info']) && !empty($this->options['download_profile_id'])) {
+            $this->downloadProfile = \App\Models\DownloadProfile::find($this->options['download_profile_id']);
+        }
 
         try {
             // Check for font files and define font path if needed
@@ -141,6 +148,13 @@ class ProcessDownload implements ShouldQueue
             throw new Exception("Cannot create zip file");
         }
 
+        // Setup font for header text if needed
+        $hasThaiFont = false;
+        $fontDir = defined('FPDF_FONTPATH') ? FPDF_FONTPATH : storage_path('fonts/');
+        if (file_exists($fontDir . 'THSarabunNew.php')) {
+            $hasThaiFont = true;
+        }
+
         foreach ($employees as $employee) {
             // Use English Title + Name if available, per user request
             if (!empty($employee->employeeNameEn)) {
@@ -152,6 +166,15 @@ class ProcessDownload implements ShouldQueue
 
             $safeName = $this->sanitizeFileName($rawName) . '_' . $employee->id;
 
+            // Prepare Header Text (for stamping)
+            if ($hasThaiFont && !empty($employee->employeeNameTh)) {
+                $nameDisplay = @iconv('UTF-8', 'cp874//TRANSLIT', $employee->employeeNameTh);
+            } else {
+                $nameDisplay = $employee->employeeNameEn ?? 'Employee ID: ' . $employee->id;
+                $nameDisplay = preg_replace('/[^\x20-\x7E]/', '', $nameDisplay);
+            }
+            $headerText = $nameDisplay . "   ID: " . $employee->id;
+
             // If singleFolder is true, we use an empty folder name (root),
             // but we might want to prefix the file with the employee name to avoid collisions.
             // If separated, we use the safeName as the folder.
@@ -159,7 +182,7 @@ class ProcessDownload implements ShouldQueue
             $filePrefix = $singleFolder ? $safeName . '_' : '';
 
             foreach ($this->selectedFiles as $fileType) {
-                $this->addFilesToZip($zip, $employee, $fileType, $folderName, $filePrefix);
+                $this->addFilesToZip($zip, $employee, $fileType, $folderName, $filePrefix, $headerText, $hasThaiFont);
             }
         }
 
@@ -167,7 +190,7 @@ class ProcessDownload implements ShouldQueue
         return 'downloads/' . $zipFileName;
     }
 
-    protected function addFilesToZip($zip, $employee, $fileType, $folderName, $filePrefix = '')
+    protected function addFilesToZip($zip, $employee, $fileType, $folderName, $filePrefix = '', $headerText = '', $hasThaiFont = false)
     {
         $attributes = $this->fileMap[$fileType] ?? [];
         if (!is_array($attributes)) {
@@ -178,7 +201,7 @@ class ProcessDownload implements ShouldQueue
             if (!empty($employee->$attr)) {
                 $filePath = $this->getFilePath($employee->$attr);
                 if ($filePath && file_exists($filePath)) {
-                    $ext = pathinfo($filePath, PATHINFO_EXTENSION);
+                    $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
 
                     // Construct the internal path in the zip
                     // If folderName is empty, it goes to root.
@@ -187,7 +210,27 @@ class ProcessDownload implements ShouldQueue
                     $internalPath = ($folderName ? $folderName . '/' : '') .
                                     $filePrefix . $fileType . '_' . basename($filePath);
 
-                    $zip->addFile($filePath, $internalPath);
+                    $shouldStamp = (!empty($this->options['stamp_company_info']) || !empty($this->options['stamp_employee_info']));
+
+                    if ($shouldStamp && in_array($ext, ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'webp'])) {
+                        // Stamp the file and add the stamped version. Note that it returns a PDF.
+                        $stampedFilePath = $this->stampFileForZip($filePath, $headerText, $hasThaiFont);
+                        if ($stampedFilePath) {
+                            // The stamped file is now a PDF, so we should change the extension in the zip path
+                            // if it was an image. If it was already a PDF, it just overwrites.
+                            if ($ext !== 'pdf') {
+                                $internalPath = preg_replace('/\.[^.]+$/', '.pdf', $internalPath);
+                            }
+                            $zip->addFile($stampedFilePath, $internalPath);
+                            // Track for cleanup
+                            $this->tempImageFiles[] = $stampedFilePath;
+                        } else {
+                            // Fallback to original if stamping fails
+                            $zip->addFile($filePath, $internalPath);
+                        }
+                    } else {
+                        $zip->addFile($filePath, $internalPath);
+                    }
                 }
             }
         }
@@ -350,10 +393,60 @@ class ProcessDownload implements ShouldQueue
         $x = $pdf->GetX();
         $y = $pdf->GetY();
 
-        // Draw header at Top Left (10, 5)
-        $pdf->SetXY(10, 5);
         $pdf->SetFont($hasThaiFont ? 'THSarabunNew' : 'Arial', 'B', 14);
-        $pdf->Cell(0, 10, $headerText, 0, 0, 'L');
+
+        // 1. Stamp Company Info (Top Left)
+        if (!empty($this->options['stamp_company_info']) && $this->downloadProfile) {
+            $currentX = 10;
+            $topY = 5;
+
+            // Draw Logo
+            if ($this->downloadProfile->logo_path) {
+                $logoPath = Storage::disk('public')->path($this->downloadProfile->logo_path);
+                if (file_exists($logoPath)) {
+                    // Try to add the logo image. Max height 15mm.
+                    try {
+                        // Image(file, x, y, w, h). If w=0, it's auto-calculated to maintain aspect ratio
+                        $pdf->Image($logoPath, $currentX, $topY, 0, 15);
+
+                        // We need to know the width to offset the text
+                        list($imgW, $imgH) = getimagesize($logoPath);
+                        if ($imgH > 0) {
+                            $ratio = $imgW / $imgH;
+                            $renderedW = 15 * $ratio;
+                            $currentX += $renderedW + 5; // Add 5mm padding
+                        } else {
+                            $currentX += 40; // Fallback spacing
+                        }
+                    } catch (Throwable $e) {
+                        Log::warning("Failed to stamp logo for profile {$this->downloadProfile->id}: " . $e->getMessage());
+                    }
+                }
+            }
+
+            // Draw Company Name and Phone Number
+            $companyText = $this->downloadProfile->name;
+            if ($this->downloadProfile->phone_number) {
+                $companyText .= '  ' . $this->downloadProfile->phone_number;
+            }
+
+            if ($hasThaiFont) {
+                $companyText = @iconv('UTF-8', 'cp874//TRANSLIT', $companyText);
+            }
+
+            // Position for text (centered vertically relative to logo if logo exists, or just top)
+            $textY = $topY + 5; // Approx middle of 15mm
+            $pdf->SetXY($currentX, $textY);
+            $pdf->Cell(0, 10, $companyText, 0, 0, 'L');
+        }
+
+        // 2. Stamp Employee Info (Top Right)
+        if (!empty($this->options['stamp_employee_info']) || !isset($this->options['stamp_employee_info'])) {
+            $pageWidth = $pdf->GetPageWidth();
+            // Position Y=5, align Right, with some margin
+            $pdf->SetXY(10, 5);
+            $pdf->Cell($pageWidth - 20, 10, $headerText, 0, 0, 'R');
+        }
 
         // Restore position
         $pdf->SetXY($x, $y);
@@ -403,6 +496,79 @@ class ProcessDownload implements ShouldQueue
 
         } catch (Throwable $e) {
             Log::error("Image normalization failed for $filePath: " . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Creates a temporary PDF version of an image or modifies an existing PDF to include stamps for ZIP downloads.
+     */
+    protected function stampFileForZip($filePath, $headerText, $hasThaiFont)
+    {
+        try {
+            $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+
+            if (!class_exists(Fpdi::class)) {
+                return null;
+            }
+
+            $pdf = new Fpdi();
+            $pdf->SetAutoPageBreak(false);
+
+            $fontDir = defined('FPDF_FONTPATH') ? FPDF_FONTPATH : storage_path('fonts/');
+            if (file_exists($fontDir . 'THSarabunNew.php')) {
+                $pdf->AddFont('THSarabunNew', '', 'THSarabunNew.php');
+                $pdf->AddFont('THSarabunNew', 'B', 'THSarabunNew-Bold.php');
+            }
+
+            if ($ext === 'pdf') {
+                $pageCount = $pdf->setSourceFile($filePath);
+                for ($i = 1; $i <= $pageCount; $i++) {
+                    $tplIdx = $pdf->importPage($i);
+                    $size = $pdf->getTemplateSize($tplIdx);
+                    $pdf->AddPage($size['orientation'], [$size['width'], $size['height']]);
+                    $pdf->useTemplate($tplIdx);
+                    $this->drawHeader($pdf, $headerText, $hasThaiFont);
+                }
+            } else {
+                // It's an image. Normalize it first
+                $normalizedPath = $this->normalizeImage($filePath);
+                if (!$normalizedPath) return null;
+
+                $this->tempImageFiles[] = $normalizedPath;
+
+                $pdf->AddPage();
+                $pageW = 210;
+                $pageH = 297;
+                $margin = 10;
+                $topMargin = 15;
+                $writableW = $pageW - ($margin * 2);
+                $writableH = $pageH - ($margin + $topMargin);
+
+                list($imgW, $imgH) = getimagesize($normalizedPath);
+                $ratio = $imgW / $imgH;
+
+                if ($writableW / $writableH > $ratio) {
+                   $newH = $writableH;
+                   $newW = $writableH * $ratio;
+                } else {
+                   $newW = $writableW;
+                   $newH = $writableW / $ratio;
+                }
+
+                $x = ($pageW - $newW) / 2;
+                $y = $topMargin + ($writableH - $newH) / 2;
+
+                $pdf->Image($normalizedPath, $x, $y, $newW, $newH);
+                $this->drawHeader($pdf, $headerText, $hasThaiFont);
+            }
+
+            $tempPath = tempnam(sys_get_temp_dir(), 'stamped_') . '.pdf';
+            $pdf->Output('F', $tempPath);
+            return $tempPath;
+
+        } catch (Throwable $e) {
+            Log::error("File stamping for ZIP failed ($filePath): " . $e->getMessage());
             return null;
         }
     }

--- a/app/Models/DownloadProfile.php
+++ b/app/Models/DownloadProfile.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DownloadProfile extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'phone_number',
+        'logo_path',
+    ];
+}

--- a/database/migrations/2026_03_22_161704_create_download_profiles_table.php
+++ b/database/migrations/2026_03_22_161704_create_download_profiles_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('download_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('phone_number')->nullable();
+            $table->string('logo_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('download_profiles');
+    }
+};

--- a/resources/views/components/download-modals.blade.php
+++ b/resources/views/components/download-modals.blade.php
@@ -35,6 +35,34 @@
 
                     <hr>
 
+                    <!-- Download Profiles / Stamping Options -->
+                    @php
+                        $downloadProfiles = \App\Models\DownloadProfile::all();
+                    @endphp
+                    <div class="mb-3 p-3 bg-light border rounded">
+                        <h6 class="fw-bold mb-3"><i class="bi bi-printer"></i> Document Stamping Options</h6>
+
+                        <div class="form-check form-switch mb-2">
+                            <input class="form-check-input" type="checkbox" id="stampEmployeeInfo" name="stamp_employee_info" value="1" checked>
+                            <label class="form-check-label" for="stampEmployeeInfo">Stamp Employee Name & ID (Top Right)</label>
+                        </div>
+
+                        <div class="form-check form-switch mb-2">
+                            <input class="form-check-input" type="checkbox" id="stampCompanyInfo" name="stamp_company_info" value="1">
+                            <label class="form-check-label" for="stampCompanyInfo">Stamp Company Info & Logo (Top Left)</label>
+                        </div>
+
+                        <div class="mt-2 ms-4" id="downloadProfileSelectContainer" style="display: none;">
+                            <label for="downloadProfileId" class="form-label small text-muted">Select Company Profile:</label>
+                            <select class="form-select form-select-sm" id="downloadProfileId" name="download_profile_id">
+                                <option value="">-- No Profile Selected --</option>
+                                @foreach($downloadProfiles as $profile)
+                                    <option value="{{ $profile->id }}">{{ $profile->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+
                     <div class="mb-3">
                         <label class="form-label fw-bold">Select Files to Include</label>
                         <div class="row">
@@ -211,14 +239,39 @@ document.addEventListener('DOMContentLoaded', function() {
             downloadModal.show();
         };
 
+        // --- 1.5 Handle Download Profile Toggle ---
+        const stampCompanyInfoCheckbox = document.getElementById('stampCompanyInfo');
+        const profileSelectContainer = document.getElementById('downloadProfileSelectContainer');
+        const downloadProfileSelect = document.getElementById('downloadProfileId');
+
+        if (stampCompanyInfoCheckbox) {
+            stampCompanyInfoCheckbox.addEventListener('change', function() {
+                if (this.checked) {
+                    profileSelectContainer.style.display = 'block';
+                } else {
+                    profileSelectContainer.style.display = 'none';
+                    downloadProfileSelect.value = ''; // Reset selection
+                }
+            });
+        }
+
         // --- 2. Handle Confirm Download ---
         document.getElementById('btnConfirmDownload').addEventListener('click', function() {
             const type = document.querySelector('input[name="download_type"]:checked').value;
             const files = Array.from(document.querySelectorAll('input[name="files[]"]:checked')).map(cb => cb.value);
             const empIds = JSON.parse(document.getElementById('downloadEmployeeIds').value || '[]');
 
+            const stampEmployeeInfo = document.getElementById('stampEmployeeInfo').checked;
+            const stampCompanyInfo = document.getElementById('stampCompanyInfo').checked;
+            const downloadProfileId = document.getElementById('downloadProfileId').value;
+
             if (files.length === 0) {
                 showToast('Please select at least one file type.', 'danger');
+                return;
+            }
+
+            if (stampCompanyInfo && !downloadProfileId) {
+                showToast('Please select a company profile to stamp.', 'danger');
                 return;
             }
 
@@ -235,7 +288,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 body: JSON.stringify({
                     employee_ids: empIds,
                     selected_files: files,
-                    type: type
+                    type: type,
+                    stamp_employee_info: stampEmployeeInfo,
+                    stamp_company_info: stampCompanyInfo,
+                    download_profile_id: stampCompanyInfo ? downloadProfileId : null
                 })
             })
             .then(res => res.json())

--- a/resources/views/partials/sidebar-menu.blade.php
+++ b/resources/views/partials/sidebar-menu.blade.php
@@ -189,4 +189,8 @@
     <i class="bi bi-gear-fill me-2"></i>
     {{ __('Super Admin Settings') }}
 </a>
+<a class="list-group-item list-group-item-action {{ request()->routeIs('super-admin.download-profiles.*') ? 'active' : '' }}" href="{{ route('super-admin.download-profiles.index') }}">
+    <i class="bi bi-file-earmark-arrow-down-fill me-2"></i>
+    {{ __('Download Profiles') }}
+</a>
 @endrole

--- a/resources/views/super-admin/download-profiles/create.blade.php
+++ b/resources/views/super-admin/download-profiles/create.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="mb-4">
+        <a href="{{ route('super-admin.download-profiles.index') }}" class="text-decoration-none">
+            <i class="bi bi-arrow-left"></i> Back to Profiles
+        </a>
+    </div>
+
+    <div class="card shadow-sm max-w-lg mx-auto" style="max-width: 600px;">
+        <div class="card-header bg-primary text-white">
+            <h5 class="card-title mb-0">Create Download Profile</h5>
+        </div>
+        <div class="card-body">
+            <form action="{{ route('super-admin.download-profiles.store') }}" method="POST" enctype="multipart/form-data">
+                @csrf
+
+                <div class="mb-3">
+                    <label for="name" class="form-label fw-bold">Company / Office Name <span class="text-danger">*</span></label>
+                    <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name') }}" required>
+                    @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                </div>
+
+                <div class="mb-3">
+                    <label for="phone_number" class="form-label fw-bold">Phone Number</label>
+                    <input type="text" class="form-control @error('phone_number') is-invalid @enderror" id="phone_number" name="phone_number" value="{{ old('phone_number') }}">
+                    @error('phone_number') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="logo" class="form-label fw-bold">Company Logo</label>
+                    <input class="form-control @error('logo') is-invalid @enderror" type="file" id="logo" name="logo" accept="image/jpeg,image/png,image/jpg,image/webp">
+                    <div class="form-text">Recommended height is about 1-1.5 cm for best PDF layout results. Maximum file size: 2MB.</div>
+                    @error('logo') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                </div>
+
+                <div class="d-grid">
+                    <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Save Profile</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/super-admin/download-profiles/edit.blade.php
+++ b/resources/views/super-admin/download-profiles/edit.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="mb-4">
+        <a href="{{ route('super-admin.download-profiles.index') }}" class="text-decoration-none">
+            <i class="bi bi-arrow-left"></i> Back to Profiles
+        </a>
+    </div>
+
+    <div class="card shadow-sm max-w-lg mx-auto" style="max-width: 600px;">
+        <div class="card-header bg-primary text-white">
+            <h5 class="card-title mb-0">Edit Download Profile</h5>
+        </div>
+        <div class="card-body">
+            <form action="{{ route('super-admin.download-profiles.update', $downloadProfile->id) }}" method="POST" enctype="multipart/form-data">
+                @csrf
+                @method('PUT')
+
+                <div class="mb-3">
+                    <label for="name" class="form-label fw-bold">Company / Office Name <span class="text-danger">*</span></label>
+                    <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name', $downloadProfile->name) }}" required>
+                    @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                </div>
+
+                <div class="mb-3">
+                    <label for="phone_number" class="form-label fw-bold">Phone Number</label>
+                    <input type="text" class="form-control @error('phone_number') is-invalid @enderror" id="phone_number" name="phone_number" value="{{ old('phone_number', $downloadProfile->phone_number) }}">
+                    @error('phone_number') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="logo" class="form-label fw-bold">Company Logo</label>
+                    @if($downloadProfile->logo_path)
+                        <div class="mb-2">
+                            <img src="{{ Storage::url($downloadProfile->logo_path) }}" alt="Current Logo" class="img-thumbnail" style="max-height: 100px;">
+                        </div>
+                        <div class="form-text text-muted mb-2">Upload a new image below to replace the current logo.</div>
+                    @endif
+                    <input class="form-control @error('logo') is-invalid @enderror" type="file" id="logo" name="logo" accept="image/jpeg,image/png,image/jpg,image/webp">
+                    <div class="form-text">Recommended height is about 1-1.5 cm for best PDF layout results. Maximum file size: 2MB.</div>
+                    @error('logo') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                </div>
+
+                <div class="d-grid">
+                    <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Update Profile</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/super-admin/download-profiles/index.blade.php
+++ b/resources/views/super-admin/download-profiles/index.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3">Download Profiles</h1>
+        <a href="{{ route('super-admin.download-profiles.create') }}" class="btn btn-primary"><i class="bi bi-plus-lg"></i> Create New Profile</a>
+    </div>
+
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    <div class="card">
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover align-middle">
+                    <thead class="table-dark">
+                        <tr>
+                            <th>Logo</th>
+                            <th>Company/Office Name</th>
+                            <th>Phone Number</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($profiles as $profile)
+                            <tr>
+                                <td>
+                                    @if($profile->logo_path)
+                                        <img src="{{ Storage::url($profile->logo_path) }}" alt="Logo" style="height: 40px; max-width: 100px; object-fit: contain;">
+                                    @else
+                                        <span class="text-muted small">No Logo</span>
+                                    @endif
+                                </td>
+                                <td class="fw-bold">{{ $profile->name }}</td>
+                                <td>{{ $profile->phone_number ?: '-' }}</td>
+                                <td class="text-end">
+                                    <a href="{{ route('super-admin.download-profiles.edit', $profile->id) }}" class="btn btn-sm btn-outline-primary">
+                                        <i class="bi bi-pencil-fill"></i> Edit
+                                    </a>
+                                    <form action="{{ route('super-admin.download-profiles.destroy', $profile->id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this profile?');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">
+                                            <i class="bi bi-trash-fill"></i> Delete
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4" class="text-center text-muted">No download profiles found.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,12 +22,15 @@ use App\Http\Controllers\PreviewController;
 use App\Http\Controllers\ChatController;
 use App\Http\Controllers\FinancialController; // Import
 use App\Http\Controllers\SuperAdmin\SettingsController as SuperAdminSettingsController;
+use App\Http\Controllers\SuperAdmin\DownloadProfileController;
 
 Route::middleware(['auth', 'role:super-admin'])->prefix('super-admin')->name('super-admin.')->group(function () {
     Route::get('/settings', [SuperAdminSettingsController::class, 'index'])->name('settings.index');
     Route::post('/settings', [SuperAdminSettingsController::class, 'update'])->name('settings.update');
     Route::post('/settings/visibility', [SuperAdminSettingsController::class, 'updateVisibility'])->name('settings.update-visibility');
     Route::get('/sidebar', [SuperAdminSettingsController::class, 'renderSidebar'])->name('sidebar');
+
+    Route::resource('download-profiles', DownloadProfileController::class)->except(['show']);
 });
 
 // Menu Unlock Routes (Publicly accessible for auth users)


### PR DESCRIPTION
Adds the ability for Super Admins to manage 'Download Profiles' consisting of a company name, phone number, and a logo. Users can now conditionally apply these stamps (along with the employee's name and ID) to all exported files, including both Single PDFs and ZIP exports. For ZIP exports, images are dynamically rendered to A4 PDFs with the selected headers before being compressed.

---
*PR created automatically by Jules for task [9157227011936541476](https://jules.google.com/task/9157227011936541476) started by @nongjossss-commits*