### PR TITLE
Fix unresponsive Update button in Finance payment modal

### DIFF
--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -1067,7 +1067,7 @@ class="row">
 
                         <!-- Right Column: Transaction Options & Items -->
                         <div class="col-md-7 border-start ps-3">
-                            <form @submit.prevent="updateTransaction">
+                            <form @submit.prevent="updateTransaction" :id="'updateTransactionForm-' + productionId">
                                 <h6 class="fw-bold mb-3 border-bottom pb-2">Transaction Options</h6>
 
                                 <!-- Summary Display -->
@@ -1236,7 +1236,7 @@ class="row">
                                 </div>
                              </div>
                         </div>
-                        <button type="submit" class="btn btn-success btn-sm w-100 mt-3">Update</button>
+                        <button type="submit" :form="'updateTransactionForm-' + productionId" class="btn btn-success btn-sm w-100 mt-3">Update</button>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
The "Update" button in the "Update Payment Modal" of the Finance module was positioned structurally outside its `<form>` tag due to DOM hierarchy, causing it to be unresponsive when clicked. This fix links the submit button to its specific transaction form dynamically using the HTML5 `form` attribute, utilizing Alpine.js binding to accommodate the existing split-column modal layout.

Fixes the issue in all menus that utilize the `financial-tab.blade.php` partial (e.g., Registration, Renewal, Workflow, Pre-Production).

---
*PR created automatically by Jules for task [11532304580194595197](https://jules.google.com/task/11532304580194595197) started by @nongjossss-commits*