### PR TITLE
Finance: Dynamic Installment Calculations and Payment-Based Receipts

### DIFF
--- a/app/Http/Controllers/ProductionDocumentController.php
+++ b/app/Http/Controllers/ProductionDocumentController.php
@@ -246,4 +246,153 @@ class ProductionDocumentController extends Controller
 
         return view($view, $data);
     }
+
+    public function showPaymentDocument($id, $paymentId, $type, Request $request)
+    {
+        $production = ProductionOrder::with(['employer', 'items.employee', 'financialGroups', 'financialAdvances'])->findOrFail($id);
+
+        // Fetch the specific payment
+        $payment = \App\Models\FinancialPayment::with('transaction')->findOrFail($paymentId);
+
+        // Mark as generated
+        if (!$payment->receipt_generated_at) {
+            $payment->update(['receipt_generated_at' => now()]);
+        }
+
+        // Ensure the payment belongs to a transaction in this production order
+        if ($payment->transaction->production_order_id !== $production->id) {
+            abort(403, 'Unauthorized access to this payment document.');
+        }
+
+        // Fake a transaction object that holds only the payment amount for the document logic
+        // This makes the existing generic document views work without massive rewrites
+        $mockTransaction = clone $payment->transaction;
+        $mockTransaction->amount = $payment->amount; // Override the transaction amount with the payment amount
+        $mockTransaction->id = $payment->transaction->id; // Keep ID
+        $mockTransaction->type = $payment->transaction->type;
+        $mockTransaction->notes = "Payment: " . ($payment->notes ?? "Partial/Full Payment");
+
+        $transactions = collect([$mockTransaction]);
+
+        // Standard setup from show()
+        $financialData = is_string($production->financial_data) ? json_decode($production->financial_data, true) : ($production->financial_data ?? []);
+
+        $groupId = $request->query('group_id', $payment->transaction->production_financial_group_id);
+        $activeGroup = null;
+        if ($groupId) {
+            $activeGroup = $production->financialGroups->where('id', $groupId)->first();
+            if ($activeGroup) {
+                $groupData = is_string($activeGroup->financial_data) ? json_decode($activeGroup->financial_data, true) : ($activeGroup->financial_data ?? []);
+                $financialData = array_merge($financialData, $groupData);
+            }
+        }
+
+        // Advance Items specific to group
+        $advanceItems = collect();
+
+        // --- Header Logic ---
+        $profileId = $financialData['profile_id'] ?? $request->query('profile_id');
+        $baseProfile = $profileId ? CompanyProfile::find($profileId) : CompanyProfile::where('is_default', true)->first();
+
+        // Fallback Base
+        if (!$baseProfile) {
+            $baseProfile = CompanyProfile::first() ?? new CompanyProfile([
+                'name' => 'Company Name (Default)',
+                'address' => 'Please configure a company profile in settings.',
+                'tax_id' => '0000000000000',
+                'phone' => '-',
+                'email' => '-',
+            ]);
+        }
+
+        $customHeader = $financialData['custom_header'] ?? null;
+
+        // If Custom Header exists, merge it with Base Profile
+        if ($customHeader && !empty($customHeader['name'])) {
+            $attributes = $baseProfile->toArray();
+
+            // Merge Overrides
+            $attributes['name'] = $customHeader['name'];
+            $attributes['address'] = $customHeader['address'] ?? ($attributes['address'] ?? '');
+            $attributes['tax_id'] = $customHeader['tax_id'] ?? ($attributes['tax_id'] ?? '');
+            $attributes['phone'] = $customHeader['phone'] ?? ($attributes['phone'] ?? '');
+            $attributes['email'] = $customHeader['email'] ?? ($attributes['email'] ?? '');
+
+            // Only override logo if provided in custom header
+            if (!empty($customHeader['logo'])) {
+                $attributes['logo_path'] = $customHeader['logo'];
+            }
+
+            $companyProfile = new CompanyProfile($attributes);
+        } else {
+            $companyProfile = $baseProfile;
+        }
+
+        // --- Bill To Logic (Customer Override) ---
+        $customCustomer = $financialData['customer_override'] ?? null;
+        $billTo = $production->employer; // Default
+
+        if ($customCustomer) {
+            $billTo = (object) [
+                'employerNameTh' => $customCustomer['name'] ?? 'Client Name',
+                'employerAddress' => $customCustomer['address'] ?? '',
+                'employerPhone' => $customCustomer['phone'] ?? '-',
+                'tax_id' => $customCustomer['tax_id'] ?? '-'
+            ];
+        }
+
+        // --- Mode Logic (Combined, Service Only, Advance Only) ---
+        $mode = $request->query('mode', 'combined');
+
+        // --- Document Title Logic ---
+        $titles = [
+            'tax_invoice' => 'ใบกำกับภาษี / Tax Invoice',
+            'receipt' => 'ใบเสร็จรับเงิน / Receipt',
+        ];
+
+        $title = $titles[$type] ?? ucfirst($type);
+
+        $employerName = $production->employer->employerNameTh ?: ($production->employer->employerNameEn ?: 'Unknown_Employer');
+        $pageTitle = "{$title}_{$employerName}_PAY-{$payment->id}";
+
+        // Prepare data for the view
+        $billerProfile = null;
+        $customerProfile = null;
+        if (!empty($financialData['custom_header']['biller_profile_id'])) {
+            $billerProfile = \App\Models\FinancialProfile::find($financialData['custom_header']['biller_profile_id']);
+        }
+        if (!empty($financialData['custom_header']['customer_profile_id'])) {
+            $customerProfile = \App\Models\FinancialProfile::find($financialData['custom_header']['customer_profile_id']);
+        }
+
+        $data = [
+            'production' => $production,
+            'includeEmployeeList' => false,
+            'employeeList' => [],
+            'profile' => $companyProfile,
+            'company' => $companyProfile,
+            'billerProfile' => $billerProfile,
+            'customerProfile' => $customerProfile,
+            'billTo' => $billTo,
+            'type' => $type,
+            'title' => $title,
+            'page_title' => $pageTitle,
+            'date' => $payment->paid_at ?? now(), // Use payment date instead of now
+            'transactions' => $transactions,
+            'financial' => $financialData,
+            'advanceItems' => collect(), // usually no advances in direct payment doc unless specified
+            'activeGroup' => $activeGroup,
+            'mode' => $mode
+        ];
+
+        $view = 'documents.generic';
+
+        if (view()->exists('documents.' . $type)) {
+            $view = 'documents.' . $type;
+        } elseif (in_array($type, ['tax_invoice', 'receipt'])) {
+             $view = 'documents.tax_invoice';
+        }
+
+        return view($view, $data);
+    }
 }

--- a/app/Models/FinancialPayment.php
+++ b/app/Models/FinancialPayment.php
@@ -16,12 +16,14 @@ class FinancialPayment extends Model
         'bank_account_id',
         'slip_path',
         'notes',
+        'receipt_generated_at',
         'created_by',
     ];
 
     protected $casts = [
         'amount' => 'decimal:2',
         'paid_at' => 'datetime',
+        'receipt_generated_at' => 'datetime',
     ];
 
     public function transaction()

--- a/database/migrations/2026_03_20_224217_add_receipt_generated_at_to_financial_payments_table.php
+++ b/database/migrations/2026_03_20_224217_add_receipt_generated_at_to_financial_payments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('financial_payments', function (Blueprint $table) {
+            $table->timestamp('receipt_generated_at')->nullable()->after('notes');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('financial_payments', function (Blueprint $table) {
+            $table->dropColumn('receipt_generated_at');
+        });
+    }
+};

--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -522,9 +522,7 @@ if (typeof window.financialManager === 'undefined') {
                     this.selectedTransactionItems.forEach(val => {
                          total += this.getItemPrice(val);
                     });
-                    // For edit mode, we generally don't auto-update paid amount, only total guidance?
-                    // Or maybe we update the transaction total?
-                    // Let's update editingTransaction.amount for display, but it's not bound to input
+                    // Update editingTransaction.amount dynamically
                     this.editingTransaction.amount = total;
                 }
             },
@@ -1233,6 +1231,19 @@ if (typeof window.financialManager === 'undefined') {
                     url += `&include_employee_list=1`;
                 }
                 window.open(url, '_blank');
+            },
+            generatePaymentDocument(paymentId, type) {
+                let url = `/production/${this.productionId}/documents/payment/${paymentId}/${type}?profile_id=${this.selectedProfileId}`;
+                if (this.activeGroupId) {
+                    url += `&group_id=${this.activeGroupId}`;
+                }
+                window.open(url, '_blank');
+
+                // Optimistically update the UI to show it's generated
+                const payment = this.editingTransaction.payments.find(p => p.id === paymentId);
+                if (payment) {
+                    payment.receipt_generated_at = new Date().toISOString();
+                }
             },
             uploadLogo() {
                 const input = this.$refs.logoInput;

--- a/resources/js/financial-manager.js
+++ b/resources/js/financial-manager.js
@@ -951,6 +951,19 @@ if (typeof window.financialManager === 'undefined') {
                 }
                 window.open(url, '_blank');
             },
+            generatePaymentDocument(paymentId, type) {
+                let url = `/production/${this.productionId}/documents/payment/${paymentId}/${type}?profile_id=${this.selectedProfileId}`;
+                if (this.activeGroupId) {
+                    url += `&group_id=${this.activeGroupId}`;
+                }
+                window.open(url, '_blank');
+
+                // Optimistically update the UI to show it's generated
+                const payment = this.editingTransaction.payments.find(p => p.id === paymentId);
+                if (payment) {
+                    payment.receipt_generated_at = new Date().toISOString();
+                }
+            },
             uploadLogo() {
                 const input = this.$refs.logoInput;
                 if (!input.files || input.files.length === 0) return;

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -969,21 +969,38 @@ class="row">
                                             <div class="fw-bold text-success" x-text="formatCurrency(pay.amount)"></div>
                                             <div class="text-muted small" x-text="formatDate(pay.paid_at)"></div>
                                         </div>
-                                        <div class="small text-muted mb-1 d-flex justify-content-between">
+                                        <div class="small text-muted mb-1 d-flex justify-content-between align-items-center">
                                             <span x-text="pay.bank_account ? pay.bank_account.bank_name : 'No Account'"></span>
-                                            <span>
+                                            <div class="d-flex gap-1 align-items-center">
+                                                <template x-if="pay.receipt_generated_at">
+                                                    <span class="badge bg-success" style="font-size: 0.6rem;" title="Document Generated"><i class="bi bi-check-circle"></i> Generated</span>
+                                                </template>
+                                                <template x-if="!pay.receipt_generated_at">
+                                                    <span class="badge bg-secondary" style="font-size: 0.6rem;" title="Not Generated"><i class="bi bi-dash-circle"></i> Not Generated</span>
+                                                </template>
                                                 <a x-show="pay.slip_path" href="#" @click.prevent="viewPDF('/storage/' + pay.slip_path, 'View Slip')" class="badge bg-info text-decoration-none">View Slip</a>
-                                            </span>
+                                            </div>
                                         </div>
                                         <div class="d-flex justify-content-between align-items-center mt-2">
-                                            <div class="small fst-italic text-muted" x-text="pay.notes"></div>
-                                            <div class="btn-group">
-                                                <button type="button" class="btn btn-sm btn-outline-primary py-0 px-1" @click="editPayment(pay)">
-                                                    <i class="bi bi-pencil"></i>
-                                                </button>
-                                                <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1" @click="deletePayment(pay.id)">
-                                                    <i class="bi bi-trash"></i>
-                                                </button>
+                                            <div class="small fst-italic text-muted text-truncate" style="max-width: 40%;" x-text="pay.notes"></div>
+                                            <div class="d-flex gap-1">
+                                                <div class="btn-group">
+                                                    <button type="button" class="btn btn-sm btn-outline-secondary py-0 px-2 dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                                                        Doc
+                                                    </button>
+                                                    <ul class="dropdown-menu shadow" style="font-size: 0.8rem;">
+                                                        <li><a class="dropdown-item py-1" href="#" @click.prevent="generatePaymentDocument(pay.id, 'receipt')"><i class="bi bi-receipt me-1"></i> Receipt</a></li>
+                                                        <li><a class="dropdown-item py-1" href="#" @click.prevent="generatePaymentDocument(pay.id, 'tax_invoice')"><i class="bi bi-file-earmark-text me-1"></i> Tax Invoice</a></li>
+                                                    </ul>
+                                                </div>
+                                                <div class="btn-group">
+                                                    <button type="button" class="btn btn-sm btn-outline-primary py-0 px-1" @click="editPayment(pay)">
+                                                        <i class="bi bi-pencil"></i>
+                                                    </button>
+                                                    <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1" @click="deletePayment(pay.id)">
+                                                        <i class="bi bi-trash"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
@@ -1157,6 +1174,16 @@ class="row">
                                         <button class="nav-link w-100 py-0" :class="{ 'active': editTransactionEmployeeFilter === 'cancelled' }" @click="editTransactionEmployeeFilter = 'cancelled'" type="button">Cancelled</button>
                                     </li>
                                 </ul>
+                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                    <div class="small text-muted" style="font-size: 0.75rem;">
+                                        Selected: <span x-text="selectedTransactionItems.length"></span>
+                                        <span x-show="pricingMode === 'per_head'">(Auto-calc active)</span>
+                                    </div>
+                                    <div class="btn-group btn-group-sm">
+                                        <button type="button" class="btn btn-outline-secondary py-0" style="font-size: 0.7rem;" @click="selectedTransactionItems = editModalItems.map(i => i.id); recalcEditAmount()">All</button>
+                                        <button type="button" class="btn btn-outline-secondary py-0" style="font-size: 0.7rem;" @click="selectedTransactionItems = []; recalcEditAmount()">None</button>
+                                    </div>
+                                </div>
                                 <div class="border rounded bg-light" style="max-height: 250px; overflow-y: auto;">
                                     <div class="list-group list-group-flush">
                                         <!-- Show ALL items for edit (Available + Currently Attached) -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -464,6 +464,7 @@ Route::middleware(['auth'])->group(function () {
     // Replaced by dedicated ProductionDocumentController
     // Route::get('production/{id}/documents/{type}', [FinancialController::class, 'generateDocument']);
     Route::get('production/{id}/documents/{type}', [App\Http\Controllers\ProductionDocumentController::class, 'show'])->name('production.documents.show');
+    Route::get('production/{id}/documents/payment/{paymentId}/{type}', [App\Http\Controllers\ProductionDocumentController::class, 'showPaymentDocument'])->name('production.documents.payment.show');
 
     // Workflow Routes
     Route::get('workflow', [\App\Http\Controllers\WorkflowController::class, 'index'])->middleware('menu:workflow')->name('workflow.index');


### PR DESCRIPTION
This submission addresses two main requests for the Finance module:

1.  **Dynamic Calculations for Installments:**
    When adding or editing a transaction (installment), the total amount now actively recalculates when checking or unchecking individual employees from the list. The UI also clearly displays the count of "Selected: X" employees.
2.  **Payment-Based Receipts and Tax Invoices:**
    Previously, documents were generated based on the entire expected transaction amount. Now, users can go to the "Payment History" of an installment and specifically generate a Receipt or Tax Invoice based solely on the `amount` actually paid for that specific `FinancialPayment`. A new database field (`receipt_generated_at`) tracks whether a document has been generated for a payment, and the UI displays a badge (Generated/Not Generated) to help users avoid confusion.

---
*PR created automatically by Jules for task [18373843821906092720](https://jules.google.com/task/18373843821906092720) started by @nongjossss-commits*