### PR TITLE
Fix GPS navigation and highlighting for employee status badges

### DIFF
--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -1786,14 +1786,29 @@
         const targetOrderId = urlParams.get('order');
         const targetItemId = urlParams.get('item');
         const highlightEmployeeId = urlParams.get('highlight_employee_id');
+        const highlightEmployerId = urlParams.get('highlight_employer_id');
 
-        if (targetOrderId && targetItemId) {
-            const orderHeading = document.getElementById('heading-' + targetOrderId);
-            const collapseElement = document.getElementById('collapse-' + targetOrderId);
+        // Note: Production index uses order_id to expand accordions.
+        // We will fallback to highlighting by employer id if passed and order is missing.
+        let actualOrderId = targetOrderId;
+        if (!actualOrderId && highlightEmployerId) {
+             const collapseEls = document.querySelectorAll('.accordion-collapse');
+             collapseEls.forEach(el => {
+                  if (el.getAttribute('data-employer-id') === highlightEmployerId) {
+                      actualOrderId = el.id.replace('collapse-', '');
+                  }
+             });
+        }
+
+        if (actualOrderId && (targetItemId || highlightEmployeeId)) {
+            const orderHeading = document.getElementById('heading-' + actualOrderId);
+            const collapseElement = document.getElementById('collapse-' + actualOrderId);
 
             if (orderHeading && collapseElement) {
                 // Scroll to Order
-                orderHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                setTimeout(() => {
+                    orderHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }, 100);
 
                 // Check if collapsed
                 if (!collapseElement.classList.contains('show')) {
@@ -1836,7 +1851,7 @@
                 });
 
                 // Start observing the content wrapper
-                const contentWrapper = document.getElementById('order-content-' + targetOrderId);
+                const contentWrapper = document.getElementById('order-content-' + actualOrderId);
                 if (contentWrapper) {
                     observer.observe(contentWrapper, { childList: true, subtree: true });
 

--- a/resources/views/production/registration/index.blade.php
+++ b/resources/views/production/registration/index.blade.php
@@ -2870,7 +2870,9 @@
 
             if (collapseEl && employerHeading) {
                 // Scroll to Employer
-                employerHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                setTimeout(() => {
+                    employerHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }, 100);
 
                 // Check if collapsed
                 if (!collapseEl.classList.contains('show')) {

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -2726,7 +2726,9 @@
 
             if (collapseEl && employerHeading) {
                 // Scroll to Employer
-                employerHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                setTimeout(() => {
+                    employerHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }, 100);
 
                 // Check if collapsed
                 if (!collapseEl.classList.contains('show')) {

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -1826,14 +1826,29 @@ window.loadBatchStats = function() {
         const targetOrderId = urlParams.get('order');
         const targetItemId = urlParams.get('item');
         const highlightEmployeeId = urlParams.get('highlight_employee_id');
+        const highlightEmployerId = urlParams.get('highlight_employer_id');
 
-        if (targetOrderId && targetItemId) {
-            const orderHeading = document.getElementById('heading-' + targetOrderId);
-            const collapseElement = document.getElementById('collapse-' + targetOrderId);
+        // Note: Workflow index uses order_id to expand accordions.
+        // We will fallback to highlighting by employer id if passed and order is missing.
+        let actualOrderId = targetOrderId;
+        if (!actualOrderId && highlightEmployerId) {
+             const collapseEls = document.querySelectorAll('.accordion-collapse');
+             collapseEls.forEach(el => {
+                  if (el.getAttribute('data-employer-id') === highlightEmployerId) {
+                      actualOrderId = el.id.replace('collapse-', '');
+                  }
+             });
+        }
+
+        if (actualOrderId && (targetItemId || highlightEmployeeId)) {
+            const orderHeading = document.getElementById('heading-' + actualOrderId);
+            const collapseElement = document.getElementById('collapse-' + actualOrderId);
 
             if (orderHeading && collapseElement) {
                 // Scroll to Order
-                orderHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                setTimeout(() => {
+                    orderHeading.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }, 100);
 
                 // Check if collapsed
                 if (!collapseElement.classList.contains('show')) {
@@ -1876,7 +1891,7 @@ window.loadBatchStats = function() {
                 });
 
                 // Start observing the content wrapper
-                const contentWrapper = document.getElementById('order-content-' + targetOrderId);
+                const contentWrapper = document.getElementById('order-content-' + actualOrderId);
                 if (contentWrapper) {
                     observer.observe(contentWrapper, { childList: true, subtree: true });
 

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Fixes the issue where clicking on employee workflow/status badges properly redirects to the right page but fails to correctly expand the employer's section, scroll to the employee, and highlight it. By updating the frontend logic on Registration, Renewal, Pre-Production, and Workflow to properly parse query parameters and delay initial scroll logic until DOM stabilization, the "GPS navigation" features now work as intended.

---
*PR created automatically by Jules for task [7212148148745976382](https://jules.google.com/task/7212148148745976382) started by @nongjossss-commits*