### PR TITLE
Fix Sales Lead employer creation form and employee search route

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -92,6 +92,38 @@ public function reinstate(Employee $employee)
     return response()->json(['success' => 'Employee reinstated successfully.']);
 }
 
+    public function search(Request $request)
+    {
+        $searchTerm = $request->input("q");
+        $query = Employee::query()
+            ->whereNull("terminated_at")
+            ->where(function($q) {
+                $q->whereNotIn("status", ["registration_cancelled"])
+                  ->orWhereNull("status");
+            });
+
+        if ($searchTerm) {
+            $term = "%" . $searchTerm . "%";
+            $query->where(function ($q) use ($term) {
+                $q->where("employeeNameTh", "like", $term)
+                  ->orWhere("employeeNameEn", "like", $term)
+                  ->orWhere("employeePassport", "like", $term)
+                  ->orWhere("pinkCardNo", "like", $term)
+                  ->orWhere("employeeWorkPermit", "like", $term)
+                  ->orWhere("employee_id_number", "like", $term)
+                  ->orWhere("name_list_number", "like", $term)
+                  ->orWhere("request_number", "like", $term)
+                  ->orWhere("employer_employee_id", "like", $term);
+            });
+        }
+
+        $employees = $query->select("id", "employeeNameEn", "employeeNameTh", "employeePassport")
+            ->limit(30)
+            ->get();
+
+        return response()->json($employees);
+    }
+
     public function index(Request $request)
 {
     // Filter out 'registration_cancelled' statuses so they don't appear until finalized

--- a/app/Http/Controllers/SalesLeadController.php
+++ b/app/Http/Controllers/SalesLeadController.php
@@ -38,6 +38,17 @@ class SalesLeadController extends Controller
             'employerTaxId' => 'nullable|string|max:255',
             'employerPhone' => 'nullable|string|max:255',
             'jobOwner' => 'nullable|string|max:255',
+            'employerEmail' => 'nullable|string|max:255',
+            'employerPassword' => 'nullable|string|max:255',
+            'outsource_re_code' => 'nullable|string|max:255',
+            'outsource_password' => 'nullable|string|max:255',
+            'socialSecurityHospital' => 'nullable|string|max:255',
+            'businessType' => 'nullable|string|max:255',
+            'businessTypeEn' => 'nullable|string|max:255',
+            'signerNameTh' => 'nullable|string|max:255',
+            'signerNameEn' => 'nullable|string|max:255',
+            'signer_2_name_th' => 'nullable|string|max:255',
+            'signer_2_name_en' => 'nullable|string|max:255',
         ]);
 
         if ($request->filled('employer_id')) {
@@ -50,6 +61,17 @@ class SalesLeadController extends Controller
         } else {
             // Temporary ID logic
             $validated['employerId'] = 'SL-EMP-' . strtoupper(uniqid());
+            $validated['employerEmail'] = $request->employerEmail;
+            $validated['employerPassword'] = $request->employerPassword;
+            $validated['outsource_re_code'] = $request->outsource_re_code;
+            $validated['outsource_password'] = $request->outsource_password;
+            $validated['socialSecurityHospital'] = $request->socialSecurityHospital;
+            $validated['businessType'] = $request->businessType;
+            $validated['businessTypeEn'] = $request->businessTypeEn;
+            $validated['signerNameTh'] = $request->signerNameTh;
+            $validated['signerNameEn'] = $request->signerNameEn;
+            $validated['signer_2_name_th'] = $request->signer_2_name_th;
+            $validated['signer_2_name_en'] = $request->signer_2_name_en;
         }
 
         $validated['status'] = 'quoted';
@@ -210,7 +232,17 @@ class SalesLeadController extends Controller
                     'employerNameEn' => $sales->employerNameEn,
                     'employerTaxId' => $sales->employerTaxId,
                     'employerPhone' => $sales->employerPhone,
-                    // Add other defaults as necessary
+                    'employerEmail' => $sales->employerEmail,
+                    'employerPassword' => $sales->employerPassword,
+                    'outsource_re_code' => $sales->outsource_re_code,
+                    'outsource_password' => $sales->outsource_password,
+                    'socialSecurityHospital' => $sales->socialSecurityHospital,
+                    'businessType' => $sales->businessType,
+                    'businessTypeEn' => $sales->businessTypeEn,
+                    'signerNameTh' => $sales->signerNameTh,
+                    'signerNameEn' => $sales->signerNameEn,
+                    'signer_2_name_th' => $sales->signer_2_name_th,
+                    'signer_2_name_en' => $sales->signer_2_name_en,
                 ]);
                 $sales->employer_id = $realEmployer->id;
                 $sales->save();

--- a/app/Models/SalesLead.php
+++ b/app/Models/SalesLead.php
@@ -22,7 +22,18 @@ class SalesLead extends Model
         'status', // quoted, deciding, confirmed, transitioned, cancelled
         'workflow_destination',
         'created_by',
-        'confirmed_by'
+        'confirmed_by',
+        'employerEmail',
+        'employerPassword',
+        'outsource_re_code',
+        'outsource_password',
+        'socialSecurityHospital',
+        'businessType',
+        'businessTypeEn',
+        'signerNameTh',
+        'signerNameEn',
+        'signer_2_name_th',
+        'signer_2_name_en'
     ];
 
     /**

--- a/database/migrations/2026_03_24_194727_add_full_employer_fields_to_sales_leads_table.php
+++ b/database/migrations/2026_03_24_194727_add_full_employer_fields_to_sales_leads_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sales_leads', function (Blueprint $table) {
+            $table->string('employerEmail')->nullable();
+            $table->string('employerPassword')->nullable();
+            $table->string('outsource_re_code')->nullable();
+            $table->string('outsource_password')->nullable();
+            $table->string('socialSecurityHospital')->nullable();
+            $table->string('businessType')->nullable();
+            $table->string('businessTypeEn')->nullable();
+            $table->string('signerNameTh')->nullable();
+            $table->string('signerNameEn')->nullable();
+            $table->string('signer_2_name_th')->nullable();
+            $table->string('signer_2_name_en')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sales_leads', function (Blueprint $table) {
+            $table->dropColumn([
+                'employerEmail',
+                'employerPassword',
+                'outsource_re_code',
+                'outsource_password',
+                'socialSecurityHospital',
+                'businessType',
+                'businessTypeEn',
+                'signerNameTh',
+                'signerNameEn',
+                'signer_2_name_th',
+                'signer_2_name_en'
+            ]);
+        });
+    }
+};

--- a/resources/views/sales/partials/_create_modal.blade.php
+++ b/resources/views/sales/partials/_create_modal.blade.php
@@ -61,6 +61,53 @@
                                     <label class="form-label">ชื่อผู้ติดต่อ / เจ้าของงาน</label>
                                     <input type="text" class="form-control" name="jobOwner">
                                 </div>
+
+                                <div class="col-md-6">
+                                    <label class="form-label">โรงพยาบาลประกันสังคม</label>
+                                    <input type="text" class="form-control" name="socialSecurityHospital">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">อีเมล</label>
+                                    <input type="text" class="form-control" name="employerEmail">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">รหัสผ่านอีเมล</label>
+                                    <input type="text" class="form-control" name="employerPassword">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">รหัส RE Outsource</label>
+                                    <input type="text" class="form-control" name="outsource_re_code">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">รหัสผ่าน Outsource</label>
+                                    <input type="text" class="form-control" name="outsource_password">
+                                </div>
+
+                                <div class="col-md-6">
+                                    <label class="form-label">ประเภทธุรกิจ (ไทย)</label>
+                                    <input type="text" class="form-control" name="businessType">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">ประเภทธุรกิจ (อังกฤษ)</label>
+                                    <input type="text" class="form-control" name="businessTypeEn">
+                                </div>
+
+                                <div class="col-md-6">
+                                    <label class="form-label">ชื่อผู้มีอำนาจลงนาม 1 (ไทย)</label>
+                                    <input type="text" class="form-control" name="signerNameTh">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">ชื่อผู้มีอำนาจลงนาม 1 (อังกฤษ)</label>
+                                    <input type="text" class="form-control" name="signerNameEn">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">ชื่อผู้มีอำนาจลงนาม 2 (ไทย)</label>
+                                    <input type="text" class="form-control" name="signer_2_name_th">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">ชื่อผู้มีอำนาจลงนาม 2 (อังกฤษ)</label>
+                                    <input type="text" class="form-control" name="signer_2_name_en">
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -119,6 +119,7 @@ Route::middleware('auth')->group(function () {
 
     Route::post('employees/photo/enhance', [EmployeeController::class, 'enhancePhoto'])->name('employees.photo.enhance');
 
+    Route::get('employees/search', [EmployeeController::class, 'search'])->name('employees.search');
     Route::resource('employees', EmployeeController::class)->middleware('menu:employees');
     Route::get('/importers/{importer}/documents/{field}/pdf', [ImporterController::class, 'downloadDocumentAsPdf'])->name('importers.documents.pdf');
     Route::resource('importers', ImporterController::class)->middleware('menu:importers');


### PR DESCRIPTION
Fix Sales Lead employer creation form and employee search route

- Expand the temporary 'New Employer' creation form in the Read and Sale module to include all full Employer fields (optional) to collect comprehensive data upfront.
- Add corresponding full Employer fields to the `sales_leads` table and model.
- Transfer these full fields explicitly when transitioning a confirmed Sales Lead into a real Employer.
- Add the missing `employees.search` route and `search` method to `EmployeeController` to resolve the RouteNotFoundException encountered when managing employees within a Sales Lead.

---
*PR created automatically by Jules for task [13631563339921576121](https://jules.google.com/task/13631563339921576121) started by @nongjossss-commits*