### PR TITLE
Add employer custom fields and file attachments to MOU tabs in Pre-Production and Workflow

### DIFF
--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -469,6 +469,13 @@
                                  </button>
                                  @endif
 
+                                @if(isset($activeTab) && $activeTab->slug === 'mou')
+                                {{-- Custom Fields Button (Employer) --}}
+                                <button class="btn btn-outline-secondary btn-sm ms-2 fw-bold" onclick="toggleEmployerInlineDrawer({{ $order->employer_id }}, {{ json_encode($order->employer->customFields ?? []) }}); event.stopPropagation();">
+                                    <i class="bi bi-list-task"></i> {{ __('Fields') }}
+                                </button>
+                                @endif
+
                                 <button class="btn btn-light btn-sm rounded-circle ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ $order->id }}">
                                     <i class="bi bi-chevron-down"></i>
                                 </button>
@@ -476,8 +483,22 @@
                         </div>
                     </div>
 
+                    {{-- Employer Custom Fields Drawer --}}
+                    @if(isset($activeTab) && $activeTab->slug === 'mou')
+                    <div class="collapse mt-3 mx-4" id="drawer-employer-{{ $order->employer_id }}">
+                        <div class="card card-body bg-light border-0 rounded-3 shadow-sm">
+                            <div id="drawer-content-employer-{{ $order->employer_id }}" class="position-relative" style="min-height: 100px;">
+                                <div class="d-flex justify-content-center align-items-center h-100 py-3">
+                                     <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+                                     <span class="ms-2 small text-muted">{{ __('Loading fields...') }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    @endif
+
                     {{-- Bottom Row: Steps Progress --}}
-                    <div class="w-100 overflow-auto custom-scrollbar pb-1" style="scrollbar-width: thin;">
+                    <div class="w-100 overflow-auto custom-scrollbar pb-1 mt-2" style="scrollbar-width: thin;">
                          <div class="d-flex flex-nowrap align-items-center gap-2">
                              @foreach($steps as $step)
                                 @php

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -507,6 +507,13 @@
                                  </a>
                                  @endif
 
+                                @if(isset($activeTab) && $activeTab->slug === 'mou')
+                                {{-- Custom Fields Button (Employer) --}}
+                                <button class="btn btn-outline-secondary btn-sm ms-2 fw-bold" onclick="toggleEmployerInlineDrawer({{ $order->employer_id }}, {{ json_encode($order->employer->customFields ?? []) }}); event.stopPropagation();">
+                                    <i class="bi bi-list-task"></i> {{ __('Fields') }}
+                                </button>
+                                @endif
+
                                 <button class="btn btn-light btn-sm rounded-circle ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ $order->id }}">
                                     <i class="bi bi-chevron-down"></i>
                                 </button>
@@ -514,8 +521,22 @@
                         </div>
                     </div>
 
+                    {{-- Employer Custom Fields Drawer --}}
+                    @if(isset($activeTab) && $activeTab->slug === 'mou')
+                    <div class="collapse mt-3 mx-4" id="drawer-employer-{{ $order->employer_id }}">
+                        <div class="card card-body bg-light border-0 rounded-3 shadow-sm">
+                            <div id="drawer-content-employer-{{ $order->employer_id }}" class="position-relative" style="min-height: 100px;">
+                                <div class="d-flex justify-content-center align-items-center h-100 py-3">
+                                     <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+                                     <span class="ms-2 small text-muted">{{ __('Loading fields...') }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    @endif
+
                     {{-- Bottom Row: Workflow Steps (Horizontal Scroll) --}}
-                    <div class="w-100 overflow-auto custom-scrollbar pb-1" style="scrollbar-width: thin;">
+                    <div class="w-100 overflow-auto custom-scrollbar pb-1 mt-2" style="scrollbar-width: thin;">
                          <div class="d-flex flex-nowrap align-items-center gap-2">
                              @foreach($steps as $step)
                                 @php


### PR DESCRIPTION
This pull request adds the "Fields" button to employer cards specifically when viewing the 'MOU นำเข้า' (MOU Import) tab in both the Pre-Production and Workflow menus. This matches the exact functionality already implemented in the Registration ('มติลงทะเบียน') menu.

Users can now expand an inline drawer for each employer to add custom text fields or attach large files (over 100MB), streamlining documentation management in the MOU processes.

**Changes:**
* Added conditional check `@if(isset($activeTab) && $activeTab->slug === 'mou')` to render the button.
* Added the "Fields" `<button>` calling `toggleEmployerInlineDrawer`.
* Added the collapsible drawer `<div id="drawer-employer-...">` to render the custom fields list.
* Modified `production/index.blade.php` and `workflow/index.blade.php` to include these changes.

---
*PR created automatically by Jules for task [13300253240942941916](https://jules.google.com/task/13300253240942941916) started by @nongjossss-commits*