### PR TITLE
Add Edit Payment Functionality and Fix History UI Update in Finance Tab

### DIFF
--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -63,7 +63,8 @@ if (typeof window.financialManager === 'undefined') {
             newTransaction: { type: 'installment', amount: '', due_date: '', notes: '' },
             editingTransaction: { payments: [] },
             selectedFile: null,
-            newPayment: { amount: '', paid_at: '', bank_account_id: '', notes: '' },
+            editingPaymentId: null,
+            newPayment: { amount: '', paid_at: '', bank_account_id: '', notes: '', slip_path: null },
             paymentSlipFile: null,
             isSavingPayment: false,
 
@@ -625,7 +626,8 @@ if (typeof window.financialManager === 'undefined') {
                 if (defaultAmount < 0) defaultAmount = 0;
 
                 let today = new Date().toISOString().split('T')[0];
-                this.newPayment = { amount: defaultAmount, paid_at: today, bank_account_id: '', notes: '' };
+                this.editingPaymentId = null;
+                this.newPayment = { amount: defaultAmount, paid_at: today, bank_account_id: '', notes: '', slip_path: null };
                 this.paymentSlipFile = null;
 
                 if (t.items) {
@@ -677,12 +679,79 @@ if (typeof window.financialManager === 'undefined') {
                         // Reset form
                         let defaultAmount = (data.transaction.amount - (data.transaction.paid_amount || 0)).toFixed(2);
                         if (defaultAmount < 0) defaultAmount = 0;
-                        this.newPayment = { amount: defaultAmount, paid_at: new Date().toISOString().split('T')[0], bank_account_id: '', notes: '' };
+                        this.editingPaymentId = null;
+                        this.newPayment = { amount: defaultAmount, paid_at: new Date().toISOString().split('T')[0], bank_account_id: '', notes: '', slip_path: null };
                         this.paymentSlipFile = null;
 
                         Swal.fire({ toast: true, position: 'top-end', icon: 'success', title: 'Payment Added', showConfirmButton: false, timer: 3000 });
                     } else {
                         throw new Error(data.message || 'Error adding payment');
+                    }
+                })
+                .catch(err => Swal.fire('Error', err.message, 'error'))
+                .finally(() => this.isSavingPayment = false);
+            },
+
+            editPayment(payment) {
+                this.editingPaymentId = payment.id;
+                this.newPayment = {
+                    amount: payment.amount,
+                    paid_at: payment.paid_at ? payment.paid_at.split('T')[0] : '',
+                    bank_account_id: payment.bank_account_id || '',
+                    notes: payment.notes || '',
+                    slip_path: payment.slip_path || null
+                };
+                this.paymentSlipFile = null;
+                // clear file input if possible
+                const fileInput = document.getElementById('paymentSlipInput');
+                if (fileInput) fileInput.value = '';
+            },
+
+            cancelEditPayment() {
+                this.editingPaymentId = null;
+                let defaultAmount = (this.editingTransaction.amount - (this.editingTransaction.paid_amount || 0)).toFixed(2);
+                if (defaultAmount < 0) defaultAmount = 0;
+                this.newPayment = { amount: defaultAmount, paid_at: new Date().toISOString().split('T')[0], bank_account_id: '', notes: '', slip_path: null };
+                this.paymentSlipFile = null;
+                const fileInput = document.getElementById('paymentSlipInput');
+                if (fileInput) fileInput.value = '';
+            },
+
+            updatePayment() {
+                if(!this.newPayment.amount || !this.newPayment.paid_at) {
+                    Swal.fire('Warning', 'Amount and Date are required.', 'warning');
+                    return;
+                }
+
+                this.isSavingPayment = true;
+                const formData = new FormData();
+                formData.append('_method', 'PUT');
+                formData.append('amount', this.newPayment.amount);
+                formData.append('paid_at', this.newPayment.paid_at);
+                formData.append('bank_account_id', this.newPayment.bank_account_id || '');
+                formData.append('notes', this.newPayment.notes || '');
+                if (this.paymentSlipFile) {
+                    formData.append('slip_file', this.paymentSlipFile);
+                }
+
+                fetch(`/production/payments/${this.editingPaymentId}`, {
+                    method: 'POST', // Use POST with _method=PUT
+                    headers: { 'X-CSRF-TOKEN': this.csrfToken, 'Accept': 'application/json' },
+                    body: formData
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if(data.success) {
+                        const idx = this.transactions.findIndex(t => t.id === data.transaction.id);
+                        if(idx !== -1) this.transactions[idx] = data.transaction;
+
+                        this.editingTransaction = { ...data.transaction };
+
+                        this.cancelEditPayment();
+
+                        Swal.fire({ toast: true, position: 'top-end', icon: 'success', title: 'Payment Updated', showConfirmButton: false, timer: 3000 });
+                    } else {
+                        throw new Error(data.message || 'Error updating payment');
                     }
                 })
                 .catch(err => Swal.fire('Error', err.message, 'error'))
@@ -748,6 +817,8 @@ if (typeof window.financialManager === 'undefined') {
                     if(data.success) {
                         const idx = this.transactions.findIndex(t => t.id === data.transaction.id);
                         if(idx !== -1) this.transactions[idx] = data.transaction;
+
+                        this.editingTransaction = { ...data.transaction };
 
                         if (data.transaction.items) {
                             data.transaction.items.forEach(newItem => {

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -977,9 +977,14 @@ class="row">
                                         </div>
                                         <div class="d-flex justify-content-between align-items-center mt-2">
                                             <div class="small fst-italic text-muted" x-text="pay.notes"></div>
-                                            <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1" @click="deletePayment(pay.id)">
-                                                <i class="bi bi-trash"></i>
-                                            </button>
+                                            <div class="btn-group">
+                                                <button type="button" class="btn btn-sm btn-outline-primary py-0 px-1" @click="editPayment(pay)">
+                                                    <i class="bi bi-pencil"></i>
+                                                </button>
+                                                <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1" @click="deletePayment(pay.id)">
+                                                    <i class="bi bi-trash"></i>
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
                                 </template>
@@ -989,8 +994,11 @@ class="row">
                             </div>
 
                             <!-- Add New Payment Form -->
-                            <div class="card shadow-sm border-success">
-                                <div class="card-header bg-success text-white py-1 small fw-bold">Add Payment</div>
+                            <div class="card shadow-sm border-success" :class="{'border-primary': editingPaymentId, 'border-success': !editingPaymentId}">
+                                <div class="card-header text-white py-1 small fw-bold d-flex justify-content-between align-items-center" :class="{'bg-primary': editingPaymentId, 'bg-success': !editingPaymentId}">
+                                    <span x-text="editingPaymentId ? 'Edit Payment' : 'Add Payment'"></span>
+                                    <button type="button" class="btn-close btn-close-white" style="font-size: 0.5rem;" x-show="editingPaymentId" @click="cancelEditPayment()"></button>
+                                </div>
                                 <div class="card-body p-2">
                                     <div class="row g-2 mb-2">
                                         <div class="col-6">
@@ -1013,16 +1021,29 @@ class="row">
                                     </div>
                                     <div class="mb-2">
                                         <label class="form-label small mb-0">Slip</label>
-                                        <input type="file" class="form-control form-control-sm" @change="handlePaymentSlipSelect" accept=".jpg,.jpeg,.png,.pdf">
+                                        <input type="file" id="paymentSlipInput" class="form-control form-control-sm" @change="handlePaymentSlipSelect" accept=".jpg,.jpeg,.png,.pdf">
+                                        <div x-show="editingPaymentId && newPayment.slip_path && !paymentSlipFile" class="mt-1 small">
+                                            <a :href="'/storage/' + newPayment.slip_path" target="_blank" class="text-decoration-none">
+                                                <i class="bi bi-file-earmark-text"></i> View Current Slip
+                                            </a>
+                                        </div>
+                                        <div x-show="editingPaymentId && paymentSlipFile" class="mt-1 small text-warning">
+                                            <i class="bi bi-info-circle"></i> New file selected.
+                                        </div>
                                     </div>
                                     <div class="mb-2">
                                         <label class="form-label small mb-0">Notes</label>
                                         <input type="text" class="form-control form-control-sm" x-model="newPayment.notes">
                                     </div>
-                                    <button type="button" class="btn btn-success btn-sm w-100" @click="addPayment" :disabled="isSavingPayment">
-                                        <span x-show="isSavingPayment" class="spinner-border spinner-border-sm me-1"></span>
-                                        Save Payment
-                                    </button>
+                                    <div class="d-flex gap-2">
+                                        <button type="button" class="btn btn-sm w-100" :class="editingPaymentId ? 'btn-primary' : 'btn-success'" @click="editingPaymentId ? updatePayment() : addPayment()" :disabled="isSavingPayment">
+                                            <span x-show="isSavingPayment" class="spinner-border spinner-border-sm me-1"></span>
+                                            <span x-text="editingPaymentId ? 'Save Changes' : 'Save Payment'"></span>
+                                        </button>
+                                        <button type="button" class="btn btn-secondary btn-sm w-50" x-show="editingPaymentId" @click="cancelEditPayment()">
+                                            Cancel
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
This PR adds the ability for users to edit previously submitted payments within the financial tab (amount, date, account, notes, and updating the attached slip file). It also resolves a bug where updating a transaction would cause the payment history to momentarily disappear from the UI by ensuring the reactive state `this.editingTransaction` is properly re-assigned.

---
*PR created automatically by Jules for task [17820778875658693229](https://jules.google.com/task/17820778875658693229) started by @nongjossss-commits*