### PR TITLE
Fix "Not Started" filter logic and empty employer card states across all operational menus

### DIFF
--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -27,11 +27,21 @@
         $overlayClass = 'opacity-50 pointer-events-none';
     }
 
+    // Determine the relevant steps relationship depending on the active module
+    $completedStepsCollection = isset($employee->production_item)
+        ? $employee->production_item->completedWorkTypeSteps
+        : $employee->registrationSteps;
+
     // Determine Highest Completed Step for Filtering
-    $highestStep = $employee->registrationSteps->sortByDesc('order')->first();
+    $highestStep = $completedStepsCollection->sortByDesc('order')->first();
     $highestStepId = $highestStep ? $highestStep->id : '';
-    // Determine if "Not Started" (only if active status and no steps)
-    $isNotStarted = (!$isCompleted && !$isCancelled && !$highestStep);
+
+    // "Not Started" logic must exactly match the backend: missing Step 1.
+    // If they have steps 2, 3, etc. but no step 1, they are STILL considered "Not Started".
+    // We check if the collection contains any step with 'order' === 1 to avoid relying on external variables.
+    $hasStepOne = $completedStepsCollection->where('order', 1)->isNotEmpty();
+
+    $isNotStarted = (!$isCancelled && !$hasStepOne);
 
     // Contextual status for JS
     $itemStatus = isset($employee->production_item) ? $employee->production_item->status : $employee->status;

--- a/resources/views/production/renewal/index.blade.php
+++ b/resources/views/production/renewal/index.blade.php
@@ -1827,14 +1827,14 @@
         document.querySelectorAll('.employee-card-wrapper').forEach(card => {
             let visible = true;
             if (filter === 'not_started') {
-                 visible = (card.dataset.isNotStarted === 'true' && card.dataset.status !== 'registration_cancelled');
+                 visible = (card.dataset.isNotStarted === 'true' && card.dataset.status !== 'renewal_cancelled');
             } else if (filter === 'saved') {
-                 visible = (card.dataset.status === 'registration_completed');
+                 visible = (card.dataset.status === 'renewal_completed');
             } else if (filter === 'cancelled') {
-                 visible = (card.dataset.status === 'registration_cancelled');
+                 visible = (card.dataset.status === 'renewal_cancelled');
             } else if (!isNaN(filter)) {
                  // Step ID
-                 visible = (card.dataset.highestStepId == filter && card.dataset.status !== 'registration_cancelled');
+                 visible = (card.dataset.highestStepId == filter && card.dataset.status !== 'renewal_cancelled');
             }
 
             if (visible) {


### PR DESCRIPTION
This submission aligns the behavior of the "Not Started" filter and counter logic across the Registration, Renewal, Pre-production, and Workflow menus. 

Previously, the backend accurately identified employees missing "Step 1" as Not Started. However, the shared frontend card view (`_employee_card.blade.php`) enforced a stricter standard, identifying employees as Not Started only if they lacked *all* steps (`$highestStep === null`). This caused the backend to match an employer and return it, but the frontend to hide the respective employee, resulting in confusing "empty" employer cards. Users misinterpreted these empty cards as the system incorrectly counting cancelled employees.

The patch directly evaluates the existence of `order === 1` steps natively in the UI template, harmonizing the state so that cards aren't erroneously hidden. Additionally, it fixes a copy-paste client-side bug in the `Renewal` menu's UI, applying the proper `renewal_cancelled` terminology.

---
*PR created automatically by Jules for task [1587438370775252875](https://jules.google.com/task/1587438370775252875) started by @nongjossss-commits*