### PR TITLE
Fix missing appointments and add bulk actions to dashboards

### DIFF
--- a/app/Http/Controllers/Production/RegistrationController.php
+++ b/app/Http/Controllers/Production/RegistrationController.php
@@ -56,13 +56,12 @@ class RegistrationController extends Controller
     public function dashboard(Request $request)
     {
         $days = \App\Models\NotificationSetting::where('notification_type', 'registration_appointment')->first()->days_before_expiry ?? 3;
-        $start = \Carbon\Carbon::now()->startOfDay();
         $end = \Carbon\Carbon::now()->addDays($days)->endOfDay();
 
         $query = Employee::query()
             ->whereIn('status', ['registration_pending', 'registration_completed'])
             ->whereNotNull('appointment_date')
-            ->whereBetween('appointment_date', [$start, $end])
+            ->where('appointment_date', '<=', $end)
             ->whereNull('appointment_completed_at')
             ->with(['employer']);
 

--- a/app/Http/Controllers/Production/RenewalController.php
+++ b/app/Http/Controllers/Production/RenewalController.php
@@ -52,13 +52,12 @@ class RenewalController extends Controller
     public function dashboard(Request $request)
     {
         $days = \App\Models\NotificationSetting::where('notification_type', 'renewal_appointment')->first()->days_before_expiry ?? 3;
-        $start = \Carbon\Carbon::now()->startOfDay();
         $end = \Carbon\Carbon::now()->addDays($days)->endOfDay();
 
         $query = Employee::query()
             ->whereIn('status', ['renewal_pending', 'renewal_completed'])
             ->whereNotNull('appointment_date')
-            ->whereBetween('appointment_date', [$start, $end])
+            ->where('appointment_date', '<=', $end)
             ->whereNull('appointment_completed_at')
             ->with(['employer']);
 

--- a/resources/views/production/registration/dashboard.blade.php
+++ b/resources/views/production/registration/dashboard.blade.php
@@ -167,11 +167,270 @@
             </div>
         </div>
     </div>
+
+    <!-- Bulk Action Bar -->
+    <div class="bulk-action-bar mt-3 align-items-center gap-2 p-2 bg-light border rounded shadow-lg"
+         style="display: none; position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); z-index: 1060; width: auto; min-width: 400px;"
+         id="bulkActionBar"
+         draggable="true"
+         ondragstart="window.startDragBulk(event)">
+        <div class="form-check mb-0">
+            <input class="form-check-input" type="checkbox" id="select-all-checkbox">
+            <label class="form-check-label fw-bold" for="select-all-checkbox">
+                {{ __('Select All') }} (<span id="selected-count">0</span>)
+            </label>
+        </div>
+
+        <div class="vr mx-2"></div>
+
+        <div class="dropdown">
+            <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" id="bulkActionDropdown" data-bs-toggle="dropdown" aria-expanded="false" disabled>
+                {{ __('Actions') }}
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="bulkActionDropdown">
+                <li><a class="dropdown-item" href="#" id="bulk-advanced-edit-btn"><i class="bi bi-pencil-square me-2"></i>{{ __('Advanced Edit') }}</a></li>
+                <li><a class="dropdown-item" href="#" id="bulk-advanced-export-btn"><i class="bi bi-file-earmark-spreadsheet me-2"></i>{{ __('Advanced Export') }}</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="#" id="bulk-download-btn"><i class="bi bi-download me-2"></i>{{ __('Download Files') }}</a></li>
+                <li><a class="dropdown-item" href="#" id="bulk-transfer-btn"><i class="bi bi-arrow-left-right me-2"></i>{{ __('Transfer') }}</a></li>
+                <li><a class="dropdown-item" href="#" id="bulk-send-data-btn"><i class="bi bi-send me-2"></i>{{ __('Send Data') }}</a></li>
+                @can('manage-tickets')
+                <li><a class="dropdown-item" href="#" id="bulk-generate-pdf-btn"><i class="bi bi-file-earmark-pdf me-2"></i>{{ __('Automated PDF') }}</a></li>
+                @endcan
+            </ul>
+        </div>
+
+        <button class="btn btn-sm btn-outline-danger ms-2" onclick="window.clearGlobalSelection();">{{ __('Clear Selection') }}</button>
+        <button class="btn btn-sm btn-info text-white" id="btn-view-selected" onclick="window.openViewSelectedModal()">
+            <i class="bi bi-eye me-1"></i> {{ __('View Selected') }}
+            <span class="badge bg-white text-info ms-1" id="view-selected-count">0</span>
+        </button>
+        <div class="ms-auto text-muted small d-none d-md-block">
+            <i class="bi bi-info-circle me-1"></i> Drag to chat
+        </div>
+    </div>
 </div>
+
+{{-- Include Advanced Export & Target Employer Modals (reused from Employees) --}}
+@include('employees.modals.advanced_export')
+@include('employees.modals.select_target_employer_modal')
 
 @endsection
 
 @push('scripts')
+<script>
+    // Include bulk action event handlers
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
+
+    document.addEventListener('DOMContentLoaded', function() {
+        // Bulk Generate PDF
+        const bulkGeneratePdfBtn = document.getElementById('bulk-generate-pdf-btn');
+        if (bulkGeneratePdfBtn) {
+            bulkGeneratePdfBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                const form = document.createElement('form');
+                form.method = 'POST';
+                form.action = '{{ route("admin.pdf-templates.generate.modal", [], false) }}';
+
+                const csrf = document.createElement('input');
+                csrf.type = 'hidden';
+                csrf.name = '_token';
+                csrf.value = csrfToken;
+                form.appendChild(csrf);
+
+                const redirectInput = document.createElement('input');
+                redirectInput.type = 'hidden';
+                redirectInput.name = 'redirect_url';
+                redirectInput.value = window.location.href;
+                form.appendChild(redirectInput);
+
+                selected.forEach(id => {
+                    const input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = 'employees[]';
+                    input.value = id;
+                    form.appendChild(input);
+                });
+
+                document.body.appendChild(form);
+                form.submit();
+            });
+        }
+
+        // Bulk Advanced Edit
+        const bulkEditBtn = document.getElementById('bulk-advanced-edit-btn');
+        if (bulkEditBtn) {
+            bulkEditBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                const form = document.createElement('form');
+                form.method = 'POST';
+                form.action = '{{ route('employees.bulk_edit.select_fields') }}';
+
+                const csrfInput = document.createElement('input');
+                csrfInput.type = 'hidden';
+                csrfInput.name = '_token';
+                csrfInput.value = csrfToken;
+                form.appendChild(csrfInput);
+
+                const redirectInput = document.createElement('input');
+                redirectInput.type = 'hidden';
+                redirectInput.name = 'redirect_to';
+                redirectInput.value = window.location.href;
+                form.appendChild(redirectInput);
+
+                selected.forEach(id => {
+                    const input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = 'employee_ids[]';
+                    input.value = id;
+                    form.appendChild(input);
+                });
+
+                document.body.appendChild(form);
+                form.submit();
+            });
+        }
+
+        // Bulk Advanced Export
+        const bulkExportBtn = document.getElementById('bulk-advanced-export-btn');
+        if (bulkExportBtn) {
+            bulkExportBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                document.getElementById('export_employee_ids').value = JSON.stringify(selected);
+                if (document.getElementById('export_source_menu')) {
+                    document.getElementById('export_source_menu').value = 'registration';
+                }
+                const modalEl = document.getElementById('advancedExportModal');
+                if (modalEl) {
+                    const modal = new bootstrap.Modal(modalEl);
+                    modal.show();
+                } else {
+                    console.error("advancedExportModal not found in DOM");
+                }
+            });
+        }
+
+        // Bulk Download Files
+        const bulkDownloadBtn = document.getElementById('bulk-download-btn');
+        if (bulkDownloadBtn) {
+            bulkDownloadBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                if (window.openBulkDownloadModal) {
+                    window.openBulkDownloadModal(selected);
+                } else {
+                    showToast('{{ __('Download module not available.') }}', 'warning');
+                }
+            });
+        }
+
+        // Bulk Send Data (Drag to Chat logic wrapper)
+        const bulkSendDataBtn = document.getElementById('bulk-send-data-btn');
+        if (bulkSendDataBtn) {
+            bulkSendDataBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selectedData = window.getGlobalSelectedData();
+                const selectedIds = selectedData.map(item => item.id);
+
+                if (selectedIds.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                const employers = [...new Set(selectedData.map(item => item.employer_id))];
+                if (employers.length > 1) {
+                    showToast('{{ __('Please select employees from a single employer to send data.') }}', 'warning');
+                    return;
+                }
+
+                const employerId = employers[0];
+                if (window.openBulkTicketModal) {
+                     window.openBulkTicketModal(employerId, selectedIds);
+                } else {
+                     showToast('{{ __('Ticket module not available.') }}', 'warning');
+                }
+            });
+        }
+
+        // Bulk Transfer
+        const bulkTransferBtn = document.getElementById('bulk-transfer-btn');
+        if (bulkTransferBtn) {
+            bulkTransferBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                document.getElementById('transfer_employee_ids').value = JSON.stringify(selected);
+
+                fetch('{{ route('employees.list_all_employers') }}')
+                    .then(res => res.json())
+                    .then(employers => {
+                        const select = document.getElementById('target_employer_id');
+                        select.innerHTML = '<option value="">{{ __("Select Target Employer") }}</option>';
+                        employers.forEach(emp => {
+                            const title = `[${emp.id}] ${emp.employerNameEn || emp.employerNameTh}`;
+                            select.add(new Option(title, emp.id));
+                        });
+
+                        const modalEl = document.getElementById('selectTargetEmployerModal');
+                        if (modalEl) {
+                            const modal = new bootstrap.Modal(modalEl);
+                            modal.show();
+                        }
+                    });
+            });
+        }
+
+        window.startDragBulk = function(e) {
+            const ids = window.getGlobalSelectedIds();
+            const count = ids.length;
+
+            if (count === 0) {
+                e.preventDefault();
+                return;
+            }
+
+            const payload = {
+                type: 'employees_bulk',
+                title: count + ' Employees',
+                count: count,
+                ids: ids,
+                url: window.location.href
+            };
+            e.dataTransfer.effectAllowed = 'copy';
+            e.dataTransfer.setData('application/json', JSON.stringify(payload));
+        }
+    });
+</script>
 <script>
     document.addEventListener('alpine:init', () => {
         Alpine.data('appointmentSearch', () => ({
@@ -326,6 +585,11 @@
                         document.getElementById('dayAppointmentsContent').innerHTML = data.html;
                         this.isLoading = false;
                         this.searchQuery = ''; // Reset search query when changing dates
+                        if (typeof window.refreshGlobalSelectionUI === 'function') {
+                            setTimeout(() => {
+                                window.refreshGlobalSelectionUI();
+                            }, 50);
+                        }
                     })
                     .catch(() => {
                         this.isLoading = false;

--- a/resources/views/production/registration/partials/day_appointments_list.blade.php
+++ b/resources/views/production/registration/partials/day_appointments_list.blade.php
@@ -21,93 +21,13 @@
                      data-reference="{{ strtolower($employee->employee_reference_id ?? '') }}"
                      x-show="matchesSearch($el)">
 
-                    <div class="card border-0 shadow-sm overflow-hidden h-100 position-relative">
-                        <div class="position-absolute top-0 start-0 h-100" style="width: 5px; background-color: {{ $employee->appointment_completed_at ? '#10B981' : '#F59E0B' }};"></div>
-
-                        <div class="card-body p-4 ms-2">
-                            <div class="row align-items-center">
-                                {{-- Employee Info --}}
-                                <div class="col-md-5 mb-3 mb-md-0">
-                                    <div class="d-flex align-items-center mb-2">
-                                        <div class="avatar bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-3 shadow-sm" style="width: 48px; height: 48px; font-size: 1.2rem;">
-                                            {{ mb_substr($employee->employeeNameTh ?? $employee->employeeNameEn ?? 'E', 0, 1) }}
-                                        </div>
-                                        <div>
-                                            <h5 class="fw-bold mb-1 text-dark">
-                                                {{ $employee->employeeTitle ?? '' }} {{ $employee->employeeNameEn ?? '' }}
-                                                <span class="text-secondary fs-6">({{ $employee->employeeNameTh ?? '' }})</span>
-                                            </h5>
-                                            <div class="text-muted small d-flex gap-3">
-                                                <span><i class="bi bi-person-badge me-1"></i>{{ $employee->employee_reference_id ?? '-' }}</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {{-- Employer Info --}}
-                                <div class="col-md-4 mb-3 mb-md-0 border-start ps-4">
-                                    <div class="d-flex align-items-start">
-                                        <div class="bg-light rounded p-2 me-3 text-secondary">
-                                            <i class="bi bi-building fs-5"></i>
-                                        </div>
-                                        <div>
-                                            <span class="text-uppercase small fw-bold text-muted d-block mb-1">{{ __('Employer') }}</span>
-                                            <h6 class="fw-bold text-dark mb-0 text-truncate" style="max-width: 200px;" title="{{ $employee->employer->employerNameTh ?? '' }}">
-                                                {{ $employee->employer->employerNameTh ?? '-' }}
-                                            </h6>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {{-- Actions --}}
-                                <div class="col-md-3 text-md-end">
-                                    <div class="d-flex flex-column gap-2 align-items-md-end">
-                                        {{-- Checkbox for bulk actions --}}
-                                        <div class="form-check form-check-inline mb-2 me-0 text-start text-md-end w-100">
-                                            <input class="form-check-input employee-checkbox float-md-end shadow-sm" type="checkbox"
-                                                   style="width: 20px; height: 20px; cursor: pointer; border-color: #6c757d;"
-                                                   value="{{ $employee->id }}"
-                                                   data-id="{{ $employee->id }}"
-                                                   data-employee-id="{{ $employee->id }}"
-                                                   data-employer-id="{{ $employee->employer_id }}"
-                                                   data-name-en="{{ $employee->employeeNameEn ?? '' }}"
-                                                   data-name-th="{{ $employee->employeeNameTh ?? '' }}">
-                                            <label class="form-check-label ms-2 d-md-none fw-bold text-muted">{{ __('Select Employee') }}</label>
-                                        </div>
-
-                                        <div class="btn-group shadow-sm w-100 mb-2">
-                                            <a href="{{ route('employees.edit', $employee->id) }}" target="_blank" class="btn btn-outline-secondary btn-sm" title="{{ __('Edit Employee') }}">
-                                                <i class="bi bi-pencil"></i>
-                                            </a>
-                                            <button type="button" class="btn btn-outline-primary btn-sm btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="{{ __('Preview Employee') }}">
-                                                <i class="bi bi-person-vcard"></i>
-                                            </button>
-                                            <button type="button" class="btn btn-outline-info btn-sm btn-preview" data-model-type="employer" data-model-id="{{ $employee->employer_id }}" title="{{ __('Preview Employer') }}">
-                                                <i class="bi bi-building"></i>
-                                            </button>
-                                        </div>
-
-                                        <div class="d-flex gap-2 w-100">
-                                            <button class="btn btn-sm w-100 fw-bold {{ $employee->appointment_completed_at ? 'btn-success' : 'btn-warning text-dark' }}"
-                                                    onclick="editAppointment({{ $employee->id }}, '{{ $employee->appointment_date ? \Carbon\Carbon::parse($employee->appointment_date)->format('Y-m-d\TH:i') : '' }}', '{{ $employee->appointment_location ?? '' }}', {{ $employee->appointment_completed_at ? 'true' : 'false' }})">
-                                                @if($employee->appointment_completed_at)
-                                                    <i class="bi bi-check-circle-fill me-1"></i> {{ __('Completed') }}
-                                                @else
-                                                    <i class="bi bi-clock-fill me-1"></i> {{ __('Update') }}
-                                                @endif
-                                            </button>
-
-                                            @if(!$employee->appointment_completed_at)
-                                            <button class="btn btn-sm btn-success w-100 fw-bold" onclick="markAppointmentCompleted({{ $employee->id }}, 'production/registration', this)" title="{{ __('Mark Appointment Completed') }}">
-                                                <i class="bi bi-check-lg me-1"></i> {{ __('Complete') }}
-                                            </button>
-                                            @endif
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    @include('production.registration._employee_card', [
+                        'employee' => $employee,
+                        'steps' => $steps,
+                        'loop' => $loop,
+                        'isHistory' => false,
+                        'show_employer' => true
+                    ])
                 </div>
             @endforeach
         </div>

--- a/resources/views/production/renewal/dashboard.blade.php
+++ b/resources/views/production/renewal/dashboard.blade.php
@@ -167,11 +167,270 @@
             </div>
         </div>
     </div>
+
+    <!-- Bulk Action Bar -->
+    <div class="bulk-action-bar mt-3 align-items-center gap-2 p-2 bg-light border rounded shadow-lg"
+         style="display: none; position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); z-index: 1060; width: auto; min-width: 400px;"
+         id="bulkActionBar"
+         draggable="true"
+         ondragstart="window.startDragBulk(event)">
+        <div class="form-check mb-0">
+            <input class="form-check-input" type="checkbox" id="select-all-checkbox">
+            <label class="form-check-label fw-bold" for="select-all-checkbox">
+                {{ __('Select All') }} (<span id="selected-count">0</span>)
+            </label>
+        </div>
+
+        <div class="vr mx-2"></div>
+
+        <div class="dropdown">
+            <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" id="bulkActionDropdown" data-bs-toggle="dropdown" aria-expanded="false" disabled>
+                {{ __('Actions') }}
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="bulkActionDropdown">
+                <li><a class="dropdown-item" href="#" id="bulk-advanced-edit-btn"><i class="bi bi-pencil-square me-2"></i>{{ __('Advanced Edit') }}</a></li>
+                <li><a class="dropdown-item" href="#" id="bulk-advanced-export-btn"><i class="bi bi-file-earmark-spreadsheet me-2"></i>{{ __('Advanced Export') }}</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="#" id="bulk-download-btn"><i class="bi bi-download me-2"></i>{{ __('Download Files') }}</a></li>
+                <li><a class="dropdown-item" href="#" id="bulk-transfer-btn"><i class="bi bi-arrow-left-right me-2"></i>{{ __('Transfer') }}</a></li>
+                <li><a class="dropdown-item" href="#" id="bulk-send-data-btn"><i class="bi bi-send me-2"></i>{{ __('Send Data') }}</a></li>
+                @can('manage-tickets')
+                <li><a class="dropdown-item" href="#" id="bulk-generate-pdf-btn"><i class="bi bi-file-earmark-pdf me-2"></i>{{ __('Automated PDF') }}</a></li>
+                @endcan
+            </ul>
+        </div>
+
+        <button class="btn btn-sm btn-outline-danger ms-2" onclick="window.clearGlobalSelection();">{{ __('Clear Selection') }}</button>
+        <button class="btn btn-sm btn-info text-white" id="btn-view-selected" onclick="window.openViewSelectedModal()">
+            <i class="bi bi-eye me-1"></i> {{ __('View Selected') }}
+            <span class="badge bg-white text-info ms-1" id="view-selected-count">0</span>
+        </button>
+        <div class="ms-auto text-muted small d-none d-md-block">
+            <i class="bi bi-info-circle me-1"></i> Drag to chat
+        </div>
+    </div>
 </div>
+
+{{-- Include Advanced Export & Target Employer Modals (reused from Employees) --}}
+@include('employees.modals.advanced_export')
+@include('employees.modals.select_target_employer_modal')
 
 @endsection
 
 @push('scripts')
+<script>
+    // Include bulk action event handlers
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
+
+    document.addEventListener('DOMContentLoaded', function() {
+        // Bulk Generate PDF
+        const bulkGeneratePdfBtn = document.getElementById('bulk-generate-pdf-btn');
+        if (bulkGeneratePdfBtn) {
+            bulkGeneratePdfBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                const form = document.createElement('form');
+                form.method = 'POST';
+                form.action = '{{ route("admin.pdf-templates.generate.modal", [], false) }}';
+
+                const csrf = document.createElement('input');
+                csrf.type = 'hidden';
+                csrf.name = '_token';
+                csrf.value = csrfToken;
+                form.appendChild(csrf);
+
+                const redirectInput = document.createElement('input');
+                redirectInput.type = 'hidden';
+                redirectInput.name = 'redirect_url';
+                redirectInput.value = window.location.href;
+                form.appendChild(redirectInput);
+
+                selected.forEach(id => {
+                    const input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = 'employees[]';
+                    input.value = id;
+                    form.appendChild(input);
+                });
+
+                document.body.appendChild(form);
+                form.submit();
+            });
+        }
+
+        // Bulk Advanced Edit
+        const bulkEditBtn = document.getElementById('bulk-advanced-edit-btn');
+        if (bulkEditBtn) {
+            bulkEditBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                const form = document.createElement('form');
+                form.method = 'POST';
+                form.action = '{{ route('employees.bulk_edit.select_fields') }}';
+
+                const csrfInput = document.createElement('input');
+                csrfInput.type = 'hidden';
+                csrfInput.name = '_token';
+                csrfInput.value = csrfToken;
+                form.appendChild(csrfInput);
+
+                const redirectInput = document.createElement('input');
+                redirectInput.type = 'hidden';
+                redirectInput.name = 'redirect_to';
+                redirectInput.value = window.location.href;
+                form.appendChild(redirectInput);
+
+                selected.forEach(id => {
+                    const input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = 'employee_ids[]';
+                    input.value = id;
+                    form.appendChild(input);
+                });
+
+                document.body.appendChild(form);
+                form.submit();
+            });
+        }
+
+        // Bulk Advanced Export
+        const bulkExportBtn = document.getElementById('bulk-advanced-export-btn');
+        if (bulkExportBtn) {
+            bulkExportBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                document.getElementById('export_employee_ids').value = JSON.stringify(selected);
+                if (document.getElementById('export_source_menu')) {
+                    document.getElementById('export_source_menu').value = 'renewal';
+                }
+                const modalEl = document.getElementById('advancedExportModal');
+                if (modalEl) {
+                    const modal = new bootstrap.Modal(modalEl);
+                    modal.show();
+                } else {
+                    console.error("advancedExportModal not found in DOM");
+                }
+            });
+        }
+
+        // Bulk Download Files
+        const bulkDownloadBtn = document.getElementById('bulk-download-btn');
+        if (bulkDownloadBtn) {
+            bulkDownloadBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                if (window.openBulkDownloadModal) {
+                    window.openBulkDownloadModal(selected);
+                } else {
+                    showToast('{{ __('Download module not available.') }}', 'warning');
+                }
+            });
+        }
+
+        // Bulk Send Data (Drag to Chat logic wrapper)
+        const bulkSendDataBtn = document.getElementById('bulk-send-data-btn');
+        if (bulkSendDataBtn) {
+            bulkSendDataBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selectedData = window.getGlobalSelectedData();
+                const selectedIds = selectedData.map(item => item.id);
+
+                if (selectedIds.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                const employers = [...new Set(selectedData.map(item => item.employer_id))];
+                if (employers.length > 1) {
+                    showToast('{{ __('Please select employees from a single employer to send data.') }}', 'warning');
+                    return;
+                }
+
+                const employerId = employers[0];
+                if (window.openBulkTicketModal) {
+                     window.openBulkTicketModal(employerId, selectedIds);
+                } else {
+                     showToast('{{ __('Ticket module not available.') }}', 'warning');
+                }
+            });
+        }
+
+        // Bulk Transfer
+        const bulkTransferBtn = document.getElementById('bulk-transfer-btn');
+        if (bulkTransferBtn) {
+            bulkTransferBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const selected = window.getGlobalSelectedIds();
+                if (selected.length === 0) {
+                    showToast('{{ __('Please select employees first.') }}', 'danger');
+                    return;
+                }
+
+                document.getElementById('transfer_employee_ids').value = JSON.stringify(selected);
+
+                fetch('{{ route('employees.list_all_employers') }}')
+                    .then(res => res.json())
+                    .then(employers => {
+                        const select = document.getElementById('target_employer_id');
+                        select.innerHTML = '<option value="">{{ __("Select Target Employer") }}</option>';
+                        employers.forEach(emp => {
+                            const title = `[${emp.id}] ${emp.employerNameEn || emp.employerNameTh}`;
+                            select.add(new Option(title, emp.id));
+                        });
+
+                        const modalEl = document.getElementById('selectTargetEmployerModal');
+                        if (modalEl) {
+                            const modal = new bootstrap.Modal(modalEl);
+                            modal.show();
+                        }
+                    });
+            });
+        }
+
+        window.startDragBulk = function(e) {
+            const ids = window.getGlobalSelectedIds();
+            const count = ids.length;
+
+            if (count === 0) {
+                e.preventDefault();
+                return;
+            }
+
+            const payload = {
+                type: 'employees_bulk',
+                title: count + ' Employees',
+                count: count,
+                ids: ids,
+                url: window.location.href
+            };
+            e.dataTransfer.effectAllowed = 'copy';
+            e.dataTransfer.setData('application/json', JSON.stringify(payload));
+        }
+    });
+</script>
 <script>
     document.addEventListener('alpine:init', () => {
         Alpine.data('appointmentSearch', () => ({
@@ -326,6 +585,11 @@
                         document.getElementById('dayAppointmentsContent').innerHTML = data.html;
                         this.isLoading = false;
                         this.searchQuery = ''; // Reset search query when changing dates
+                        if (typeof window.refreshGlobalSelectionUI === 'function') {
+                            setTimeout(() => {
+                                window.refreshGlobalSelectionUI();
+                            }, 50);
+                        }
                     })
                     .catch(() => {
                         this.isLoading = false;

--- a/resources/views/production/renewal/partials/day_appointments_list.blade.php
+++ b/resources/views/production/renewal/partials/day_appointments_list.blade.php
@@ -21,93 +21,13 @@
                      data-reference="{{ strtolower($employee->employee_reference_id ?? '') }}"
                      x-show="matchesSearch($el)">
 
-                    <div class="card border-0 shadow-sm overflow-hidden h-100 position-relative">
-                        <div class="position-absolute top-0 start-0 h-100" style="width: 5px; background-color: {{ $employee->appointment_completed_at ? '#10B981' : '#F59E0B' }};"></div>
-
-                        <div class="card-body p-4 ms-2">
-                            <div class="row align-items-center">
-                                {{-- Employee Info --}}
-                                <div class="col-md-5 mb-3 mb-md-0">
-                                    <div class="d-flex align-items-center mb-2">
-                                        <div class="avatar bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-3 shadow-sm" style="width: 48px; height: 48px; font-size: 1.2rem;">
-                                            {{ mb_substr($employee->employeeNameTh ?? $employee->employeeNameEn ?? 'E', 0, 1) }}
-                                        </div>
-                                        <div>
-                                            <h5 class="fw-bold mb-1 text-dark">
-                                                {{ $employee->employeeTitle ?? '' }} {{ $employee->employeeNameEn ?? '' }}
-                                                <span class="text-secondary fs-6">({{ $employee->employeeNameTh ?? '' }})</span>
-                                            </h5>
-                                            <div class="text-muted small d-flex gap-3">
-                                                <span><i class="bi bi-person-badge me-1"></i>{{ $employee->employee_reference_id ?? '-' }}</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {{-- Employer Info --}}
-                                <div class="col-md-4 mb-3 mb-md-0 border-start ps-4">
-                                    <div class="d-flex align-items-start">
-                                        <div class="bg-light rounded p-2 me-3 text-secondary">
-                                            <i class="bi bi-building fs-5"></i>
-                                        </div>
-                                        <div>
-                                            <span class="text-uppercase small fw-bold text-muted d-block mb-1">{{ __('Employer') }}</span>
-                                            <h6 class="fw-bold text-dark mb-0 text-truncate" style="max-width: 200px;" title="{{ $employee->employer->employerNameTh ?? '' }}">
-                                                {{ $employee->employer->employerNameTh ?? '-' }}
-                                            </h6>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {{-- Actions --}}
-                                <div class="col-md-3 text-md-end">
-                                    <div class="d-flex flex-column gap-2 align-items-md-end">
-                                        {{-- Checkbox for bulk actions --}}
-                                        <div class="form-check form-check-inline mb-2 me-0 text-start text-md-end w-100">
-                                            <input class="form-check-input employee-checkbox float-md-end shadow-sm" type="checkbox"
-                                                   style="width: 20px; height: 20px; cursor: pointer; border-color: #6c757d;"
-                                                   value="{{ $employee->id }}"
-                                                   data-id="{{ $employee->id }}"
-                                                   data-employee-id="{{ $employee->id }}"
-                                                   data-employer-id="{{ $employee->employer_id }}"
-                                                   data-name-en="{{ $employee->employeeNameEn ?? '' }}"
-                                                   data-name-th="{{ $employee->employeeNameTh ?? '' }}">
-                                            <label class="form-check-label ms-2 d-md-none fw-bold text-muted">{{ __('Select Employee') }}</label>
-                                        </div>
-
-                                        <div class="btn-group shadow-sm w-100 mb-2">
-                                            <a href="{{ route('employees.edit', $employee->id) }}" target="_blank" class="btn btn-outline-secondary btn-sm" title="{{ __('Edit Employee') }}">
-                                                <i class="bi bi-pencil"></i>
-                                            </a>
-                                            <button type="button" class="btn btn-outline-primary btn-sm btn-preview" data-model-type="employee" data-model-id="{{ $employee->id }}" title="{{ __('Preview Employee') }}">
-                                                <i class="bi bi-person-vcard"></i>
-                                            </button>
-                                            <button type="button" class="btn btn-outline-info btn-sm btn-preview" data-model-type="employer" data-model-id="{{ $employee->employer_id }}" title="{{ __('Preview Employer') }}">
-                                                <i class="bi bi-building"></i>
-                                            </button>
-                                        </div>
-
-                                        <div class="d-flex gap-2 w-100">
-                                            <button class="btn btn-sm w-100 fw-bold {{ $employee->appointment_completed_at ? 'btn-success' : 'btn-warning text-dark' }}"
-                                                    onclick="editAppointment({{ $employee->id }}, '{{ $employee->appointment_date ? \Carbon\Carbon::parse($employee->appointment_date)->format('Y-m-d\TH:i') : '' }}', '{{ $employee->appointment_location ?? '' }}', {{ $employee->appointment_completed_at ? 'true' : 'false' }})">
-                                                @if($employee->appointment_completed_at)
-                                                    <i class="bi bi-check-circle-fill me-1"></i> {{ __('Completed') }}
-                                                @else
-                                                    <i class="bi bi-clock-fill me-1"></i> {{ __('Update') }}
-                                                @endif
-                                            </button>
-
-                                            @if(!$employee->appointment_completed_at)
-                                            <button class="btn btn-sm btn-success w-100 fw-bold" onclick="markAppointmentCompleted({{ $employee->id }}, 'production/renewal', this)" title="{{ __('Mark Appointment Completed') }}">
-                                                <i class="bi bi-check-lg me-1"></i> {{ __('Complete') }}
-                                            </button>
-                                            @endif
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    @include('production.registration._employee_card', [
+                        'employee' => $employee,
+                        'steps' => $steps,
+                        'loop' => $loop,
+                        'isHistory' => false,
+                        'show_employer' => true
+                    ])
                 </div>
             @endforeach
         </div>


### PR DESCRIPTION
This resolves the issues with missing appointment notifications by adjusting the date filter to include past due items. It also fixes the broken layout of the appointment cards when selected by replacing them with the standard `_employee_card` partial. Finally, it adds comprehensive bulk action capabilities (select all, edit, export, transfer, etc.) to both the Registration and Renewal dashboard views, matching the functionality available on the main operations list pages.

---
*PR created automatically by Jules for task [10684627498750301691](https://jules.google.com/task/10684627498750301691) started by @nongjossss-commits*