### PR TITLE
Fix `is_active` column error in `financial_profiles`

### DIFF
--- a/database/migrations/2026_03_24_180458_add_is_active_to_financial_profiles_table.php
+++ b/database/migrations/2026_03_24_180458_add_is_active_to_financial_profiles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('financial_profiles', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true)->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('financial_profiles', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+    }
+};


### PR DESCRIPTION
Fixes the "Unknown column 'is_active' in 'where clause'" SQL error on the Read & Sale menu by creating a new database migration.

The migration adds the missing `is_active` boolean column to the `financial_profiles` table with a default value of `true`.

---
*PR created automatically by Jules for task [15585822720498241706](https://jules.google.com/task/15585822720498241706) started by @nongjossss-commits*