### PR TITLE
feat: Add Visa Status filter and badges for Employees and Finance

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -245,6 +245,18 @@ class EmployerController extends Controller
             }
         }
 
+        if ($request->filled('visa_status')) {
+            if ($request->input('visa_status') === 'has_visa') {
+                $employeeQuery->where(function ($q) {
+                    $q->whereNotNull('visaExpiryDate')->where('visaExpiryDate', '!=', '');
+                });
+            } elseif ($request->input('visa_status') === 'no_visa') {
+                $employeeQuery->where(function ($q) {
+                    $q->whereNull('visaExpiryDate')->orWhere('visaExpiryDate', '=', '');
+                });
+            }
+        }
+
         if ($request->filled('work_permit_expiry_date')) {
             $employeeQuery->whereDate('workPermitExpiryDate', $request->input('work_permit_expiry_date'));
         }

--- a/public/js/financial-manager.js
+++ b/public/js/financial-manager.js
@@ -291,7 +291,7 @@ if (typeof window.financialManager === 'undefined') {
                     if (this.tierEmployeeFilter === 'active' && isCancelled) return;
                     if (this.tierEmployeeFilter === 'cancelled' && !isCancelled) return;
 
-                    list.push({ ...item, type: 'item', last_step_name: item.last_step_name });
+                    list.push({ ...item, type: 'item', last_step_name: item.last_step_name, has_visa: item.has_visa });
                 });
 
                 // 2. Candidates
@@ -312,6 +312,7 @@ if (typeof window.financialManager === 'undefined') {
                         nationality: emp.nationality,
                         insurance_type: emp.insurance_type,
                         passport: emp.passport,
+                        has_visa: emp.has_visa,
                         employee_id: emp.id,
                         last_step_name: emp.last_step_name,
                         status: emp.status,
@@ -374,6 +375,7 @@ if (typeof window.financialManager === 'undefined') {
                         nationality: item.nationality,
                         insurance_type: item.insurance_type,
                         passport: item.passport,
+                        has_visa: item.has_visa,
                         last_step_name: item.last_step_name,
                         status: item.status,
                         type: 'item'
@@ -399,6 +401,7 @@ if (typeof window.financialManager === 'undefined') {
                             nationality: emp.nationality,
                             insurance_type: emp.insurance_type,
                             passport: emp.passport,
+                            has_visa: emp.has_visa,
                             last_step_name: emp.last_step_name,
                             status: emp.status,
                             type: 'employee'
@@ -454,6 +457,7 @@ if (typeof window.financialManager === 'undefined') {
                             nationality: item.nationality,
                             insurance_type: item.insurance_type,
                             passport: item.passport,
+                            has_visa: item.has_visa,
                             last_step_name: item.last_step_name,
                             status: item.status,
                             type: 'item',
@@ -480,6 +484,7 @@ if (typeof window.financialManager === 'undefined') {
                         nationality: emp.nationality,
                         insurance_type: emp.insurance_type,
                         passport: emp.passport,
+                        has_visa: emp.has_visa,
                         last_step_name: emp.last_step_name,
                         status: emp.status,
                         type: 'employee',

--- a/resources/views/employers/edit.blade.php
+++ b/resources/views/employers/edit.blade.php
@@ -593,6 +593,11 @@
                     <option value="has_passport" {{ request('passport_status') == 'has_passport' ? 'selected' : '' }}>{{ __('Has Passport') }}</option>
                     <option value="no_passport" {{ request('passport_status') == 'no_passport' ? 'selected' : '' }}>{{ __('No Passport') }}</option>
                 </select>
+                <select name="visa_status" class="form-select form-select-sm" style="width: auto;">
+                    <option value="">-- {{ __('Visa Status') }} --</option>
+                    <option value="has_visa" {{ request('visa_status') == 'has_visa' ? 'selected' : '' }}>{{ __('มีวีซ่า') }}</option>
+                    <option value="no_visa" {{ request('visa_status') == 'no_visa' ? 'selected' : '' }}>{{ __('ไม่มีวีซ่า') }}</option>
+                </select>
                 <select name="passport_type_myanmar" class="form-select form-select-sm" style="width: auto;">
                     <option value="">-- {{ __('Passport Type (Myanmar)') }} --</option>
                     <option value="CI" {{ request('passport_type_myanmar') == 'CI' ? 'selected' : '' }}>เล่ม CI</option>

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -21,6 +21,7 @@
             'nationality' => $item->employee ? $item->employee->employeeNationality : '',
             'insurance_type' => $item->employee ? $item->employee->insurance_type : '',
             'passport' => $item->employee ? $item->employee->employeePassport : '',
+            'has_visa' => $item->employee ? !empty($item->employee->visaExpiryDate) : false,
             'employee_id' => $item->employee_id,
             'last_step_name' => $lastStepName,
             'status' => $item->status
@@ -41,6 +42,7 @@
             'nationality' => $emp->employeeNationality,
             'insurance_type' => $emp->insurance_type,
             'passport' => $emp->employeePassport,
+            'has_visa' => !empty($emp->visaExpiryDate),
             'last_step_name' => $lastStepName,
             'status' => $emp->status
         ];
@@ -694,6 +696,13 @@ class="row">
                                             <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
                                                 <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
                                             </template>
+                                            <!-- Visa Badge -->
+                                            <template x-if="item.has_visa">
+                                                <span class="badge bg-success rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('Visa') }}</span>
+                                            </template>
+                                            <template x-if="!item.has_visa">
+                                                <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('None') }}</span>
+                                            </template>
                                             <!-- Last Step Badge -->
                                             <template x-if="item.last_step_name">
                                                 <span class="badge border border-primary text-primary rounded-pill ms-1" style="font-size: 0.6rem;" x-text="item.last_step_name"></span>
@@ -914,6 +923,13 @@ class="row">
                                                             </template>
                                                             <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
                                                                 <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
+                                                            </template>
+                                                            <!-- Visa Badge -->
+                                                            <template x-if="item.has_visa">
+                                                                <span class="badge bg-success rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('Visa') }}</span>
+                                                            </template>
+                                                            <template x-if="!item.has_visa">
+                                                                <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('None') }}</span>
                                                             </template>
                                                             <!-- Last Step Badge -->
                                                             <template x-if="item.last_step_name">
@@ -1215,6 +1231,13 @@ class="row">
                                                             </template>
                                                             <template x-if="!item.passport || item.passport === '-' || item.passport === 'No' || item.passport === 'ไม่มี'">
                                                                 <span class="badge bg-light text-dark border rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('No Passport') }}</span>
+                                                            </template>
+                                                            <!-- Visa Badge -->
+                                                            <template x-if="item.has_visa">
+                                                                <span class="badge bg-success rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('Visa') }}</span>
+                                                            </template>
+                                                            <template x-if="!item.has_visa">
+                                                                <span class="badge bg-secondary rounded-pill ms-1" style="font-size: 0.6rem;">{{ __('None') }}</span>
                                                             </template>
                                                             <!-- Last Step Badge -->
                                                             <template x-if="item.last_step_name">


### PR DESCRIPTION
This submission fulfills the requirements to:
1. Allow filtering of employees by Visa status (checking if `visaExpiryDate` is filled) directly on the Employer Edit page.
2. In the Finance tab modules (Installments and Tier Assignments), display visual indicators of whether an employee has a visa or not, aiding billing clerks.

### Changes
- **`resources/views/employers/edit.blade.php`**: Added `<select name="visa_status">` to the filter form.
- **`app/Http/Controllers/EmployerController.php`**: Handled the new `visa_status` filter parameter to query employees with or without a `visaExpiryDate`.
- **`resources/views/production/partials/financial-tab.blade.php`**: Updated the employee mapping JSON to include `has_visa` based on the existence of `visaExpiryDate`, and rendered a success "Visa" or secondary "None" badge respectively in all employee listings.
- **`public/js/financial-manager.js`**: Ensured `has_visa` is propagated through all mapped employee models across `productionItems` and `employees`.

---
*PR created automatically by Jules for task [9549874064837477487](https://jules.google.com/task/9549874064837477487) started by @nongjossss-commits*