### PR TITLE
Fix workflow search by request number

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -106,19 +106,22 @@ class ProductionController extends Controller
                             });
                       })
                       ->orWhereHas('items', function($itemQuery) use ($search, $cleanedSearch) {
-                          $itemQuery->where('request_number', 'like', "%{$search}%")
-                              ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
-                                  $emp->where('employeeNameTh', 'like', "%{$search}%")
-                                      ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                                      ->orWhere('employeePassport', 'like', "%{$search}%")
-                                      ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
-                                      ->orWhere('employee_id_number', 'like', "%{$search}%")
-                                      ->orWhere('name_list_number', 'like', "%{$search}%")
-                                      ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                                      ->orWhere('employer_employee_id', 'like', "%{$search}%")
-                                      ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                                      ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
-                              });
+                          $itemQuery->where(function($q) use ($search, $cleanedSearch) {
+                              $q->where('request_number', 'like', "%{$search}%")
+                                ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
+                                    $emp->where('employeeNameTh', 'like', "%{$search}%")
+                                        ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                                        ->orWhere('employeePassport', 'like', "%{$search}%")
+                                        ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
+                                        ->orWhere('employee_id_number', 'like', "%{$search}%")
+                                        ->orWhere('name_list_number', 'like', "%{$search}%")
+                                        ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                                        ->orWhere('request_number', 'like', "%{$search}%")
+                                        ->orWhere('employer_employee_id', 'like', "%{$search}%")
+                                        ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                                        ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                                });
+                          });
                       })
                       ->orWhereHas('creator', function($creator) use ($search) {
                           $creator->where('name', 'like', "%{$search}%");
@@ -235,19 +238,22 @@ class ProductionController extends Controller
                             ->orWhere(function($addrQ) use ($search) { $addrQ->filterByAddress($search); });
                       })
                       ->orWhereHas('items', function($itemQuery) use ($search, $cleanedSearch) {
-                          $itemQuery->where('request_number', 'like', "%{$search}%")
-                              ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
-                                  $emp->where('employeeNameTh', 'like', "%{$search}%")
-                                      ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                                      ->orWhere('employeePassport', 'like', "%{$search}%")
-                                      ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
-                                      ->orWhere('employee_id_number', 'like', "%{$search}%")
-                                      ->orWhere('name_list_number', 'like', "%{$search}%")
-                                      ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                                      ->orWhere('employer_employee_id', 'like', "%{$search}%")
-                                      ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                                      ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
-                              });
+                          $itemQuery->where(function($q) use ($search, $cleanedSearch) {
+                              $q->where('request_number', 'like', "%{$search}%")
+                                ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
+                                    $emp->where('employeeNameTh', 'like', "%{$search}%")
+                                        ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                                        ->orWhere('employeePassport', 'like', "%{$search}%")
+                                        ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
+                                        ->orWhere('employee_id_number', 'like', "%{$search}%")
+                                        ->orWhere('name_list_number', 'like', "%{$search}%")
+                                        ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                                        ->orWhere('request_number', 'like', "%{$search}%")
+                                        ->orWhere('employer_employee_id', 'like', "%{$search}%")
+                                        ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                                        ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                                });
+                          });
                       })
                       ->orWhereHas('employer.jobOwner', function($owner) use ($search) {
                           $owner->where('name', 'like', "%{$search}%");
@@ -881,6 +887,7 @@ class ProductionController extends Controller
                           ->orWhere('employee_id_number', 'like', "%{$search}%")
                           ->orWhere('name_list_number', 'like', "%{$search}%")
                           ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                          ->orWhere('request_number', 'like', "%{$search}%")
                           ->orWhere('employer_employee_id', 'like', "%{$search}%")
                           ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                           ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
@@ -1014,6 +1021,7 @@ class ProductionController extends Controller
                               ->orWhere('employee_id_number', 'like', "%{$search}%")
                               ->orWhere('name_list_number', 'like', "%{$search}%")
                               ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                              ->orWhere('request_number', 'like', "%{$search}%")
                               ->orWhere('employer_employee_id', 'like', "%{$search}%")
                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -78,19 +78,22 @@ class WorkflowController extends Controller
                         });
                   })
                   ->orWhereHas('items', function($itemQuery) use ($search, $cleanedSearch) {
-                      $itemQuery->where('request_number', 'like', "%{$search}%")
-                          ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
-                              $emp->where('employeeNameTh', 'like', "%{$search}%")
-                                  ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                                  ->orWhere('employeePassport', 'like', "%{$search}%")
-                                  ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
-                                  ->orWhere('employee_id_number', 'like', "%{$search}%")
-                                  ->orWhere('name_list_number', 'like', "%{$search}%")
-                                  ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                                  ->orWhere('employer_employee_id', 'like', "%{$search}%")
-                                  ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                                  ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
-                          });
+                      $itemQuery->where(function($q) use ($search, $cleanedSearch) {
+                          $q->where('request_number', 'like', "%{$search}%")
+                            ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
+                                $emp->where('employeeNameTh', 'like', "%{$search}%")
+                                    ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                                    ->orWhere('employeePassport', 'like', "%{$search}%")
+                                    ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
+                                    ->orWhere('employee_id_number', 'like', "%{$search}%")
+                                    ->orWhere('name_list_number', 'like', "%{$search}%")
+                                    ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                                    ->orWhere('request_number', 'like', "%{$search}%")
+                                    ->orWhere('employer_employee_id', 'like', "%{$search}%")
+                                    ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                                    ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                            });
+                      });
                   })
                   ->orWhereHas('creator', function($creator) use ($search) {
                       $creator->where('name', 'like', "%{$search}%");
@@ -216,18 +219,23 @@ class WorkflowController extends Controller
                             ->orWhereRaw("REPLACE(employerNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                             ->orWhere(function($addrQ) use ($search) { $addrQ->filterByAddress($search); });
                       })
-                      ->orWhereHas('items.employee', function($emp) use ($search, $cleanedSearch) {
-                          $emp->where('employeeNameTh', 'like', "%{$search}%")
-                              ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                              ->orWhere('employeePassport', 'like', "%{$search}%")
-                              ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
-                              ->orWhere('employee_id_number', 'like', "%{$search}%")
-                              ->orWhere('name_list_number', 'like', "%{$search}%")
-                              ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                              ->orWhere('request_number', 'like', "%{$search}%")
-                              ->orWhere('employer_employee_id', 'like', "%{$search}%")
-                              ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                              ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                      ->orWhereHas('items', function($itemQuery) use ($search, $cleanedSearch) {
+                          $itemQuery->where(function($q) use ($search, $cleanedSearch) {
+                              $q->where('request_number', 'like', "%{$search}%")
+                                ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
+                                    $emp->where('employeeNameTh', 'like', "%{$search}%")
+                                        ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                                        ->orWhere('employeePassport', 'like', "%{$search}%")
+                                        ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
+                                        ->orWhere('employee_id_number', 'like', "%{$search}%")
+                                        ->orWhere('name_list_number', 'like', "%{$search}%")
+                                        ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                                        ->orWhere('request_number', 'like', "%{$search}%")
+                                        ->orWhere('employer_employee_id', 'like', "%{$search}%")
+                                        ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                                        ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                                });
+                          });
                       })
                       ->orWhereHas('employer.jobOwner', function($owner) use ($search) {
                           $owner->where('name', 'like', "%{$search}%");
@@ -729,18 +737,21 @@ class WorkflowController extends Controller
                 ->exists();
 
             if (!$orderMatches) {
-                 $query->whereHas('employee', function($q) use ($search, $cleanedSearch) {
-                      $q->where('employeeNameTh', 'like', "%{$search}%")
-                        ->orWhere('employeeNameEn', 'like', "%{$search}%")
-                        ->orWhere('employeePassport', 'like', "%{$search}%")
-                        ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
-                        ->orWhere('employee_id_number', 'like', "%{$search}%")
-                        ->orWhere('name_list_number', 'like', "%{$search}%")
-                        ->orWhere('pinkCardNo', 'like', "%{$search}%")
-                        ->orWhere('request_number', 'like', "%{$search}%")
-                        ->orWhere('employer_employee_id', 'like', "%{$search}%")
-                        ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
-                        ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                 $query->where(function($q) use ($search, $cleanedSearch) {
+                     $q->where('request_number', 'like', "%{$search}%")
+                       ->orWhereHas('employee', function($emp) use ($search, $cleanedSearch) {
+                           $emp->where('employeeNameTh', 'like', "%{$search}%")
+                               ->orWhere('employeeNameEn', 'like', "%{$search}%")
+                               ->orWhere('employeePassport', 'like', "%{$search}%")
+                               ->orWhere('employeeWorkPermit', 'like', "%{$search}%")
+                               ->orWhere('employee_id_number', 'like', "%{$search}%")
+                               ->orWhere('name_list_number', 'like', "%{$search}%")
+                               ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                               ->orWhere('request_number', 'like', "%{$search}%")
+                               ->orWhere('employer_employee_id', 'like', "%{$search}%")
+                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
+                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
+                       });
                  });
             }
         }
@@ -1941,6 +1952,7 @@ class WorkflowController extends Controller
                           ->orWhere('employee_id_number', 'like', "%{$search}%")
                           ->orWhere('name_list_number', 'like', "%{$search}%")
                           ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                          ->orWhere('request_number', 'like', "%{$search}%")
                           ->orWhere('employer_employee_id', 'like', "%{$search}%")
                           ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                           ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);
@@ -2052,6 +2064,7 @@ class WorkflowController extends Controller
                               ->orWhere('employee_id_number', 'like', "%{$search}%")
                               ->orWhere('name_list_number', 'like', "%{$search}%")
                               ->orWhere('pinkCardNo', 'like', "%{$search}%")
+                              ->orWhere('request_number', 'like', "%{$search}%")
                               ->orWhere('employer_employee_id', 'like', "%{$search}%")
                               ->orWhereRaw("REPLACE(employeeNameTh, ' ', '') LIKE ?", ["%{$cleanedSearch}%"])
                               ->orWhereRaw("REPLACE(employeeNameEn, ' ', '') LIKE ?", ["%{$cleanedSearch}%"]);

--- a/tests/Feature/WorkflowSearchTest.php
+++ b/tests/Feature/WorkflowSearchTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\ProductionOrder;
+use App\Models\ProductionItem;
+use App\Models\WorkType;
+use App\Models\WorkTypeStep;
+use App\Models\Employer;
+use App\Models\Employee;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Seed WorkTypes
+    WorkType::create(['name' => 'Notify In', 'slug' => 'notify_in', 'order' => 1]);
+
+    // Seed Employer
+    $this->employer = Employer::create([
+        'employerNameTh' => 'Test Employer Search',
+        'employerId' => 'EMP-SEARCH-001',
+    ]);
+
+    // Seed User
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+test('can search by production item request number in workflow index', function () {
+    $workType = WorkType::where('slug', 'notify_in')->first();
+
+    $order = ProductionOrder::create([
+        'employer_id' => $this->employer->id,
+        'work_type_id' => $workType->id,
+        'status' => 'active',
+        'type' => 'employer',
+        'project_name' => 'Active Project Search',
+        'created_by' => $this->user->id,
+    ]);
+
+    $employee = Employee::create([
+        'employer_id' => $this->employer->id,
+        'employeeNameEn' => 'John Doe',
+        'request_number' => 'EMP-REQ-001', // Base employee request number
+        'status' => 'active',
+    ]);
+
+    $item = ProductionItem::create([
+        'production_order_id' => $order->id,
+        'employee_id' => $employee->id,
+        'status' => 'pending',
+        'request_number' => 'WORKFLOW-REQ-123', // ProductionItem request number
+    ]);
+
+    // Call index with search matching ProductionItem request number
+    $response = $this->get(route('workflow.index', ['tab' => 'notify_in', 'search' => 'WORKFLOW-REQ-123']));
+    $response->assertStatus(200);
+
+    // The order should be found and present in the view's $orders variable
+    $orders = $response->viewData('orders');
+    expect($orders->count())->toBeGreaterThan(0);
+    expect($orders->first()->id)->toBe($order->id);
+
+    // Call batch stats with search matching ProductionItem request number
+    $response = $this->postJson(route('workflow.stats.batch'), [
+        'order_ids' => [$order->id],
+        'search' => 'WORKFLOW-REQ-123'
+    ]);
+    $response->assertStatus(200);
+    $response->assertJsonPath("stats.{$order->id}.total", 1);
+});
+
+
+test('can search by employee request number in workflow index', function () {
+    $workType = WorkType::where('slug', 'notify_in')->first();
+
+    $order = ProductionOrder::create([
+        'employer_id' => $this->employer->id,
+        'work_type_id' => $workType->id,
+        'status' => 'active',
+        'type' => 'employer',
+        'project_name' => 'Active Project Search',
+        'created_by' => $this->user->id,
+    ]);
+
+    $employee = Employee::create([
+        'employer_id' => $this->employer->id,
+        'employeeNameEn' => 'John Doe',
+        'request_number' => 'EMP-REQ-002', // Base employee request number
+        'status' => 'active',
+    ]);
+
+    $item = ProductionItem::create([
+        'production_order_id' => $order->id,
+        'employee_id' => $employee->id,
+        'status' => 'pending',
+    ]);
+
+    // Call index with search matching Employee request number
+    $response = $this->get(route('workflow.index', ['tab' => 'notify_in', 'search' => 'EMP-REQ-002']));
+    $response->assertStatus(200);
+
+    // The order should be found and present in the view's $orders variable
+    $orders = $response->viewData('orders');
+    expect($orders->count())->toBeGreaterThan(0);
+    expect($orders->first()->id)->toBe($order->id);
+
+    // Call batch stats with search matching Employee request number
+    $response = $this->postJson(route('workflow.stats.batch'), [
+        'order_ids' => [$order->id],
+        'search' => 'EMP-REQ-002'
+    ]);
+    $response->assertStatus(200);
+    $response->assertJsonPath("stats.{$order->id}.total", 1);
+});


### PR DESCRIPTION
Fixes a bug in the workflow and production modules where searching by an employee's workflow request number would return the employer but display an empty list of employees when expanded. The issue occurred because the system was only searching the `Employee` database for `request_number` instead of also searching the `ProductionItem`'s `request_number`. The controllers have been refactored to check both.

Added corresponding tests to `WorkflowSearchTest.php` to prevent regressions.

---
*PR created automatically by Jules for task [14450098137984926125](https://jules.google.com/task/14450098137984926125) started by @nongjossss-commits*