### PR TITLE
feat: add quick print modal to pdf templates

### DIFF
--- a/app/Http/Controllers/Admin/PdfGenerationController.php
+++ b/app/Http/Controllers/Admin/PdfGenerationController.php
@@ -73,6 +73,80 @@ class PdfGenerationController extends Controller
         ]);
     }
 
+    public function quickGenerate(Request $request)
+    {
+        $this->authorize('view-pdf-templates');
+
+        $request->validate([
+            'template_id' => 'required|exists:pdf_templates,id',
+            'target_employer_id' => 'nullable|exists:employers,id',
+            'target_importer_id' => 'nullable|exists:importers,id',
+            'target_delegate_id' => 'nullable|exists:delegates,id',
+            'employee_id' => 'nullable|exists:employees,id',
+        ]);
+
+        try {
+            $template = PdfTemplate::findOrFail($request->template_id);
+
+            $targetEmployerModel = null;
+            if ($request->target_employer_id) {
+                $targetEmployerModel = Employer::find($request->target_employer_id);
+            }
+
+            $targetImporterModel = null;
+            if ($request->target_importer_id) {
+                $targetImporterModel = \App\Models\Importer::find($request->target_importer_id);
+            }
+
+            $targetDelegateModel = null;
+            if ($request->target_delegate_id) {
+                $targetDelegateModel = \App\Models\Delegate::find($request->target_delegate_id);
+            }
+
+            // Either an actual employee or a new empty instance
+            $employee = null;
+            if ($request->employee_id) {
+                $employee = Employee::withTrashed()->with('employer')->find($request->employee_id);
+            } else {
+                $employee = new Employee();
+            }
+
+            $useEmptyEmployer = false;
+            if ($template->type === 'global' && empty($request->target_employer_id)) {
+                $useEmptyEmployer = true;
+            }
+
+            // Generate Single PDF content directly
+            $content = $this->pdfService->generateSinglePdf(
+                $template,
+                $employee,
+                $targetEmployerModel,
+                $useEmptyEmployer,
+                $targetImporterModel,
+                $targetDelegateModel
+            );
+
+            // Generate appropriate filename
+            $filename = "quick_export_" . date('Ymd_His') . ".pdf";
+            if ($request->employee_id && $employee->employeeNameEn) {
+                $filename = "{$employee->employeeNameEn}_{$filename}";
+            } elseif ($request->target_employer_id && $targetEmployerModel) {
+                $filename = "{$targetEmployerModel->employerNameEn}_{$filename}";
+            }
+
+            return response()->streamDownload(function () use ($content) {
+                echo $content;
+            }, $filename, [
+                'Content-Type' => 'application/pdf',
+                'Cache-Control' => 'no-cache, no-store, must-revalidate'
+            ]);
+
+        } catch (\Throwable $e) {
+            \Log::error("Quick PDF Gen Error: " . $e->getMessage());
+            return redirect()->back()->with('danger', 'การสร้างเอกสารล้มเหลว (Generation Failed): ' . $e->getMessage());
+        }
+    }
+
     public function process(Request $request)
     {
         $this->authorize('view-pdf-templates');

--- a/app/Http/Controllers/Admin/PdfTemplateController.php
+++ b/app/Http/Controllers/Admin/PdfTemplateController.php
@@ -78,7 +78,10 @@ class PdfTemplateController extends Controller
              $employers = $empQuery->orderBy('employerNameTh')->get();
         }
 
-        return view('pdf_templates.index', compact('templates', 'employers'));
+        $importers = \App\Models\Importer::select('id', 'importerNameTh', 'importerNameEn')->orderBy('importerNameTh')->get();
+        $delegates = \App\Models\Delegate::select('id', 'delegateNameTh', 'delegateNameEn')->orderBy('delegateNameTh')->get();
+
+        return view('pdf_templates.index', compact('templates', 'employers', 'importers', 'delegates'));
     }
 
     public function listTemplates(Request $request)

--- a/resources/views/pdf_templates/index.blade.php
+++ b/resources/views/pdf_templates/index.blade.php
@@ -4,6 +4,11 @@
 <div class="container-fluid py-4" x-data="witnessManager()">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2 class="text-2xl font-bold text-gray-800">PDF Templates</h2>
+        <div class="d-flex gap-2 align-items-center justify-content-center flex-grow-1" style="max-width: fit-content; margin: 0 auto;">
+            <button type="button" class="btn btn-warning shadow-sm fw-bold px-4" data-bs-toggle="modal" data-bs-target="#quickGenerateModal">
+                <i class="bi bi-printer-fill me-2"></i>สร้างการพิมพ์เอกสารอัตโนมัติ (Quick Print)
+            </button>
+        </div>
         <div class="d-flex gap-2">
             @can('create-pdf-templates')
             <button type="button" @click="openModal()" class="btn btn-outline-info">
@@ -318,9 +323,327 @@
     </div>
 </div>
 
+<!-- Quick Generate Modal -->
+<div class="modal fade" id="quickGenerateModal" tabindex="-1" aria-labelledby="quickGenerateModalLabel" aria-hidden="true" x-data="quickGenerateModal()">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content border-0 shadow">
+            <div class="modal-header bg-warning text-dark border-bottom-0 py-3">
+                <h5 class="modal-title fw-bold" id="quickGenerateModalLabel">
+                    <i class="bi bi-printer-fill me-2"></i>สร้างการพิมพ์เอกสารอัตโนมัติ (Quick Print)
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body p-4 bg-light">
+                <form action="{{ route('admin.pdf-templates.quick-generate') }}" method="POST" id="quickGenerateForm" @submit="handleSubmit">
+                    @csrf
+
+                    <!-- Select Template -->
+                    <div class="mb-4 bg-white p-3 rounded shadow-sm border">
+                        <label class="form-label fw-bold text-primary mb-3"><i class="bi bi-file-earmark-pdf me-2"></i>1. เลือกเทมเพลต (Select Template)</label>
+                        <select name="template_id" class="form-select form-select-lg" required x-model="form.template_id">
+                            <option value="">-- กรุณาเลือกเทมเพลต --</option>
+                            @foreach($templates as $template)
+                                <option value="{{ $template->id }}">
+                                    {{ $template->name }}
+                                    ({{ $template->type === 'global' ? 'ส่วนกลาง/Global' : 'ส่วนตัวนายจ้าง' }})
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+
+                    <!-- Target Employer Selection -->
+                    @if(isset($employers) && $employers->count() > 0)
+                    <div class="mb-4 bg-white p-3 rounded shadow-sm border">
+                        <label class="form-label fw-bold mb-3"><i class="bi bi-building me-2"></i>2. เลือกข้อมูลนายจ้าง (Target Employer)</label>
+                        <div class="alert alert-light border small text-muted mb-3">
+                            <i class="bi bi-info-circle me-1"></i> หากไม่ต้องการระบุข้อมูลนายจ้าง ให้เลือก "เว้นว่าง / ไม่มีนายจ้าง"
+                        </div>
+
+                        <div x-data="searchableDropdown({
+                            options: [
+                                {id: '', name_th: 'เว้นว่าง / ไม่มีนายจ้าง (Empty)', name_en: 'None', search_str: 'เว้นว่าง ไม่มีนายจ้าง empty none'},
+                                @foreach($employers as $e)
+                                {id: '{{ $e->id }}', name_th: '{{ addslashes($e->employerNameTh) }}', name_en: '{{ addslashes($e->employerNameEn) }}', search_str: '{{ strtolower(addslashes($e->employerNameTh . ' ' . $e->employerNameEn)) }}'},
+                                @endforeach
+                            ],
+                            value: ''
+                        })" @click.outside="open = false; syncSearch()">
+
+                            <input type="hidden" name="target_employer_id" :value="value" x-model="form.target_employer_id">
+
+                            <div class="position-relative">
+                                <div class="input-group">
+                                    <span class="input-group-text bg-white"><i class="bi bi-search"></i></span>
+                                    <input type="text" class="form-control" placeholder="ค้นหานายจ้าง หรือเลือกเว้นว่าง..."
+                                        x-model="search" @focus="open = true; search = ''" @keydown.escape="open = false">
+                                    <button class="btn btn-outline-secondary dropdown-toggle" type="button" @click="open = !open"></button>
+                                </div>
+
+                                <div class="card position-absolute w-100 shadow mt-1 border-0" style="z-index: 1050; max-height: 250px; overflow-y: auto; display: none;" x-show="open" x-transition>
+                                    <ul class="list-group list-group-flush">
+                                        <template x-for="opt in filteredOptions" :key="opt.id">
+                                            <li class="list-group-item list-group-item-action cursor-pointer" @click="selectOption(opt)">
+                                                <div class="fw-bold" x-text="opt.name_th"></div>
+                                                <div class="small text-muted" x-show="opt.name_en !== 'None'" x-text="opt.name_en"></div>
+                                            </li>
+                                        </template>
+                                        <li class="list-group-item text-muted text-center" x-show="filteredOptions.length === 0">ไม่พบข้อมูล</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    @endif
+
+                    <div class="row mb-4">
+                        <!-- Target Importer -->
+                        <div class="col-md-6">
+                            <div class="bg-white p-3 rounded shadow-sm border h-100">
+                                <label class="form-label fw-bold mb-3"><i class="bi bi-truck me-2"></i>3. เลือกบริษัทนำเข้า</label>
+                                <div x-data="searchableDropdown({
+                                    options: [
+                                        {id: '', name_th: 'เว้นว่าง / ไม่มีบริษัทนำเข้า', name_en: 'None', search_str: 'เว้นว่าง none'},
+                                        @foreach($importers as $i)
+                                        {id: '{{ $i->id }}', name_th: '{{ addslashes($i->importerNameTh) }}', name_en: '{{ addslashes($i->importerNameEn) }}', search_str: '{{ strtolower(addslashes($i->importerNameTh . ' ' . $i->importerNameEn)) }}'},
+                                        @endforeach
+                                    ], value: ''
+                                })" @click.outside="open = false; syncSearch()">
+                                    <input type="hidden" name="target_importer_id" :value="value">
+                                    <div class="position-relative">
+                                        <div class="input-group input-group-sm">
+                                            <input type="text" class="form-control" placeholder="ค้นหาบริษัทนำเข้า..." x-model="search" @focus="open = true; search = ''" @keydown.escape="open = false">
+                                            <button class="btn btn-outline-secondary dropdown-toggle" type="button" @click="open = !open"></button>
+                                        </div>
+                                        <div class="card position-absolute w-100 shadow mt-1 border-0" style="z-index: 1050; max-height: 200px; overflow-y: auto; display: none;" x-show="open">
+                                            <ul class="list-group list-group-flush">
+                                                <template x-for="opt in filteredOptions" :key="opt.id">
+                                                    <li class="list-group-item list-group-item-action cursor-pointer p-2" @click="selectOption(opt)">
+                                                        <div class="fw-bold small" x-text="opt.name_th"></div>
+                                                    </li>
+                                                </template>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Target Delegate -->
+                        <div class="col-md-6">
+                            <div class="bg-white p-3 rounded shadow-sm border h-100">
+                                <label class="form-label fw-bold mb-3"><i class="bi bi-person-badge me-2"></i>4. เลือกผู้รับมอบอำนาจ</label>
+                                <div x-data="searchableDropdown({
+                                    options: [
+                                        {id: '', name_th: 'เว้นว่าง / ไม่มีผู้รับมอบอำนาจ', name_en: 'None', search_str: 'เว้นว่าง none'},
+                                        @foreach($delegates as $d)
+                                        {id: '{{ $d->id }}', name_th: '{{ addslashes($d->delegateNameTh) }}', name_en: '{{ addslashes($d->delegateNameEn) }}', search_str: '{{ strtolower(addslashes($d->delegateNameTh . ' ' . $d->delegateNameEn)) }}'},
+                                        @endforeach
+                                    ], value: ''
+                                })" @click.outside="open = false; syncSearch()">
+                                    <input type="hidden" name="target_delegate_id" :value="value">
+                                    <div class="position-relative">
+                                        <div class="input-group input-group-sm">
+                                            <input type="text" class="form-control" placeholder="ค้นหาผู้รับมอบอำนาจ..." x-model="search" @focus="open = true; search = ''" @keydown.escape="open = false">
+                                            <button class="btn btn-outline-secondary dropdown-toggle" type="button" @click="open = !open"></button>
+                                        </div>
+                                        <div class="card position-absolute w-100 shadow mt-1 border-0" style="z-index: 1050; max-height: 200px; overflow-y: auto; display: none;" x-show="open">
+                                            <ul class="list-group list-group-flush">
+                                                <template x-for="opt in filteredOptions" :key="opt.id">
+                                                    <li class="list-group-item list-group-item-action cursor-pointer p-2" @click="selectOption(opt)">
+                                                        <div class="fw-bold small" x-text="opt.name_th"></div>
+                                                    </li>
+                                                </template>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Target Employee -->
+                    <div class="mb-4 bg-white p-3 rounded shadow-sm border">
+                        <label class="form-label fw-bold mb-3"><i class="bi bi-person me-2"></i>5. เลือกลูกจ้าง (Target Employee)</label>
+                        <div class="alert alert-light border small text-muted mb-3">
+                            <i class="bi bi-info-circle me-1"></i> หากไม่ต้องการระบุข้อมูลลูกจ้าง ให้เลือก "เว้นว่าง / ไม่มีลูกจ้าง"
+                        </div>
+
+                        <div x-data="employeeSearchDropdown()" @click.outside="open = false">
+                            <input type="hidden" name="employee_id" :value="selectedId">
+
+                            <div class="position-relative">
+                                <div class="input-group">
+                                    <span class="input-group-text bg-white" x-show="!isSearching"><i class="bi bi-search"></i></span>
+                                    <span class="input-group-text bg-white" x-show="isSearching"><i class="spinner-border spinner-border-sm text-primary"></i></span>
+                                    <input type="text" class="form-control" placeholder="พิมพ์ชื่อลูกจ้าง พาสปอร์ต หรือเว้นว่าง..."
+                                        x-model="search" @input.debounce.500ms="fetchEmployees" @focus="open = true; search = ''" @keydown.escape="open = false">
+                                    <button class="btn btn-outline-danger" type="button" @click="clearSelection()" x-show="selectedId" title="Clear Selection"><i class="bi bi-x"></i></button>
+                                </div>
+
+                                <div class="form-text text-primary fw-bold mt-1" x-show="selectedName" style="display: none;">
+                                    <i class="bi bi-check-circle-fill me-1"></i> เลือกลูกจ้าง: <span x-text="selectedName"></span>
+                                </div>
+
+                                <div class="card position-absolute w-100 shadow mt-1 border-0" style="z-index: 1050; max-height: 250px; overflow-y: auto; display: none;" x-show="open" x-transition>
+                                    <ul class="list-group list-group-flush">
+                                        <li class="list-group-item list-group-item-action cursor-pointer text-muted bg-light" @click="selectEmpty()">
+                                            <div class="fw-bold">เว้นว่าง / ไม่มีลูกจ้าง (Empty)</div>
+                                        </li>
+                                        <template x-for="emp in results" :key="emp.id">
+                                            <li class="list-group-item list-group-item-action cursor-pointer" @click="selectOption(emp)">
+                                                <div class="fw-bold" x-text="(emp.employeeNameTh || '') + ' ' + (emp.employeeNameEn || '')"></div>
+                                                <div class="small text-muted">
+                                                    <span x-show="emp.employeePassport">PP: <span x-text="emp.employeePassport"></span></span>
+                                                    <span x-show="emp.employeeWorkPermit" class="ms-2">WP: <span x-text="emp.employeeWorkPermit"></span></span>
+                                                </div>
+                                            </li>
+                                        </template>
+                                        <li class="list-group-item text-muted text-center" x-show="search.length > 0 && results.length === 0 && !isSearching">ไม่พบข้อมูล</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="d-flex justify-content-end mt-4 gap-2 pt-3 border-top">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก (Cancel)</button>
+                        <button type="submit" class="btn btn-primary px-4 fw-bold shadow-sm" :disabled="isSubmitting">
+                            <span x-show="!isSubmitting"><i class="bi bi-download me-2"></i>สร้างและดาวน์โหลด (Generate PDF)</span>
+                            <span x-show="isSubmitting"><span class="spinner-border spinner-border-sm me-2"></span>กำลังสร้าง...</span>
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
 @push('scripts')
 <script>
     document.addEventListener('alpine:init', () => {
+
+        Alpine.data('quickGenerateModal', () => ({
+            isSubmitting: false,
+            form: {
+                template_id: '',
+                target_employer_id: ''
+            },
+            handleSubmit(e) {
+                if(!this.form.template_id) {
+                    alert('กรุณาเลือกเทมเพลต (Please select a template)');
+                    e.preventDefault();
+                    return;
+                }
+
+                // Optional Warning Message
+                if(!this.form.target_employer_id && !document.querySelector('input[name="employee_id"]').value) {
+                    if(!confirm('คุณกำลังจะสร้าง PDF โดยไม่ระบุทั้ง "นายจ้าง" และ "ลูกจ้าง" ข้อมูลใน PDF จะว่างเปล่าในส่วนนั้น ยืนยันที่จะทำต่อหรือไม่?')) {
+                        e.preventDefault();
+                        return;
+                    }
+                }
+
+                this.isSubmitting = true;
+                // Automatically restore button after short delay because browser will trigger download
+                setTimeout(() => {
+                    this.isSubmitting = false;
+                }, 3000);
+            }
+        }));
+
+        Alpine.data('searchableDropdown', (config) => ({
+            open: false,
+            search: '',
+            value: config.value,
+            options: config.options,
+            selectedName: '',
+
+            get filteredOptions() {
+                if (this.search === '') {
+                    return this.options;
+                }
+                const term = this.search.toLowerCase();
+                return this.options.filter(opt => opt.search_str.includes(term));
+            },
+
+            selectOption(opt) {
+                this.value = opt.id;
+                this.selectedName = opt.name_th;
+                this.search = opt.name_th;
+                this.open = false;
+            },
+
+            syncSearch() {
+                if (this.value === '') {
+                    this.search = 'เว้นว่าง / ไม่มีข้อมูล';
+                } else {
+                    const opt = this.options.find(o => o.id === this.value);
+                    if(opt) this.search = opt.name_th;
+                }
+            },
+
+            init() {
+                this.syncSearch();
+            }
+        }));
+
+        Alpine.data('employeeSearchDropdown', () => ({
+            open: false,
+            search: '',
+            selectedId: '',
+            selectedName: '',
+            results: [],
+            isSearching: false,
+
+            async fetchEmployees() {
+                if (this.search.length < 2) {
+                    this.results = [];
+                    return;
+                }
+
+                this.isSearching = true;
+                try {
+                    // The EmployeeController search expects '?q='
+                    const res = await fetch(`{{ route('employees.search') }}?q=${encodeURIComponent(this.search)}`);
+                    if(res.ok) {
+                        const data = await res.json();
+                        // Select2 format returns { results: [{id, text, employee: {}}] }
+                        if (data.results) {
+                            this.results = data.results.map(item => item.employee || item);
+                        } else {
+                            this.results = data.data || data;
+                        }
+                    }
+                } catch(e) {
+                    console.error('Failed to search employees', e);
+                } finally {
+                    this.isSearching = false;
+                    this.open = true;
+                }
+            },
+
+            selectOption(emp) {
+                this.selectedId = emp.id;
+                this.selectedName = (emp.employeeNameTh || '') + ' ' + (emp.employeeNameEn || '');
+                this.search = this.selectedName;
+                this.open = false;
+            },
+
+            selectEmpty() {
+                this.selectedId = '';
+                this.selectedName = '';
+                this.search = 'เว้นว่าง / ไม่มีลูกจ้าง (Empty)';
+                this.open = false;
+            },
+
+            clearSelection() {
+                this.selectedId = '';
+                this.selectedName = '';
+                this.search = '';
+                this.results = [];
+            }
+        }));
+
         Alpine.data('witnessManager', () => ({
             witnesses: [],
             isLoading: false,

--- a/routes/web.php
+++ b/routes/web.php
@@ -202,6 +202,7 @@ Route::middleware(['auth', 'permission:manage-tickets', 'menu:ticket_inbox'])->p
     Route::post('tickets/{ticket}/replies', [TicketReplyController::class, 'store'])->name('tickets.replies.store');
 
     // PDF Generation
+    Route::post('pdf-templates/quick-generate', [\App\Http\Controllers\Admin\PdfGenerationController::class, 'quickGenerate'])->name('pdf-templates.quick-generate');
     Route::post('pdf-templates/generate', [\App\Http\Controllers\Admin\PdfGenerationController::class, 'showGenerateModal'])->name('pdf-templates.generate.modal');
     Route::get('pdf-templates/generate', function () {
         return redirect()->route('employees.index')->with('error', 'Please select employees to generate PDF.');


### PR DESCRIPTION
# Description

This PR introduces a "Quick Print" (สร้างการพิมพ์เอกสารอัตโนมัติ) feature to the PDF Templates menu. Previously, users were required to navigate to an employee list and select records before they could generate an automated PDF. Now, they can initiate the process directly from the templates page.

### Features
* **Quick Print Modal**: Added a new modal to `pdf_templates/index.blade.php` triggered by a prominent "Quick Print" button.
* **Flexible Selection**: Users can select a template and then use searchable dropdowns to specify an Employer, Importer, Delegate, and **up to one** Employee.
* **Optional Fields**: All relationship fields are completely optional. Users can select "None / Empty" (เว้นว่าง).
* **Empty Context Support**: The backend `quickGenerate` method gracefully handles empty relationships by passing `null` or an empty `Employee` model to the `pdfService`, preventing errors when generating PDFs that only rely on Global information (e.g., Witness signatures).
* **Direct Download**: Generated PDFs are immediately streamed to the browser.

### Technical Details
* Added `quickGenerate` POST method to `PdfGenerationController`.
* Added new `/pdf-templates/quick-generate` route.
* Built reusable Alpine.js `searchableDropdown` and `employeeSearchDropdown` components in the blade file, reusing the existing `/employees/search` API endpoint for the employee list to ensure performance.
* Tested and visually verified via Playwright.

---
*PR created automatically by Jules for task [4197392468624086347](https://jules.google.com/task/4197392468624086347) started by @nongjossss-commits*