### PR TITLE
Fix Sales Lead enhancements, attachments, edits, and layout

### DIFF
--- a/app/Http/Controllers/SalesLeadController.php
+++ b/app/Http/Controllers/SalesLeadController.php
@@ -49,6 +49,16 @@ class SalesLeadController extends Controller
             'signerNameEn' => 'nullable|string|max:255',
             'signer_2_name_th' => 'nullable|string|max:255',
             'signer_2_name_en' => 'nullable|string|max:255',
+            'employer_doc_company' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_company_expiry' => 'nullable|date',
+            'employer_doc_lease' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_construction' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_other_1' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_other_1_desc' => 'nullable|string|max:255',
+            'employer_doc_other_2' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_other_2_desc' => 'nullable|string|max:255',
+            'employer_doc_other_3' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_other_3_desc' => 'nullable|string|max:255',
         ]);
 
         if ($request->filled('employer_id')) {
@@ -72,6 +82,22 @@ class SalesLeadController extends Controller
             $validated['signerNameEn'] = $request->signerNameEn;
             $validated['signer_2_name_th'] = $request->signer_2_name_th;
             $validated['signer_2_name_en'] = $request->signer_2_name_en;
+
+            // Handle file uploads
+            $fileFields = [
+                'employer_doc_company',
+                'employer_doc_lease',
+                'employer_doc_construction',
+                'employer_doc_other_1',
+                'employer_doc_other_2',
+                'employer_doc_other_3'
+            ];
+
+            foreach ($fileFields as $field) {
+                if ($request->hasFile($field)) {
+                    $validated[$field] = $request->file($field)->store('sales_leads/employers', 'public');
+                }
+            }
         }
 
         $validated['status'] = 'quoted';
@@ -80,6 +106,58 @@ class SalesLeadController extends Controller
         SalesLead::create($validated);
 
         return redirect()->route('sales.index')->with('success', 'สร้างรายการเสนอราคาสำเร็จ');
+    }
+
+    public function update(Request $request, SalesLead $sales)
+    {
+        $validated = $request->validate([
+            'employerNameTh' => 'required|string|max:255',
+            'employerNameEn' => 'nullable|string|max:255',
+            'employerTaxId' => 'nullable|string|max:255',
+            'employerPhone' => 'nullable|string|max:255',
+            'jobOwner' => 'nullable|string|max:255',
+            'employerEmail' => 'nullable|string|max:255',
+            'employerPassword' => 'nullable|string|max:255',
+            'outsource_re_code' => 'nullable|string|max:255',
+            'outsource_password' => 'nullable|string|max:255',
+            'socialSecurityHospital' => 'nullable|string|max:255',
+            'businessType' => 'nullable|string|max:255',
+            'businessTypeEn' => 'nullable|string|max:255',
+            'signerNameTh' => 'nullable|string|max:255',
+            'signerNameEn' => 'nullable|string|max:255',
+            'signer_2_name_th' => 'nullable|string|max:255',
+            'signer_2_name_en' => 'nullable|string|max:255',
+            'employer_doc_company' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_company_expiry' => 'nullable|date',
+            'employer_doc_lease' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_construction' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_other_1' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_other_1_desc' => 'nullable|string|max:255',
+            'employer_doc_other_2' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_other_2_desc' => 'nullable|string|max:255',
+            'employer_doc_other_3' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employer_doc_other_3_desc' => 'nullable|string|max:255',
+        ]);
+
+        // Handle file uploads
+        $fileFields = [
+            'employer_doc_company',
+            'employer_doc_lease',
+            'employer_doc_construction',
+            'employer_doc_other_1',
+            'employer_doc_other_2',
+            'employer_doc_other_3'
+        ];
+
+        foreach ($fileFields as $field) {
+            if ($request->hasFile($field)) {
+                $validated[$field] = $request->file($field)->store('sales_leads/employers', 'public');
+            }
+        }
+
+        $sales->update($validated);
+
+        return redirect()->back()->with('success', 'อัปเดตข้อมูลลูกค้าสำเร็จ');
     }
 
     public function updateStatus(Request $request, SalesLead $sales)
@@ -130,7 +208,17 @@ class SalesLeadController extends Controller
             'employeePassport' => 'nullable|string',
             'employeeWorkPermit' => 'nullable|string',
             'photo' => 'nullable|image|max:5120',
-            'document' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_1' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_2' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_visa' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_3' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_4' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_other_1' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'other_doc_1_desc' => 'nullable|string|max:255',
+            'employee_doc_other_2' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'other_doc_2_desc' => 'nullable|string|max:255',
+            'employee_doc_other_3' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'other_doc_3_desc' => 'nullable|string|max:255',
         ]);
 
         $validated['sales_lead_id'] = $sales->id;
@@ -148,13 +236,76 @@ class SalesLeadController extends Controller
         if ($request->hasFile('photo')) {
             $validated['photo_path'] = $request->file('photo')->store('sales_lead_employees/photos', 'public');
         }
-        if ($request->hasFile('document')) {
-            $validated['document_path'] = $request->file('document')->store('sales_lead_employees/documents', 'public');
+
+        $employeeDocs = [
+            'employee_doc_1',
+            'employee_doc_2',
+            'employee_doc_visa',
+            'employee_doc_3',
+            'employee_doc_4',
+            'employee_doc_other_1',
+            'employee_doc_other_2',
+            'employee_doc_other_3'
+        ];
+
+        foreach ($employeeDocs as $doc) {
+            if ($request->hasFile($doc)) {
+                $validated[$doc] = $request->file($doc)->store('sales_lead_employees/documents', 'public');
+            }
         }
 
         SalesLeadEmployee::create($validated);
 
         return redirect()->back()->with('success', 'เพิ่มลูกจ้างสำเร็จ');
+    }
+
+    public function updateEmployee(Request $request, SalesLead $sales, SalesLeadEmployee $employee)
+    {
+        $validated = $request->validate([
+            'employeeNameEn' => 'required|string|max:255',
+            'employeeNameTh' => 'nullable|string|max:255',
+            'employeeGender' => 'nullable|string',
+            'employeePassport' => 'nullable|string',
+            'employeeWorkPermit' => 'nullable|string',
+            'photo' => 'nullable|image|max:5120',
+            'employee_doc_1' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_2' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_visa' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_3' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_4' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'employee_doc_other_1' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'other_doc_1_desc' => 'nullable|string|max:255',
+            'employee_doc_other_2' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'other_doc_2_desc' => 'nullable|string|max:255',
+            'employee_doc_other_3' => 'nullable|file|mimes:pdf,doc,docx,jpg,png|max:10240',
+            'other_doc_3_desc' => 'nullable|string|max:255',
+        ]);
+
+        // Handle file uploads
+        if ($request->hasFile('photo')) {
+            $validated['photo_path'] = $request->file('photo')->store('sales_lead_employees/photos', 'public');
+        }
+
+        $employeeDocs = [
+            'employee_doc_1',
+            'employee_doc_2',
+            'employee_doc_visa',
+            'employee_doc_3',
+            'employee_doc_4',
+            'employee_doc_other_1',
+            'employee_doc_other_2',
+            'employee_doc_other_3'
+        ];
+
+        foreach ($employeeDocs as $doc) {
+            if ($request->hasFile($doc)) {
+                $validated[$doc] = $request->file($doc)->store('sales_lead_employees/documents', 'public');
+            }
+        }
+
+        $employee->update($validated);
+
+        return redirect()->back()->with('success', 'อัปเดตข้อมูลลูกจ้างสำเร็จ');
     }
 
     public function destroyEmployee(SalesLead $sales, SalesLeadEmployee $employee)
@@ -243,6 +394,16 @@ class SalesLeadController extends Controller
                     'signerNameEn' => $sales->signerNameEn,
                     'signer_2_name_th' => $sales->signer_2_name_th,
                     'signer_2_name_en' => $sales->signer_2_name_en,
+                    'employer_doc_company' => $sales->employer_doc_company,
+                    'employer_doc_company_expiry' => $sales->employer_doc_company_expiry,
+                    'employer_doc_lease' => $sales->employer_doc_lease,
+                    'employer_doc_construction' => $sales->employer_doc_construction,
+                    'employer_doc_other_1' => $sales->employer_doc_other_1,
+                    'employer_doc_other_1_desc' => $sales->employer_doc_other_1_desc,
+                    'employer_doc_other_2' => $sales->employer_doc_other_2,
+                    'employer_doc_other_2_desc' => $sales->employer_doc_other_2_desc,
+                    'employer_doc_other_3' => $sales->employer_doc_other_3,
+                    'employer_doc_other_3_desc' => $sales->employer_doc_other_3_desc,
                 ]);
                 $sales->employer_id = $realEmployer->id;
                 $sales->save();
@@ -262,16 +423,19 @@ class SalesLeadController extends Controller
                         'employeePassport' => $slEmp->employeePassport,
                         'employeeWorkPermit' => $slEmp->employeeWorkPermit,
                         'status' => 'active', // Default status
+                        'employee_doc_1' => $slEmp->employee_doc_1,
+                        'employee_doc_2' => $slEmp->employee_doc_2,
+                        'employee_doc_visa' => $slEmp->employee_doc_visa,
+                        'employee_doc_3' => $slEmp->employee_doc_3,
+                        'employee_doc_4' => $slEmp->employee_doc_4,
+                        'employee_doc_other_1' => $slEmp->employee_doc_other_1,
+                        'other_doc_1_desc' => $slEmp->other_doc_1_desc,
+                        'employee_doc_other_2' => $slEmp->employee_doc_other_2,
+                        'other_doc_2_desc' => $slEmp->other_doc_2_desc,
+                        'employee_doc_other_3' => $slEmp->employee_doc_other_3,
+                        'other_doc_3_desc' => $slEmp->other_doc_3_desc,
+                        'photo_path' => $slEmp->photo_path,
                     ]);
-
-                    // Handle transferring files to the real employee record
-                    // using Spatie Media Library or simple path updates depending on the system implementation.
-                    // For now, we update the path references on the real employee model if it supports it,
-                    // or just keep them in storage. The main system usually uses Media Library for Employees.
-                    if ($slEmp->photo_path) {
-                        // $newEmp->addMedia(storage_path('app/public/' . $slEmp->photo_path))->toMediaCollection('employee_photo'); // Example
-                        $newEmp->photo_path = $slEmp->photo_path; // Simple fallback
-                    }
 
                     $newEmp->save();
 

--- a/app/Models/SalesLead.php
+++ b/app/Models/SalesLead.php
@@ -33,7 +33,17 @@ class SalesLead extends Model
         'signerNameTh',
         'signerNameEn',
         'signer_2_name_th',
-        'signer_2_name_en'
+        'signer_2_name_en',
+        'employer_doc_company',
+        'employer_doc_company_expiry',
+        'employer_doc_lease',
+        'employer_doc_construction',
+        'employer_doc_other_1',
+        'employer_doc_other_1_desc',
+        'employer_doc_other_2',
+        'employer_doc_other_2_desc',
+        'employer_doc_other_3',
+        'employer_doc_other_3_desc'
     ];
 
     /**

--- a/app/Models/SalesLeadEmployee.php
+++ b/app/Models/SalesLeadEmployee.php
@@ -29,7 +29,19 @@ class SalesLeadEmployee extends Model
         'employer_employee_id',
         'name_list_number',
         'employeeAddress',
-        'employeePhone'
+        'employeePhone',
+        'employee_doc_1',
+        'employee_doc_2',
+        'employee_doc_visa',
+        'employee_doc_3',
+        'employee_doc_4',
+        'employee_doc_other_1',
+        'other_doc_1_desc',
+        'employee_doc_other_2',
+        'other_doc_2_desc',
+        'employee_doc_other_3',
+        'other_doc_3_desc',
+        'photo_path'
     ];
 
     /**

--- a/database/migrations/2026_03_25_100000_add_missing_file_fields_to_sales_leads_and_employees.php
+++ b/database/migrations/2026_03_25_100000_add_missing_file_fields_to_sales_leads_and_employees.php
@@ -1,0 +1,92 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sales_leads', function (Blueprint $table) {
+            $table->string('employer_doc_company')->nullable();
+            $table->date('employer_doc_company_expiry')->nullable();
+            $table->string('employer_doc_lease')->nullable();
+            $table->string('employer_doc_construction')->nullable();
+            $table->string('employer_doc_other_1')->nullable();
+            $table->string('employer_doc_other_1_desc')->nullable();
+            $table->string('employer_doc_other_2')->nullable();
+            $table->string('employer_doc_other_2_desc')->nullable();
+            $table->string('employer_doc_other_3')->nullable();
+            $table->string('employer_doc_other_3_desc')->nullable();
+        });
+
+        Schema::table('sales_lead_employees', function (Blueprint $table) {
+            $table->string('employee_doc_visa')->nullable();
+            $table->string('employee_doc_other_1')->nullable();
+            $table->string('employee_doc_other_2')->nullable();
+            $table->string('employee_doc_other_3')->nullable();
+            $table->string('employee_doc_other_4')->nullable();
+            $table->string('employee_doc_other_5')->nullable();
+            $table->string('employee_doc_other_6')->nullable();
+            $table->string('employee_doc_other_7')->nullable();
+            $table->string('employee_doc_other_8')->nullable();
+            $table->string('employee_doc_other_9')->nullable();
+            $table->string('employee_doc_other_10')->nullable();
+            $table->string('other_doc_1_desc')->nullable();
+            $table->string('other_doc_2_desc')->nullable();
+            $table->string('other_doc_3_desc')->nullable();
+            $table->string('other_doc_4_desc')->nullable();
+            $table->string('other_doc_5_desc')->nullable();
+            $table->string('other_doc_6_desc')->nullable();
+            $table->string('other_doc_7_desc')->nullable();
+            $table->string('other_doc_8_desc')->nullable();
+            $table->string('other_doc_9_desc')->nullable();
+            $table->string('other_doc_10_desc')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sales_leads', function (Blueprint $table) {
+            $table->dropColumn([
+                'employer_doc_company',
+                'employer_doc_company_expiry',
+                'employer_doc_lease',
+                'employer_doc_construction',
+                'employer_doc_other_1',
+                'employer_doc_other_1_desc',
+                'employer_doc_other_2',
+                'employer_doc_other_2_desc',
+                'employer_doc_other_3',
+                'employer_doc_other_3_desc',
+            ]);
+        });
+
+        Schema::table('sales_lead_employees', function (Blueprint $table) {
+            $table->dropColumn([
+                'employee_doc_visa',
+                'employee_doc_other_1',
+                'employee_doc_other_2',
+                'employee_doc_other_3',
+                'employee_doc_other_4',
+                'employee_doc_other_5',
+                'employee_doc_other_6',
+                'employee_doc_other_7',
+                'employee_doc_other_8',
+                'employee_doc_other_9',
+                'employee_doc_other_10',
+                'other_doc_1_desc',
+                'other_doc_2_desc',
+                'other_doc_3_desc',
+                'other_doc_4_desc',
+                'other_doc_5_desc',
+                'other_doc_6_desc',
+                'other_doc_7_desc',
+                'other_doc_8_desc',
+                'other_doc_9_desc',
+                'other_doc_10_desc',
+            ]);
+        });
+    }
+};

--- a/resources/views/sales/index.blade.php
+++ b/resources/views/sales/index.blade.php
@@ -27,9 +27,9 @@
         </div>
     @endif
 
-    <div class="row kanban-board">
+    <div class="row kanban-board flex-nowrap overflow-auto pb-3">
         {{-- Column 1: Quoted --}}
-        <div class="col-md-4">
+        <div class="col-md-4" style="min-width: 350px;">
             <div class="card bg-light h-100 border-0 shadow-sm">
                 <div class="card-header bg-white border-bottom-0 pt-3 pb-2">
                     <h5 class="mb-0 text-primary fw-bold">1. เสนอราคา <span class="badge bg-primary rounded-pill ms-2">{{ $quoted->count() }}</span></h5>
@@ -43,7 +43,7 @@
         </div>
 
         {{-- Column 2: Deciding --}}
-        <div class="col-md-4">
+        <div class="col-md-4" style="min-width: 350px;">
             <div class="card bg-light h-100 border-0 shadow-sm">
                 <div class="card-header bg-white border-bottom-0 pt-3 pb-2">
                     <h5 class="mb-0 text-warning fw-bold">2. รอตัดสินใจ/คอนเฟิร์ม <span class="badge bg-warning text-dark rounded-pill ms-2">{{ $deciding->count() }}</span></h5>
@@ -57,7 +57,7 @@
         </div>
 
         {{-- Column 3: Confirmed --}}
-        <div class="col-md-4">
+        <div class="col-md-4" style="min-width: 350px;">
             <div class="card bg-light h-100 border-0 shadow-sm">
                 <div class="card-header bg-white border-bottom-0 pt-3 pb-2">
                     <h5 class="mb-0 text-success fw-bold">3. คอนเฟิร์มแล้ว (พร้อมส่งต่อ) <span class="badge bg-success rounded-pill ms-2">{{ $confirmed->count() }}</span></h5>

--- a/resources/views/sales/partials/_create_modal.blade.php
+++ b/resources/views/sales/partials/_create_modal.blade.php
@@ -108,6 +108,43 @@
                                     <label class="form-label">ชื่อผู้มีอำนาจลงนาม 2 (อังกฤษ)</label>
                                     <input type="text" class="form-control" name="signer_2_name_en">
                                 </div>
+                                <div class="col-12">
+                                    <hr class="my-4">
+                                    <h6 class="fw-bold"><i class="bi bi-folder-fill me-2"></i>เอกสารแนบ (ถ้ามี)</h6>
+                                </div>
+
+                                <div class="col-md-6">
+                                    <label class="form-label">1. หนังสือรับรองบริษัท / บัตรประชาชน</label>
+                                    <input type="file" class="form-control" name="employer_doc_company" accept=".pdf,.doc,.docx,.jpg,.png">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">1.1 วันหมดอายุ</label>
+                                    <input type="date" class="form-control" name="employer_doc_company_expiry">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">2. สัญญาเช่าบ้าน / ทะเบียนบ้าน</label>
+                                    <input type="file" class="form-control" name="employer_doc_lease" accept=".pdf,.doc,.docx,.jpg,.png">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label">3. สัญญาก่อสร้าง / แผนที่</label>
+                                    <input type="file" class="form-control" name="employer_doc_construction" accept=".pdf,.doc,.docx,.jpg,.png">
+                                </div>
+
+                                <div class="col-md-6 mt-3">
+                                    <label class="form-label">4. เอกสารอื่นๆ 1</label>
+                                    <input type="file" class="form-control" name="employer_doc_other_1" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    <input type="text" class="form-control form-control-sm mt-1" name="employer_doc_other_1_desc" placeholder="ระบุรายละเอียดเอกสาร">
+                                </div>
+                                <div class="col-md-6 mt-3">
+                                    <label class="form-label">5. เอกสารอื่นๆ 2</label>
+                                    <input type="file" class="form-control" name="employer_doc_other_2" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    <input type="text" class="form-control form-control-sm mt-1" name="employer_doc_other_2_desc" placeholder="ระบุรายละเอียดเอกสาร">
+                                </div>
+                                <div class="col-md-6 mt-3 mb-4">
+                                    <label class="form-label">6. เอกสารอื่นๆ 3</label>
+                                    <input type="file" class="form-control" name="employer_doc_other_3" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    <input type="text" class="form-control form-control-sm mt-1" name="employer_doc_other_3_desc" placeholder="ระบุรายละเอียดเอกสาร">
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/resources/views/sales/partials/_edit_employee_modal.blade.php
+++ b/resources/views/sales/partials/_edit_employee_modal.blade.php
@@ -1,0 +1,108 @@
+<div class="modal fade" id="editEmployeeModal-{{ $emp->id }}" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <form action="{{ route('sales.employees.update', [$lead->id, $emp->id]) }}" method="POST" enctype="multipart/form-data">
+                @csrf
+                @method('PUT')
+                <div class="modal-header bg-primary text-white">
+                    <h5 class="modal-title"><i class="bi bi-pencil me-2"></i>แก้ไขข้อมูลลูกจ้างใหม่ (ชั่วคราว)</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label">ชื่อ-นามสกุล (ภาษาอังกฤษ) <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" name="employeeNameEn" value="{{ $emp->employeeNameEn }}" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">ชื่อ-นามสกุล (ภาษาไทย)</label>
+                            <input type="text" class="form-control" name="employeeNameTh" value="{{ $emp->employeeNameTh }}">
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">เพศ</label>
+                            <select class="form-select" name="employeeGender">
+                                <option value="">ไม่ได้ระบุ</option>
+                                <option value="Male" {{ $emp->employeeGender == 'Male' ? 'selected' : '' }}>ชาย (Male)</option>
+                                <option value="Female" {{ $emp->employeeGender == 'Female' ? 'selected' : '' }}>หญิง (Female)</option>
+                            </select>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">เลขพาสปอร์ต</label>
+                            <input type="text" class="form-control" name="employeePassport" value="{{ $emp->employeePassport }}">
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">เลขใบอนุญาตทำงาน</label>
+                            <input type="text" class="form-control" name="employeeWorkPermit" value="{{ $emp->employeeWorkPermit }}">
+                        </div>
+                        <div class="col-md-12 mt-4">
+                            <hr>
+                            <h6 class="fw-bold"><i class="bi bi-folder-fill me-2"></i>อัปเดตเอกสารแนบลูกจ้าง</h6>
+                            <small class="text-muted d-block mb-3">หากไม่ต้องการเปลี่ยนเอกสาร ไม่ต้องเลือกไฟล์ใหม่</small>
+                        </div>
+                        <div class="col-md-6 mt-2">
+                            <label class="form-label">รูปถ่ายหน้าตรง</label>
+                            @if($emp->photo_path)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$emp->photo_path) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="photo" accept="image/*">
+                        </div>
+                        <div class="col-md-6 mt-2">
+                            <label class="form-label">1. พาสปอร์ต (Passport)</label>
+                            @if($emp->employee_doc_1)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$emp->employee_doc_1) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employee_doc_1" accept=".pdf,.doc,.docx,.jpg,.png">
+                        </div>
+                        <div class="col-md-6 mt-2">
+                            <label class="form-label">2. ใบอนุญาตทำงาน (Work Permit)</label>
+                            @if($emp->employee_doc_2)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$emp->employee_doc_2) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employee_doc_2" accept=".pdf,.doc,.docx,.jpg,.png">
+                        </div>
+                        <div class="col-md-6 mt-2">
+                            <label class="form-label">3. วีซ่า (Visa)</label>
+                            @if($emp->employee_doc_visa)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$emp->employee_doc_visa) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employee_doc_visa" accept=".pdf,.doc,.docx,.jpg,.png">
+                        </div>
+                        <div class="col-md-6 mt-2">
+                            <label class="form-label">4. บัตรชมพู (Pink Card)</label>
+                            @if($emp->employee_doc_3)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$emp->employee_doc_3) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employee_doc_3" accept=".pdf,.doc,.docx,.jpg,.png">
+                        </div>
+                        <div class="col-md-6 mt-2">
+                            <label class="form-label">5. ทะเบียนบ้านลูกจ้าง (TR 38/1)</label>
+                            @if($emp->employee_doc_4)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$emp->employee_doc_4) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employee_doc_4" accept=".pdf,.doc,.docx,.jpg,.png">
+                        </div>
+
+                        @for($i = 1; $i <= 3; $i++)
+                            @php
+                                $fieldName = "employee_doc_other_" . $i;
+                                $descName = "other_doc_" . $i . "_desc";
+                            @endphp
+                            <div class="col-md-6 mt-3">
+                                <label class="form-label">เอกสารอื่นๆ {{ $i }}</label>
+                                @if($emp->$fieldName)
+                                    <div class="mb-1"><a href="{{ asset('storage/'.$emp->$fieldName) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                                @endif
+                                <input type="file" class="form-control" name="{{ $fieldName }}" accept=".pdf,.doc,.docx,.jpg,.png">
+                                <input type="text" class="form-control form-control-sm mt-1" name="{{ $descName }}" value="{{ $emp->$descName }}" placeholder="ระบุรายละเอียดเอกสาร">
+                            </div>
+                        @endfor
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                    <button type="submit" class="btn btn-primary"><i class="bi bi-save me-1"></i> บันทึกการแก้ไข</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/sales/partials/_edit_employer_modal.blade.php
+++ b/resources/views/sales/partials/_edit_employer_modal.blade.php
@@ -1,0 +1,145 @@
+<div class="modal fade" id="editEmployerModal-{{ $lead->id }}" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <form action="{{ route('sales.update', $lead->id) }}" method="POST" enctype="multipart/form-data">
+                @csrf
+                @method('PUT')
+                <div class="modal-header bg-primary text-white">
+                    <h5 class="modal-title"><i class="bi bi-pencil me-2"></i>แก้ไขข้อมูลลูกค้าใหม่ (ชั่วคราว)</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label">ชื่อลูกค้า (ไทย) <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" name="employerNameTh" value="{{ $lead->employerNameTh }}" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">ชื่อลูกค้า (อังกฤษ)</label>
+                            <input type="text" class="form-control" name="employerNameEn" value="{{ $lead->employerNameEn }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">เบอร์โทรศัพท์</label>
+                            <input type="text" class="form-control" name="employerPhone" value="{{ $lead->employerPhone }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">เลขเสียภาษี/บัตรประชาชน</label>
+                            <input type="text" class="form-control" name="employerTaxId" value="{{ $lead->employerTaxId }}">
+                        </div>
+                        <div class="col-md-12">
+                            <label class="form-label">ชื่อผู้ติดต่อ / เจ้าของงาน</label>
+                            <input type="text" class="form-control" name="jobOwner" value="{{ $lead->jobOwner }}">
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label">โรงพยาบาลประกันสังคม</label>
+                            <input type="text" class="form-control" name="socialSecurityHospital" value="{{ $lead->socialSecurityHospital }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">อีเมล</label>
+                            <input type="text" class="form-control" name="employerEmail" value="{{ $lead->employerEmail }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">รหัสผ่านอีเมล</label>
+                            <input type="text" class="form-control" name="employerPassword" value="{{ $lead->employerPassword }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">รหัส RE Outsource</label>
+                            <input type="text" class="form-control" name="outsource_re_code" value="{{ $lead->outsource_re_code }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">รหัสผ่าน Outsource</label>
+                            <input type="text" class="form-control" name="outsource_password" value="{{ $lead->outsource_password }}">
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label">ประเภทธุรกิจ (ไทย)</label>
+                            <input type="text" class="form-control" name="businessType" value="{{ $lead->businessType }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">ประเภทธุรกิจ (อังกฤษ)</label>
+                            <input type="text" class="form-control" name="businessTypeEn" value="{{ $lead->businessTypeEn }}">
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label">ชื่อผู้มีอำนาจลงนาม 1 (ไทย)</label>
+                            <input type="text" class="form-control" name="signerNameTh" value="{{ $lead->signerNameTh }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">ชื่อผู้มีอำนาจลงนาม 1 (อังกฤษ)</label>
+                            <input type="text" class="form-control" name="signerNameEn" value="{{ $lead->signerNameEn }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">ชื่อผู้มีอำนาจลงนาม 2 (ไทย)</label>
+                            <input type="text" class="form-control" name="signer_2_name_th" value="{{ $lead->signer_2_name_th }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">ชื่อผู้มีอำนาจลงนาม 2 (อังกฤษ)</label>
+                            <input type="text" class="form-control" name="signer_2_name_en" value="{{ $lead->signer_2_name_en }}">
+                        </div>
+                        <div class="col-12">
+                            <hr class="my-4">
+                            <h6 class="fw-bold"><i class="bi bi-folder-fill me-2"></i>อัปเดตเอกสารแนบ</h6>
+                            <small class="text-muted d-block mb-3">หากไม่ต้องการเปลี่ยนเอกสาร ไม่ต้องเลือกไฟล์ใหม่</small>
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label">1. หนังสือรับรองบริษัท / บัตรประชาชน</label>
+                            @if($lead->employer_doc_company)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$lead->employer_doc_company) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employer_doc_company" accept=".pdf,.doc,.docx,.jpg,.png">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">1.1 วันหมดอายุ</label>
+                            <input type="date" class="form-control" name="employer_doc_company_expiry" value="{{ $lead->employer_doc_company_expiry }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">2. สัญญาเช่าบ้าน / ทะเบียนบ้าน</label>
+                            @if($lead->employer_doc_lease)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$lead->employer_doc_lease) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employer_doc_lease" accept=".pdf,.doc,.docx,.jpg,.png">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">3. สัญญาก่อสร้าง / แผนที่</label>
+                            @if($lead->employer_doc_construction)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$lead->employer_doc_construction) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employer_doc_construction" accept=".pdf,.doc,.docx,.jpg,.png">
+                        </div>
+
+                        <div class="col-md-6 mt-3">
+                            <label class="form-label">4. เอกสารอื่นๆ 1</label>
+                            @if($lead->employer_doc_other_1)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$lead->employer_doc_other_1) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employer_doc_other_1" accept=".pdf,.doc,.docx,.jpg,.png">
+                            <input type="text" class="form-control form-control-sm mt-1" name="employer_doc_other_1_desc" value="{{ $lead->employer_doc_other_1_desc }}" placeholder="ระบุรายละเอียดเอกสาร">
+                        </div>
+                        <div class="col-md-6 mt-3">
+                            <label class="form-label">5. เอกสารอื่นๆ 2</label>
+                            @if($lead->employer_doc_other_2)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$lead->employer_doc_other_2) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employer_doc_other_2" accept=".pdf,.doc,.docx,.jpg,.png">
+                            <input type="text" class="form-control form-control-sm mt-1" name="employer_doc_other_2_desc" value="{{ $lead->employer_doc_other_2_desc }}" placeholder="ระบุรายละเอียดเอกสาร">
+                        </div>
+                        <div class="col-md-6 mt-3 mb-4">
+                            <label class="form-label">6. เอกสารอื่นๆ 3</label>
+                            @if($lead->employer_doc_other_3)
+                                <div class="mb-1"><a href="{{ asset('storage/'.$lead->employer_doc_other_3) }}" target="_blank"><i class="bi bi-file-earmark-check text-success"></i> ดูไฟล์เดิม</a></div>
+                            @endif
+                            <input type="file" class="form-control" name="employer_doc_other_3" accept=".pdf,.doc,.docx,.jpg,.png">
+                            <input type="text" class="form-control form-control-sm mt-1" name="employer_doc_other_3_desc" value="{{ $lead->employer_doc_other_3_desc }}" placeholder="ระบุรายละเอียดเอกสาร">
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+                    <button type="submit" class="btn btn-primary"><i class="bi bi-save me-1"></i> บันทึกข้อมูล</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/sales/partials/_lead_card.blade.php
+++ b/resources/views/sales/partials/_lead_card.blade.php
@@ -20,6 +20,13 @@
                     <i class="bi bi-three-dots-vertical"></i>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-end shadow-sm">
+                    @if(!$lead->employer_id)
+                        <li>
+                            <a class="dropdown-item text-primary" href="#" data-bs-toggle="modal" data-bs-target="#editEmployerModal-{{ $lead->id }}">
+                                <i class="bi bi-pencil me-2"></i>แก้ไขข้อมูลลูกค้า
+                            </a>
+                        </li>
+                    @endif
                     <li><a class="dropdown-item text-danger" href="#" onclick="if(confirm('ย้ายรายการนี้ลงประวัติ/ถังขยะ ใช่หรือไม่?')) { document.getElementById('delete-lead-{{ $lead->id }}').submit(); }"><i class="bi bi-trash me-2"></i>ทิ้ง/ยกเลิก</a></li>
                 </ul>
                 <form id="delete-lead-{{ $lead->id }}" action="{{ route('sales.destroy', $lead->id) }}" method="POST" class="d-none">
@@ -62,6 +69,9 @@
 </div>
 
 {{-- Modals for this Lead --}}
+@if(!$lead->employer_id)
+    @include('sales.partials._edit_employer_modal', ['lead' => $lead])
+@endif
 @include('sales.partials._manage_employees_modal', ['lead' => $lead])
 @include('sales.partials._quotation_modal', ['lead' => $lead, 'profiles' => $financialProfiles])
 

--- a/resources/views/sales/partials/_manage_employees_modal.blade.php
+++ b/resources/views/sales/partials/_manage_employees_modal.blade.php
@@ -89,14 +89,46 @@
                                         <label class="form-label">เลขใบอนุญาตทำงาน</label>
                                         <input type="text" class="form-control" name="employeeWorkPermit">
                                     </div>
-                                    <div class="col-md-6 mt-3">
-                                        <label class="form-label">รูปถ่ายหน้าตรง (ถ้ามี)</label>
+                                    <div class="col-md-12 mt-4">
+                                        <hr>
+                                        <h6 class="fw-bold"><i class="bi bi-folder-fill me-2"></i>เอกสารแนบลูกจ้าง (ถ้ามี)</h6>
+                                    </div>
+                                    <div class="col-md-6 mt-2">
+                                        <label class="form-label">รูปถ่ายหน้าตรง</label>
                                         <input type="file" class="form-control" name="photo" accept="image/*">
                                     </div>
-                                    <div class="col-md-6 mt-3">
-                                        <label class="form-label">เอกสารอื่นๆ (ถ้ามี)</label>
-                                        <input type="file" class="form-control" name="document" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    <div class="col-md-6 mt-2">
+                                        <label class="form-label">1. พาสปอร์ต (Passport)</label>
+                                        <input type="file" class="form-control" name="employee_doc_1" accept=".pdf,.doc,.docx,.jpg,.png">
                                     </div>
+                                    <div class="col-md-6 mt-2">
+                                        <label class="form-label">2. ใบอนุญาตทำงาน (Work Permit)</label>
+                                        <input type="file" class="form-control" name="employee_doc_2" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    </div>
+                                    <div class="col-md-6 mt-2">
+                                        <label class="form-label">3. วีซ่า (Visa)</label>
+                                        <input type="file" class="form-control" name="employee_doc_visa" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    </div>
+                                    <div class="col-md-6 mt-2">
+                                        <label class="form-label">4. บัตรชมพู (Pink Card)</label>
+                                        <input type="file" class="form-control" name="employee_doc_3" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    </div>
+                                    <div class="col-md-6 mt-2">
+                                        <label class="form-label">5. ทะเบียนบ้านลูกจ้าง (TR 38/1)</label>
+                                        <input type="file" class="form-control" name="employee_doc_4" accept=".pdf,.doc,.docx,.jpg,.png">
+                                    </div>
+
+                                    @for($i = 1; $i <= 3; $i++)
+                                        @php
+                                            $fieldName = "employee_doc_other_" . $i;
+                                            $descName = "other_doc_" . $i . "_desc";
+                                        @endphp
+                                        <div class="col-md-6 mt-3">
+                                            <label class="form-label">เอกสารอื่นๆ {{ $i }}</label>
+                                            <input type="file" class="form-control" name="{{ $fieldName }}" accept=".pdf,.doc,.docx,.jpg,.png">
+                                            <input type="text" class="form-control form-control-sm mt-1" name="{{ $descName }}" placeholder="ระบุรายละเอียดเอกสาร">
+                                        </div>
+                                    @endfor
                                 </div>
                             </div>
 
@@ -157,11 +189,18 @@
                                         @endif
                                     </td>
                                     <td class="text-center">
-                                        <form action="{{ route('sales.employees.destroy', [$lead->id, $emp->id]) }}" method="POST" onsubmit="return confirm('ยืนยันการลบลูกจ้างออกจากรายการนี้?');">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
-                                        </form>
+                                        <div class="d-flex justify-content-center gap-1">
+                                            @if(!$emp->employee_id)
+                                                <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editEmployeeModal-{{ $emp->id }}" title="แก้ไข">
+                                                    <i class="bi bi-pencil"></i>
+                                                </button>
+                                            @endif
+                                            <form action="{{ route('sales.employees.destroy', [$lead->id, $emp->id]) }}" method="POST" onsubmit="return confirm('ยืนยันการลบลูกจ้างออกจากรายการนี้?');" class="d-inline">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="ลบ"><i class="bi bi-trash"></i></button>
+                                            </form>
+                                        </div>
                                     </td>
                                 </tr>
                             @empty
@@ -180,6 +219,13 @@
         </div>
     </div>
 </div>
+
+{{-- Edit Employee Modals --}}
+@foreach($lead->employees as $emp)
+    @if(!$emp->employee_id)
+        @include('sales.partials._edit_employee_modal', ['lead' => $lead, 'emp' => $emp])
+    @endif
+@endforeach
 
 @push('scripts')
 <script>

--- a/resources/views/sales/partials/_quotation_modal.blade.php
+++ b/resources/views/sales/partials/_quotation_modal.blade.php
@@ -39,7 +39,7 @@
                     <div class="card shadow-sm border-0 mb-4">
                         <div class="card-header bg-white border-bottom-0 pt-3 pb-2 d-flex justify-content-between align-items-center">
                             <h6 class="mb-0 fw-bold"><i class="bi bi-list-check me-2"></i>รายการเสนอราคา</h6>
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="addQuoteItem({{ $lead->id }})">
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="addQuoteItem({{ $lead->id }}, {{ $lead->employees->count() ?: 1 }})">
                                 <i class="bi bi-plus-circle"></i> เพิ่มรายการ
                             </button>
                         </div>
@@ -115,10 +115,12 @@
 <script>
     let quoteItemCounter = 1;
 
-    function addQuoteItem(leadId) {
+    function addQuoteItem(leadId, numEmployees) {
         const tbody = document.querySelector(`#quoteItemsTable-${leadId} tbody`);
         const tr = document.createElement('tr');
-        const numEmployees = {{ $lead->employees->count() ?: 1 }};
+
+        // numEmployees passed as arg instead of relying on blade directive that only captures the last lead in the loop
+        numEmployees = numEmployees || 1;
 
         tr.innerHTML = `
             <td><input type="text" class="form-control form-control-sm" name="items[${quoteItemCounter}][description]" placeholder="ระบุรายละเอียดงาน" required></td>

--- a/resources/views/sales/partials/_transition_modal.blade.php
+++ b/resources/views/sales/partials/_transition_modal.blade.php
@@ -61,14 +61,19 @@
 </div>
 
 @push('scripts')
+@once
 <script>
     document.addEventListener('DOMContentLoaded', function () {
         if (typeof jQuery !== 'undefined') {
-            $('.select2-destination').select2({
-                theme: 'bootstrap-5',
-                dropdownParent: $('.modal') // This assumes only one modal opens at a time
+            // Need to apply to specific modal to avoid bugs when there are multiple modals in DOM
+            $('.modal').on('shown.bs.modal', function () {
+                $(this).find('.select2-destination').select2({
+                    theme: 'bootstrap-5',
+                    dropdownParent: $(this)
+                });
             });
         }
     });
 </script>
+@endonce
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -388,10 +388,12 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/', [\App\Http\Controllers\SalesLeadController::class, 'index'])->name('index');
         Route::post('/', [\App\Http\Controllers\SalesLeadController::class, 'store'])->name('store');
         Route::put('/{sales}/status', [\App\Http\Controllers\SalesLeadController::class, 'updateStatus'])->name('status.update');
+        Route::put('/{sales}', [\App\Http\Controllers\SalesLeadController::class, 'update'])->name('update');
         Route::delete('/{sales}', [\App\Http\Controllers\SalesLeadController::class, 'destroy'])->name('destroy');
         Route::post('/{id}/restore', [\App\Http\Controllers\SalesLeadController::class, 'restore'])->name('restore');
 
         Route::post('/{sales}/employees', [\App\Http\Controllers\SalesLeadController::class, 'storeEmployee'])->name('employees.store');
+        Route::put('/{sales}/employees/{employee}', [\App\Http\Controllers\SalesLeadController::class, 'updateEmployee'])->name('employees.update');
         Route::delete('/{sales}/employees/{employee}', [\App\Http\Controllers\SalesLeadController::class, 'destroyEmployee'])->name('employees.destroy');
 
         Route::post('/{sales}/quotation', [\App\Http\Controllers\SalesLeadController::class, 'storeQuotation'])->name('quotation.store');


### PR DESCRIPTION
This PR addresses multiple requests for the Read & Sale (Sales Leads) feature:
1. The temporary Employer creation form now includes all document attachment fields found in the main Employer creation form.
2. The temporary Employee creation form now includes comprehensive details and file attachments (Passport, Work Permit, etc.) mirroring the main system.
3. Edit functionality has been added for both temporary Employers and Employees via new modals and backend endpoints.
4. A bug preventing the Quotation modal from functioning correctly has been resolved.
5. A Select2 initialization bug that broke the Transition (Confirm/Send) modal has been fixed.
6. The Kanban board layout has been adjusted to prevent columns from wrapping vertically when there are few items.

---
*PR created automatically by Jules for task [10731527826010432993](https://jules.google.com/task/10731527826010432993) started by @nongjossss-commits*