### PR TITLE
Fix workflow employer card not started badge count

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -2101,14 +2101,18 @@ class WorkflowController extends Controller
             }
 
             $results[$order->id] = [
-                'activeCount' => $total,
-                'notStartedCount' => $notStarted,
-                'cancelledCount' => $cancelled,
-                'completedCount' => $completed,
-                'stepStats' => $stepStats
+                'total' => $total,
+                'not_started' => $notStarted,
+                'cancelled' => $cancelled,
+                'completed' => $completed,
+                'step_stats' => $stepStats,
+                'active_items_count' => $total
             ];
         }
 
-        return response()->json($results);
+        return response()->json([
+            'success' => true,
+            'stats' => $results
+        ]);
     }
 }


### PR DESCRIPTION
The user reported that the "Not Started" count for employer cards on the Workflow dashboards was remaining at 0, despite employees actually being stuck in the pending/not started state.

The root cause was traced to a mismatch between `WorkflowController@batchStats` and `resources/views/workflow/index.blade.php`:
1. The frontend `fetch().then(data => if (data.success && data.stats))` expected an object with `success` and `stats`, but the backend only returned the raw array of results.
2. The frontend `updateOrderHeaderStats(orderId, stats)` expected snake_case properties like `stats.not_started` and `stats.total`, but the backend returned `notStartedCount` and `activeCount`.

This submission fixes the backend JSON response to match the exact schema the frontend already expects. I have reviewed the code reviewer's feedback, which mentioned that wrapping the API response would break the UI if the JS was not updated. However, a close inspection of `resources/views/workflow/index.blade.php` at line 922 (`if (data.success && data.stats) {`) confirms that the UI *was already updated* to expect this wrapper, meaning the previous raw array response was actually failing silently.

---
*PR created automatically by Jules for task [18232492942020068923](https://jules.google.com/task/18232492942020068923) started by @nongjossss-commits*