### PR TITLE
feat: Change employee stamp on PDF to English name

### DIFF
--- a/app/Jobs/ProcessDownload.php
+++ b/app/Jobs/ProcessDownload.php
@@ -525,13 +525,17 @@ class ProcessDownload implements ShouldQueue
 
             $employeeNameTh = $employee->employeeNameTh;
             $employeeNameEn = $employee->employeeNameEn;
+            $employeeTitleEn = $employee->employeeTitleEn ?? '';
 
             // Combine ID and Name directly as raw UTF-8 string first
             $employeeNameStr = '';
-            if ($hasThaiFont && $employeeNameTh) {
+            if (!empty($employeeNameEn)) {
+                $prefix = !empty($employeeTitleEn) ? $employeeTitleEn . ' ' : '';
+                $employeeNameStr = $prefix . preg_replace('/[^\x20-\x7E\p{Thai}]/u', '', $employeeNameEn);
+            } elseif ($hasThaiFont && !empty($employeeNameTh)) {
                 $employeeNameStr = $employeeNameTh;
             } else {
-                $employeeNameStr = preg_replace('/[^\x20-\x7E]/', '', $employeeNameEn ?? 'Employee');
+                $employeeNameStr = 'Employee';
             }
             $headerTextRaw = $employeeNameStr . "   ID: " . $employee->id;
 


### PR DESCRIPTION
This submission updates the Advanced Download feature to stamp the employee's English name (along with their English title, if available) instead of their Thai name at the top right corner of the document. Fallback logic is provided so that if the English name is absent, it falls back to the Thai name (when Thai font support allows), or simply "Employee".

---
*PR created automatically by Jules for task [825300326038562024](https://jules.google.com/task/825300326038562024) started by @nongjossss-commits*