### PR TITLE
Add Active/Cancelled Filter to Financial Tabs

### DIFF
--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -24,6 +24,11 @@ if (typeof window.financialManager === 'undefined') {
             employees: initialData.employees || [], // List of candidates {id, name} (Scoped to Current Stage)
             selectedTransactionItems: [], // List of IDs (ProductionItem ID or 'emp_ID')
 
+            // Employee Filter State
+            tierEmployeeFilter: 'active', // 'active' or 'cancelled'
+            newTransactionEmployeeFilter: 'active',
+            editTransactionEmployeeFilter: 'active',
+
             // Tax Settings
             vatIncluded: false,
             vatRate: 7,
@@ -247,6 +252,11 @@ if (typeof window.financialManager === 'undefined') {
             },
 
             // --- Employee Filter Logic ---
+            isCancelledStatus(status) {
+                if (!status) return false;
+                return status.endsWith('cancelled') || status === 'cancelled';
+            },
+
             get allEmployeesForTier() {
                 // Return Merged List for Price Tier Modal
                 // This includes Existing ProductionItems AND Candidates (Employees not yet in Order)
@@ -274,6 +284,10 @@ if (typeof window.financialManager === 'undefined') {
                 this.productionItems.forEach(item => {
                     if (usedItemIds.has(item.id)) return; // Locked by installment
 
+                    const isCancelled = this.isCancelledStatus(item.status);
+                    if (this.tierEmployeeFilter === 'active' && isCancelled) return;
+                    if (this.tierEmployeeFilter === 'cancelled' && !isCancelled) return;
+
                     if (item.employee_id) itemsByEmpId[item.employee_id] = item.id;
                     list.push({ ...item, type: 'item', last_step_name: item.last_step_name });
                 });
@@ -282,6 +296,10 @@ if (typeof window.financialManager === 'undefined') {
                 this.employees.forEach(emp => {
                     if (itemsByEmpId[emp.id]) return; // Already exists as item
                     if (usedEmployeeIds.has(emp.id)) return; // Locked
+
+                    const isCancelled = this.isCancelledStatus(emp.status);
+                    if (this.tierEmployeeFilter === 'active' && isCancelled) return;
+                    if (this.tierEmployeeFilter === 'cancelled' && !isCancelled) return;
 
                     list.push({
                         id: 'emp_' + emp.id,
@@ -294,6 +312,7 @@ if (typeof window.financialManager === 'undefined') {
                         passport: emp.passport,
                         employee_id: emp.id,
                         last_step_name: emp.last_step_name,
+                        status: emp.status,
                         type: 'employee'
                     });
                 });
@@ -325,6 +344,10 @@ if (typeof window.financialManager === 'undefined') {
                 this.productionItems.forEach(item => {
                     if (usedItemIds.has(item.id)) return;
 
+                    const isCancelled = this.isCancelledStatus(item.status);
+                    if (this.newTransactionEmployeeFilter === 'active' && isCancelled) return;
+                    if (this.newTransactionEmployeeFilter === 'cancelled' && !isCancelled) return;
+
                     let hasPrice = true;
                     if (this.pricingMode === 'per_head') {
                          hasPrice = !!this.getTierForItem(item.id);
@@ -347,6 +370,7 @@ if (typeof window.financialManager === 'undefined') {
                         insurance_type: item.insurance_type,
                         passport: item.passport,
                         last_step_name: item.last_step_name,
+                        status: item.status,
                         type: 'item'
                     });
                 });
@@ -356,6 +380,10 @@ if (typeof window.financialManager === 'undefined') {
                     this.employees.forEach(emp => {
                         if (itemsByEmpId[emp.id]) return;
                         if (usedEmployeeIds.has(emp.id)) return;
+
+                        const isCancelled = this.isCancelledStatus(emp.status);
+                        if (this.newTransactionEmployeeFilter === 'active' && isCancelled) return;
+                        if (this.newTransactionEmployeeFilter === 'cancelled' && !isCancelled) return;
 
                         list.push({
                             id: 'emp_' + emp.id,
@@ -367,6 +395,7 @@ if (typeof window.financialManager === 'undefined') {
                             insurance_type: emp.insurance_type,
                             passport: emp.passport,
                             last_step_name: emp.last_step_name,
+                            status: emp.status,
                             type: 'employee'
                         });
                     });
@@ -406,6 +435,10 @@ if (typeof window.financialManager === 'undefined') {
                     const isAttached = attachedItemIds.has(item.id);
                     const isUsed = usedItemIds.has(item.id);
 
+                    const isCancelled = this.isCancelledStatus(item.status);
+                    if (this.editTransactionEmployeeFilter === 'active' && isCancelled) return;
+                    if (this.editTransactionEmployeeFilter === 'cancelled' && !isCancelled) return;
+
                     if (isAttached || !isUsed) {
                          list.push({
                             id: item.id,
@@ -417,6 +450,7 @@ if (typeof window.financialManager === 'undefined') {
                             insurance_type: item.insurance_type,
                             passport: item.passport,
                             last_step_name: item.last_step_name,
+                            status: item.status,
                             type: 'item',
                             attached: isAttached
                         });
@@ -428,6 +462,10 @@ if (typeof window.financialManager === 'undefined') {
                     if (itemsByEmpId[emp.id]) return; // Already has item
                     if (usedEmployeeIds.has(emp.id)) return; // Used elsewhere
 
+                    const isCancelled = this.isCancelledStatus(emp.status);
+                    if (this.editTransactionEmployeeFilter === 'active' && isCancelled) return;
+                    if (this.editTransactionEmployeeFilter === 'cancelled' && !isCancelled) return;
+
                     list.push({
                         id: 'emp_' + emp.id,
                         name: emp.name,
@@ -438,6 +476,7 @@ if (typeof window.financialManager === 'undefined') {
                         insurance_type: emp.insurance_type,
                         passport: emp.passport,
                         last_step_name: emp.last_step_name,
+                        status: emp.status,
                         type: 'employee',
                         attached: false
                     });

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -22,7 +22,8 @@
             'insurance_type' => $item->employee ? $item->employee->insurance_type : '',
             'passport' => $item->employee ? $item->employee->employeePassport : '',
             'employee_id' => $item->employee_id,
-            'last_step_name' => $lastStepName
+            'last_step_name' => $lastStepName,
+            'status' => $item->employee ? $item->employee->status : $item->status
         ];
     })) }},
     employees: {{ json_encode(($employees ?? collect())->map(function($emp) {
@@ -40,7 +41,8 @@
             'nationality' => $emp->employeeNationality,
             'insurance_type' => $emp->insurance_type,
             'passport' => $emp->employeePassport,
-            'last_step_name' => $lastStepName
+            'last_step_name' => $lastStepName,
+            'status' => $emp->status
         ];
     })) }},
     productionId: {{ $production->id }},
@@ -640,14 +642,24 @@ class="row">
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body p-2">
-                    <div class="mb-2 d-flex gap-2">
-                        <input type="text" class="form-control form-control-sm" placeholder="Search employee..." x-model="modalSearch">
-                        <button class="btn btn-sm btn-outline-secondary" @click="selectAllForModal()" title="Select All Visible">
-                            <i class="bi bi-check-all"></i>
-                        </button>
-                        <button class="btn btn-sm btn-outline-secondary" @click="deselectAllForModal()" title="Clear Selection">
-                            <i class="bi bi-x-lg"></i>
-                        </button>
+                    <div class="d-flex justify-content-between mb-2 gap-2">
+                        <ul class="nav nav-pills nav-pills-sm custom-nav-pills w-50" style="font-size: 0.8rem;">
+                            <li class="nav-item flex-fill text-center">
+                                <button class="nav-link w-100 py-1 px-2" :class="{ 'active': tierEmployeeFilter === 'active' }" @click="tierEmployeeFilter = 'active'" type="button">Active</button>
+                            </li>
+                            <li class="nav-item flex-fill text-center">
+                                <button class="nav-link w-100 py-1 px-2" :class="{ 'active': tierEmployeeFilter === 'cancelled' }" @click="tierEmployeeFilter = 'cancelled'" type="button">Cancelled</button>
+                            </li>
+                        </ul>
+                        <div class="d-flex gap-1 w-50">
+                            <input type="text" class="form-control form-control-sm" placeholder="Search..." x-model="modalSearch">
+                            <button class="btn btn-sm btn-outline-secondary" @click="selectAllForModal()" title="Select All Visible">
+                                <i class="bi bi-check-all"></i>
+                            </button>
+                            <button class="btn btn-sm btn-outline-secondary" @click="deselectAllForModal()" title="Clear Selection">
+                                <i class="bi bi-x-lg"></i>
+                            </button>
+                        </div>
                     </div>
                     <div class="list-group list-group-flush border rounded small" style="max-height: 300px; overflow-y: auto;">
                         <template x-for="item in allEmployeesForTier" :key="item.id">
@@ -853,6 +865,14 @@ class="row">
                             </div>
                             <div class="col-md-6 border-start">
                                 <label class="form-label small fw-bold mb-1">Select Employees</label>
+                                <ul class="nav nav-pills nav-pills-sm custom-nav-pills mb-2" style="font-size: 0.75rem;">
+                                    <li class="nav-item flex-fill text-center">
+                                        <button class="nav-link w-100 py-0" :class="{ 'active': newTransactionEmployeeFilter === 'active' }" @click="newTransactionEmployeeFilter = 'active'" type="button">Active</button>
+                                    </li>
+                                    <li class="nav-item flex-fill text-center">
+                                        <button class="nav-link w-100 py-0" :class="{ 'active': newTransactionEmployeeFilter === 'cancelled' }" @click="newTransactionEmployeeFilter = 'cancelled'" type="button">Cancelled</button>
+                                    </li>
+                                </ul>
                                 <div class="d-flex justify-content-between align-items-center mb-2">
                                     <div class="small text-muted" style="font-size: 0.75rem;">
                                         Selected: <span x-text="selectedTransactionItems.length"></span>
@@ -1108,6 +1128,14 @@ class="row">
                              </div>
                              <div class="col-md-6 border-start">
                                 <label class="form-label small fw-bold mb-1">Edit Employees</label>
+                                <ul class="nav nav-pills nav-pills-sm custom-nav-pills mb-2" style="font-size: 0.75rem;">
+                                    <li class="nav-item flex-fill text-center">
+                                        <button class="nav-link w-100 py-0" :class="{ 'active': editTransactionEmployeeFilter === 'active' }" @click="editTransactionEmployeeFilter = 'active'" type="button">Active</button>
+                                    </li>
+                                    <li class="nav-item flex-fill text-center">
+                                        <button class="nav-link w-100 py-0" :class="{ 'active': editTransactionEmployeeFilter === 'cancelled' }" @click="editTransactionEmployeeFilter = 'cancelled'" type="button">Cancelled</button>
+                                    </li>
+                                </ul>
                                 <div class="border rounded bg-light" style="max-height: 250px; overflow-y: auto;">
                                     <div class="list-group list-group-flush">
                                         <!-- Show ALL items for edit (Available + Currently Attached) -->


### PR DESCRIPTION
Added tabbed filters in the financial manager interfaces to allow users to toggle viewing of 'Active' vs 'Cancelled' employees when assigning prices or setting up transactions.

---
*PR created automatically by Jules for task [17512834439167203360](https://jules.google.com/task/17512834439167203360) started by @nongjossss-commits*