### PR TITLE
Retain employee photo image formats in ZIP downloads

### DIFF
--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -213,7 +213,7 @@ class ProcessDownload implements ShouldQueue
 
                     $shouldStamp = (!empty($this->options['stamp_company_info']) || !empty($this->options['stamp_employee_info']));
 
-                    if ($shouldStamp && in_array($ext, ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'webp'])) {
+                    if ($shouldStamp && $fileType !== 'photo' && in_array($ext, ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'webp'])) {
                         // Stamp the file and add the stamped version. Note that it returns a PDF.
                         $stampedFilePath = $this->stampFileForZip($filePath, $employee, $hasThaiFont);
                         if ($stampedFilePath) {


### PR DESCRIPTION
Fixes an issue where employee profile photos were being converted to PDFs when downloaded using the ZIP modes (separate folders/single folder) during an Advanced Download. Now, photos will be kept as raw image files, but other images or documents will still receive stamps and be converted as expected.

---
*PR created automatically by Jules for task [6934636023282725030](https://jules.google.com/task/6934636023282725030) started by @nongjossss-commits*