### PR TITLE
Enable Employer Custom Fields Drawer and Increase File Upload Limit

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -23,3 +23,8 @@
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 </IfModule>
+
+<IfModule mod_php.c>
+    php_value upload_max_filesize 128M
+    php_value post_max_size 128M
+</IfModule>

--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -664,6 +664,8 @@
 @include('employees.partials._edit_scripts')
 @include('production.registration.partials.edit_modal_script')
 @include('employees.modals.advanced_export')
+@include('production.registration.partials.offcanvas_drawer')
+@include('production.registration.partials.modals.add_custom_field')
 
 {{-- Trash Modal --}}
 <div class="modal fade" id="trashModal" tabindex="-1" aria-hidden="true">

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -788,6 +788,8 @@
 @include('employees.partials._edit_scripts')
 @include('production.registration.partials.edit_modal_script')
 @include('employees.modals.advanced_export')
+@include('production.registration.partials.offcanvas_drawer')
+@include('production.registration.partials.modals.add_custom_field')
 
 @push('scripts')
 <script>


### PR DESCRIPTION
The user requested the "Custom Fields" (ปุ่มฟิวส์) button and its sliding drawer functionality to be active on employer cards in the Pre Production and Workflow menus (MOU tab), similar to its behavior in the Registration menu. I found that the HTML for the button and drawer container was already present but lacked the required included partials (`offcanvas_drawer` and `add_custom_field`) for the JavaScript to function. I added these includes to the respective index blade files.

Additionally, the user noted issues with uploading files larger than 100 MB. I confirmed that the application's form validation already allows up to 100 MB (`max:102400`), but the server-level limitations (`upload_max_filesize`, `post_max_size`) were likely causing the failure. I appended directives to `public/.htaccess` setting these limits to `128M` to fully support this requirement.

---
*PR created automatically by Jules for task [5356211416819124547](https://jules.google.com/task/5356211416819124547) started by @nongjossss-commits*