### PR TITLE
Fix GPS deep-linking, accordion expansion, and employee highlighting across all operation menus

### DIFF
--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -495,7 +495,7 @@
                     </div>
                 </div>
 
-                    <div id="collapse-{{ $order->id }}" class="accordion-collapse collapse" aria-labelledby="heading-{{ $order->id }}" data-bs-parent="#productionAccordion">
+                    <div id="collapse-{{ $order->id }}" class="accordion-collapse collapse" data-employer-id="{{ $order->employer_id }}" aria-labelledby="heading-{{ $order->id }}" data-bs-parent="#productionAccordion">
                         <div class="card-body bg-light p-4">
                              {{-- Lazy Load Content Container --}}
                             <div id="order-content-{{ $order->id }}" class="order-content-wrapper hide-cancelled">

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -2716,11 +2716,11 @@
 
         // --- Restore UI State on Load (After Reload) ---
         const urlParams = new URLSearchParams(window.location.search);
-        const restoreEmployerId = sessionStorage.getItem('registration_restore_employer_id') || urlParams.get('highlight_employer_id');
-        const restoreEmployeeId = sessionStorage.getItem('registration_restore_employee_id') || urlParams.get('highlight_employee_id');
+        const restoreEmployerId = sessionStorage.getItem('renewal_restore_employer_id') || urlParams.get('highlight_employer_id');
+        const restoreEmployeeId = sessionStorage.getItem('renewal_restore_employee_id') || urlParams.get('highlight_employee_id');
 
         if (restoreEmployerId) {
-            sessionStorage.removeItem('registration_restore_employer_id'); // Clear immediately
+            sessionStorage.removeItem('renewal_restore_employer_id'); // Clear immediately
             const collapseEl = document.getElementById(`collapse${restoreEmployerId}`);
             const employerHeading = document.getElementById(`heading${restoreEmployerId}`);
 
@@ -2739,7 +2739,7 @@
 
                 // If we also have an employee to scroll to
                 if (restoreEmployeeId) {
-                    sessionStorage.removeItem('registration_restore_employee_id');
+                    sessionStorage.removeItem('renewal_restore_employee_id');
 
                     const highlightTarget = (card) => {
                         setTimeout(() => {

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -534,7 +534,7 @@
 
                 </div>
 
-                    <div id="collapse-{{ $order->id }}" class="accordion-collapse collapse" aria-labelledby="heading-{{ $order->id }}" data-bs-parent="#workflowAccordion">
+                    <div id="collapse-{{ $order->id }}" class="accordion-collapse collapse" data-employer-id="{{ $order->employer_id }}" aria-labelledby="heading-{{ $order->id }}" data-bs-parent="#workflowAccordion">
                         <div class="card-body bg-light p-4">
                             {{-- Default: hide-cancelled class added --}}
                             <div id="order-content-{{ $order->id }}" class="order-content-wrapper hide-cancelled">


### PR DESCRIPTION
The user reported that clicking on the GPS status tags on employee cards in the Employer Edit and Employee Info menus navigated to the correct destination menu but failed to open the employer accordion and highlight the employee, specifically noting that the "Renewal" (มติต่ออายุ) menu was broken.

Investigation revealed:
1.  **Renewal Menu:** A copy-paste error caused the renewal JavaScript to read from `registration_restore_employer_id` in `sessionStorage` instead of its own `renewal_` prefixed key, preventing the restoration logic from executing.
2.  **Pre-Production and Workflow Menus:** The JavaScript relies on finding `.accordion-collapse` elements by matching `data-employer-id` to the `highlightEmployerId` URL parameter. However, the `data-employer-id` HTML attribute was missing from the accordions in both blade views.

The fixes applied directly address these issues across all four operational menus to ensure robust deep-linking and visual highlighting.

---
*PR created automatically by Jules for task [17796734392387777952](https://jules.google.com/task/17796734392387777952) started by @nongjossss-commits*