### PR TITLE
Update MOU UI actions to Job-level

### DIFF
--- a/resources/views/production/index.blade.php
+++ b/resources/views/production/index.blade.php
@@ -125,9 +125,15 @@
             <button class="btn btn-light btn-sm shadow-sm border" data-bs-toggle="modal" data-bs-target="#manageStepsModal">
                 <i class="bi bi-gear-fill me-1"></i> {{ __('Steps') }}
             </button>
-            <button class="btn btn-primary fw-bold shadow-sm" onclick="openAddEmployeeModal(null, null, {{ $activeTab->id ?? 'null' }}, '{{ $activeTab->slug ?? '' }}', 'production')">
-                <i class="bi bi-plus-lg me-1"></i> {{ __('Add Employee') }}
-            </button>
+            @if(isset($activeTab) && $activeTab->slug === 'mou')
+                <button class="btn btn-primary fw-bold shadow-sm" data-bs-toggle="modal" data-bs-target="#createJobModal">
+                    <i class="bi bi-plus-lg me-1"></i> {{ __('Create Job') }}
+                </button>
+            @else
+                <button class="btn btn-primary fw-bold shadow-sm" onclick="openAddEmployeeModal(null, null, {{ $activeTab->id ?? 'null' }}, '{{ $activeTab->slug ?? '' }}', 'production')">
+                    <i class="bi bi-plus-lg me-1"></i> {{ __('Add Employee') }}
+                </button>
+            @endif
         </div>
         @endif
     </div>
@@ -464,15 +470,24 @@
                                  </button>
 
                                  {{-- Add Employee Button --}}
-                                 <button class="btn btn-outline-warning btn-sm fw-bold" onclick="openAddEmployeeModal({{ $order->id }}, {{ $order->employer_id }}, {{ $order->workType->id ?? 'null' }}, '{{ $order->workType->slug ?? '' }}', 'production')">
-                                    <i class="bi bi-plus-lg"></i> {{ __('Add') }}
-                                 </button>
+                                 @if(isset($activeTab) && $activeTab->slug !== 'mou')
+                                     <button class="btn btn-outline-warning btn-sm fw-bold" onclick="openAddEmployeeModal({{ $order->id }}, {{ $order->employer_id }}, {{ $order->workType->id ?? 'null' }}, '{{ $order->workType->slug ?? '' }}', 'production')">
+                                        <i class="bi bi-plus-lg"></i> {{ __('Add') }}
+                                     </button>
+                                 @endif
                                  @endif
 
                                 @if(isset($activeTab) && $activeTab->slug === 'mou')
-                                {{-- Custom Fields Button (Employer) --}}
-                                <button class="btn btn-outline-secondary btn-sm ms-2 fw-bold" onclick="toggleEmployerInlineDrawer({{ $order->employer_id }}, {{ json_encode($order->employer->customFields ?? []) }}); event.stopPropagation();">
+                                {{-- Custom Fields Button (Order/Job) --}}
+                                <button class="btn btn-outline-secondary btn-sm ms-2 fw-bold" onclick="toggleOrderInlineDrawer({{ $order->id }}, {{ json_encode($order->customFields ?? []) }}); event.stopPropagation();">
                                     <i class="bi bi-list-task"></i> {{ __('Fields') }}
+                                </button>
+
+                                {{-- SEND ENTIRE ORDER TO WORKFLOW --}}
+                                <button class="btn btn-primary btn-sm ms-2 fw-bold px-3 shadow-sm"
+                                        onclick="sendOrderToWorkflow({{ $order->id }})"
+                                        title="{{ __('Send Job to Workflow') }}">
+                                    <i class="bi bi-box-arrow-right"></i> <span class="d-none d-lg-inline">{{ __('Send to Workflow') }}</span>
                                 </button>
                                 @endif
 
@@ -483,11 +498,11 @@
                         </div>
                     </div>
 
-                    {{-- Employer Custom Fields Drawer --}}
+                    {{-- Order Custom Fields Drawer --}}
                     @if(isset($activeTab) && $activeTab->slug === 'mou')
-                    <div class="collapse mt-3 mx-4" id="drawer-employer-{{ $order->employer_id }}">
+                    <div class="collapse mt-3 mx-4" id="drawer-order-{{ $order->id }}">
                         <div class="card card-body bg-light border-0 rounded-3 shadow-sm">
-                            <div id="drawer-content-employer-{{ $order->employer_id }}" class="position-relative" style="min-height: 100px;">
+                            <div id="drawer-content-order-{{ $order->id }}" class="position-relative" style="min-height: 100px;">
                                 <div class="d-flex justify-content-center align-items-center h-100 py-3">
                                      <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
                                      <span class="ms-2 small text-muted">{{ __('Loading fields...') }}</span>

--- a/resources/views/production/registration/_employee_card.blade.php
+++ b/resources/views/production/registration/_employee_card.blade.php
@@ -928,13 +928,15 @@
                 @endphp
 
                 @if($isPreProductionContext && isset($employee->production_item))
-                    {{-- SEND TO WORKFLOW (P Production Context) --}}
-                    <button class="btn btn-sm btn-primary rounded-pill px-3"
-                        id="btn-send-to-workflow-{{ $employee->id }}"
-                        title="{{ __('Send to Workflow') }}"
-                        onclick="sendToWorkflow({{ $employee->production_item->id }})">
-                        <i class="bi bi-send-check"></i> <span class="d-none d-lg-inline">{{ __('Send to Workflow') }}</span>
-                    </button>
+                    @if($activeTab->slug !== 'mou')
+                        {{-- SEND TO WORKFLOW (P Production Context) - Not shown in MOU --}}
+                        <button class="btn btn-sm btn-primary rounded-pill px-3"
+                            id="btn-send-to-workflow-{{ $employee->id }}"
+                            title="{{ __('Send to Workflow') }}"
+                            onclick="sendToWorkflow({{ $employee->production_item->id }})">
+                            <i class="bi bi-send-check"></i> <span class="d-none d-lg-inline">{{ __('Send to Workflow') }}</span>
+                        </button>
+                    @endif
 
                     {{-- CANCEL --}}
                     <button class="btn btn-sm btn-outline-secondary rounded-pill px-3 {{ ($isCompleted || $isCancelled || $isHistory) ? 'd-none' : '' }}"

--- a/resources/views/workflow/index.blade.php
+++ b/resources/views/workflow/index.blade.php
@@ -224,9 +224,15 @@
             <button class="btn btn-secondary shadow-sm" onclick="openTrashModal()">
                 <i class="bi bi-trash-fill me-1"></i> {{ __('Trash') }}
             </button>
-            <button class="btn btn-primary fw-bold shadow-sm" onclick="openAddEmployeeModal(null, null, {{ $activeTab->id ?? 'null' }}, '{{ $activeTab->slug ?? '' }}', 'workflow')">
-                <i class="bi bi-plus-lg me-1"></i> {{ __('Add Employee') }}
-            </button>
+            @if(isset($activeTab) && $activeTab->slug === 'mou')
+                <button class="btn btn-primary fw-bold shadow-sm" data-bs-toggle="modal" data-bs-target="#createJobModal">
+                    <i class="bi bi-plus-lg me-1"></i> {{ __('Create Job') }}
+                </button>
+            @else
+                <button class="btn btn-primary fw-bold shadow-sm" onclick="openAddEmployeeModal(null, null, {{ $activeTab->id ?? 'null' }}, '{{ $activeTab->slug ?? '' }}', 'workflow')">
+                    <i class="bi bi-plus-lg me-1"></i> {{ __('Add Employee') }}
+                </button>
+            @endif
         </div>
         @endif
     </div>
@@ -498,19 +504,28 @@
                                      <i class="bi bi-eye"></i>
                                  </button>
 
-                                 <button class="btn btn-outline-warning btn-sm fw-bold" onclick="openAddEmployeeModal({{ $order->id }}, {{ $order->employer_id }}, {{ $order->workType->id ?? 'null' }}, '{{ $order->workType->slug ?? '' }}', 'workflow')">
-                                    <i class="bi bi-plus-lg"></i> {{ __('Add') }}
-                                 </button>
+                                 @if(isset($activeTab) && $activeTab->slug !== 'mou')
+                                     <button class="btn btn-outline-warning btn-sm fw-bold" onclick="openAddEmployeeModal({{ $order->id }}, {{ $order->employer_id }}, {{ $order->workType->id ?? 'null' }}, '{{ $order->workType->slug ?? '' }}', 'workflow')">
+                                        <i class="bi bi-plus-lg"></i> {{ __('Add') }}
+                                     </button>
 
-                                 <a href="{{ route('employees.import_view', ['production_id' => $order->id, 'employer_id' => $order->employer_id, 'return_to' => 'workflow']) }}" class="btn btn-outline-success btn-sm fw-bold">
-                                    <i class="bi bi-file-earmark-spreadsheet"></i> {{ __('Import') }}
-                                 </a>
+                                     <a href="{{ route('employees.import_view', ['production_id' => $order->id, 'employer_id' => $order->employer_id, 'return_to' => 'workflow']) }}" class="btn btn-outline-success btn-sm fw-bold">
+                                        <i class="bi bi-file-earmark-spreadsheet"></i> {{ __('Import') }}
+                                     </a>
+                                 @endif
                                  @endif
 
                                 @if(isset($activeTab) && $activeTab->slug === 'mou')
-                                {{-- Custom Fields Button (Employer) --}}
-                                <button class="btn btn-outline-secondary btn-sm ms-2 fw-bold" onclick="toggleEmployerInlineDrawer({{ $order->employer_id }}, {{ json_encode($order->employer->customFields ?? []) }}); event.stopPropagation();">
+                                {{-- Custom Fields Button (Order/Job) --}}
+                                <button class="btn btn-outline-secondary btn-sm ms-2 fw-bold" onclick="toggleOrderInlineDrawer({{ $order->id }}, {{ json_encode($order->customFields ?? []) }}); event.stopPropagation();">
                                     <i class="bi bi-list-task"></i> {{ __('Fields') }}
+                                </button>
+
+                                {{-- SEND ENTIRE ORDER BACK TO PRE-PRODUCTION --}}
+                                <button class="btn btn-info btn-sm ms-2 fw-bold px-3 text-white shadow-sm"
+                                        onclick="sendOrderBackToPreProduction({{ $order->id }})"
+                                        title="{{ __('Return Job to Pre-production') }}">
+                                    <i class="bi bi-arrow-counterclockwise"></i> <span class="d-none d-lg-inline">{{ __('Back to Prep') }}</span>
                                 </button>
                                 @endif
 
@@ -521,11 +536,11 @@
                         </div>
                     </div>
 
-                    {{-- Employer Custom Fields Drawer --}}
+                    {{-- Order Custom Fields Drawer --}}
                     @if(isset($activeTab) && $activeTab->slug === 'mou')
-                    <div class="collapse mt-3 mx-4" id="drawer-employer-{{ $order->employer_id }}">
+                    <div class="collapse mt-3 mx-4" id="drawer-order-{{ $order->id }}">
                         <div class="card card-body bg-light border-0 rounded-3 shadow-sm">
-                            <div id="drawer-content-employer-{{ $order->employer_id }}" class="position-relative" style="min-height: 100px;">
+                            <div id="drawer-content-order-{{ $order->id }}" class="position-relative" style="min-height: 100px;">
                                 <div class="d-flex justify-content-center align-items-center h-100 py-3">
                                      <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
                                      <span class="ms-2 small text-muted">{{ __('Loading fields...') }}</span>

--- a/resources/views/workflow/partials/_item_card.blade.php
+++ b/resources/views/workflow/partials/_item_card.blade.php
@@ -667,20 +667,24 @@
 
                 @if(!$isReadOnly)
                     @if($isPreProduction)
-                        {{-- Send to Workflow Button (Only in Pre-Production) --}}
-                        <button class="btn btn-primary btn-sm fw-bold shadow-sm px-3"
-                                onclick="sendToWorkflow({{ $item->id }})"
-                                title="{{ __('Send to Workflow') }}">
-                            <i class="bi bi-box-arrow-right"></i> <span class="d-none d-lg-inline">{{ __('Send to Workflow') }}</span>
-                        </button>
+                        @if($activeTab->slug !== 'mou')
+                            {{-- Send to Workflow Button (Only in Pre-Production) --}}
+                            <button class="btn btn-primary btn-sm fw-bold shadow-sm px-3"
+                                    onclick="sendToWorkflow({{ $item->id }})"
+                                    title="{{ __('Send to Workflow') }}">
+                                <i class="bi bi-box-arrow-right"></i> <span class="d-none d-lg-inline">{{ __('Send to Workflow') }}</span>
+                            </button>
+                        @endif
                     @else
                         {{-- Send Back to Pre-Production --}}
                         @if(!$isCompleted && !$isCancelled)
-                        <button class="btn btn-info btn-sm fw-bold shadow-sm px-3 text-white"
-                                onclick="sendBackToPreProduction({{ $item->id }})"
-                                title="{{ __('Back to Preparation') }}">
-                             <i class="bi bi-arrow-counterclockwise"></i> <span class="d-none d-lg-inline">{{ __('Back to Prep') }}</span>
-                        </button>
+                            @if($activeTab->slug !== 'mou')
+                            <button class="btn btn-info btn-sm fw-bold shadow-sm px-3 text-white"
+                                    onclick="sendBackToPreProduction({{ $item->id }})"
+                                    title="{{ __('Back to Preparation') }}">
+                                 <i class="bi bi-arrow-counterclockwise"></i> <span class="d-none d-lg-inline">{{ __('Back to Prep') }}</span>
+                            </button>
+                            @endif
                         @endif
 
                         {{-- Daily Check Button (Only in Workflow) --}}


### PR DESCRIPTION
Updates the UI for the MOU tab within Pre-Production and Workflow menus. The individual employee action buttons ("Send to Workflow" and "Back to Preparation") are hidden and replaced by job-level (order-level) actions since the entire MOU job must be advanced/returned as a single unit. Also replaces "Add Employee" with "Create Job".

---
*PR created automatically by Jules for task [12299120459103899026](https://jules.google.com/task/12299120459103899026) started by @nongjossss-commits*