### PR TITLE
feat: Implement Read and Sale CRM module and update Finance sidebar menu

### DIFF
--- a/app/Http/Controllers/Sales/SalesLeadImportController.php
+++ b/app/Http/Controllers/Sales/SalesLeadImportController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Sales;
+
+use App\Models\SalesLead;
+use App\Models\SalesLeadEmployee;
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Shared\Date;
+
+class SalesLeadImportController extends Controller
+{
+    public function importExcel(Request $request, SalesLead $sales)
+    {
+        $request->validate([
+            'excel_file' => 'required|file|mimes:xlsx,xls'
+        ]);
+
+        try {
+            $file = $request->file('excel_file');
+            $spreadsheet = IOFactory::load($file->getPathname());
+            $worksheet = $spreadsheet->getActiveSheet();
+            $rows = $worksheet->toArray();
+
+            // Expected Columns:
+            // 0: NO.
+            // 1: Name En
+            // 2: Name Th
+            // 3: Gender
+            // 4: Nationality
+            // 5: Passport
+            // 6: Work Permit
+
+            $importedCount = 0;
+            // Skip header (row 0)
+            for ($i = 1; $i < count($rows); $i++) {
+                $row = $rows[$i];
+
+                // Name EN is mandatory as per business rule for temporary lead
+                $nameEn = $row[1] ?? null;
+                if (empty($nameEn)) {
+                    continue; // Skip rows without name
+                }
+
+                SalesLeadEmployee::create([
+                    'sales_lead_id' => $sales->id,
+                    'employeeNameEn' => $nameEn,
+                    'employeeNameTh' => $row[2] ?? null,
+                    'employeeGender' => $row[3] ?? null,
+                    'employeeNationality' => $row[4] ?? null,
+                    'employeePassport' => $row[5] ?? null,
+                    'employeeWorkPermit' => $row[6] ?? null,
+                ]);
+
+                $importedCount++;
+            }
+
+            return redirect()->back()->with('success', "นำเข้าข้อมูลลูกจ้างสำเร็จ {$importedCount} รายการ");
+        } catch (\Exception $e) {
+            return redirect()->back()->with('error', 'เกิดข้อผิดพลาดในการอ่านไฟล์ Excel: ' . $e->getMessage());
+        }
+    }
+}

--- a/app/Http/Controllers/SalesLeadController.php
+++ b/app/Http/Controllers/SalesLeadController.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\SalesLead;
+use App\Models\SalesLeadEmployee;
+use App\Models\Employer;
+use App\Models\Employee;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use App\Models\FinancialProfile;
+
+class SalesLeadController extends Controller
+{
+    public function index()
+    {
+        $leads = SalesLead::with(['employees', 'employer', 'quotation'])->orderBy('updated_at', 'desc')->get();
+        $employers = Employer::all(['id', 'employerNameTh', 'employerNameEn', 'employerTaxId']);
+
+        $quoted = $leads->where('status', 'quoted');
+        $deciding = $leads->where('status', 'deciding');
+        $confirmed = $leads->where('status', 'confirmed');
+        $history = SalesLead::onlyTrashed()->with(['employees', 'employer'])->orderBy('deleted_at', 'desc')->get()
+                            ->merge($leads->whereIn('status', ['transitioned', 'cancelled']));
+
+        // Get profiles for quotation
+        $financialProfiles = FinancialProfile::where('is_active', true)->get();
+
+        return view('sales.index', compact('quoted', 'deciding', 'confirmed', 'history', 'employers', 'financialProfiles'));
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'employer_id' => 'nullable|exists:employers,id',
+            'employerNameTh' => 'required_without:employer_id|string|max:255|nullable',
+            'employerNameEn' => 'nullable|string|max:255',
+            'employerTaxId' => 'nullable|string|max:255',
+            'employerPhone' => 'nullable|string|max:255',
+            'jobOwner' => 'nullable|string|max:255',
+        ]);
+
+        if ($request->filled('employer_id')) {
+            $employer = Employer::find($request->employer_id);
+            $validated['employerNameTh'] = $employer->employerNameTh;
+            $validated['employerNameEn'] = $employer->employerNameEn;
+            $validated['employerTaxId'] = $employer->employerTaxId;
+            $validated['employerPhone'] = $employer->employerPhone;
+            $validated['jobOwner'] = $employer->jobOwner ? $employer->jobOwner->name_th : null;
+        } else {
+            // Temporary ID logic
+            $validated['employerId'] = 'SL-EMP-' . strtoupper(uniqid());
+        }
+
+        $validated['status'] = 'quoted';
+        $validated['created_by'] = auth()->id();
+
+        SalesLead::create($validated);
+
+        return redirect()->route('sales.index')->with('success', 'สร้างรายการเสนอราคาสำเร็จ');
+    }
+
+    public function updateStatus(Request $request, SalesLead $sales)
+    {
+        $request->validate([
+            'status' => 'required|in:quoted,deciding,confirmed,transitioned,cancelled'
+        ]);
+
+        $sales->status = $request->status;
+        if ($request->status === 'confirmed') {
+            $sales->confirmed_by = auth()->id();
+        }
+        $sales->save();
+
+        if ($request->wantsJson()) {
+            return response()->json(['success' => true]);
+        }
+
+        return redirect()->back()->with('success', 'อัปเดตสถานะสำเร็จ');
+    }
+
+    public function destroy(SalesLead $sales)
+    {
+        $sales->status = 'cancelled';
+        $sales->save();
+        $sales->delete(); // Soft delete for history
+        return redirect()->back()->with('success', 'ย้ายไปประวัติแล้ว');
+    }
+
+    public function restore($id)
+    {
+        $sales = SalesLead::withTrashed()->findOrFail($id);
+        $sales->restore();
+        $sales->status = 'quoted'; // Reset to initial state
+        $sales->save();
+        return redirect()->back()->with('success', 'กู้คืนรายการสำเร็จ');
+    }
+
+    // --- Employee Management within Sales Lead ---
+
+    public function storeEmployee(Request $request, SalesLead $sales)
+    {
+        $validated = $request->validate([
+            'employee_id' => 'nullable|exists:employees,id',
+            'employeeNameEn' => 'required_without:employee_id|string|max:255|nullable',
+            'employeeNameTh' => 'nullable|string|max:255',
+            'employeeGender' => 'nullable|string',
+            'employeePassport' => 'nullable|string',
+            'employeeWorkPermit' => 'nullable|string',
+            'photo' => 'nullable|image|max:5120',
+            'document' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+        ]);
+
+        $validated['sales_lead_id'] = $sales->id;
+
+        if ($request->filled('employee_id')) {
+            $employee = Employee::find($request->employee_id);
+            $validated['employeeNameEn'] = $employee->employeeNameEn;
+            $validated['employeeNameTh'] = $employee->employeeNameTh;
+            $validated['employeeGender'] = $employee->employeeGender;
+            $validated['employeePassport'] = $employee->employeePassport;
+            $validated['employeeWorkPermit'] = $employee->employeeWorkPermit;
+        }
+
+        // Handle file uploads
+        if ($request->hasFile('photo')) {
+            $validated['photo_path'] = $request->file('photo')->store('sales_lead_employees/photos', 'public');
+        }
+        if ($request->hasFile('document')) {
+            $validated['document_path'] = $request->file('document')->store('sales_lead_employees/documents', 'public');
+        }
+
+        SalesLeadEmployee::create($validated);
+
+        return redirect()->back()->with('success', 'เพิ่มลูกจ้างสำเร็จ');
+    }
+
+    public function destroyEmployee(SalesLead $sales, SalesLeadEmployee $employee)
+    {
+        $employee->delete();
+        return redirect()->back()->with('success', 'ลบลูกจ้างสำเร็จ');
+    }
+
+    // --- Quotation ---
+    public function storeQuotation(Request $request, SalesLead $sales)
+    {
+        $validated = $request->validate([
+            'financial_profile_id' => 'required|exists:financial_profiles,id',
+            'quotation_date' => 'required|date',
+            'payment_terms' => 'nullable|string',
+            'items' => 'required|array|min:1',
+            'items.*.description' => 'required|string',
+            'items.*.qty' => 'required|numeric|min:1',
+            'items.*.price' => 'required|numeric|min:0',
+        ]);
+
+        $grandTotal = 0;
+        $itemsData = [];
+        foreach ($request->items as $item) {
+            $qty = $item['qty'] ?? 1;
+            $price = $item['price'] ?? 0;
+            $total = $qty * $price;
+            $grandTotal += $total;
+
+            $itemsData[] = [
+                'description' => $item['description'],
+                'qty' => $qty,
+                'price' => $price,
+                'total' => $total,
+            ];
+        }
+
+        $sales->quotation()->updateOrCreate(
+            ['sales_lead_id' => $sales->id],
+            [
+                'financial_profile_id' => $validated['financial_profile_id'],
+                'quotation_date' => $validated['quotation_date'],
+                'payment_terms' => $validated['payment_terms'] ?? null,
+                'grand_total' => $grandTotal,
+                'items_data' => $itemsData,
+            ]
+        );
+
+        return redirect()->back()->with('success', 'บันทึกใบเสนอราคาสำเร็จ');
+    }
+
+    // --- Transition to Production/Workflow ---
+
+    public function transition(Request $request, SalesLead $sales)
+    {
+        $request->validate([
+            'destination' => 'required|string', // e.g. 'production.registration', 'production.renewal', 'workflow.notify_out'
+        ]);
+
+        DB::beginTransaction();
+        try {
+            // 1. Create Real Employer if it doesn't exist
+            $realEmployer = null;
+            if ($sales->employer_id) {
+                $realEmployer = Employer::find($sales->employer_id);
+            } else {
+                // Must generate a real employerId that satisfies constraints (EMP-REG-XXX etc.)
+                $lastEmployer = Employer::orderBy('id', 'desc')->first();
+                $nextId = $lastEmployer ? $lastEmployer->id + 1 : 1;
+                $employerId = 'EMP-SL-' . str_pad($nextId, 4, '0', STR_PAD_LEFT);
+
+                $realEmployer = Employer::create([
+                    'employerId' => $employerId,
+                    'employerNameTh' => $sales->employerNameTh,
+                    'employerNameEn' => $sales->employerNameEn,
+                    'employerTaxId' => $sales->employerTaxId,
+                    'employerPhone' => $sales->employerPhone,
+                    // Add other defaults as necessary
+                ]);
+                $sales->employer_id = $realEmployer->id;
+                $sales->save();
+            }
+
+            // 2. Create Real Employees
+            $realEmployeeIds = [];
+            foreach ($sales->employees as $slEmp) {
+                if ($slEmp->employee_id) {
+                    $realEmployeeIds[] = $slEmp->employee_id;
+                } else {
+                    $newEmp = Employee::create([
+                        'employer_id' => $realEmployer->id,
+                        'employeeNameEn' => $slEmp->employeeNameEn,
+                        'employeeNameTh' => $slEmp->employeeNameTh,
+                        'employeeGender' => $slEmp->employeeGender ?? 'Not Specified',
+                        'employeePassport' => $slEmp->employeePassport,
+                        'employeeWorkPermit' => $slEmp->employeeWorkPermit,
+                        'status' => 'active', // Default status
+                    ]);
+
+                    // Handle transferring files to the real employee record
+                    // using Spatie Media Library or simple path updates depending on the system implementation.
+                    // For now, we update the path references on the real employee model if it supports it,
+                    // or just keep them in storage. The main system usually uses Media Library for Employees.
+                    if ($slEmp->photo_path) {
+                        // $newEmp->addMedia(storage_path('app/public/' . $slEmp->photo_path))->toMediaCollection('employee_photo'); // Example
+                        $newEmp->photo_path = $slEmp->photo_path; // Simple fallback
+                    }
+
+                    $newEmp->save();
+
+                    $slEmp->employee_id = $newEmp->id;
+                    $slEmp->save();
+                    $realEmployeeIds[] = $newEmp->id;
+                }
+            }
+
+            // 3. Mark as transitioned
+            $sales->status = 'transitioned';
+            $sales->workflow_destination = $request->destination;
+            $sales->save();
+
+            // 4. Generate actual Finance Transaction from Quotation if exists
+            if ($sales->quotation) {
+                // We create a generic FinancialTransaction linked to the employer.
+                // The main system's finance module uses `FinancialTransaction` Model.
+                if (class_exists(\App\Models\FinancialTransaction::class)) {
+                    $transaction = \App\Models\FinancialTransaction::create([
+                        'employer_id' => $realEmployer->id,
+                        'financial_profile_id' => $sales->quotation->financial_profile_id,
+                        'type' => 'income',
+                        'status' => 'pending',
+                        'amount' => $sales->quotation->grand_total,
+                        'transaction_date' => now(),
+                        'reference_number' => 'SL-' . str_pad($sales->id, 5, '0', STR_PAD_LEFT),
+                        'remarks' => 'Generated from Read and Sale Quotation',
+                        'created_by' => auth()->id(),
+                    ]);
+
+                    // Iterate items to create transaction items
+                    if (class_exists(\App\Models\FinancialTransactionItem::class) && is_array($sales->quotation->items_data)) {
+                        foreach ($sales->quotation->items_data as $item) {
+                            \App\Models\FinancialTransactionItem::create([
+                                'transaction_id' => $transaction->id,
+                                'description' => $item['description'],
+                                'quantity' => $item['qty'],
+                                'unit_price' => $item['price'],
+                                'total_amount' => $item['total'],
+                            ]);
+                        }
+                    }
+                }
+            }
+
+            // 5. Redirect the user to the respective page
+            DB::commit();
+
+            $destRoute = 'dashboard';
+            if ($request->destination === 'production.registration') $destRoute = 'production.registration.index';
+            if ($request->destination === 'production.renewal') $destRoute = 'production.renewal.index';
+            if (str_starts_with($request->destination, 'workflow.')) $destRoute = 'workflow.index';
+
+            return redirect()->route($destRoute, [
+                'highlight_employer_id' => $realEmployer->id,
+            ])->with('success', 'โอนข้อมูลสำเร็จ กรุณาสร้างรายการงานต่อในหน้านี้');
+
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return redirect()->back()->with('error', 'เกิดข้อผิดพลาด: ' . $e->getMessage());
+        }
+    }
+}

--- a/app/Models/SalesLead.php
+++ b/app/Models/SalesLead.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SalesLead extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'employer_id',
+        'employerNameTh',
+        'employerNameEn',
+        'employerId',
+        'employerTaxId',
+        'employerPhone',
+        'jobOwner',
+        'requires_special_attention',
+        'status', // quoted, deciding, confirmed, transitioned, cancelled
+        'workflow_destination',
+        'created_by',
+        'confirmed_by'
+    ];
+
+    /**
+     * Get the real employer if linked.
+     */
+    public function employer()
+    {
+        return $this->belongsTo(Employer::class, 'employer_id');
+    }
+
+    /**
+     * Get the employees associated with this sales lead.
+     */
+    public function employees()
+    {
+        return $this->hasMany(SalesLeadEmployee::class, 'sales_lead_id');
+    }
+
+    /**
+     * Get the quotation associated with this sales lead.
+     */
+    public function quotation()
+    {
+        return $this->hasOne(SalesQuotation::class, 'sales_lead_id');
+    }
+}

--- a/app/Models/SalesLeadEmployee.php
+++ b/app/Models/SalesLeadEmployee.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SalesLeadEmployee extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'sales_lead_id',
+        'employee_id',
+        'employeeNameEn',
+        'employeeNameTh',
+        'employeeGender',
+        'employeeDob',
+        'employeePassport',
+        'employeeWorkPermit',
+        'insurance_type',
+        'pinkCardNo',
+        'employeeNationality',
+        'workPermitMOUGroup',
+        'passportExpiryDate',
+        'workPermitExpiryDate',
+        'system_employee_id',
+        'employer_employee_id',
+        'name_list_number',
+        'employeeAddress',
+        'employeePhone'
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'employeeDob' => 'date',
+        'passportExpiryDate' => 'date',
+        'workPermitExpiryDate' => 'date',
+    ];
+
+    /**
+     * Get the sales lead that owns the employee.
+     */
+    public function salesLead()
+    {
+        return $this->belongsTo(SalesLead::class, 'sales_lead_id');
+    }
+
+    /**
+     * Get the real employee if linked.
+     */
+    public function employee()
+    {
+        return $this->belongsTo(Employee::class, 'employee_id');
+    }
+}

--- a/app/Models/SalesQuotation.php
+++ b/app/Models/SalesQuotation.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SalesQuotation extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'sales_lead_id',
+        'financial_profile_id',
+        'quotation_date',
+        'payment_terms',
+        'grand_total',
+        'items_data'
+    ];
+
+    protected $casts = [
+        'quotation_date' => 'date',
+        'items_data' => 'array'
+    ];
+
+    public function salesLead()
+    {
+        return $this->belongsTo(SalesLead::class);
+    }
+}

--- a/database/migrations/2026_03_24_150426_create_sales_leads_table.php
+++ b/database/migrations/2026_03_24_150426_create_sales_leads_table.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sales_leads', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('employer_id')->nullable()->comment('Linked to real employer if selected from search');
+
+            // Replicating Employer fields, but mostly nullable
+            $table->string('employerNameTh'); // Only required field
+            $table->string('employerNameEn')->nullable();
+            $table->string('employerId')->nullable()->comment('Temporary ID for display before confirmed');
+            $table->string('employerTaxId')->nullable();
+            $table->string('employerPhone')->nullable();
+            $table->string('jobOwner')->nullable();
+            $table->boolean('requires_special_attention')->default(false);
+
+            $table->string('status')->default('quoted')->comment('quoted, deciding, confirmed, transitioned, cancelled');
+            $table->string('workflow_destination')->nullable()->comment('To remember where it went (e.g. renewal, registration, notify_out)');
+
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('confirmed_by')->nullable();
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sales_leads');
+    }
+};

--- a/database/migrations/2026_03_24_150427_create_sales_lead_employees_table.php
+++ b/database/migrations/2026_03_24_150427_create_sales_lead_employees_table.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sales_lead_employees', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sales_lead_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('employee_id')->nullable()->comment('Linked to real employee if selected from search');
+
+            // Replicating Employee fields, but mostly nullable
+            $table->string('employeeNameEn'); // Only required field
+            $table->string('employeeNameTh')->nullable();
+            $table->string('employeeGender')->nullable();
+            $table->date('employeeDob')->nullable();
+            $table->string('employeePassport')->nullable();
+            $table->string('employeeWorkPermit')->nullable();
+            $table->string('insurance_type')->nullable(); // 'ประกันเอกชน', 'ประกันโรงพยาบาล', 'ประกันสังคม'
+            $table->string('pinkCardNo')->nullable();
+
+            // We won't mirror all fields for the temporary state to keep it light,
+            // just the essentials needed for quotation and identification.
+            // When transitioned, if it's an existing employee, we use the real one.
+            // If it's a new employee, they'll fill out the rest in the real module or here if they choose.
+            // Wait, the user said: "แนบรูปภาพได้ด้วยแนบไฟล์ได้ด้วยทุกอย่างได้เหมือนกันหมดเลยแต่ก็บังคับให้กรอกแค่ชื่อภาษาอังกฤษอย่างเดียวเท่านั้น"
+            // So we need more fields to match the real employee creation if they want to fill it out completely here.
+            $table->string('employeeNationality')->nullable();
+            $table->string('workPermitMOUGroup')->nullable();
+            $table->date('passportExpiryDate')->nullable();
+            $table->date('workPermitExpiryDate')->nullable();
+            $table->string('system_employee_id')->nullable();
+            $table->string('employer_employee_id')->nullable();
+            $table->string('name_list_number')->nullable();
+            $table->text('employeeAddress')->nullable();
+            $table->string('employeePhone')->nullable();
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sales_lead_employees');
+    }
+};

--- a/database/migrations/2026_03_24_151013_add_quotation_and_files_to_sales_leads_tables.php
+++ b/database/migrations/2026_03_24_151013_add_quotation_and_files_to_sales_leads_tables.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sales_lead_employees', function (Blueprint $table) {
+            $table->string('photo_path')->nullable();
+            $table->string('document_path')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sales_lead_employees', function (Blueprint $table) {
+            $table->dropColumn(['photo_path', 'document_path']);
+        });
+    }
+};

--- a/database/migrations/2026_03_24_151013_create_sales_quotations_table.php
+++ b/database/migrations/2026_03_24_151013_create_sales_quotations_table.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sales_quotations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sales_lead_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('financial_profile_id')->nullable();
+            $table->date('quotation_date');
+            $table->string('payment_terms')->nullable();
+            $table->decimal('grand_total', 12, 2)->default(0);
+            $table->json('items_data')->nullable(); // Store JSON representation of quotation items for simplicity
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sales_quotations');
+    }
+};

--- a/resources/views/partials/sidebar-menu.blade.php
+++ b/resources/views/partials/sidebar-menu.blade.php
@@ -93,25 +93,49 @@
 
 @if(\App\Facades\SuperAdmin::isVisible('finance'))
 @hasanyrole('admin|super-admin')
-<a href="{{ route('finance.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.index') || request()->routeIs('finance.create') ? 'active' : '' }}">
-    <i class="bi bi-cash-coin me-2"></i>{{ __('Finance') }}
-</a>
-<a href="{{ route('finance.bank-accounts.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.bank-accounts.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
-    <i class="bi bi-bank me-2"></i>{{ __('Bank Accounts') }}
-</a>
-<a href="{{ route('finance.expense-categories.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.expense-categories.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
-    <i class="bi bi-tags me-2"></i>{{ __('Expense Categories') }}
-</a>
-<a href="{{ route('finance.expenses.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.expenses.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
-    <i class="bi bi-receipt-cutoff me-2"></i>{{ __('Expenses (รายจ่าย)') }}
-</a>
-@if(\App\Facades\SuperAdmin::isVisible('financial_profiles'))
-<a href="{{ route('finance.profiles.builder') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.profiles.*') ? 'active' : '' }}" style="padding-left: 2.5rem;">
-    <i class="bi bi-file-earmark-person me-2"></i>{{ __('Financial Profiles') }}
-</a>
-@endif
+@php
+    $isFinanceActive = request()->routeIs('finance.index') || request()->routeIs('finance.create');
+    $isFinanceSubMenuActive = request()->routeIs('finance.bank-accounts.*') || request()->routeIs('finance.expense-categories.*') || request()->routeIs('finance.expenses.*') || request()->routeIs('finance.profiles.*');
+@endphp
+
+<div class="list-group-item list-group-item-action p-0 {{ $isFinanceActive || $isFinanceSubMenuActive ? 'active-parent' : '' }}" style="border: none;">
+    <div class="d-flex align-items-stretch w-100">
+        {{-- Left side: Clickable link to Finance Index --}}
+        <a href="{{ route('finance.index') }}" class="flex-grow-1 d-flex align-items-center {{ $isFinanceActive ? 'active text-white' : 'text-dark' }}" style="padding: 0.75rem 1.25rem; text-decoration: none; {{ $isFinanceActive ? 'background-color: var(--bs-primary);' : '' }}">
+            <i class="bi bi-cash-coin me-2"></i>{{ __('Finance') }}
+        </a>
+
+        {{-- Right side: Clickable toggle for sub-menus --}}
+        <button class="btn btn-link shadow-none {{ $isFinanceActive ? 'text-white' : 'text-dark' }} d-flex align-items-center justify-content-center" type="button" data-bs-toggle="collapse" data-bs-target="#financeSubMenu" aria-expanded="{{ $isFinanceSubMenuActive ? 'true' : 'false' }}" aria-controls="financeSubMenu" style="width: 40px; padding: 0; border-radius: 0; {{ $isFinanceActive ? 'background-color: var(--bs-primary);' : '' }}" onclick="this.querySelector('i').classList.toggle('bi-chevron-down'); this.querySelector('i').classList.toggle('bi-chevron-up');">
+            <i class="bi bi-chevron-{{ $isFinanceSubMenuActive ? 'up' : 'down' }}"></i>
+        </button>
+    </div>
+</div>
+
+<div class="collapse {{ $isFinanceSubMenuActive ? 'show' : '' }}" id="financeSubMenu">
+    <a href="{{ route('finance.bank-accounts.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.bank-accounts.*') ? 'active' : '' }}" style="padding-left: 3rem; border-top: none;">
+        <i class="bi bi-bank me-2"></i>{{ __('Bank Accounts') }}
+    </a>
+    <a href="{{ route('finance.expense-categories.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.expense-categories.*') ? 'active' : '' }}" style="padding-left: 3rem;">
+        <i class="bi bi-tags me-2"></i>{{ __('Expense Categories') }}
+    </a>
+    <a href="{{ route('finance.expenses.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.expenses.*') ? 'active' : '' }}" style="padding-left: 3rem;">
+        <i class="bi bi-receipt-cutoff me-2"></i>{{ __('Expenses (รายจ่าย)') }}
+    </a>
+    @if(\App\Facades\SuperAdmin::isVisible('financial_profiles'))
+    <a href="{{ route('finance.profiles.builder') }}" class="list-group-item list-group-item-action {{ request()->routeIs('finance.profiles.*') ? 'active' : '' }}" style="padding-left: 3rem;">
+        <i class="bi bi-file-earmark-person me-2"></i>{{ __('Financial Profiles') }}
+    </a>
+    @endif
+</div>
 @endhasanyrole
 @endif
+
+@hasanyrole('admin|super-admin|staff')
+<a href="{{ route('sales.index') }}" class="list-group-item list-group-item-action {{ request()->routeIs('sales.*') ? 'active' : '' }}">
+    <i class="bi bi-megaphone-fill me-2"></i>{{ __('Read and Sale') }}
+</a>
+@endhasanyrole
 
 {{-- V2.4-S14: Production & Workflow Menus --}}
 @if(Route::has('production.index'))

--- a/resources/views/sales/index.blade.php
+++ b/resources/views/sales/index.blade.php
@@ -1,0 +1,189 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container-fluid py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2><i class="bi bi-megaphone-fill me-2 text-primary"></i>{{ __('Read and Sale') }}</h2>
+        <div>
+            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createSalesLeadModal">
+                <i class="bi bi-plus-circle me-1"></i> เพิ่มรายการเสนอราคาใหม่
+            </button>
+            <button class="btn btn-secondary ms-2" data-bs-toggle="modal" data-bs-target="#historyModal">
+                <i class="bi bi-clock-history me-1"></i> ประวัติรายการ (Snapshots)
+            </button>
+        </div>
+    </div>
+
+    @if(session('success'))
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            {{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+    @if(session('error'))
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            {{ session('error') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+
+    <div class="row kanban-board">
+        {{-- Column 1: Quoted --}}
+        <div class="col-md-4">
+            <div class="card bg-light h-100 border-0 shadow-sm">
+                <div class="card-header bg-white border-bottom-0 pt-3 pb-2">
+                    <h5 class="mb-0 text-primary fw-bold">1. เสนอราคา <span class="badge bg-primary rounded-pill ms-2">{{ $quoted->count() }}</span></h5>
+                </div>
+                <div class="card-body kanban-column" id="col-quoted" data-status="quoted" style="overflow-y: auto; max-height: 75vh;">
+                    @foreach($quoted as $lead)
+                        @include('sales.partials._lead_card', ['lead' => $lead, 'nextStatus' => 'deciding'])
+                    @endforeach
+                </div>
+            </div>
+        </div>
+
+        {{-- Column 2: Deciding --}}
+        <div class="col-md-4">
+            <div class="card bg-light h-100 border-0 shadow-sm">
+                <div class="card-header bg-white border-bottom-0 pt-3 pb-2">
+                    <h5 class="mb-0 text-warning fw-bold">2. รอตัดสินใจ/คอนเฟิร์ม <span class="badge bg-warning text-dark rounded-pill ms-2">{{ $deciding->count() }}</span></h5>
+                </div>
+                <div class="card-body kanban-column" id="col-deciding" data-status="deciding" style="overflow-y: auto; max-height: 75vh;">
+                    @foreach($deciding as $lead)
+                        @include('sales.partials._lead_card', ['lead' => $lead, 'nextStatus' => 'confirmed'])
+                    @endforeach
+                </div>
+            </div>
+        </div>
+
+        {{-- Column 3: Confirmed --}}
+        <div class="col-md-4">
+            <div class="card bg-light h-100 border-0 shadow-sm">
+                <div class="card-header bg-white border-bottom-0 pt-3 pb-2">
+                    <h5 class="mb-0 text-success fw-bold">3. คอนเฟิร์มแล้ว (พร้อมส่งต่อ) <span class="badge bg-success rounded-pill ms-2">{{ $confirmed->count() }}</span></h5>
+                </div>
+                <div class="card-body kanban-column" id="col-confirmed" data-status="confirmed" style="overflow-y: auto; max-height: 75vh;">
+                    @foreach($confirmed as $lead)
+                        @include('sales.partials._lead_card', ['lead' => $lead, 'nextStatus' => 'transition'])
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- Modals --}}
+@include('sales.partials._create_modal')
+@include('sales.partials._history_modal')
+
+{{-- Forms and scripts for Drag and Drop / Status Updates --}}
+<form id="updateStatusForm" method="POST" style="display: none;">
+    @csrf
+    @method('PUT')
+    <input type="hidden" name="status" id="updateStatusInput">
+</form>
+
+@endsection
+
+@push('styles')
+<style>
+    .kanban-board {
+        height: 80vh;
+    }
+    .kanban-column {
+        min-height: 200px;
+    }
+    .lead-card {
+        cursor: grab;
+        transition: transform 0.2s, box-shadow 0.2s;
+    }
+    .lead-card:active {
+        cursor: grabbing;
+        transform: scale(1.02);
+        box-shadow: 0 4px 8px rgba(0,0,0,0.1) !important;
+    }
+    .gu-mirror {
+        position: fixed !important;
+        margin: 0 !important;
+        z-index: 9999 !important;
+        opacity: 0.8;
+    }
+    .gu-hide {
+        display: none !important;
+    }
+    .gu-unselectable {
+        -webkit-user-select: none !important;
+        -moz-user-select: none !important;
+        -ms-user-select: none !important;
+        user-select: none !important;
+    }
+    .gu-transit {
+        opacity: 0.2;
+    }
+</style>
+@endpush
+
+@push('scripts')
+{{-- Include Dragula for drag and drop --}}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dragula/3.7.3/dragula.min.css" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dragula/3.7.3/dragula.min.js"></script>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        // Init Dragula
+        const drake = dragula([
+            document.getElementById('col-quoted'),
+            document.getElementById('col-deciding'),
+            document.getElementById('col-confirmed')
+        ]);
+
+        drake.on('drop', function (el, target, source, sibling) {
+            if (target === source) return; // Didn't move between columns
+
+            const leadId = el.getAttribute('data-id');
+            const newStatus = target.getAttribute('data-status');
+
+            // Update via AJAX
+            updateLeadStatus(leadId, newStatus, el);
+        });
+
+        function updateLeadStatus(id, status, el) {
+            const form = document.getElementById('updateStatusForm');
+            const url = `{{ url('sales') }}/${id}/status`;
+
+            fetch(url, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                    'Accept': 'application/json'
+                },
+                body: JSON.stringify({ status: status })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if(data.success) {
+                    // Update badges manually or reload. We'll just let it be, or you can update DOM.
+                    // A quick reload makes sure all action buttons inside the card refresh properly.
+                    window.location.reload();
+                } else {
+                    alert('Error updating status');
+                    window.location.reload();
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                window.location.reload();
+            });
+        }
+    });
+
+    // Helper for explicit status change buttons
+    function changeStatusExplicit(id, status) {
+        const form = document.getElementById('updateStatusForm');
+        form.action = `{{ url('sales') }}/${id}/status`;
+        document.getElementById('updateStatusInput').value = status;
+        form.submit();
+    }
+</script>
+@endpush

--- a/resources/views/sales/partials/_create_modal.blade.php
+++ b/resources/views/sales/partials/_create_modal.blade.php
@@ -1,0 +1,128 @@
+{{-- resources/views/sales/partials/_create_modal.blade.php --}}
+<div class="modal fade" id="createSalesLeadModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <form action="{{ route('sales.store') }}" method="POST">
+                @csrf
+                <div class="modal-header bg-primary text-white">
+                    <h5 class="modal-title"><i class="bi bi-plus-circle me-2"></i>สร้างรายการเสนอราคาใหม่</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <ul class="nav nav-tabs mb-3" id="createTypeTabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active fw-bold" id="existing-tab" data-bs-toggle="tab" data-bs-target="#existing-tab-pane" type="button" role="tab" aria-controls="existing-tab-pane" aria-selected="true">
+                                <i class="bi bi-search me-1"></i> เลือกลูกค้าเดิม
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link fw-bold" id="new-tab" data-bs-toggle="tab" data-bs-target="#new-tab-pane" type="button" role="tab" aria-controls="new-tab-pane" aria-selected="false">
+                                <i class="bi bi-person-plus me-1"></i> เพิ่มลูกค้าใหม่ (ชั่วคราว)
+                            </button>
+                        </li>
+                    </ul>
+                    <div class="tab-content" id="createTypeTabsContent">
+                        {{-- Existing Employer Tab --}}
+                        <div class="tab-pane fade show active" id="existing-tab-pane" role="tabpanel" aria-labelledby="existing-tab" tabindex="0">
+                            <div class="mb-3">
+                                <label for="employer_id" class="form-label">ค้นหาและเลือกลูกค้า <span class="text-danger">*</span></label>
+                                <select class="form-select select2-employer" name="employer_id" id="employer_id" style="width: 100%;">
+                                    <option value="">-- เลือกลูกค้าที่มีในระบบ --</option>
+                                    @foreach($employers as $emp)
+                                        <option value="{{ $emp->id }}">{{ $emp->employerNameTh }} ({{ $emp->employerTaxId ?? '-' }})</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+
+                        {{-- New Employer Tab --}}
+                        <div class="tab-pane fade" id="new-tab-pane" role="tabpanel" aria-labelledby="new-tab" tabindex="0">
+                            <div class="alert alert-info py-2">
+                                <i class="bi bi-info-circle me-2"></i> ข้อมูลนี้จะยังไม่ถูกบันทึกลงฐานข้อมูลจริง จนกว่าจะมีการคอนเฟิร์มส่งต่องาน
+                            </div>
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    <label class="form-label">ชื่อลูกค้า (ไทย) <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control" name="employerNameTh" id="employerNameTh_new">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">ชื่อลูกค้า (อังกฤษ)</label>
+                                    <input type="text" class="form-control" name="employerNameEn">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">เบอร์โทรศัพท์</label>
+                                    <input type="text" class="form-control" name="employerPhone">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">เลขเสียภาษี/บัตรประชาชน</label>
+                                    <input type="text" class="form-control" name="employerTaxId">
+                                </div>
+                                <div class="col-md-12">
+                                    <label class="form-label">ชื่อผู้ติดต่อ / เจ้าของงาน</label>
+                                    <input type="text" class="form-control" name="jobOwner">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                    <button type="submit" class="btn btn-primary" id="submitCreateLead"><i class="bi bi-save me-1"></i> บันทึกและสร้างใบเสนอราคา</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@push('scripts')
+{{-- Select2 for employer search --}}
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.3.0/dist/select2-bootstrap-5-theme.min.css" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        // Initialize Select2 if jQuery is loaded
+        if (typeof jQuery !== 'undefined') {
+            $('.select2-employer').select2({
+                theme: 'bootstrap-5',
+                dropdownParent: $('#createSalesLeadModal')
+            });
+        }
+
+        // Logic to clear inputs based on active tab to pass validation
+        const form = document.querySelector('#createSalesLeadModal form');
+        const employerSelect = document.getElementById('employer_id');
+        const employerNameInput = document.getElementById('employerNameTh_new');
+
+        form.addEventListener('submit', function(e) {
+            const isNewTabActive = document.getElementById('new-tab').classList.contains('active');
+
+            if (isNewTabActive) {
+                if(!employerNameInput.value) {
+                    e.preventDefault();
+                    alert('กรุณากรอกชื่อลูกค้า (ไทย)');
+                    return;
+                }
+                if(employerSelect) employerSelect.value = ''; // Clear select
+            } else {
+                if(!employerSelect || !employerSelect.value) {
+                    e.preventDefault();
+                    alert('กรุณาเลือกลูกค้าเดิม');
+                    return;
+                }
+                if(employerNameInput) employerNameInput.value = ''; // Clear new input
+            }
+        });
+
+        // Tab change listener to clear fields
+        document.getElementById('new-tab').addEventListener('shown.bs.tab', function () {
+            if(typeof jQuery !== 'undefined') {
+                $('#employer_id').val(null).trigger('change');
+            }
+        });
+        document.getElementById('existing-tab').addEventListener('shown.bs.tab', function () {
+            document.getElementById('employerNameTh_new').value = '';
+        });
+    });
+</script>
+@endpush

--- a/resources/views/sales/partials/_history_modal.blade.php
+++ b/resources/views/sales/partials/_history_modal.blade.php
@@ -1,0 +1,72 @@
+{{-- resources/views/sales/partials/_history_modal.blade.php --}}
+<div class="modal fade" id="historyModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header bg-secondary text-white">
+                <h5 class="modal-title"><i class="bi bi-clock-history me-2"></i>ประวัติรายการเสนอราคา</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover align-middle">
+                        <thead class="table-dark">
+                            <tr>
+                                <th>#</th>
+                                <th>ลูกค้า</th>
+                                <th>จำนวนลูกจ้าง</th>
+                                <th>สถานะ</th>
+                                <th>วันที่จัดการล่าสุด</th>
+                                <th>จัดการ</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($history as $item)
+                                <tr>
+                                    <td>{{ $loop->iteration }}</td>
+                                    <td>
+                                        <span class="fw-bold">{{ $item->employerNameTh }}</span>
+                                        <div class="text-muted small">
+                                            @if($item->employer_id)
+                                                <i class="bi bi-person-check-fill text-info" title="ลูกค้าเดิม"></i>
+                                            @else
+                                                <i class="bi bi-person-plus-fill text-warning" title="ลูกค้าชั่วคราว"></i>
+                                            @endif
+                                            {{ $item->employerTaxId ?? '-' }}
+                                        </div>
+                                    </td>
+                                    <td>{{ $item->employees->count() }} คน</td>
+                                    <td>
+                                        @if($item->status == 'transitioned')
+                                            <span class="badge bg-success">ส่งต่องานแล้ว</span>
+                                            <div class="small text-muted mt-1"><i class="bi bi-arrow-right"></i> {{ $item->workflow_destination }}</div>
+                                        @elseif($item->status == 'cancelled' || $item->trashed())
+                                            <span class="badge bg-danger">ยกเลิก/ลบ</span>
+                                        @endif
+                                    </td>
+                                    <td>{{ $item->updated_at->format('d/m/Y H:i') }}</td>
+                                    <td>
+                                        @if($item->trashed() || $item->status == 'cancelled')
+                                            <form action="{{ route('sales.restore', $item->id) }}" method="POST" class="d-inline" onsubmit="return confirm('ยืนยันการกู้คืนรายการนี้ เพื่อกลับไปหน้า เสนอราคา หรือไม่?');">
+                                                @csrf
+                                                <button type="submit" class="btn btn-sm btn-outline-success"><i class="bi bi-arrow-counterclockwise"></i> กู้คืน</button>
+                                            </form>
+                                        @else
+                                            <span class="text-muted small">ดำเนินการแล้ว</span>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="text-center py-4 text-muted">ไม่มีประวัติการจัดการ</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/sales/partials/_lead_card.blade.php
+++ b/resources/views/sales/partials/_lead_card.blade.php
@@ -1,0 +1,70 @@
+{{-- resources/views/sales/partials/_lead_card.blade.php --}}
+<div class="card lead-card mb-3 border border-1 border-secondary shadow-sm" data-id="{{ $lead->id }}" data-status="{{ $lead->status }}">
+    <div class="card-body p-3">
+        <div class="d-flex justify-content-between align-items-start mb-2">
+            <h6 class="card-title fw-bold text-dark mb-0">
+                {{ $lead->employerNameTh }}
+                @if($lead->employer_id)
+                    <span class="badge bg-info text-dark ms-1" title="ลูกค้าเดิมจากระบบ">
+                        <i class="bi bi-person-check-fill"></i>
+                    </span>
+                @else
+                    <span class="badge bg-warning text-dark ms-1" title="ลูกค้าใหม่ชั่วคราว">
+                        <i class="bi bi-person-plus-fill"></i>
+                    </span>
+                @endif
+            </h6>
+
+            <div class="dropdown">
+                <button class="btn btn-sm btn-link text-muted p-0" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <i class="bi bi-three-dots-vertical"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end shadow-sm">
+                    <li><a class="dropdown-item text-danger" href="#" onclick="if(confirm('ย้ายรายการนี้ลงประวัติ/ถังขยะ ใช่หรือไม่?')) { document.getElementById('delete-lead-{{ $lead->id }}').submit(); }"><i class="bi bi-trash me-2"></i>ทิ้ง/ยกเลิก</a></li>
+                </ul>
+                <form id="delete-lead-{{ $lead->id }}" action="{{ route('sales.destroy', $lead->id) }}" method="POST" class="d-none">
+                    @csrf
+                    @method('DELETE')
+                </form>
+            </div>
+        </div>
+
+        <p class="card-text text-muted small mb-2"><i class="bi bi-telephone me-1"></i> {{ $lead->employerPhone ?? 'ไม่ได้ระบุ' }}</p>
+
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <span class="badge bg-light text-dark border"><i class="bi bi-people me-1"></i>ลูกจ้าง {{ $lead->employees->count() }} คน</span>
+
+            {{-- Action buttons based on status --}}
+            @if($lead->status === 'confirmed')
+                <button class="btn btn-sm btn-success rounded-pill px-3 fw-bold shadow-sm" data-bs-toggle="modal" data-bs-target="#transitionModal-{{ $lead->id }}">
+                    <i class="bi bi-send-check me-1"></i> ส่งต่องาน
+                </button>
+            @else
+                <button class="btn btn-sm btn-outline-primary rounded-pill px-3" onclick="changeStatusExplicit({{ $lead->id }}, '{{ $nextStatus }}')">
+                    @if($nextStatus == 'deciding')
+                        <i class="bi bi-arrow-right-circle me-1"></i> รอตัดสินใจ
+                    @else
+                        <i class="bi bi-check-circle me-1"></i> คอนเฟิร์ม
+                    @endif
+                </button>
+            @endif
+        </div>
+
+        <div class="d-grid gap-2 mt-2">
+            <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#manageEmployeesModal-{{ $lead->id }}">
+                <i class="bi bi-person-lines-fill me-1"></i> จัดการลูกจ้าง
+            </button>
+            <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#quotationModal-{{ $lead->id }}">
+                <i class="bi bi-file-earmark-text me-1"></i> ใบเสนอราคา
+            </button>
+        </div>
+    </div>
+</div>
+
+{{-- Modals for this Lead --}}
+@include('sales.partials._manage_employees_modal', ['lead' => $lead])
+@include('sales.partials._quotation_modal', ['lead' => $lead, 'profiles' => $financialProfiles])
+
+@if($lead->status === 'confirmed')
+    @include('sales.partials._transition_modal', ['lead' => $lead])
+@endif

--- a/resources/views/sales/partials/_manage_employees_modal.blade.php
+++ b/resources/views/sales/partials/_manage_employees_modal.blade.php
@@ -1,0 +1,249 @@
+{{-- resources/views/sales/partials/_manage_employees_modal.blade.php --}}
+<div class="modal fade" id="manageEmployeesModal-{{ $lead->id }}" tabindex="-1" aria-labelledby="manageEmployeesLabel-{{ $lead->id }}" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header bg-info text-white">
+                <h5 class="modal-title" id="manageEmployeesLabel-{{ $lead->id }}"><i class="bi bi-people-fill me-2"></i>จัดการลูกจ้าง - {{ $lead->employerNameTh }}</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row mb-3">
+                    <div class="col-12 d-flex justify-content-end">
+                        <button class="btn btn-primary" data-bs-toggle="collapse" data-bs-target="#addEmployeeCollapse-{{ $lead->id }}">
+                            <i class="bi bi-person-plus-fill me-1"></i> เพิ่มลูกจ้างใหม่
+                        </button>
+                    </div>
+                </div>
+
+                {{-- Add Employee Form Collapse --}}
+                <div class="collapse mb-4 border border-info rounded p-3 bg-light" id="addEmployeeCollapse-{{ $lead->id }}">
+                    <h5 class="text-info border-bottom border-info pb-2 mb-3">เพิ่มลูกจ้างเข้ารายการเสนอราคา</h5>
+
+                    <ul class="nav nav-pills mb-3" id="employeeTypeTabs-{{ $lead->id }}" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active" id="exist-emp-tab-{{ $lead->id }}" data-bs-toggle="tab" data-bs-target="#exist-emp-pane-{{ $lead->id }}" type="button" role="tab" aria-controls="exist-emp-pane-{{ $lead->id }}" aria-selected="true">
+                                เลือกลูกจ้างเดิม (ในระบบ)
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="new-emp-tab-{{ $lead->id }}" data-bs-toggle="tab" data-bs-target="#new-emp-pane-{{ $lead->id }}" type="button" role="tab" aria-controls="new-emp-pane-{{ $lead->id }}" aria-selected="false">
+                                กรอกข้อมูลลูกจ้างใหม่ (ชั่วคราว)
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link text-success fw-bold" id="import-emp-tab-{{ $lead->id }}" data-bs-toggle="tab" data-bs-target="#import-emp-pane-{{ $lead->id }}" type="button" role="tab" aria-controls="import-emp-pane-{{ $lead->id }}" aria-selected="false">
+                                <i class="bi bi-file-earmark-excel me-1"></i> นำเข้าผ่าน Excel
+                            </button>
+                        </li>
+                    </ul>
+
+                    <div class="tab-content" id="employeeTypeTabsContent-{{ $lead->id }}">
+
+                        {{-- Wrapper for manual forms --}}
+                        <div class="tab-pane fade show active" id="manual-emp-wrapper-{{ $lead->id }}" role="tabpanel" tabindex="0">
+                            <form action="{{ route('sales.employees.store', $lead->id) }}" method="POST" enctype="multipart/form-data">
+                                @csrf
+                                <div class="tab-content">
+
+                            {{-- Existing Employee --}}
+                            <div class="tab-pane fade show active" id="exist-emp-pane-{{ $lead->id }}" role="tabpanel" aria-labelledby="exist-emp-tab-{{ $lead->id }}" tabindex="0">
+                                <div class="mb-3">
+                                    <label class="form-label">ค้นหาลูกจ้าง <span class="text-danger">*</span></label>
+                                    <select class="form-select select2-employee-{{ $lead->id }}" name="employee_id" style="width: 100%;">
+                                        <option value="">-- พิมพ์ชื่อ, พาสปอร์ต, หรือเลขประจำตัว --</option>
+                                        {{-- Using AJAX in real scenario, but for now we'll fetch all or use select2 ajax. --}}
+                                        {{-- As requested, search existing employees drop down. --}}
+                                        <option value="temp-disabled" disabled>กรุณาพิมพ์เพื่อค้นหา (ระบบจะเชื่อมต่อ API)</option>
+                                    </select>
+                                    <div class="form-text text-muted">ระบบจะดึงข้อมูลที่เกี่ยวข้องมาแสดงในใบเสนอราคา</div>
+                                </div>
+                            </div>
+
+                            {{-- New Employee --}}
+                            <div class="tab-pane fade" id="new-emp-pane-{{ $lead->id }}" role="tabpanel" aria-labelledby="new-emp-tab-{{ $lead->id }}" tabindex="0">
+                                <div class="alert alert-warning py-2 mb-3">
+                                    <i class="bi bi-exclamation-triangle-fill me-2"></i> ข้อมูลนี้จะไม่ถูกบันทึกจริงจนกว่าจะคอนเฟิร์มงาน (บังคับแค่ชื่อภาษาอังกฤษ)
+                                </div>
+                                <div class="row g-3">
+                                    <div class="col-md-6">
+                                        <label class="form-label">ชื่อ-นามสกุล (ภาษาอังกฤษ) <span class="text-danger">*</span></label>
+                                        <input type="text" class="form-control" name="employeeNameEn" id="empNameEn-{{ $lead->id }}">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label">ชื่อ-นามสกุล (ภาษาไทย)</label>
+                                        <input type="text" class="form-control" name="employeeNameTh">
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label class="form-label">เพศ</label>
+                                        <select class="form-select" name="employeeGender">
+                                            <option value="">ไม่ได้ระบุ</option>
+                                            <option value="Male">ชาย (Male)</option>
+                                            <option value="Female">หญิง (Female)</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label class="form-label">เลขพาสปอร์ต</label>
+                                        <input type="text" class="form-control" name="employeePassport">
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label class="form-label">เลขใบอนุญาตทำงาน</label>
+                                        <input type="text" class="form-control" name="employeeWorkPermit">
+                                    </div>
+                                    <div class="col-md-6 mt-3">
+                                        <label class="form-label">รูปถ่ายหน้าตรง (ถ้ามี)</label>
+                                        <input type="file" class="form-control" name="photo" accept="image/*">
+                                    </div>
+                                    <div class="col-md-6 mt-3">
+                                        <label class="form-label">เอกสารอื่นๆ (ถ้ามี)</label>
+                                        <input type="file" class="form-control" name="document" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    </div>
+                                </div>
+                            </div>
+
+                                </div>
+
+                                <div class="mt-3 text-end">
+                                    <button type="submit" class="btn btn-success" id="btn-save-emp-{{ $lead->id }}" onclick="return validateAddEmployee(this, {{ $lead->id }})">
+                                        <i class="bi bi-save me-1"></i> บันทึกเข้ารายการ
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+
+                    {{-- Excel Import Form --}}
+                    <div class="tab-pane fade mt-3" id="import-emp-pane-{{ $lead->id }}" role="tabpanel" aria-labelledby="import-emp-tab-{{ $lead->id }}" tabindex="0">
+                        <form action="{{ route('sales.import', $lead->id) }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            <div class="alert alert-info">
+                                <i class="bi bi-info-circle me-2"></i> กรุณาอัปโหลดไฟล์ Excel (.xlsx, .xls) โดยเรียงคอลัมน์ดังนี้: NO, Name En, Name Th, Gender, Nationality, Passport, Work Permit
+                            </div>
+                            <div class="input-group mb-3">
+                                <input type="file" class="form-control" name="excel_file" accept=".xlsx, .xls" required>
+                                <button class="btn btn-success" type="submit" id="button-import"><i class="bi bi-upload me-1"></i> อัปโหลดและนำเข้า</button>
+                            </div>
+                        </form>
+                    </div>
+
+                </div>
+
+                {{-- Employees List Table --}}
+                <div class="table-responsive">
+                    <table class="table table-bordered table-hover align-middle mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>#</th>
+                                <th>ชื่อลูกจ้าง</th>
+                                <th>พาสปอร์ต</th>
+                                <th>ใบอนุญาตทำงาน</th>
+                                <th>ประเภท</th>
+                                <th class="text-center">จัดการ</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($lead->employees as $emp)
+                                <tr>
+                                    <td>{{ $loop->iteration }}</td>
+                                    <td>
+                                        <div class="fw-bold">{{ $emp->employeeNameEn }}</div>
+                                        <div class="small text-muted">{{ $emp->employeeNameTh }}</div>
+                                    </td>
+                                    <td>{{ $emp->employeePassport ?? '-' }}</td>
+                                    <td>{{ $emp->employeeWorkPermit ?? '-' }}</td>
+                                    <td>
+                                        @if($emp->employee_id)
+                                            <span class="badge bg-info"><i class="bi bi-database me-1"></i>ในระบบ</span>
+                                        @else
+                                            <span class="badge bg-warning text-dark"><i class="bi bi-hourglass-split me-1"></i>ชั่วคราว</span>
+                                        @endif
+                                    </td>
+                                    <td class="text-center">
+                                        <form action="{{ route('sales.employees.destroy', [$lead->id, $emp->id]) }}" method="POST" onsubmit="return confirm('ยืนยันการลบลูกจ้างออกจากรายการนี้?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="text-center py-4 text-muted">ยังไม่มีข้อมูลลูกจ้างในรายการนี้</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Basic validation handler for employee submission
+    window.validateAddEmployee = function(btn, leadId) {
+        const isNewTabActive = document.getElementById('new-emp-tab-' + leadId).classList.contains('active');
+        const form = btn.closest('form');
+
+        if (isNewTabActive) {
+            const nameEn = form.querySelector('input[name="employeeNameEn"]').value;
+            if(!nameEn) {
+                alert('กรุณากรอกชื่อ-นามสกุล (ภาษาอังกฤษ)');
+                return false;
+            }
+            // Clear select2
+            $(form.querySelector('select[name="employee_id"]')).val(null).trigger('change');
+        } else {
+            const empId = form.querySelector('select[name="employee_id"]').value;
+            if(!empId) {
+                alert('กรุณาเลือกลูกจ้างเดิม');
+                return false;
+            }
+            // Clear text inputs
+            form.querySelector('input[name="employeeNameEn"]').value = '';
+        }
+        return true;
+    };
+
+    // Initialize Select2 for employees with AJAX
+    if (typeof jQuery !== 'undefined') {
+        $('.select2-employee-{{ $lead->id }}').select2({
+            theme: 'bootstrap-5',
+            dropdownParent: $('#manageEmployeesModal-{{ $lead->id }}'),
+            ajax: {
+                url: '{{ route('employees.search') }}', // Existing route for employee search
+                dataType: 'json',
+                delay: 250,
+                data: function (params) {
+                    return {
+                        q: params.term, // search term
+                        page: params.page
+                    };
+                },
+                processResults: function (data, params) {
+                    params.page = params.page || 1;
+                    return {
+                        results: data.map(function(item) {
+                            return {
+                                id: item.id,
+                                text: item.employeeNameEn + ' ' + (item.employeePassport ? '('+item.employeePassport+')' : '')
+                            }
+                        }),
+                        pagination: {
+                            more: (params.page * 30) < data.total_count
+                        }
+                    };
+                },
+                cache: true
+            },
+            placeholder: '-- พิมพ์ชื่อ, พาสปอร์ต, หรือเลขประจำตัว --',
+            minimumInputLength: 2,
+        });
+    }
+});
+</script>
+@endpush

--- a/resources/views/sales/partials/_quotation_modal.blade.php
+++ b/resources/views/sales/partials/_quotation_modal.blade.php
@@ -1,0 +1,166 @@
+{{-- resources/views/sales/partials/_quotation_modal.blade.php --}}
+<div class="modal fade" id="quotationModal-{{ $lead->id }}" tabindex="-1" aria-labelledby="quotationModalLabel-{{ $lead->id }}" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header bg-dark text-white">
+                <h5 class="modal-title" id="quotationModalLabel-{{ $lead->id }}">
+                    <i class="bi bi-file-earmark-text me-2"></i> สร้างใบเสนอราคา (Quotation) - {{ $lead->employerNameTh }}
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-info">
+                    <i class="bi bi-info-circle me-2"></i> เมื่อลูกค้าคอนเฟิร์ม ใบเสนอราคานี้จะถูกแปลงเป็นรายการบิลในเมนู "การเงิน (Finance)" หลักโดยอัตโนมัติ
+                </div>
+
+                {{-- Mock Finance UI for Sales Lead --}}
+                <form id="financeForm-{{ $lead->id }}" action="{{ route('sales.quotation.store', $lead->id) }}" method="POST">
+                    @csrf
+                    <div class="row g-3 mb-4">
+                        <div class="col-md-6">
+                            <label class="form-label">โปรไฟล์การเงิน <span class="text-danger">*</span></label>
+                            <select class="form-select" name="financial_profile_id" required>
+                                <option value="">-- เลือกโปรไฟล์/บริษัทผู้ออกบิล --</option>
+                                @foreach($profiles as $profile)
+                                    <option value="{{ $profile->id }}" {{ ($lead->quotation && $lead->quotation->financial_profile_id == $profile->id) ? 'selected' : '' }}>{{ $profile->company_name_th }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">วันที่เสนอราคา</label>
+                            <input type="date" class="form-control" name="quotation_date" value="{{ $lead->quotation ? $lead->quotation->quotation_date->format('Y-m-d') : date('Y-m-d') }}" required>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">เงื่อนไขการชำระเงิน</label>
+                            <input type="text" class="form-control" name="payment_terms" value="{{ $lead->quotation->payment_terms ?? '' }}" placeholder="เช่น เงินสด 100%, แบ่งจ่าย">
+                        </div>
+                    </div>
+
+                    <div class="card shadow-sm border-0 mb-4">
+                        <div class="card-header bg-white border-bottom-0 pt-3 pb-2 d-flex justify-content-between align-items-center">
+                            <h6 class="mb-0 fw-bold"><i class="bi bi-list-check me-2"></i>รายการเสนอราคา</h6>
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="addQuoteItem({{ $lead->id }})">
+                                <i class="bi bi-plus-circle"></i> เพิ่มรายการ
+                            </button>
+                        </div>
+                        <div class="card-body p-0">
+                            <table class="table table-hover align-middle mb-0" id="quoteItemsTable-{{ $lead->id }}">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width: 40%">รายละเอียดงาน</th>
+                                        <th style="width: 15%">จำนวน</th>
+                                        <th style="width: 20%">ราคาต่อหน่วย (บาท)</th>
+                                        <th style="width: 20%">รวม (บาท)</th>
+                                        <th style="width: 5%"></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @if($lead->quotation && $lead->quotation->items_data)
+                                        @foreach($lead->quotation->items_data as $index => $item)
+                                        <tr>
+                                            <td><input type="text" class="form-control form-control-sm" name="items[{{ $index }}][description]" value="{{ $item['description'] ?? '' }}" required></td>
+                                            <td>
+                                                <div class="input-group input-group-sm">
+                                                    <input type="number" class="form-control text-end quote-qty" name="items[{{ $index }}][qty]" value="{{ $item['qty'] ?? 1 }}" min="1" oninput="calcQuoteRow(this)">
+                                                    <span class="input-group-text">คน</span>
+                                                </div>
+                                            </td>
+                                            <td><input type="number" class="form-control form-control-sm text-end quote-price" name="items[{{ $index }}][price]" value="{{ $item['price'] ?? 0 }}" min="0" oninput="calcQuoteRow(this)"></td>
+                                            <td><input type="text" class="form-control form-control-sm text-end quote-total" name="items[{{ $index }}][total]" value="{{ number_format(($item['qty'] ?? 1) * ($item['price'] ?? 0), 2) }}" readonly></td>
+                                            <td><button type="button" class="btn btn-sm btn-outline-danger" onclick="this.closest('tr').remove(); calcQuoteGrandTotal({{ $lead->id }});"><i class="bi bi-trash"></i></button></td>
+                                        </tr>
+                                        @endforeach
+                                    @else
+                                        {{-- Default row --}}
+                                        <tr>
+                                            <td><input type="text" class="form-control form-control-sm" name="items[0][description]" placeholder="เช่น ค่าดำเนินการนำเข้า" required></td>
+                                            <td>
+                                                <div class="input-group input-group-sm">
+                                                    <input type="number" class="form-control text-end quote-qty" name="items[0][qty]" value="{{ $lead->employees->count() ?: 1 }}" min="1" oninput="calcQuoteRow(this)">
+                                                    <span class="input-group-text">คน</span>
+                                                </div>
+                                            </td>
+                                            <td><input type="number" class="form-control form-control-sm text-end quote-price" name="items[0][price]" value="0" min="0" oninput="calcQuoteRow(this)"></td>
+                                            <td><input type="text" class="form-control form-control-sm text-end quote-total" name="items[0][total]" value="0.00" readonly></td>
+                                            <td><button type="button" class="btn btn-sm btn-outline-danger" onclick="this.closest('tr').remove(); calcQuoteGrandTotal({{ $lead->id }});"><i class="bi bi-trash"></i></button></td>
+                                        </tr>
+                                    @endif
+                                </tbody>
+                                <tfoot class="table-light">
+                                    <tr>
+                                        <td colspan="3" class="text-end fw-bold">ยอดรวมสุทธิ:</td>
+                                        <td class="fw-bold fs-5 text-end text-primary" id="quoteGrandTotal-{{ $lead->id }}">{{ number_format($lead->quotation->grand_total ?? 0, 2) }}</td>
+                                        <td></td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="text-end">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-save me-1"></i> บันทึกใบเสนอราคา
+                        </button>
+                    </div>
+                </form>
+
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('scripts')
+@once
+<script>
+    let quoteItemCounter = 1;
+
+    function addQuoteItem(leadId) {
+        const tbody = document.querySelector(`#quoteItemsTable-${leadId} tbody`);
+        const tr = document.createElement('tr');
+        const numEmployees = {{ $lead->employees->count() ?: 1 }};
+
+        tr.innerHTML = `
+            <td><input type="text" class="form-control form-control-sm" name="items[${quoteItemCounter}][description]" placeholder="ระบุรายละเอียดงาน" required></td>
+            <td>
+                <div class="input-group input-group-sm">
+                    <input type="number" class="form-control text-end quote-qty" name="items[${quoteItemCounter}][qty]" value="${numEmployees}" min="1" oninput="calcQuoteRow(this)">
+                    <span class="input-group-text">คน</span>
+                </div>
+            </td>
+            <td><input type="number" class="form-control form-control-sm text-end quote-price" name="items[${quoteItemCounter}][price]" value="0" min="0" oninput="calcQuoteRow(this)"></td>
+            <td><input type="text" class="form-control form-control-sm text-end quote-total" name="items[${quoteItemCounter}][total]" value="0.00" readonly></td>
+            <td><button type="button" class="btn btn-sm btn-outline-danger" onclick="this.closest('tr').remove(); calcQuoteGrandTotal(${leadId});"><i class="bi bi-trash"></i></button></td>
+        `;
+        tbody.appendChild(tr);
+        quoteItemCounter++;
+    }
+
+    function calcQuoteRow(input) {
+        const tr = input.closest('tr');
+        const qty = parseFloat(tr.querySelector('.quote-qty').value) || 0;
+        const price = parseFloat(tr.querySelector('.quote-price').value) || 0;
+        const totalInput = tr.querySelector('.quote-total');
+
+        const total = qty * price;
+        totalInput.value = total.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+
+        const leadId = input.closest('table').id.replace('quoteItemsTable-', '');
+        calcQuoteGrandTotal(leadId);
+    }
+
+    function calcQuoteGrandTotal(leadId) {
+        const table = document.getElementById(`quoteItemsTable-${leadId}`);
+        const totalInputs = table.querySelectorAll('.quote-total');
+        let grandTotal = 0;
+
+        totalInputs.forEach(input => {
+            const val = parseFloat(input.value.replace(/,/g, '')) || 0;
+            grandTotal += val;
+        });
+
+        document.getElementById(`quoteGrandTotal-${leadId}`).innerText = grandTotal.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+    }
+</script>
+@endonce
+@endpush

--- a/resources/views/sales/partials/_transition_modal.blade.php
+++ b/resources/views/sales/partials/_transition_modal.blade.php
@@ -1,0 +1,74 @@
+{{-- resources/views/sales/partials/_transition_modal.blade.php --}}
+<div class="modal fade" id="transitionModal-{{ $lead->id }}" tabindex="-1" aria-labelledby="transitionModalLabel-{{ $lead->id }}" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form action="{{ route('sales.transition', $lead->id) }}" method="POST">
+                @csrf
+                <div class="modal-header bg-success text-white">
+                    <h5 class="modal-title" id="transitionModalLabel-{{ $lead->id }}"><i class="bi bi-send-check me-2"></i>ส่งต่องาน (Transition) - {{ $lead->employerNameTh }}</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="alert alert-warning mb-4">
+                        <i class="bi bi-exclamation-triangle-fill me-2"></i> เมื่อกดยืนยัน ข้อมูลลูกค้าและลูกจ้างชั่วคราวทั้งหมด <strong>จะถูกบันทึกลงในฐานข้อมูลหลัก (Employers/Employees) โดยอัตโนมัติ</strong>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">เลือกปลายทางของงาน <span class="text-danger">*</span></label>
+                        <select name="destination" class="form-select select2-destination" style="width: 100%;" required>
+                            <option value="">-- เลือกเมนูปลายทาง --</option>
+                            <optgroup label="เมนู Production (มติ)">
+                                <option value="production.registration">มติลงทะเบียน (Registration)</option>
+                                <option value="production.renewal">มติต่ออายุ (Renewal)</option>
+                            </optgroup>
+                            <optgroup label="เมนู Workflow (แจ้งเข้า/ออก)">
+                                <option value="workflow.notify_out">แจ้งออก</option>
+                                <option value="workflow.mou_import">MOU นำเข้า</option>
+                                <option value="workflow.mou_renewal">ต่ออายุ MOU</option>
+                                <option value="workflow.change_employer">เปลี่ยนนายจ้าง</option>
+                            </optgroup>
+                        </select>
+                    </div>
+
+                    <div class="card bg-light border-0 shadow-sm mt-3">
+                        <div class="card-body p-3">
+                            <h6 class="fw-bold text-dark mb-2">สรุปข้อมูลที่จะถูกสร้างจริง:</h6>
+                            <ul class="list-unstyled mb-0">
+                                <li>
+                                    <i class="bi bi-building me-2 text-primary"></i> ลูกค้า: <strong>{{ $lead->employerNameTh }}</strong>
+                                    @if($lead->employer_id)
+                                        <span class="badge bg-secondary ms-1">ลูกค้าเดิม</span>
+                                    @else
+                                        <span class="badge bg-danger ms-1">สร้างลูกค้าใหม่</span>
+                                    @endif
+                                </li>
+                                <li class="mt-2">
+                                    <i class="bi bi-people-fill me-2 text-success"></i> ลูกจ้างทั้งหมด <strong>{{ $lead->employees->count() }}</strong> คน
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer border-top-0 pt-0">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                    <button type="submit" class="btn btn-success fw-bold">
+                        <i class="bi bi-check-circle me-1"></i> ยืนยันการส่งต่อข้อมูล
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@push('scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        if (typeof jQuery !== 'undefined') {
+            $('.select2-destination').select2({
+                theme: 'bootstrap-5',
+                dropdownParent: $('.modal') // This assumes only one modal opens at a time
+            });
+        }
+    });
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -382,6 +382,24 @@ Route::middleware(['auth'])->group(function () {
     Route::post('production/{id}/add-employee', [\App\Http\Controllers\ProductionController::class, 'addEmployee'])->name('production.add_employee');
     Route::post('production/{id}/add-new-employee', [\App\Http\Controllers\ProductionController::class, 'addNewEmployee'])->name('production.add_new_employee');
 
+    // Read and Sale (Sales Leads)
+    Route::middleware('role:super-admin|admin|staff')->prefix('sales')->name('sales.')->group(function () {
+        Route::get('/', [\App\Http\Controllers\SalesLeadController::class, 'index'])->name('index');
+        Route::post('/', [\App\Http\Controllers\SalesLeadController::class, 'store'])->name('store');
+        Route::put('/{sales}/status', [\App\Http\Controllers\SalesLeadController::class, 'updateStatus'])->name('status.update');
+        Route::delete('/{sales}', [\App\Http\Controllers\SalesLeadController::class, 'destroy'])->name('destroy');
+        Route::post('/{id}/restore', [\App\Http\Controllers\SalesLeadController::class, 'restore'])->name('restore');
+
+        Route::post('/{sales}/employees', [\App\Http\Controllers\SalesLeadController::class, 'storeEmployee'])->name('employees.store');
+        Route::delete('/{sales}/employees/{employee}', [\App\Http\Controllers\SalesLeadController::class, 'destroyEmployee'])->name('employees.destroy');
+
+        Route::post('/{sales}/quotation', [\App\Http\Controllers\SalesLeadController::class, 'storeQuotation'])->name('quotation.store');
+
+        Route::post('/{sales}/transition', [\App\Http\Controllers\SalesLeadController::class, 'transition'])->name('transition');
+
+        Route::post('/{sales}/import', [\App\Http\Controllers\Sales\SalesLeadImportController::class, 'importExcel'])->name('import');
+    });
+
     // NEW: Pre-Production Routes
     Route::post('production/{item}/send-to-workflow', [\App\Http\Controllers\ProductionController::class, 'sendToWorkflow'])->name('production.item.send_to_workflow');
     Route::post('production/bulk-send-to-workflow', [\App\Http\Controllers\ProductionController::class, 'bulkSendToWorkflow'])->name('production.bulk_send_to_workflow');


### PR DESCRIPTION
This PR fulfills the request to redesign the Finance sidebar menu and introduces a completely new, major CRM feature called "Read and Sale". 

The Read and Sale module acts as a buffer zone. It allows the team to create quotations and manage potential client data (employers and employees) in a Kanban-style board without polluting the main operational database with unconfirmed or incomplete records. Users can add clients manually or import employees via an Excel template. 

Crucially, once a client confirms the quotation, the system features a powerful "Transition" tool. With a single click, it migrates all the temporary data into real `Employer` and `Employee` records, creates a real Income transaction in the Finance module, and immediately forwards the data into the production line (like the Registration or Renewal menus), eliminating duplicate data entry.

---
*PR created automatically by Jules for task [1907493058160737598](https://jules.google.com/task/1907493058160737598) started by @nongjossss-commits*