### PR TITLE
Fix cancelled employees visibility in Finance modal and Workflow toggles

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -847,9 +847,8 @@ class ProductionController extends Controller
         $query = ProductionItem::with(['employee', 'completedWorkTypeSteps'])
             ->where('production_order_id', $orderId);
 
-        if ($request->boolean('hide_cancelled', true)) {
-            $query->where('status', '!=', 'cancelled');
-        }
+        // We fetch all items including cancelled ones, and use CSS classes (e.g. .status-cancelled)
+        // to hide them on the frontend unless toggled.
 
         // Status/Step Filter
         if ($request->has('filter') && $request->filter) {

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -1912,9 +1912,8 @@ class WorkflowController extends Controller
         $query = ProductionItem::with(['employee', 'completedWorkTypeSteps'])
             ->where('production_order_id', $orderId);
 
-        if ($request->boolean('hide_cancelled', true)) {
-            $query->where('status', '!=', 'cancelled');
-        }
+        // We fetch all items including cancelled ones, and use CSS classes (e.g. .status-cancelled)
+        // to hide them on the frontend unless toggled.
 
         // Status/Step Filter
         if ($request->has('filter') && $request->filter) {

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -41,7 +41,7 @@
     }
 @endphp
 
-<div class="d-flex align-items-center employee-card-outer mb-3 employee-card-wrapper"
+<div class="d-flex align-items-center employee-card-outer mb-3 employee-card-wrapper {{ $isCancelled ? 'status-cancelled' : '' }}"
      id="employee-card-{{ $employee->id }}"
      data-highest-step-id="{{ $highestStepId }}"
      data-status="{{ $employee->status }}"

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -99,7 +99,7 @@
     $isMe = $operatorId === auth()->id();
 @endphp
 
-<div class="d-flex align-items-center item-card-outer mb-3"
+<div class="d-flex align-items-center item-card-outer mb-3 {{ $isCancelled ? 'status-cancelled' : '' }}"
      id="item-card-{{ $item->id }}"
      data-status="{{ $status }}"
      style="transition: all 0.3s ease; {{ $isCancelled ? 'filter: grayscale(100%);' : '' }}">


### PR DESCRIPTION
Fixes a bug where cancelled employees were entirely omitted from the data payload in the Pre-Production and Workflow modules. This caused two distinct issues:
1. The "Show Cancelled Items" button in the order/employer cards did not work (as the data was not present).
2. The Finance module's pricing tier setup could not display cancelled employees.

The backend filtering was removed so that all items are fetched. Instead, visibility is now correctly controlled on the frontend by applying the `.status-cancelled` class and using the existing JavaScript toggle logic.

---
*PR created automatically by Jules for task [7199205848585816230](https://jules.google.com/task/7199205848585816230) started by @nongjossss-commits*