### PR TITLE
Update Advanced Download PDF stamp header name priority

### DIFF
--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -526,13 +526,22 @@ class ProcessDownload implements ShouldQueue
             $employeeNameTh = $employee->employeeNameTh;
             $employeeNameEn = $employee->employeeNameEn;
 
+            $employeeTitleEn = $employee->employeeTitleEn;
+            $employeeTitleTh = $employee->employeeTitleTh;
+
             // Combine ID and Name directly as raw UTF-8 string first
             $employeeNameStr = '';
-            if ($hasThaiFont && $employeeNameTh) {
-                $employeeNameStr = $employeeNameTh;
+
+            if (!empty($employeeNameEn)) {
+                $prefixEn = !empty($employeeTitleEn) ? $employeeTitleEn . ' ' : '';
+                $employeeNameStr = preg_replace('/[^\x20-\x7E\p{Thai}]/u', '', $prefixEn . $employeeNameEn);
+            } elseif (!empty($employeeNameTh) && $hasThaiFont) {
+                $prefixTh = !empty($employeeTitleTh) ? $employeeTitleTh . ' ' : '';
+                $employeeNameStr = $prefixTh . $employeeNameTh;
             } else {
-                $employeeNameStr = preg_replace('/[^\x20-\x7E]/', '', $employeeNameEn ?? 'Employee');
+                $employeeNameStr = 'Employee';
             }
+
             $headerTextRaw = $employeeNameStr . "   ID: " . $employee->id;
 
             // Convert the ENTIRE right-side string using iconv correctly


### PR DESCRIPTION
Updated the Advanced Download header stamping logic to prioritize the English name over the Thai name as requested.

- Added logic to display `$employee->employeeTitleEn` and `$employee->employeeNameEn` first if they exist.
- Falls back to `$employee->employeeTitleTh` and `$employee->employeeNameTh` if the English name is absent.
- Keeps appending the employee's system ID at the end (`ID: {id}`).
- Uses strict UTF-8 extraction matching Thai and English characters to prevent filtering out correct text representations.

---
*PR created automatically by Jules for task [633535967307082912](https://jules.google.com/task/633535967307082912) started by @nongjossss-commits*