### PR TITLE
Fix gibberish Thai text in downloaded PDF header

### DIFF
--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -258,7 +258,6 @@ class ProcessDownload implements ShouldQueue
 
             if (file_exists($fontDir . 'THSarabunNew.php')) {
                 $pdf->AddFont('THSarabunNew', '', 'THSarabunNew.php');
-                $pdf->AddFont('THSarabunNew', 'B', 'THSarabunNew-Bold.php'); // Assuming bold exists too if main does
                 $hasThaiFont = true;
             }
 
@@ -396,10 +395,10 @@ class ProcessDownload implements ShouldQueue
         // Always try to use THSarabunNew if possible since we force iconv to cp874 later.
         // FPDF handles missing font gracefully or throws error. We assume THSarabunNew is setup.
         try {
-             $pdf->SetFont('THSarabunNew', 'B', 14);
+             $pdf->SetFont('THSarabunNew', '', 14);
              $hasThaiFont = true;
         } catch (Throwable $e) {
-             $pdf->SetFont($hasThaiFont ? 'THSarabunNew' : 'Arial', 'B', 14);
+             $pdf->SetFont($hasThaiFont ? 'THSarabunNew' : 'Arial', '', 14);
         }
 
         // 1. Stamp Company Info (Top Left)
@@ -526,7 +525,6 @@ class ProcessDownload implements ShouldQueue
             $fontDir = defined('FPDF_FONTPATH') ? FPDF_FONTPATH : storage_path('fonts/');
             if (file_exists($fontDir . 'THSarabunNew.php')) {
                 $pdf->AddFont('THSarabunNew', '', 'THSarabunNew.php');
-                $pdf->AddFont('THSarabunNew', 'B', 'THSarabunNew-Bold.php');
             }
 
             if ($ext === 'pdf') {


### PR DESCRIPTION
This resolves the issue where Thai text (specifically the company name at the top of the document) displayed as gibberish when downloading documents. 

The cause was that the code was trying to load and use a bold variant of the `THSarabunNew` font, which was missing from the server. Because the bold font file couldn't be loaded, FPDF would throw an error and try to fallback. In the fallback, it would still attempt to use the bold style, ultimately defaulting to `Arial` (which does not support the Thai `cp874` charset), leading to gibberish text output like `ºÃÔÉÑ·...`.

By modifying `app/Jobs/ProcessDownload.php` to use the standard (non-bold) variant of `THSarabunNew`, the text will now render properly in the PDF headers without crashing or falling back.

---
*PR created automatically by Jules for task [7763113854658067582](https://jules.google.com/task/7763113854658067582) started by @nongjossss-commits*