### PR TITLE
Add Visa Status filter to Employee Menu

### DIFF
--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -214,6 +214,18 @@ public function reinstate(Employee $employee)
         }
     }
 
+    if ($request->filled('visa_status')) {
+        if ($request->input('visa_status') === 'has_visa') {
+            $query->where(function ($q) {
+                $q->whereNotNull('visaExpiryDate')->where('visaExpiryDate', '!=', '');
+            });
+        } elseif ($request->input('visa_status') === 'no_visa') {
+            $query->where(function ($q) {
+                $q->whereNull('visaExpiryDate')->orWhere('visaExpiryDate', '=', '');
+            });
+        }
+    }
+
     if ($request->filled('bank_account_status')) {
         $status = $request->input('bank_account_status');
         if ($status === 'opened') {
@@ -965,6 +977,7 @@ public function create(Request $request) // เพิ่ม Request $request เ
             }
         }
 
+
         if ($request->filled('passport_type_myanmar')) {
             $query->where('passportType', $request->input('passport_type_myanmar'))
                   ->where('employeeNationality', 'เมียนมา');
@@ -1143,6 +1156,18 @@ public function create(Request $request) // เพิ่ม Request $request เ
             } elseif ($request->input('passport_status') === 'no_passport') {
                 $query->where(function ($q) {
                     $q->whereNull('employeePassport')->orWhere('employeePassport', '=', '');
+                });
+            }
+        }
+
+        if ($request->filled('visa_status')) {
+            if ($request->input('visa_status') === 'has_visa') {
+                $query->where(function ($q) {
+                    $q->whereNotNull('visaExpiryDate')->where('visaExpiryDate', '!=', '');
+                });
+            } elseif ($request->input('visa_status') === 'no_visa') {
+                $query->where(function ($q) {
+                    $q->whereNull('visaExpiryDate')->orWhere('visaExpiryDate', '=', '');
                 });
             }
         }

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -60,10 +60,17 @@
                 <option value="yes" {{ request('pink_card') == 'yes' ? 'selected' : '' }}>{{ __('Has Pink Card') }}</option>
                 <option value="no" {{ request('pink_card') == 'no' ? 'selected' : '' }}>{{ __('No Pink Card') }}</option>
             </select>
+            <select name="visa_status" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- {{ __(Visa
             <select name="passport_status" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- {{ __('Passport Status') }} --</option>
                 <option value="has_passport" {{ request('passport_status') == 'has_passport' ? 'selected' : '' }}>{{ __('Has Passport') }}</option>
                 <option value="no_passport" {{ request('passport_status') == 'no_passport' ? 'selected' : '' }}>{{ __('No Passport') }}</option>
+            </select>
+            <select name="visa_status" class="form-select form-select-sm" style="width: auto;">
+                <option value="">-- {{ __('Visa Status') }} --</option>
+                <option value="has_visa" {{ request('visa_status') == 'has_visa' ? 'selected' : '' }}>{{ __('มีวีซ่า') }}</option>
+                <option value="no_visa" {{ request('visa_status') == 'no_visa' ? 'selected' : '' }}>{{ __('ไม่มีวีซ่า') }}</option>
             </select>
             <select name="passport_type_myanmar" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- {{ __('Passport Type (Myanmar)') }} --</option>


### PR DESCRIPTION
This change aligns the Employee list filter (`/employees`) with the Employer edit menu by adding a "Visa Status" filter. The `EmployeeController` index and historyIndex endpoints now properly check if a `visaExpiryDate` is present or null when applying the filter to list results.

---
*PR created automatically by Jules for task [1562556179496916081](https://jules.google.com/task/1562556179496916081) started by @nongjossss-commits*