### PR TITLE
Fix missing cancelled items on reload in Pre-Production and Workflow

### DIFF
--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -666,9 +666,8 @@ class WorkflowController extends Controller
         $query = ProductionItem::with(['employee', 'completedWorkTypeSteps'])
             ->where('production_order_id', $orderId);
 
-        if ($request->boolean('hide_cancelled', true)) {
-            $query->where('status', '!=', 'cancelled');
-        }
+        // We fetch all items including cancelled ones, and use CSS classes (e.g. .status-cancelled)
+        // to hide them on the frontend unless toggled.
 
         // 1. History Filter (Default: Hide completed > 24h)
         // Unless we are filtering specifically for "Completed", we keep this rule.

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -4,6 +4,12 @@
     $isCompleted = in_array($employee->status, ['registration_completed', 'renewal_completed']);
     $isCancelled = in_array($employee->status, ['registration_cancelled', 'renewal_cancelled']);
 
+    // Support for Pre-Production / Workflow where the card is reused and status is on the item
+    if (isset($employee->production_item)) {
+        $isCompleted = $employee->production_item->status === 'completed';
+        $isCancelled = $employee->production_item->status === 'cancelled';
+    }
+
     if ($isHistory) {
         // $isCompleted = true; // Force completed styling if not already
     }
@@ -27,6 +33,9 @@
     // Determine if "Not Started" (only if active status and no steps)
     $isNotStarted = (!$isCompleted && !$isCancelled && !$highestStep);
 
+    // Contextual status for JS
+    $itemStatus = isset($employee->production_item) ? $employee->production_item->status : $employee->status;
+
     // Operator Logic
     $operator = $employee->operator;
     $operatorId = $employee->operator_id;
@@ -44,7 +53,7 @@
 <div class="d-flex align-items-center employee-card-outer mb-3 employee-card-wrapper {{ $isCancelled ? 'status-cancelled' : '' }}"
      id="employee-card-{{ $employee->id }}"
      data-highest-step-id="{{ $highestStepId }}"
-     data-status="{{ $employee->status }}"
+     data-status="{{ $itemStatus }}"
      data-is-not-started="{{ $isNotStarted ? 'true' : 'false' }}"
      data-employer-id="{{ $employee->employer_id }}"
      data-biometrics-collected="{{ $employee->biometrics_collected_at ? 'true' : 'false' }}"
@@ -100,7 +109,7 @@
                            id="check_{{ $employee->id }}"
                            data-employee-id="{{ $employee->id }}"
                            data-employer-id="{{ $employee->employer_id }}"
-                           data-status="{{ $employee->status }}"
+                           data-status="{{ $itemStatus }}"
                            data-name-th="{{ $employee->employeeNameTh }}"
                            data-name-en="{{ $employee->employeeNameEn }}"
                            data-title-th="{{ $employee->employeeTitleTh }}"


### PR DESCRIPTION
Fix missing cancelled items on reload in Pre-Production and Workflow

- Remove explicit backend filter `where('status', '!=', 'cancelled')` in `WorkflowController::fetchOrderItems` so all items are returned to the frontend.
- Update `resources/views/production/registration/_employee_card.blade.php` to derive the cancellation status from `$employee->production_item->status` when used in the Pre-Production/Workflow context.
- This ensures the `.status-cancelled` CSS class is properly applied, allowing the `.hide-cancelled` toggle button to function and resolving the missing employee issue in the Finance module.

---
*PR created automatically by Jules for task [5251882543358509240](https://jules.google.com/task/5251882543358509240) started by @nongjossss-commits*