### PR TITLE
Fix finance modal visa status badge and layout

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -155,6 +155,8 @@ class Employee extends Model
         'custom_operator_name',
     ];
 
+    protected $appends = ['has_visa'];
+
     protected $casts = [
         'passportExpiryDate' => 'date:Y-m-d',
         'workPermitExpiryDate' => 'date:Y-m-d',
@@ -265,6 +267,11 @@ class Employee extends Model
     public function productionItems()
     {
         return $this->hasMany(ProductionItem::class);
+    }
+
+    public function getHasVisaAttribute()
+    {
+        return !empty($this->visaExpiryDate);
     }
 
     public function getActiveWorkflowsAttribute()

--- a/app/Models/ProductionItem.php
+++ b/app/Models/ProductionItem.php
@@ -31,6 +31,8 @@ class ProductionItem extends Model
         'remarks', // Added remarks
     ];
 
+    protected $appends = ['has_visa'];
+
     protected $casts = [
         'new_employee_data' => 'array',
         'appointment_date' => 'datetime',
@@ -90,6 +92,11 @@ class ProductionItem extends Model
     }
 
     // ACCESSORS
+
+    public function getHasVisaAttribute()
+    {
+        return $this->employee ? !empty($this->employee->visaExpiryDate) : false;
+    }
 
     public function getIsCheckedTodayAttribute()
     {

--- a/resources/views/production/partials/financial-tab.blade.php
+++ b/resources/views/production/partials/financial-tab.blade.php
@@ -670,10 +670,10 @@ class="row">
                                    style="cursor: pointer;">
                                 <input class="form-check-input me-1 mt-0" type="checkbox" :value="item.id" x-model="modalSelectedIds">
 
-                                <div class="d-flex align-items-center gap-2 overflow-hidden">
+                                <div class="d-flex align-items-center gap-2 overflow-hidden w-100">
                                     <img :src="item.photo || 'https://ui-avatars.com/api/?name=User&background=random'" class="rounded-circle flex-shrink-0" style="width: 32px; height: 32px; object-fit: cover;">
                                     <div class="d-flex flex-column" style="line-height: 1.2; min-width: 0;">
-                                        <div class="fw-bold text-truncate" style="font-size: 0.85rem;">
+                                        <div class="fw-bold text-wrap" style="font-size: 0.85rem;">
                                             <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
                                             <!-- Insurance Badge -->
                                             <template x-if="item.insurance_type && item.insurance_type !== '-' && item.insurance_type !== 'No' && item.insurance_type !== 'ไม่มี'">
@@ -902,7 +902,7 @@ class="row">
                                                 <div class="d-flex align-items-center gap-2 overflow-hidden w-100">
                                                     <img :src="item.photo || 'https://ui-avatars.com/api/?name=User&background=random'" class="rounded-circle flex-shrink-0" style="width: 24px; height: 24px; object-fit: cover;">
                                                     <div class="d-flex flex-column" style="line-height: 1.1; min-width: 0;">
-                                                        <div class="fw-bold text-truncate">
+                                                        <div class="fw-bold text-wrap">
                                                             <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
                                                             <template x-if="item.insurance_type && item.insurance_type !== '-' && item.insurance_type !== 'No' && item.insurance_type !== 'ไม่มี'">
                                                                 <span class="badge rounded-pill ms-1" style="font-size: 0.6rem;"
@@ -1210,7 +1210,7 @@ class="row">
                                                 <div class="d-flex align-items-center gap-2 overflow-hidden w-100">
                                                     <img :src="item.photo || 'https://ui-avatars.com/api/?name=User&background=random'" class="rounded-circle flex-shrink-0" style="width: 24px; height: 24px; object-fit: cover;">
                                                     <div class="d-flex flex-column" style="line-height: 1.1; min-width: 0;">
-                                                        <div class="fw-bold text-truncate">
+                                                        <div class="fw-bold text-wrap">
                                                             <span x-text="item.name_en ? (item.title_en + ' ' + item.name_en) : item.name"></span>
                                                             <template x-if="item.insurance_type && item.insurance_type !== '-' && item.insurance_type !== 'No' && item.insurance_type !== 'ไม่มี'">
                                                                 <span class="badge rounded-pill ms-1" style="font-size: 0.6rem;"


### PR DESCRIPTION
- Added `getHasVisaAttribute` to Employee and ProductionItem models based on `visaExpiryDate` being set.
- Appended `has_visa` to both models so they are serialized into JSON for frontend logic.
- Updated `resources/views/production/partials/financial-tab.blade.php` to use `text-wrap` instead of `text-truncate` in the Manage Employees Modals so that the full employee name and their new Visa badge (and other badges) can be seen clearly without being cut off by the fixed width limit.

---
*PR created automatically by Jules for task [1459063929419982548](https://jules.google.com/task/1459063929419982548) started by @nongjossss-commits*