### PR TITLE
Fix finance payment history disappearing after refresh

### DIFF
--- a/app/Http/Controllers/FinancialHubController.php
+++ b/app/Http/Controllers/FinancialHubController.php
@@ -81,7 +81,7 @@ class FinancialHubController extends Controller
 
             $stats = $this->getStatsForOrders($baseQuery);
 
-            $query = (clone $baseQuery)->with(['employer', 'financialGroups.transactions'])
+            $query = (clone $baseQuery)->with(['employer', 'financialGroups.transactions', 'financialGroups.transactions.payments'])
                 ->latest('created_at')
                 ->withCount('items');
 
@@ -157,7 +157,7 @@ class FinancialHubController extends Controller
                 );
             } else {
                 $orders = $query->paginate(20)->withQueryString();
-                $orders->load(['financialGroups.transactions', 'financialGroups.advanceItems']);
+                $orders->load(['financialGroups.transactions', 'financialGroups.transactions.payments', 'financialGroups.advanceItems']);
                 foreach ($orders as $order) {
                     $this->calculateOrderFinancials($order, $employeeCounts[$order->employer_id] ?? 0);
                 }
@@ -223,7 +223,7 @@ class FinancialHubController extends Controller
                 );
             } else {
                 $orders = $query->paginate(20)->withQueryString();
-                $orders->load(['financialGroups.transactions', 'financialGroups.advanceItems']);
+                $orders->load(['financialGroups.transactions', 'financialGroups.transactions.payments', 'financialGroups.advanceItems']);
                 foreach ($orders as $order) {
                     $this->calculateOrderFinancials($order, $employeeCounts[$order->employer_id] ?? 0);
                 }
@@ -234,7 +234,7 @@ class FinancialHubController extends Controller
 
             $stats = $this->getStatsForOrders($baseQuery);
 
-            $query = (clone $baseQuery)->with(['employer', 'financialGroups.transactions'])
+            $query = (clone $baseQuery)->with(['employer', 'financialGroups.transactions', 'financialGroups.transactions.payments'])
                 ->latest('created_at')
                 ->withCount('items');
 
@@ -303,7 +303,7 @@ class FinancialHubController extends Controller
         $pricedItemIds = [];
         $totalAmount = 0;
 
-        $order->loadMissing(['financialGroups.transactions']);
+        $order->loadMissing(['financialGroups.transactions', 'financialGroups.transactions.payments']);
 
         foreach ($order->financialGroups as $group) {
             $financialData = $group->financial_data ?? [];

--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -573,7 +573,7 @@ class RegistrationController extends Controller
         }
 
         // Load relationships needed for the view
-        $financeOrder->load(['financialGroups.transactions.items', 'financialGroups.advanceItems', 'items.employee']);
+        $financeOrder->load(['financialGroups.transactions.items', 'financialGroups.transactions.payments', 'financialGroups.advanceItems', 'items.employee']);
 
         // Fetch ALL Active Employees for this employer (ignoring search)
         $query = $employer->employees()
@@ -708,7 +708,7 @@ class RegistrationController extends Controller
         }
 
         // --- Calculate Financial Status ---
-        $financeOrder = ProductionOrder::with('financialGroups.transactions.items')
+        $financeOrder = ProductionOrder::with('financialGroups.transactions.items', 'financialGroups.transactions.payments')
             ->where('employer_id', $employerId)
             ->whereIn('status', ['registration_resolution', 'registration_resolution_cancelled'])
             ->first();

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -620,7 +620,7 @@ class RenewalController extends Controller
             $employees = $query->paginate($perPage)->withQueryString();
         }
 
-        $financeOrder = ProductionOrder::with('financialGroups.transactions.items')
+        $financeOrder = ProductionOrder::with('financialGroups.transactions.items', 'financialGroups.transactions.payments')
             ->where('employer_id', $employerId)
             ->whereIn('status', ['renewal_resolution', 'renewal_resolution_cancelled'])
             ->first();
@@ -763,7 +763,7 @@ class RenewalController extends Controller
         }
 
         // Load relationships needed for the view
-        $financeOrder->load(['financialGroups.transactions.items', 'financialGroups.advanceItems', 'items.employee']);
+        $financeOrder->load(['financialGroups.transactions.items', 'financialGroups.transactions.payments', 'financialGroups.advanceItems', 'items.employee']);
 
         // Fetch ALL Active Employees for this employer (ignoring search)
         $query = $employer->employees()

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -202,7 +202,7 @@ class ProductionController extends Controller
                 if ($order->work_type_id !== null) {
                     $sharedGroups = \App\Models\ProductionFinancialGroup::where('employer_id', $order->employer_id)
                         ->where('work_type_id', $order->work_type_id)
-                        ->with(['transactions.items', 'advanceItems'])
+                        ->with(['transactions.items', 'transactions.payments', 'advanceItems'])
                         ->get();
                     if ($sharedGroups->isEmpty()) {
                         $sharedGroups = $order->financialGroups;
@@ -741,16 +741,16 @@ class ProductionController extends Controller
         // IMPORTANT: Manual bills have work_type_id = null. We do NOT want to share groups
         // across all manual bills for the same employer. If null, fetch ONLY its own groups.
         if ($production->work_type_id === null) {
-             $sharedGroups = $production->financialGroups()->with(['transactions.items', 'advanceItems'])->get();
+             $sharedGroups = $production->financialGroups()->with(['transactions.items', 'transactions.payments', 'advanceItems'])->get();
         } else {
              $sharedGroups = ProductionFinancialGroup::where('employer_id', $production->employer_id)
                 ->where('work_type_id', $production->work_type_id)
-                ->with(['transactions.items', 'advanceItems'])
+                ->with(['transactions.items', 'transactions.payments', 'advanceItems'])
                 ->get();
 
              // If no shared groups exist, but the order has old groups (migration fallback), fetch them
              if ($sharedGroups->isEmpty()) {
-                 $sharedGroups = $production->financialGroups()->with(['transactions.items', 'advanceItems'])->get();
+                 $sharedGroups = $production->financialGroups()->with(['transactions.items', 'transactions.payments', 'advanceItems'])->get();
              }
         }
 
@@ -925,7 +925,7 @@ class ProductionController extends Controller
         if ($order->work_type_id !== null) {
             $sharedGroups = \App\Models\ProductionFinancialGroup::where('employer_id', $order->employer_id)
                 ->where('work_type_id', $order->work_type_id)
-                ->with(['transactions.items', 'advanceItems'])
+                ->with(['transactions.items', 'transactions.payments', 'advanceItems'])
                 ->get();
             if ($sharedGroups->isEmpty()) {
                 $sharedGroups = $order->financialGroups;

--- a/app/Http/Controllers/WorkflowController.php
+++ b/app/Http/Controllers/WorkflowController.php
@@ -1984,7 +1984,7 @@ class WorkflowController extends Controller
         if ($order->work_type_id !== null) {
             $sharedGroups = \App\Models\ProductionFinancialGroup::where('employer_id', $order->employer_id)
                 ->where('work_type_id', $order->work_type_id)
-                ->with(['transactions.items', 'advanceItems'])
+                ->with(['transactions.items', 'transactions.payments', 'advanceItems'])
                 ->get();
             if ($sharedGroups->isEmpty()) {
                 $sharedGroups = $order->financialGroups;


### PR DESCRIPTION
Fix finance payment history disappearing after refresh

Update eager loading in various controllers to include `financialGroups.transactions.payments`. Previously, the relationships were only loading `financialGroups.transactions.items` which caused the `payments` list to disappear when the page was refreshed (e.g. going back into the finance modal) as the array was empty until another payment logic was triggered on the frontend or backend.

---
*PR created automatically by Jules for task [9306016572088049828](https://jules.google.com/task/9306016572088049828) started by @nongjossss-commits*