### PR TITLE
Fix employee other documents description not saving

### DIFF
--- a/resources/views/employees/partials/_edit_form.blade.php
+++ b/resources/views/employees/partials/_edit_form.blade.php
@@ -475,7 +475,7 @@
                     :label="$i . '. ' . $label"
                     :value="$employee->{$docField}"
                     :pdfRoute="route('employees.documents.pdf', ['employee' => $employee->id, 'field' => $docField])"
-                    :description="in_array($i, $descSlots) ? 'edit_' . $descField : null"
+                    :description="in_array($i, $descSlots) ? $descField : null"
                     :descriptionValue="in_array($i, $descSlots) ? $employee->{$descField} : null"
                 />
             </div>

--- a/resources/views/tickets/partials/_new_employee_preview_modal.blade.php
+++ b/resources/views/tickets/partials/_new_employee_preview_modal.blade.php
@@ -316,6 +316,12 @@
             'employee_doc_10': 'เอกสารอื่นๆ 2',
             'employee_doc_11': 'เอกสารอื่นๆ 3',
             'employee_doc_12': 'เอกสารอื่นๆ 4',
+            'employee_doc_13': 'เอกสารอื่นๆ 5',
+            'employee_doc_14': 'เอกสารอื่นๆ 6',
+            'employee_doc_15': 'เอกสารอื่นๆ 7',
+            'employee_doc_16': 'เอกสารอื่นๆ 8',
+            'employee_doc_17': 'เอกสารอื่นๆ 9',
+            'employee_doc_18': 'เอกสารอื่นๆ 10',
             'insurance_document_path_social': 'เอกสารประกันสังคม',
             'insurance_document_path_hospital': 'เอกสารประกัน รพ.',
             'insurance_document_path_private': 'เอกสารประกันเอกชน'
@@ -332,6 +338,12 @@
                 if (key === 'employee_doc_10' && data.other_doc_2_desc) displayLabel += ': ' + data.other_doc_2_desc;
                 if (key === 'employee_doc_11' && data.other_doc_3_desc) displayLabel += ': ' + data.other_doc_3_desc;
                 if (key === 'employee_doc_12' && data.other_doc_4_desc) displayLabel += ': ' + data.other_doc_4_desc;
+                if (key === 'employee_doc_13' && data.other_doc_5_desc) displayLabel += ': ' + data.other_doc_5_desc;
+                if (key === 'employee_doc_14' && data.other_doc_6_desc) displayLabel += ': ' + data.other_doc_6_desc;
+                if (key === 'employee_doc_15' && data.other_doc_7_desc) displayLabel += ': ' + data.other_doc_7_desc;
+                if (key === 'employee_doc_16' && data.other_doc_8_desc) displayLabel += ': ' + data.other_doc_8_desc;
+                if (key === 'employee_doc_17' && data.other_doc_9_desc) displayLabel += ': ' + data.other_doc_9_desc;
+                if (key === 'employee_doc_18' && data.other_doc_10_desc) displayLabel += ': ' + data.other_doc_10_desc;
 
 
                 const col = document.createElement('div');


### PR DESCRIPTION
This PR fixes a bug in the employee editing form where custom descriptions for "Other Documents 1-10" (เอกสารอื่นๆ 1-10) were not being saved. The input names were incorrectly prefixed with `edit_` (e.g., `edit_other_doc_1_desc`), which caused the backend to ignore them. Removing the prefix fixes the issue. It also updates the new employee ticket preview modal to display descriptions up to document 10.

---
*PR created automatically by Jules for task [6315798837178319985](https://jules.google.com/task/6315798837178319985) started by @nongjossss-commits*