### PR TITLE
fix: Exclude cancelled employees from workflow summary stats

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -91,7 +91,7 @@ class RegistrationController extends Controller
 
         // Step Stats (Optimized via SQL)
         // We filter statsQuery to active employees for step stats usually
-        $stepStatsQuery = (clone $statsQuery);
+        $stepStatsQuery = (clone $statsQuery)->where('status', '!=', 'registration_cancelled');
         $stepStats = $this->getGlobalStepStats($stepStatsQuery, $steps);
 
         // Total Appointments
@@ -1323,6 +1323,9 @@ class RegistrationController extends Controller
             $globalNotStarted = 0;
 
             foreach ($allEmployees as $emp) {
+                if ($emp->status === 'registration_cancelled') {
+                    continue;
+                }
                 // Count Not Started
                 if ($stepOneId && in_array($emp->status, ['registration_pending', 'registration_completed']) && !$emp->registrationSteps->contains('id', $stepOneId)) {
                     $globalNotStarted++;
@@ -1397,6 +1400,9 @@ class RegistrationController extends Controller
             $employerNotStarted = 0;
 
             foreach ($employerEmployees as $emp) {
+                 if ($emp->status === 'registration_cancelled') {
+                     continue;
+                 }
                  // Count Not Started
                  if ($stepOneId && in_array($emp->status, ['registration_pending', 'registration_completed']) && !$emp->registrationSteps->contains('id', $stepOneId)) {
                      $employerNotStarted++;

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -82,7 +82,7 @@ class RenewalController extends Controller
         }
 
         // Step Stats (Optimized via SQL)
-        $stepStatsQuery = (clone $statsQuery);
+        $stepStatsQuery = (clone $statsQuery)->where('status', '!=', 'renewal_cancelled');
         $stepStats = $this->getGlobalStepStats($stepStatsQuery, $steps);
 
         // Total Appointments
@@ -1307,6 +1307,9 @@ class RenewalController extends Controller
             $globalNotStarted = 0;
 
             foreach ($allEmployees as $emp) {
+                if ($emp->status === 'renewal_cancelled') {
+                    continue;
+                }
                 if ($stepOneId && in_array($emp->status, ['renewal_pending', 'renewal_completed']) && !$emp->registrationSteps->contains('id', $stepOneId)) {
                     $globalNotStarted++;
                 }
@@ -1374,6 +1377,9 @@ class RenewalController extends Controller
             $employerNotStarted = 0;
 
             foreach ($employerEmployees as $emp) {
+                 if ($emp->status === 'renewal_cancelled') {
+                     continue;
+                 }
                  if ($stepOneId && in_array($emp->status, ['renewal_pending', 'renewal_completed']) && !$emp->registrationSteps->contains('id', $stepOneId)) {
                      $employerNotStarted++;
                  }


### PR DESCRIPTION
This patch ensures that cancelled employees do not inflate the "Not Started" count or custom step counts in the summary cards across the 4 main operational menus.

- `ProductionController` & `WorkflowController`: Already properly handle exclusions, no major changes needed.
- `RegistrationController`: Updated global stats and AJAX updates to strictly exclude `registration_cancelled`.
- `RenewalController`: Updated global stats and AJAX updates to strictly exclude `renewal_cancelled`.

---
*PR created automatically by Jules for task [16568963484518754178](https://jules.google.com/task/16568963484518754178) started by @nongjossss-commits*