### PR TITLE
Fix Syntax Error in Employees Index Page

### DIFF
--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -60,8 +60,6 @@
                 <option value="yes" {{ request('pink_card') == 'yes' ? 'selected' : '' }}>{{ __('Has Pink Card') }}</option>
                 <option value="no" {{ request('pink_card') == 'no' ? 'selected' : '' }}>{{ __('No Pink Card') }}</option>
             </select>
-            <select name="visa_status" class="form-select form-select-sm" style="width: auto;">
-                <option value="">-- {{ __(Visa
             <select name="passport_status" class="form-select form-select-sm" style="width: auto;">
                 <option value="">-- {{ __('Passport Status') }} --</option>
                 <option value="has_passport" {{ request('passport_status') == 'has_passport' ? 'selected' : '' }}>{{ __('Has Passport') }}</option>


### PR DESCRIPTION
This commit fixes a `ParseError` on the employee index page. A partially complete `select` tag block for `visa_status` was removed from `resources/views/employees/index.blade.php`.

---
*PR created automatically by Jules for task [17525280721867808696](https://jules.google.com/task/17525280721867808696) started by @nongjossss-commits*