### PR TITLE
Fix cancelled employees not showing in Finance Cancelled tab

### DIFF
--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -23,7 +23,7 @@
             'passport' => $item->employee ? $item->employee->employeePassport : '',
             'employee_id' => $item->employee_id,
             'last_step_name' => $lastStepName,
-            'status' => $item->employee ? $item->employee->status : $item->status
+            'status' => $item->status
         ];
     })) }},
     employees: {{ json_encode(($employees ?? collect())->map(function($emp) {


### PR DESCRIPTION
Fix cancelled employees not showing in Finance Cancelled tab

Updated the status mapping in `financial-tab.blade.php` to correctly pass the `status` of the contextual `$item` (the `ProductionItem` model) instead of falling back to the global `$item->employee->status`. This ensures that employees who are cancelled within the context of a specific Pre-Production or Workflow item are correctly filtered into the 'Cancelled' tab in the finance UI.

---
*PR created automatically by Jules for task [15296399453838769803](https://jules.google.com/task/15296399453838769803) started by @nongjossss-commits*